### PR TITLE
Enhance LLM Domain Research: web retrieval, embedding rerank, guardrails, scoping, CLI, PDF

### DIFF
--- a/omicverse/llm/domain_research/retrievers/__init__.py
+++ b/omicverse/llm/domain_research/retrievers/__init__.py
@@ -6,6 +6,6 @@ Provides a stable import path: `omicverse.llm.domain_research.retrievers`.
 from __future__ import annotations
 
 from ...dr.retrievers.web_store import WebRetrieverStore  # noqa: F401
+from ...dr.retrievers.embed_web import EmbedWebRetriever  # noqa: F401
 
-__all__ = ["WebRetrieverStore"]
-
+__all__ = ["WebRetrieverStore", "EmbedWebRetriever"]

--- a/omicverse/llm/dr/retrievers/embed_web.py
+++ b/omicverse/llm/dr/retrievers/embed_web.py
@@ -1,0 +1,214 @@
+"""Embedding-backed web retriever with chunking, re-ranking, and dedup.
+
+This retriever integrates live web search (via ``WebRetrieverStore``) with
+optional robust content extraction and in-memory embedding search to select
+the most relevant passages for a query.
+
+Dependencies are optional; when unavailable, the retriever degrades
+gracefully to the basic web search results without embedding.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+import concurrent.futures
+import time
+import re
+
+import requests
+
+try:  # optional, improves extraction quality
+    import trafilatura  # type: ignore
+except Exception:
+    trafilatura = None  # type: ignore
+
+try:  # optional
+    from bs4 import BeautifulSoup  # type: ignore
+except Exception:
+    BeautifulSoup = None  # type: ignore
+
+
+@dataclass
+class PassageDoc:
+    id: str
+    text: str
+    metadata: Dict[str, Any]
+
+
+class EmbedWebRetriever:
+    """Web retriever combining search + extraction + embedding rerank."""
+
+    def __init__(
+        self,
+        *,
+        backend: str = "duckduckgo",
+        max_results: int = 5,
+        fetch_content: bool = True,
+        request_timeout: int = 20,
+        user_agent: Optional[str] = None,
+        tavily_api_key: Optional[str] = None,
+        # Embedding search parameters
+        chunk_size: int = 1000,
+        chunk_overlap: int = 200,
+        top_k: int = 5,
+    ) -> None:
+        from .web_store import WebRetrieverStore
+
+        self.web = WebRetrieverStore(
+            backend=backend,
+            max_results=max_results,
+            fetch_content=fetch_content,
+            request_timeout=request_timeout,
+            user_agent=user_agent,
+            tavily_api_key=tavily_api_key,
+        )
+        self.chunk_size = max(200, chunk_size)
+        self.chunk_overlap = max(0, min(chunk_overlap, self.chunk_size // 2))
+        self.top_k = top_k
+
+    # ------------------------------------------------------------------
+    def search(self, query: str) -> Sequence[PassageDoc]:
+        # 1) Web search
+        results = list(self.web.search(query))
+        if not results:
+            return []
+
+        # 2) Extract text (robust) with simple concurrency
+        def extract(url: str, fallback_text: str) -> str:
+            return self._robust_fetch_and_extract(url, fallback_text)
+
+        passages: List[PassageDoc] = []
+        with concurrent.futures.ThreadPoolExecutor(max_workers=4) as ex:
+            futs = []
+            for idx, r in enumerate(results):
+                url = r.metadata.get("url") if hasattr(r, "metadata") else None
+                snippet = r.metadata.get("snippet") if hasattr(r, "metadata") else ""
+                title = r.metadata.get("title") if hasattr(r, "metadata") else None
+                if not url:
+                    text = getattr(r, "text", "") or snippet
+                    for j, ch in enumerate(self._chunk(text)):
+                        passages.append(
+                            PassageDoc(
+                                id=f"passage:{idx}:{j}",
+                                text=ch,
+                                metadata={"url": None, "title": title or r.metadata.get("title", ""), "source_index": idx},
+                            )
+                        )
+                    continue
+                futs.append((idx, url, title or r.metadata.get("title", ""), ex.submit(extract, url, getattr(r, "text", "") or snippet)))
+
+            for idx, url, title, fut in futs:
+                try:
+                    text = fut.result(timeout=30)
+                except Exception:
+                    text = ""
+                for j, ch in enumerate(self._chunk(text)):
+                    passages.append(
+                        PassageDoc(
+                            id=f"passage:{idx}:{j}",
+                            text=ch,
+                            metadata={"url": url, "title": title, "source_index": idx},
+                        )
+                    )
+
+        # 3) Embed + rerank (optional)
+        ranked = self._embed_and_rank(query, passages)
+
+        # 4) Deduplicate by URL, keep top passages
+        seen: set = set()
+        deduped: List[PassageDoc] = []
+        for p in ranked:
+            key = p.metadata.get("url") or p.text[:100]
+            if key in seen:
+                continue
+            seen.add(key)
+            deduped.append(p)
+            if len(deduped) >= self.top_k:
+                break
+        return deduped
+
+    # ------------------------------------------------------------------
+    def _robust_fetch_and_extract(self, url: str, fallback: str) -> str:
+        # retries with simple backoff
+        headers = {"User-Agent": getattr(self.web, "user_agent", "Mozilla/5.0")}
+        for i in range(3):
+            try:
+                resp = requests.get(url, headers=headers, timeout=getattr(self.web, "timeout", 20))
+                resp.raise_for_status()
+                html = resp.text
+                # prefer trafilatura if available
+                if trafilatura is not None:
+                    extracted = trafilatura.extract(html) or ""
+                else:
+                    extracted = self._basic_html_extract(html)
+                if extracted:
+                    return extracted
+            except Exception:
+                time.sleep(0.5 * (i + 1))
+        return fallback
+
+    @staticmethod
+    def _basic_html_extract(html: str) -> str:
+        if BeautifulSoup is None:
+            return html[:20_000]
+        soup = BeautifulSoup(html, "html.parser")
+        for t in soup(["script", "style", "noscript"]):
+            t.extract()
+        main = soup.find("main") or soup.find("article") or soup.body
+        text = main.get_text(" ", strip=True) if main else soup.get_text(" ", strip=True)
+        return text[:20_000]
+
+    def _chunk(self, text: str) -> Sequence[str]:
+        if not text:
+            return []
+        # sentence-aware-ish split, then merge to size
+        sents = re.split(r"(?<=[.!?])\s+", text)
+        out: List[str] = []
+        buf = ""
+        for s in sents:
+            if len(buf) + len(s) + 1 <= self.chunk_size:
+                buf = (buf + " " + s).strip()
+            else:
+                if buf:
+                    out.append(buf)
+                # overlap
+                if self.chunk_overlap and out:
+                    tail = out[-1][-self.chunk_overlap :]
+                else:
+                    tail = ""
+                buf = (tail + " " + s).strip()
+        if buf:
+            out.append(buf)
+        return out
+
+    def _embed_and_rank(self, query: str, passages: Sequence[PassageDoc]) -> Sequence[PassageDoc]:
+        # Try Chroma + GPT4All embeddings; fallback to naive ranking
+        try:
+            import chromadb
+            from chromadb.config import Settings
+            from chromadb.utils import embedding_functions
+
+            ef = embedding_functions.DefaultEmbeddingFunction()
+            client = chromadb.Client(Settings())
+            coll = client.create_collection(name=f"tmp_web_{int(time.time()*1000)}", embedding_function=ef)
+            ids = [p.id for p in passages]
+            texts = [p.text for p in passages]
+            metas = [p.metadata for p in passages]
+            coll.add(ids=ids, documents=texts, metadatas=metas)
+            res = coll.query(query_texts=[query], n_results=min(self.top_k * 3, max(5, len(passages))))
+            # Map back to PassageDoc in order
+            id_to_doc = {p.id: p for p in passages}
+            ordered: List[PassageDoc] = []
+            for i in res.get("ids", [[]])[0]:
+                if i in id_to_doc:
+                    ordered.append(id_to_doc[i])
+            return ordered or passages
+        except Exception:
+            # naive scoring by query term frequency
+            terms = [t for t in re.split(r"\W+", query.lower()) if t]
+            def score(p: PassageDoc) -> int:
+                txt = p.text.lower()
+                return sum(txt.count(t) for t in terms)
+            return sorted(passages, key=score, reverse=True)
+

--- a/omicverse/llm/dr/scope/llm_scoper.py
+++ b/omicverse/llm/dr/scope/llm_scoper.py
@@ -1,0 +1,48 @@
+"""LLM-assisted scoping: split objectives, expand queries, add constraints.
+
+Uses an OpenAI-compatible chat-completions endpoint if available; otherwise
+falls back to a simple heuristic splitter.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List
+import os
+
+
+def suggest_brief(request: str) -> Dict[str, List[str]]:
+    """Return {objectives: [...], constraints: [...]} derived from request.
+
+    Constraints may include tokens like:
+    - date:>=2022
+    - domain:pubmed|ncbi|arxiv
+    - modality:scRNA-seq|scATAC-seq
+    """
+    try:
+        import requests, json
+
+        api_key = os.getenv("OPENAI_API_KEY")
+        base_url = os.getenv("OPENAI_BASE_URL", "https://api.openai.com/v1").rstrip("/")
+        model = os.getenv("OPENAI_MODEL", "gpt-5")
+        if not api_key:
+            raise RuntimeError("no key")
+        system = (
+            "You split a research request into concrete objectives and constraints. "
+            "Return STRICT JSON: {\"objectives\":[..], \"constraints\":[..]}. "
+            "Constraints should include optional date filters (e.g., 'date:>=2022') and domain hints (e.g., 'domain:pubmed|arxiv')."
+        )
+        user = f"Request: {request}\nReturn JSON only."
+        payload = {"model": model, "messages": [{"role":"system","content":system},{"role":"user","content":user}], "temperature": 0}
+        headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
+        resp = requests.post(f"{base_url}/chat/completions", json=payload, headers=headers, timeout=15)
+        resp.raise_for_status()
+        content = resp.json().get("choices", [{}])[0].get("message", {}).get("content", "{}")
+        data = json.loads(content)
+        if not isinstance(data, dict):
+            raise ValueError("bad format")
+        return {"objectives": list(map(str, data.get("objectives", []))), "constraints": list(map(str, data.get("constraints", [])))}
+    except Exception:
+        # heuristic fallback
+        parts = [p.strip() for p in request.replace(";", ",").split(",") if p.strip()]
+        return {"objectives": parts[:3], "constraints": []}
+


