### PR TITLE
Fix cytotrace2 bug 

### DIFF
--- a/omicverse/externel/cytotrace2/gen_utils.py
+++ b/omicverse/externel/cytotrace2/gen_utils.py
@@ -116,8 +116,7 @@ def preprocess(expression, species):
         expression.columns = mapped_genes.values
         num_genes_mapped = len([i for i in mapped_genes if i in features.values])
         print("    Mapped "+str(num_genes_mapped)+" input gene names to mouse orthologs")    
-        duplicate_genes = expression.columns[expression.columns.duplicated()].values
-        duplicate_genes = [i for i in duplicate_genes if i is not np.nan]
+        duplicate_genes = expression.columns[expression.columns.duplicated()].dropna().values
         idx = [unmapped_genes[i.upper()] for i in duplicate_genes if i.upper() in unmapped_genes.keys()]
         expression = expression.iloc[:, [j for j, c in enumerate(expression.columns) if j not in idx]]
         

--- a/omicverse/single/_cytotrace2.py
+++ b/omicverse/single/_cytotrace2.py
@@ -141,7 +141,7 @@ def cytotrace2(
     if issparse(adata.X):
         expression=pd.DataFrame(adata.X.toarray(),index=adata.obs.index,columns=adata.var.index)
     else:
-        expression=adata.X
+        expression = pd.DataFrame(adata.X, index=adata.obs.index, columns=adata.var.index)
     print('cytotrace2: Dataset characteristics')
     print('    Number of input genes: ',str(expression.shape[1]))
     print('    Number of input cells: ',str(expression.shape[0]))


### PR DESCRIPTION
Fix the bug when adata.X is not sparse data, it will raise AttributeError: 'numpy.ndarray' object has no attribute 'columns',