### PR TITLE
Fix the bug that ov.utils.plot_paga layout parameter doesn't work 

### DIFF
--- a/omicverse/utils/_paga.py
+++ b/omicverse/utils/_paga.py
@@ -438,6 +438,9 @@ def plot_paga(adata,
     scatter_flag=None,
     **kwargs,):
 
+    if layout is not None:
+        basis = None
+    
     import scvelo as scv
     return scv.pl.paga(adata,
     basis=basis,


### PR DESCRIPTION
The layout parameter of ov.utils.plot_paga does not work when you set the basis parameter, like `ov.utils.plot_paga(adata, basis='umap', layout="rt")`. This should be an issue with scvelo, but to make ov run correctly, an if statement is added here to ensure it works properly.