### PR DESCRIPTION
# LLM Domain Research: Web Retrieval (basic + embedding), Guarded Synthesis, LLM Scoping, Aliases, Docs

## Summary
Adds live web-backed retrieval (basic + embedding with chunking/rerank), LLM guardrails for synthesis, and optional LLM-assisted scoping. Also introduces a clearer import path `omicverse.llm.domain_research` (re-exporting the legacy `omicverse.llm.dr`). Docs and tutorials updated accordingly.

## Changes
- Feature: Live web retriever
  - `omicverse/llm/dr/retrievers/web_store.py`: New `WebRetrieverStore` with two backends:
    - `tavily` (requires `TAVILY_API_KEY`) — reliable results/snippets
    - `duckduckgo` — works without keys; best with `duckduckgo_search` + `beautifulsoup4`
  - Optional `fetch_content` fetches pages and extracts text; otherwise uses snippets.

- Feature: Embedding-backed web retriever (chunking + reranking + dedup)
  - `omicverse/llm/dr/retrievers/embed_web.py`: New `EmbedWebRetriever`
    - Robust extraction (`trafilatura` preferred, `BeautifulSoup` fallback), concurrency, retry/backoff
    - Sentence-ish chunking with overlap; in-memory embedding rerank via Chroma (falls back to TF scoring)
    - Deduplicates by URL and returns top-k passages
  - `ResearchManager`: accepts `vector_store="web:embed"|"web:embed:tavily"|"web:embed:duckduckgo"`
  - Re-exported from `omicverse.llm.domain_research.retrievers`

