### PR TITLE
Fix serveral bugs in ov.space.svg with mode='prost'

### DIFF
--- a/omicverse/externel/PROST/calculate_PI.py
+++ b/omicverse/externel/PROST/calculate_PI.py
@@ -237,7 +237,7 @@ def get_sub(adata, kernel_size = 5, platform="visium",del_rate = 0.01):
                     del_index[i] = 0
             else:
                 del_index[i] = 0
-            output[i, :] = gene_img_flatten(targe_image, image_idx_1d)      
+            output[i, :] = gene_img_flatten(targe_image, image_idx_1d.values)      
     #--------------------------------------------------------------------------
     else:
         output = np.zeros((gene_data.shape[0], adata.uns['shape'][0]*adata.uns['shape'][1]))

--- a/omicverse/externel/PROST/utils.py
+++ b/omicverse/externel/PROST/utils.py
@@ -98,8 +98,8 @@ def minmax_normalize(data):
 def get_image_idx_1D(image_idx_2d):
     print("\nCalculating image index 1D:")
     max_value = np.max(image_idx_2d[:])
-    image_idx_1d = np.ones(max_value).astype(int)
-    for i in tqdm(range(1, max_value + 1)):
+    image_idx_1d = np.ones(max_value).astype(np.int64)
+    for i in range(1, max_value + 1):
         idx = np.where(image_idx_2d.T.flatten() == i)[0]
         if len(idx) > 0:
             image_idx_1d[i-1] = idx[0] + 1

