### PR TITLE
Fix code scanning alert no. 1: Binding a socket to all network interfaces

### DIFF
--- a/omicverse/externel/scdiffusion/guided_diffusion/dist_util.py
+++ b/omicverse/externel/scdiffusion/guided_diffusion/dist_util.py
@@ -89,7 +89,7 @@ def sync_params(params):
 def _find_free_port():
     try:
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        s.bind(("", 0))
+        s.bind(("127.0.0.1", 0))
         s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         return s.getsockname()[1]
     finally:


### PR DESCRIPTION
Fixes [https://github.com/Starlitnightly/omicverse/security/code-scanning/1](https://github.com/Starlitnightly/omicverse/security/code-scanning/1)

To fix the problem, we should bind the socket to a specific interface rather than all interfaces. This can be achieved by specifying a dedicated IP address instead of an empty string. Since the code is part of a distributed training setup, we can use `localhost` (127.0.0.1) to limit the binding to the local machine. This change will ensure that the socket is not exposed to external networks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