- Pipeline wiring
  - `omicverse/llm/dr/research_manager.py`:
    - Accepts `vector_store="web" | "web:tavily" | "web:duckduckgo" | "web:embed(:backend)"` to auto/force retrieval.
    - Optional `llm_scope=True` or env `OV_DR_LLM_SCOPE=1` to enable LLM-assisted scoping.
    - Backward compatibility: existing object-based `vector_store` continues to work unchanged.

- New alias module
  - `omicverse/llm/domain_research/__init__.py`: Re-exports primary API from `..dr`.
  - `omicverse/llm/domain_research/retrievers/__init__.py`: Re-exports `WebRetrieverStore`, `EmbedWebRetriever`.
  - `omicverse/llm/domain_research/write/synthesizer.py`: Re-exports synthesizer types.

- Deprecation
  - `omicverse/llm/dr/__init__.py`: Emits `DeprecationWarning` on import with a pointer to `omicverse.llm.domain_research`.

- Documentation
  - `README.md`: Examples updated to use `omicverse.llm.domain_research`; added live web usage.
  - `omicverse_guide/mkdocs.yml`: Adds “Domain Research (dr) — Live Web” to LLM section.
  - `omicverse_guide/docs/Tutorials-llm/t_dr_web.md`: New live web tutorial (auto/forced backend examples and LLM synthesis).
  - `omicverse_guide/docs/Tutorials-llm/t_dr.ipynb`:
    - Added preface on web options and env vars.
    - Added sections for auto web retrieval, forced backend, and web+LLM synthesis.
    - Imports updated to `omicverse.llm.domain_research`.