--- a/omicverse/space/_svg.py
+++ b/omicverse/space/_svg.py
@@ -10,6 +10,12 @@ def svg(adata,mode='prost',n_svgs=3000,target_sum=50*1e4,platform="visium",
         if 'counts' not in adata.layers.keys():
             adata.layers['counts'] = adata.X.copy()
         # Calculate PI
+        try:
+            import cv2
+        except ImportError:
+            print("Please install the package cv2 by \"pip install opencv-python\"")
+            import sys
+            sys.exit(1)
         adata = prepare_for_PI(adata, platform=platform)
         adata = cal_PI(adata, platform=platform)
         print('PI calculation is done!')


### PR DESCRIPTION
1. Untyped global name 'tqdm': Cannot determine Numba type of <class 'type'>

```
---------------------------------------------------------------------------
TypingError                               Traceback (most recent call last)
Cell In[4], line 3
      1 sc.pp.calculate_qc_metrics(adata, inplace=True)
      2 adata = adata[:,adata.var['total_counts']>100]
----> 3 adata=ov.space.svg(adata,mode='prost',n_svgs=3000,target_sum=1e4,platform="visium",)
      4 adata

File ~/anaconda3/envs/omicverse/lib/python3.12/site-packages/omicverse/space/_svg.py:13, in svg(adata, mode, n_svgs, target_sum, platform, mt_startwith, **kwargs)
     11     adata.layers['counts'] = adata.X.copy()
     12 # Calculate PI
---> 13 adata = prepare_for_PI(adata, platform=platform)
     14 adata = cal_PI(adata, platform=platform)
     15 print('PI calculation is done!')

File ~/anaconda3/envs/omicverse/lib/python3.12/site-packages/omicverse/externel/PROST/calculate_PI.py:26, in prepare_for_PI(adata, grid_size, percentage, platform)
     24 if np.min(locates) == 0:
     25     locates += 1
---> 26 _, image_idx = make_image(postcount[0], locates, platform, get_image_idx = True, grid_size=grid_size)
     27 adata = adata[:, selected_gene_idxs]
     28 sc.pp.filter_genes(adata, min_cells=3)

File ~/anaconda3/envs/omicverse/lib/python3.12/site-packages/omicverse/externel/PROST/utils.py:162, in make_image(genecount, locates, platform, get_image_idx, grid_size, interpolation_method)
    160     image_idx_1d = np.ones(np.max(image_idx_2d[:])).astype(int)
    161     if get_image_idx:
--> 162         image_idx_1d = get_image_idx_1D(image_idx_2d)
    164     return image, image_idx_1d
    165 #--------------------------------------------------------------------------
    166 else:

File ~/anaconda3/envs/omicverse/lib/python3.12/site-packages/numba/core/dispatcher.py:423, in _DispatcherBase._compile_for_args(self, *args, **kws)
    419         msg = (f"{str(e).rstrip()} \n\nThis error may have been caused "
    420                f"by the following argument(s):\n{args_str}\n")
    421         e.patch_message(msg)
--> 423     error_rewrite(e, 'typing')
    424 except errors.UnsupportedError as e:
    425     # Something unsupported is present in the user code, add help info
    426     error_rewrite(e, 'unsupported_error')

File ~/anaconda3/envs/omicverse/lib/python3.12/site-packages/numba/core/dispatcher.py:364, in _DispatcherBase._compile_for_args.<locals>.error_rewrite(e, issue_type)
    362     raise e
    363 else:
--> 364     raise e.with_traceback(None)

TypingError: Failed in nopython mode pipeline (step: nopython frontend)
Untyped global name 'tqdm': Cannot determine Numba type of <class 'type'>

File "../../../home/user/anaconda3/envs/omicverse/lib/python3.12/site-packages/omicverse/externel/PROST/utils.py", line 102:
def get_image_idx_1D(image_idx_2d):
    <source elided>
    image_idx_1d = np.ones(max_value).astype(int)
    for i in tqdm(range(1, max_value + 1)):
    ^

```

2. Invalid use of BoundFunction(array.astype for array(float64, 1d, C)) with parameters (Function(<class 'int'>))

```
---------------------------------------------------------------------------
TypingError                               Traceback (most recent call last)
Cell In[3], line 3
      1 sc.pp.calculate_qc_metrics(adata, inplace=True)
      2 adata = adata[:,adata.var['total_counts']>100]
----> 3 adata=ov.space.svg(adata,mode='prost',n_svgs=3000,target_sum=1e4,platform="visium",)
      4 adata

File ~/anaconda3/envs/omicverse/lib/python3.12/site-packages/omicverse/space/_svg.py:13, in svg(adata, mode, n_svgs, target_sum, platform, mt_startwith, **kwargs)
     11     adata.layers['counts'] = adata.X.copy()
     12 # Calculate PI
---> 13 adata = prepare_for_PI(adata, platform=platform)
     14 adata = cal_PI(adata, platform=platform)
     15 print('PI calculation is done!')

File ~/anaconda3/envs/omicverse/lib/python3.12/site-packages/omicverse/externel/PROST/calculate_PI.py:26, in prepare_for_PI(adata, grid_size, percentage, platform)
     24 if np.min(locates) == 0:
     25     locates += 1
---> 26 _, image_idx = make_image(postcount[0], locates, platform, get_image_idx = True, grid_size=grid_size)
     27 adata = adata[:, selected_gene_idxs]
     28 sc.pp.filter_genes(adata, min_cells=3)

File ~/anaconda3/envs/omicverse/lib/python3.12/site-packages/omicverse/externel/PROST/utils.py:162, in make_image(genecount, locates, platform, get_image_idx, grid_size, interpolation_method)
    160     image_idx_1d = np.ones(np.max(image_idx_2d[:])).astype(int)
    161     if get_image_idx:
--> 162         image_idx_1d = get_image_idx_1D(image_idx_2d)
    164     return image, image_idx_1d
    165 #--------------------------------------------------------------------------
    166 else:

File ~/anaconda3/envs/omicverse/lib/python3.12/site-packages/numba/core/dispatcher.py:423, in _DispatcherBase._compile_for_args(self, *args, **kws)
    419         msg = (f"{str(e).rstrip()} \n\nThis error may have been caused "
    420                f"by the following argument(s):\n{args_str}\n")
    421         e.patch_message(msg)
--> 423     error_rewrite(e, 'typing')
    424 except errors.UnsupportedError as e:
    425     # Something unsupported is present in the user code, add help info
    426     error_rewrite(e, 'unsupported_error')

File ~/anaconda3/envs/omicverse/lib/python3.12/site-packages/numba/core/dispatcher.py:364, in _DispatcherBase._compile_for_args.<locals>.error_rewrite(e, issue_type)
    362     raise e
    363 else:
--> 364     raise e.with_traceback(None)

TypingError: Failed in nopython mode pipeline (step: nopython frontend)
Invalid use of BoundFunction(array.astype for array(float64, 1d, C)) with parameters (Function(<class 'int'>))

During: resolving callee type: BoundFunction(array.astype for array(float64, 1d, C))
During: typing of call at /home/user/anaconda3/envs/omicverse/lib/python3.12/site-packages/omicverse/externel/PROST/utils.py (101)


File "../../../home/user/anaconda3/envs/omicverse/lib/python3.12/site-packages/omicverse/externel/PROST/utils.py", line 101:
def get_image_idx_1D(image_idx_2d):
    <source elided>
    max_value = np.max(image_idx_2d[:])
    image_idx_1d = np.ones(max_value).astype(int)
```

3. argument 1: Cannot determine Numba type of <class 'pandas.core.series.Series'>
```
---------------------------------------------------------------------------
TypingError                               Traceback (most recent call last)
Cell In[4], line 3
      1 sc.pp.calculate_qc_metrics(adata, inplace=True)
      2 adata = adata[:,adata.var['total_counts']>100]
----> 3 adata=ov.space.svg(adata,mode='prost',n_svgs=3000,target_sum=1e4,platform="visium",)
      4 adata

File ~/anaconda3/envs/omicverse/lib/python3.12/site-packages/omicverse/space/_svg.py:20, in svg(adata, mode, n_svgs, target_sum, platform, mt_startwith, **kwargs)
     18     sys.exit(1)
     19 adata = prepare_for_PI(adata, platform=platform)
---> 20 adata = cal_PI(adata, platform=platform)
     21 print('PI calculation is done!')
     23 # Spatial autocorrelation test

File ~/anaconda3/envs/omicverse/lib/python3.12/site-packages/omicverse/externel/PROST/PROST.py:47, in cal_PI(adata, layer, kernel_size, del_rate, platform, multiprocess)
     45 adata = gau_filter(adata, platform, multiprocess=multiprocess)
     46 adata = get_binary(adata, platform, method = "iterative", multiprocess=multiprocess)
---> 47 adata = get_sub(adata, kernel_size, platform, del_rate)
     48 adata = cal_prost_index(adata, platform)
     49 print("\nPROST Index calculation completed !!")    

File ~/anaconda3/envs/omicverse/lib/python3.12/site-packages/omicverse/externel/PROST/calculate_PI.py:240, in get_sub(adata, kernel_size, platform, del_rate)
    238         else:
    239             del_index[i] = 0
--> 240         output[i, :] = gene_img_flatten(targe_image, image_idx_1d)      
    241 #--------------------------------------------------------------------------
    242 else:
    243     output = np.zeros((gene_data.shape[0], adata.uns['shape'][0]*adata.uns['shape'][1]))

File ~/anaconda3/envs/omicverse/lib/python3.12/site-packages/numba/core/dispatcher.py:423, in _DispatcherBase._compile_for_args(self, *args, **kws)
    419         msg = (f"{str(e).rstrip()} \n\nThis error may have been caused "
    420                f"by the following argument(s):\n{args_str}\n")
    421         e.patch_message(msg)
--> 423     error_rewrite(e, 'typing')
    424 except errors.UnsupportedError as e:
    425     # Something unsupported is present in the user code, add help info
    426     error_rewrite(e, 'unsupported_error')

File ~/anaconda3/envs/omicverse/lib/python3.12/site-packages/numba/core/dispatcher.py:364, in _DispatcherBase._compile_for_args.<locals>.error_rewrite(e, issue_type)
    362     raise e
    363 else:
--> 364     raise e.with_traceback(None)

TypingError: Failed in nopython mode pipeline (step: nopython frontend)
non-precise type pyobject
During: typing of argument at /home/user/anaconda3/envs/omicverse/lib/python3.12/site-packages/omicverse/externel/PROST/utils.py (186)

File "../../../home/user/anaconda3/envs/omicverse/lib/python3.12/site-packages/omicverse/externel/PROST/utils.py", line 186:
def make_image(genecount, locates, platform = "visium", get_image_idx = False, 
    <source elided>

@numba.jit
^ 

This error may have been caused by the following argument(s):
- argument 1: Cannot determine Numba type of <class 'pandas.core.series.Series'>
```

4. Check package "cv2" before starting large-scale calculations
