### PR TITLE
Fix a bug in SCSA

### DIFF
--- a/omicverse/single/_SCSA.py
+++ b/omicverse/single/_SCSA.py
@@ -278,7 +278,7 @@ class Annotator(object):
                     if all_outs.size == 0:
                         all_outs = outs
                     else:
-                        all_outs = all_outs.append(outs)
+                        all_outs = pd.concat([all_outs,outs])
                     if self.noprint == False:
                         print()
                 if self.output:


### PR DESCRIPTION
The use of deprecated methods in SCSA can result in the following error:
```
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
/tmp/ipykernel_1771165/3971618998.py in ?()
----> 1 anno=scsa.cell_anno(clustertype='leiden',
      2                cluster='all',rank_rep=True)

~/miniconda3/envs/omicverse_cpu/lib/python3.10/site-packages/omicverse/single/_anno.py in ?(self, clustertype, cluster, rank_rep)
    460 
    461         print('...Auto annotate cell')
    462 
    463         p = Process()
--> 464         p.run_cmd_p(foldchange=self.foldchange,
    465                     weight=self.weight,
    466                     pvalue=self.pvalue,
    467                     tissue=self.tissue,

~/miniconda3/envs/omicverse_cpu/lib/python3.10/site-packages/omicverse/single/_SCSA.py in ?(self, foldchange, weight, pvalue, tissue, species, target, norefdb, MarkerDB, db, noprint, input, output, source, cluster, fc, outfmt, celltype, Gensymbol, list_tissue, cellrange)
   1382                  target,norefdb,MarkerDB,db,
   1383                  noprint,input,output,source,cluster,fc,
   1384                  outfmt,celltype,Gensymbol,list_tissue,cellrange)
   1385         anno.load_pickle_module(rdbname)
-> 1386         outs=anno.run_detail_cmd()
   1387         print("#Cluster","Type","Celltype","Score","Times")
   1388         for o in outs:
   1389             print(o)

~/miniconda3/envs/omicverse_cpu/lib/python3.10/site-packages/omicverse/single/_SCSA.py in ?(self)
   1278             if self.Gensymbol:
   1279                 self.read_user_markers('gene')
   1280             else:
   1281                 self.read_user_markers('ensemblID')
-> 1282             outs = self.calcu_scanpy_group(self.input,self.Gensymbol)
   1283             return outs
   1284         elif self.source.lower() == "scran":
   1285             self.load_pickle_module(self.db)

~/miniconda3/envs/omicverse_cpu/lib/python3.10/site-packages/omicverse/single/_SCSA.py in ?(self, expfile, hgvc)
    667             elif self.target.lower() == "cancersea":
    668                 tfc,trownames,trownum,tcolnames,tcolnum = self.get_cell_gene_names(otherexps,self.smarkers,ofid,gcol,ccol,'other')
    669                 if not trownames:continue
    670                 other_gene_names = set(tcolnames)
--> 671                 self.deal_with_badtype(cname,other_gene_names,colnames)
    672             elif self.target.lower() == "panglaodb":
    673                 tfc,trownames,trownum,tcolnames,tcolnum = self.get_cell_gene_names(otherexps,self.pmarkers,ofid,gcol,ccol,'other')
    674                 if not trownames:continue

~/miniconda3/envs/omicverse_cpu/lib/python3.10/site-packages/omicverse/single/_SCSA.py in ?(self, cname, other_gene_names, colnames)
    277                     if outs.size == 0:continue
    278                     if all_outs.size == 0:
    279                         all_outs = outs
    280                     else:
--> 281                         all_outs = all_outs.append(outs)
    282                     if self.noprint == False:
    283                         print()
    284                 if self.output:

~/miniconda3/envs/omicverse_cpu/lib/python3.10/site-packages/pandas/core/generic.py in ?(self, name)
   6295         and index are copied). Any changes to the data of the original
   6296         will be reflected in the shallow copy (and vice versa).
   6297 
   6298         Parameters
-> 6299         ----------
   6300         deep : bool, default True
   6301             Make a deep copy, including a copy of the data and the indices.
   6302             With ``deep=False`` neither the indices nor the data are copied.

AttributeError: 'DataFrame' object has no attribute 'append'
```