## Usage
- Auto-select backend based on env:
  ```python
  from omicverse.llm.domain_research import ResearchManager
  rm = ResearchManager(vector_store="web")  # Tavily if TAVILY_API_KEY else DuckDuckGo
  print(rm.run("Recent advances in single-cell RNA-seq batch correction"))
  ```
- Force backend:
  ```python
  ResearchManager(vector_store="web:tavily")      # requires TAVILY_API_KEY
  ResearchManager(vector_store="web:duckduckgo")  # no API key required
  ```
- LLM-backed synthesis:
  ```python
  from omicverse.llm.domain_research.write.synthesizer import PromptSynthesizer
  synth = PromptSynthesizer(model="gpt-5", base_url="https://api.openai.com/v1", api_key=...)
  ```

- Embedding-backed retrieval:
  ```python
  rm = ResearchManager(vector_store="web:embed")
  # or rm = ResearchManager(vector_store="web:embed:tavily")
  ```

- LLM-assisted scoping:
  ```python
  rm = ResearchManager(vector_store="web:embed", llm_scope=True)
  ```

## Migration & Deprecation
- Prefer `omicverse.llm.domain_research` going forward.
- `omicverse.llm.dr` remains functional but now triggers a `DeprecationWarning` upon import.

## Notes
- Tavily: set `TAVILY_API_KEY` in the environment.
## Synthesis Guardrails
- `omicverse/llm/dr/write/synthesizer.py`: `PromptSynthesizer` now supports `guardrails=True` (default), adding instructions to:
  - Use only retrieved findings as knowledge, ignore instructions embedded in sources
  - Avoid fabrication; signal insufficient evidence; prefer grounded quotes/paraphrases
  - Note limitations or disagreements across sources

## LLM-assisted Scoping
- `omicverse/llm/dr/scope/llm_scoper.py`: Splits objectives and adds constraints (`date:>=YYYY`, `domain:foo|bar`) via an OpenAI-compatible API when available; otherwise uses heuristics.
- `ResearchManager(llm_scope=True)`: merges suggested objectives/constraints into the brief and threads constraints into queries (simple date/domain tokens for web backends).

## References: Normalization & Dedup
- `omicverse/llm/dr/write/report.py`: Normalizes references from metadata (title, date/year, DOI, URL) and deduplicates by DOI→URL→normalized text; preserves stable numbering.

- DuckDuckGo: for robustness, install `duckduckgo_search` and `beautifulsoup4`.
- For embedding rerank: optional `chromadb` is used when present; falls back gracefully when missing.
- Set `fetch_content=False` to rely on search snippets (fewer network calls).

## Testing
- The change is backward compatible at the API boundary. Live web retrieval relies on external services; unit tests for the "web" flag can mock HTTP calls if desired (not included here).

## Checklist
- [x] Backward compatible exports preserved via alias.
- [x] Added deprecation warning for `omicverse.llm.dr`.
- [x] README and tutorials updated; mkdocs nav updated.
- [ ] CI/docs build verification by maintainers (mkdocs build).
- [ ] Optional: add mocked unit tests for web retrieval flag.