### PR TITLE
Fix: Resolve dependency conflicts in omicverse_gpu.yml

### DIFF
--- a/conda/omicverse_gpu.yml
+++ b/conda/omicverse_gpu.yml
@@ -22,13 +22,13 @@ dependencies:
  - fa2
  - jupyterlab
  - pandas=1.5.3
+ - decoupler
+ - omnipath
+ - gdown
+ - wget
+ - scikit-misc
+ - harmonypy
+ - pytorch_geometric
  - pip
  - pip:
-    - decoupler
-    - omnipath
-    - gdown
-    - wget
-    - scikit-misc
-    - harmonypy
-    - rapids-singlecell
-    - torch_geometric
+   - rapids-singlecell


### PR DESCRIPTION
**Problem:**

When setting up the environment using `omicverse_gpu.yml`, installing certain packages via the `pip:` section after the main conda dependencies can lead to unexpected package upgrades (e.g., NumPy being upgraded to v2.2.5). This subsequently causes compatibility issues with other core dependencies managed by conda, such as PyArrow and Matplotlib, which rely on a lower NumPy version.

**Solution:**

This PR moves most dependencies previously listed under the `pip:` section into the main `dependencies:` list within the `omicverse_gpu.yml` file. By doing this, we allow conda's dependency resolver to manage these packages and their versions consistently, ensuring compatibility across the environment.

**Verification:**

Tested locally: The environment setup using the modified `omicverse_gpu.yml` now completes successfully without the previously encountered compatibility errors between NumPy, PyArrow, and Matplotlib.

Thank you for your hard work on this project!