### PR TITLE
datacollect: import robustness, lazy client loads, and exports fixes

### DIFF
--- a/omicverse/external/datacollect/__init__.py
+++ b/omicverse/external/datacollect/__init__.py
@@ -19,11 +19,14 @@ Main API clients:
     Specialized: BLAST, JASPAR, MPD, IUCN, PRIDE, cBioPortal, RegulomeDB
 """
 
-# Import all API clients from organized structure
+# Import API clients if all dependencies are available; otherwise defer to lazy imports in wrappers
 try:
-    from .api import *
-except ImportError:
-    pass
+    from .api import *  # noqa: F401,F403
+except Exception as _e:
+    # Defer failures to function-level lazy imports so the module remains usable
+    _API_IMPORT_ERROR = _e  # type: ignore
+else:
+    _API_IMPORT_ERROR = None  # type: ignore
 
 # Import collectors
 try:
@@ -51,12 +54,26 @@ def collect_protein_data(identifier, source='uniprot', to_format='pandas', **kwa
     Returns:
     - Data in specified format
     """
+    # Lazy import to avoid failing on optional dependencies at module import time
+    try:
+        from .api.proteins import (
+            UniProtClient,
+            PDBClient,
+            AlphaFoldClient,
+            InterProClient,
+            STRINGClient,
+        )
+    except Exception as e:
+        raise ImportError(
+            f"Protein API clients unavailable. Ensure dependencies are installed (e.g., httpx). Root cause: {e}"
+        )
+
     source_map = {
         'uniprot': UniProtClient,
         'pdb': PDBClient,
         'alphafold': AlphaFoldClient,
         'interpro': InterProClient,
-        'string': STRINGClient
+        'string': STRINGClient,
     }
     
     if source not in source_map:
@@ -88,9 +105,17 @@ def collect_expression_data(identifier, source='geo', to_format='anndata', **kwa
     Returns:
     - Expression data in AnnData format (default) or specified format
     """
+    # Lazy import
+    try:
+        from .api.expression import GEOClient, CCREClient
+    except Exception as e:
+        raise ImportError(
+            f"Expression API clients unavailable. Ensure dependencies are installed. Root cause: {e}"
+        )
+
     source_map = {
         'geo': GEOClient,
-        'ccre': CCREClient
+        'ccre': CCREClient,
     }
     
     if source not in source_map:
@@ -125,10 +150,18 @@ def collect_pathway_data(identifier, source='kegg', to_format='pandas', **kwargs
     Returns:
     - Pathway data in specified format
     """
+    # Lazy import
+    try:
+        from .api.pathways import KEGGClient, ReactomeClient, GtoPdbClient
+    except Exception as e:
+        raise ImportError(
+            f"Pathway API clients unavailable. Ensure dependencies are installed. Root cause: {e}"
+        )
+
     source_map = {
         'kegg': KEGGClient,
         'reactome': ReactomeClient,
-        'gtopdb': GtoPdbClient
+        'gtopdb': GtoPdbClient,
     }
     
     if source not in source_map:
@@ -143,7 +176,7 @@ def collect_pathway_data(identifier, source='kegg', to_format='pandas', **kwargs
     elif to_format == 'mudata':
         return to_mudata(data)
     elif to_format == 'pandas':
-        return to_pandas(data, "protein")
+        return to_pandas(data, "pathway")
     else:
         return data
 

--- a/omicverse/external/datacollect/api/alphafold.py
+++ b/omicverse/external/datacollect/api/alphafold.py
@@ -1,7 +1,7 @@
 """AlphaFold Protein Structure Database API client."""
 
 from typing import Dict, List, Optional, Any
-from src.api.base import BaseAPIClient
+from .base import BaseAPIClient
 
 
 class AlphaFoldClient(BaseAPIClient):

--- a/omicverse/external/datacollect/api/base.py
+++ b/omicverse/external/datacollect/api/base.py
@@ -7,12 +7,16 @@ from abc import ABC, abstractmethod
 from typing import Any, Dict, Optional, Union
 from urllib.parse import urljoin
 
-import httpx
+from typing import TYPE_CHECKING
+try:
+    import httpx  # type: ignore
+except Exception:  # pragma: no cover - allow import without httpx
+    httpx = None  # type: ignore
 import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
-from config import settings
+from ..config.config import settings
 
 
 logger = logging.getLogger(__name__)
@@ -73,7 +77,8 @@ class BaseAPIClient(ABC):
         self.session = self._create_session()
         
         # Client for async requests
-        self._async_client: Optional[httpx.AsyncClient] = None
+        # Defer httpx usage until actually needed; keep import optional
+        self._async_client = None  # type: ignore
     
     def _create_session(self) -> requests.Session:
         """Create a requests session with retry logic."""
@@ -96,8 +101,12 @@ class BaseAPIClient(ABC):
         return session
     
     @property
-    async def async_client(self) -> httpx.AsyncClient:
+    async def async_client(self):  # -> httpx.AsyncClient
         """Get or create async client."""
+        if httpx is None:
+            raise ImportError(
+                "httpx is required for async requests. Install with: pip install httpx"
+            )
         if self._async_client is None:
             self._async_client = httpx.AsyncClient(
                 timeout=self.timeout,
@@ -213,7 +222,7 @@ class BaseAPIClient(ABC):
     def close(self):
         """Close the session."""
         self.session.close()
-        if self._async_client:
+        if self._async_client and httpx is not None:
             asyncio.create_task(self._async_client.aclose())
     
     def __enter__(self):
@@ -230,5 +239,5 @@ class BaseAPIClient(ABC):
     
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         """Async context manager exit."""
-        if self._async_client:
+        if self._async_client and httpx is not None:
             await self._async_client.aclose()

--- a/omicverse/external/datacollect/api/blast.py
+++ b/omicverse/external/datacollect/api/blast.py
@@ -6,7 +6,7 @@ import xml.etree.ElementTree as ET
 from typing import Any, Dict, List, Optional
 
 from .base import BaseAPIClient
-from config.config import settings
+from ..config.config import settings
 
 
 logger = logging.getLogger(__name__)

--- a/omicverse/external/datacollect/api/cbioportal.py
+++ b/omicverse/external/datacollect/api/cbioportal.py
@@ -4,7 +4,7 @@ import logging
 from typing import Any, Dict, List, Optional, Union
 
 from .base import BaseAPIClient
-from config.config import settings
+from ..config.config import settings
 
 logger = logging.getLogger(__name__)
 

--- a/omicverse/external/datacollect/api/ccre.py
+++ b/omicverse/external/datacollect/api/ccre.py
@@ -1,7 +1,7 @@
 """ENCODE cCRE (candidate cis-Regulatory Elements) API client."""
 
 from typing import Dict, List, Optional, Any
-from src.api.base import BaseAPIClient
+from .base import BaseAPIClient
 
 
 class CCREClient(BaseAPIClient):

--- a/omicverse/external/datacollect/api/clinvar.py
+++ b/omicverse/external/datacollect/api/clinvar.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Optional, Union
 from datetime import datetime
 
 from .base import BaseAPIClient
-from config.config import settings
+from ..config.config import settings
 
 
 logger = logging.getLogger(__name__)

--- a/omicverse/external/datacollect/api/dbsnp.py
+++ b/omicverse/external/datacollect/api/dbsnp.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Optional, Union
 import json
 
 from .base import BaseAPIClient
-from config.config import settings
+from ..config.config import settings
 
 
 logger = logging.getLogger(__name__)

--- a/omicverse/external/datacollect/api/emdb.py
+++ b/omicverse/external/datacollect/api/emdb.py
@@ -1,7 +1,7 @@
 """Electron Microscopy Data Bank API client."""
 
 from typing import Dict, List, Optional, Any
-from src.api.base import BaseAPIClient
+from .base import BaseAPIClient
 
 
 class EMDBClient(BaseAPIClient):

--- a/omicverse/external/datacollect/api/ensembl.py
+++ b/omicverse/external/datacollect/api/ensembl.py
@@ -4,7 +4,7 @@ import logging
 from typing import Any, Dict, List, Optional
 
 from .base import BaseAPIClient
-from config.config import settings
+from ..config.config import settings
 
 
 logger = logging.getLogger(__name__)

--- a/omicverse/external/datacollect/api/expression/ccre.py
+++ b/omicverse/external/datacollect/api/expression/ccre.py
@@ -1,7 +1,7 @@
 """ENCODE cCRE (candidate cis-Regulatory Elements) API client."""
 
 from typing import Dict, List, Optional, Any
-from src.api.base import BaseAPIClient
+from ..base import BaseAPIClient
 
 
 class CCREClient(BaseAPIClient):

--- a/omicverse/external/datacollect/api/expression/geo.py
+++ b/omicverse/external/datacollect/api/expression/geo.py
@@ -4,8 +4,8 @@ import logging
 from typing import Any, Dict, List, Optional, Union
 import xml.etree.ElementTree as ET
 
-from .base import BaseAPIClient
-from config.config import settings
+from ..base import BaseAPIClient
+from ...config.config import settings
 
 
 logger = logging.getLogger(__name__)

--- a/omicverse/external/datacollect/api/expression/opentargets.py
+++ b/omicverse/external/datacollect/api/expression/opentargets.py
@@ -4,8 +4,8 @@ import logging
 from typing import Any, Dict, List, Optional
 import json
 
-from .base import BaseAPIClient
-from config.config import settings
+from ..base import BaseAPIClient
+from ...config.config import settings
 
 
 logger = logging.getLogger(__name__)

--- a/omicverse/external/datacollect/api/expression/opentargets_genetics.py
+++ b/omicverse/external/datacollect/api/expression/opentargets_genetics.py
@@ -4,8 +4,8 @@ import logging
 from typing import Any, Dict, List, Optional
 import json
 
-from .base import BaseAPIClient
-from config.config import settings
+from ..base import BaseAPIClient
+from ...config.config import settings
 
 
 logger = logging.getLogger(__name__)

--- a/omicverse/external/datacollect/api/expression/remap.py
+++ b/omicverse/external/datacollect/api/expression/remap.py
@@ -1,7 +1,7 @@
 """ReMap Transcription Factor Binding Database API client."""
 
 from typing import Dict, List, Optional, Any
-from src.api.base import BaseAPIClient
+from ..base import BaseAPIClient
 
 
 class ReMapClient(BaseAPIClient):

--- a/omicverse/external/datacollect/api/genomics/__init__.py
+++ b/omicverse/external/datacollect/api/genomics/__init__.py
@@ -14,7 +14,9 @@ This module provides API clients for genomics databases including:
 from .ensembl import EnsemblClient
 from .clinvar import ClinVarClient
 from .dbsnp import dbSNPClient
-from .gnomad import gnomADClient
+# Export both canonical and legacy-cased names for compatibility
+from .gnomad import GnomADClient as gnomADClient  # legacy alias
+from .gnomad import GnomADClient
 from .gwas_catalog import GWASCatalogClient
 from .ucsc import UCSCClient
 from .regulomedb import RegulomeDBClient
@@ -23,8 +25,9 @@ __all__ = [
     'EnsemblClient',
     'ClinVarClient',
     'dbSNPClient',
-    'gnomADClient',
-    'GWASCatalogClient', 
+    'GnomADClient',
+    'gnomADClient',  # legacy export
+    'GWASCatalogClient',
     'UCSCClient',
-    'RegulomeDBClient'
+    'RegulomeDBClient',
 ]

--- a/omicverse/external/datacollect/api/genomics/clinvar.py
+++ b/omicverse/external/datacollect/api/genomics/clinvar.py
@@ -4,8 +4,8 @@ import logging
 from typing import Any, Dict, List, Optional, Union
 from datetime import datetime
 
-from .base import BaseAPIClient
-from config.config import settings
+from ..base import BaseAPIClient
+from ...config.config import settings
 
 
 logger = logging.getLogger(__name__)

--- a/omicverse/external/datacollect/api/genomics/dbsnp.py
+++ b/omicverse/external/datacollect/api/genomics/dbsnp.py
@@ -4,8 +4,8 @@ import logging
 from typing import Any, Dict, List, Optional, Union
 import json
 
-from .base import BaseAPIClient
-from config.config import settings
+from ..base import BaseAPIClient
+from ...config.config import settings
 
 
 logger = logging.getLogger(__name__)

--- a/omicverse/external/datacollect/api/genomics/ensembl.py
+++ b/omicverse/external/datacollect/api/genomics/ensembl.py
@@ -3,8 +3,8 @@
 import logging
 from typing import Any, Dict, List, Optional
 
-from .base import BaseAPIClient
-from config.config import settings
+from ..base import BaseAPIClient
+from ...config.config import settings
 
 
 logger = logging.getLogger(__name__)

--- a/omicverse/external/datacollect/api/genomics/gnomad.py
+++ b/omicverse/external/datacollect/api/genomics/gnomad.py
@@ -4,8 +4,8 @@ import logging
 from typing import Any, Dict, List, Optional
 import json
 
-from .base import BaseAPIClient
-from config.config import settings
+from ..base import BaseAPIClient
+from ...config.config import settings
 
 
 logger = logging.getLogger(__name__)

--- a/omicverse/external/datacollect/api/genomics/gwas_catalog.py
+++ b/omicverse/external/datacollect/api/genomics/gwas_catalog.py
@@ -4,8 +4,8 @@ import logging
 from typing import Any, Dict, List, Optional
 import json
 
-from .base import BaseAPIClient
-from config.config import settings
+from ..base import BaseAPIClient
+from ...config.config import settings
 
 
 logger = logging.getLogger(__name__)

--- a/omicverse/external/datacollect/api/genomics/regulomedb.py
+++ b/omicverse/external/datacollect/api/genomics/regulomedb.py
@@ -3,8 +3,8 @@
 import logging
 from typing import Any, Dict, List, Optional
 
-from .base import BaseAPIClient
-from config.config import settings
+from ..base import BaseAPIClient
+from ...config.config import settings
 
 
 logger = logging.getLogger(__name__)

--- a/omicverse/external/datacollect/api/genomics/ucsc.py
+++ b/omicverse/external/datacollect/api/genomics/ucsc.py
@@ -4,8 +4,8 @@ import logging
 from typing import Any, Dict, List, Optional
 import json
 
-from .base import BaseAPIClient
-from config.config import settings
+from ..base import BaseAPIClient
+from ...config.config import settings
 
 
 logger = logging.getLogger(__name__)

--- a/omicverse/external/datacollect/api/geo.py
+++ b/omicverse/external/datacollect/api/geo.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Optional, Union
 import xml.etree.ElementTree as ET
 
 from .base import BaseAPIClient
-from config.config import settings
+from ..config.config import settings
 
 
 logger = logging.getLogger(__name__)

--- a/omicverse/external/datacollect/api/geo_backup.py
+++ b/omicverse/external/datacollect/api/geo_backup.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Optional, Union
 import xml.etree.ElementTree as ET
 
 from .base import BaseAPIClient
-from config.config import settings
+from ..config.config import settings
 
 
 logger = logging.getLogger(__name__)

--- a/omicverse/external/datacollect/api/gnomad.py
+++ b/omicverse/external/datacollect/api/gnomad.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Optional
 import json
 
 from .base import BaseAPIClient
-from config.config import settings
+from ..config.config import settings
 
 
 logger = logging.getLogger(__name__)

--- a/omicverse/external/datacollect/api/gtopdb.py
+++ b/omicverse/external/datacollect/api/gtopdb.py
@@ -4,7 +4,7 @@ import logging
 from typing import Any, Dict, List, Optional
 
 from .base import BaseAPIClient
-from config.config import settings
+from ..config.config import settings
 
 
 logger = logging.getLogger(__name__)

--- a/omicverse/external/datacollect/api/gwas_catalog.py
+++ b/omicverse/external/datacollect/api/gwas_catalog.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Optional
 import json
 
 from .base import BaseAPIClient
-from config.config import settings
+from ..config.config import settings
 
 
 logger = logging.getLogger(__name__)

--- a/omicverse/external/datacollect/api/interpro.py
+++ b/omicverse/external/datacollect/api/interpro.py
@@ -1,7 +1,7 @@
 """InterPro Protein Families and Domains API client."""
 
 from typing import Dict, List, Optional, Any
-from src.api.base import BaseAPIClient
+from .base import BaseAPIClient
 
 
 class InterProClient(BaseAPIClient):

--- a/omicverse/external/datacollect/api/iucn.py
+++ b/omicverse/external/datacollect/api/iucn.py
@@ -2,7 +2,7 @@
 
 import logging
 from typing import Dict, List, Optional, Any
-from src.api.base import BaseAPIClient
+from .base import BaseAPIClient
 
 logger = logging.getLogger(__name__)
 

--- a/omicverse/external/datacollect/api/jaspar.py
+++ b/omicverse/external/datacollect/api/jaspar.py
@@ -4,7 +4,7 @@ import logging
 from typing import Any, Dict, List, Optional
 
 from .base import BaseAPIClient
-from config.config import settings
+from ..config.config import settings
 
 logger = logging.getLogger(__name__)
 

--- a/omicverse/external/datacollect/api/kegg.py
+++ b/omicverse/external/datacollect/api/kegg.py
@@ -4,7 +4,7 @@ import logging
 from typing import Any, Dict, List, Optional
 
 from .base import BaseAPIClient
-from config.config import settings
+from ..config.config import settings
 
 
 logger = logging.getLogger(__name__)

--- a/omicverse/external/datacollect/api/mpd.py
+++ b/omicverse/external/datacollect/api/mpd.py
@@ -1,7 +1,7 @@
 """Mouse Phenome Database API client."""
 
 from typing import Dict, List, Optional, Any
-from src.api.base import BaseAPIClient
+from .base import BaseAPIClient
 
 
 class MPDClient(BaseAPIClient):

--- a/omicverse/external/datacollect/api/opentargets.py
+++ b/omicverse/external/datacollect/api/opentargets.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Optional
 import json
 
 from .base import BaseAPIClient
-from config.config import settings
+from ..config.config import settings
 
 
 logger = logging.getLogger(__name__)

--- a/omicverse/external/datacollect/api/opentargets_genetics.py
+++ b/omicverse/external/datacollect/api/opentargets_genetics.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Optional
 import json
 
 from .base import BaseAPIClient
-from config.config import settings
+from ..config.config import settings
 
 
 logger = logging.getLogger(__name__)

--- a/omicverse/external/datacollect/api/paleobiology.py
+++ b/omicverse/external/datacollect/api/paleobiology.py
@@ -1,7 +1,7 @@
 """Paleobiology Database API client for fossil data."""
 
 from typing import Dict, List, Optional, Any
-from src.api.base import BaseAPIClient
+from .base import BaseAPIClient
 
 
 class PaleobiologyClient(BaseAPIClient):

--- a/omicverse/external/datacollect/api/pathways/gtopdb.py
+++ b/omicverse/external/datacollect/api/pathways/gtopdb.py
@@ -3,8 +3,8 @@
 import logging
 from typing import Any, Dict, List, Optional
 
-from .base import BaseAPIClient
-from config.config import settings
+from ..base import BaseAPIClient
+from ...config.config import settings
 
 
 logger = logging.getLogger(__name__)

--- a/omicverse/external/datacollect/api/pathways/kegg.py
+++ b/omicverse/external/datacollect/api/pathways/kegg.py
@@ -3,8 +3,8 @@
 import logging
 from typing import Any, Dict, List, Optional
 
-from .base import BaseAPIClient
-from config.config import settings
+from ..base import BaseAPIClient
+from ...config.config import settings
 
 
 logger = logging.getLogger(__name__)

--- a/omicverse/external/datacollect/api/pathways/reactome.py
+++ b/omicverse/external/datacollect/api/pathways/reactome.py
@@ -3,8 +3,8 @@
 import logging
 from typing import Any, Dict, List, Optional
 
-from .base import BaseAPIClient
-from config.config import settings
+from ..base import BaseAPIClient
+from ...config.config import settings
 
 
 logger = logging.getLogger(__name__)

--- a/omicverse/external/datacollect/api/pdb.py
+++ b/omicverse/external/datacollect/api/pdb.py
@@ -4,7 +4,7 @@ import logging
 from typing import Any, Dict, List, Optional
 
 from .base import BaseAPIClient
-from config import settings
+from ..config.config import settings
 
 
 logger = logging.getLogger(__name__)

--- a/omicverse/external/datacollect/api/pdb_simple.py
+++ b/omicverse/external/datacollect/api/pdb_simple.py
@@ -4,7 +4,7 @@ import logging
 from typing import Any, Dict, List, Optional
 
 from .base import BaseAPIClient
-from config import settings
+from ..config.config import settings
 
 
 logger = logging.getLogger(__name__)

--- a/omicverse/external/datacollect/api/pride.py
+++ b/omicverse/external/datacollect/api/pride.py
@@ -4,7 +4,7 @@ import logging
 from typing import Any, Dict, List, Optional
 
 from .base import BaseAPIClient
-from config.config import settings
+from ..config.config import settings
 
 
 logger = logging.getLogger(__name__)

--- a/omicverse/external/datacollect/api/proteins/alphafold.py
+++ b/omicverse/external/datacollect/api/proteins/alphafold.py
@@ -1,7 +1,7 @@
 """AlphaFold Protein Structure Database API client."""
 
 from typing import Dict, List, Optional, Any
-from src.api.base import BaseAPIClient
+from ..base import BaseAPIClient
 
 
 class AlphaFoldClient(BaseAPIClient):

--- a/omicverse/external/datacollect/api/proteins/emdb.py
+++ b/omicverse/external/datacollect/api/proteins/emdb.py
@@ -1,7 +1,7 @@
 """Electron Microscopy Data Bank API client."""
 
 from typing import Dict, List, Optional, Any
-from src.api.base import BaseAPIClient
+from ..base import BaseAPIClient
 
 
 class EMDBClient(BaseAPIClient):

--- a/omicverse/external/datacollect/api/proteins/interpro.py
+++ b/omicverse/external/datacollect/api/proteins/interpro.py
@@ -1,7 +1,7 @@
 """InterPro Protein Families and Domains API client."""
 
 from typing import Dict, List, Optional, Any
-from src.api.base import BaseAPIClient
+from ..base import BaseAPIClient
 
 
 class InterProClient(BaseAPIClient):

--- a/omicverse/external/datacollect/api/proteins/pdb.py
+++ b/omicverse/external/datacollect/api/proteins/pdb.py
@@ -3,8 +3,8 @@
 import logging
 from typing import Any, Dict, List, Optional
 
-from .base import BaseAPIClient
-from config import settings
+from ..base import BaseAPIClient
+from ...config.config import settings
 
 
 logger = logging.getLogger(__name__)

--- a/omicverse/external/datacollect/api/proteins/string.py
+++ b/omicverse/external/datacollect/api/proteins/string.py
@@ -4,8 +4,8 @@ import logging
 from typing import Any, Dict, List, Optional
 from urllib.parse import urlencode
 
-from .base import BaseAPIClient
-from config.config import settings
+from ..base import BaseAPIClient
+from ...config.config import settings
 
 
 logger = logging.getLogger(__name__)

--- a/omicverse/external/datacollect/api/reactome.py
+++ b/omicverse/external/datacollect/api/reactome.py
@@ -4,7 +4,7 @@ import logging
 from typing import Any, Dict, List, Optional
 
 from .base import BaseAPIClient
-from config.config import settings
+from ..config.config import settings
 
 
 logger = logging.getLogger(__name__)

--- a/omicverse/external/datacollect/api/regulomedb.py
+++ b/omicverse/external/datacollect/api/regulomedb.py
@@ -4,7 +4,7 @@ import logging
 from typing import Any, Dict, List, Optional
 
 from .base import BaseAPIClient
-from config.config import settings
+from ..config.config import settings
 
 
 logger = logging.getLogger(__name__)

--- a/omicverse/external/datacollect/api/remap.py
+++ b/omicverse/external/datacollect/api/remap.py
@@ -1,7 +1,7 @@
 """ReMap Transcription Factor Binding Database API client."""
 
 from typing import Dict, List, Optional, Any
-from src.api.base import BaseAPIClient
+from .base import BaseAPIClient
 
 
 class ReMapClient(BaseAPIClient):

--- a/omicverse/external/datacollect/api/specialized/__init__.py
+++ b/omicverse/external/datacollect/api/specialized/__init__.py
@@ -18,7 +18,8 @@ from .mpd import MPDClient
 from .iucn import IUCNClient
 from .pride import PRIDEClient
 from .cbioportal import cBioPortalClient
-from .worms import WORMSClient
+from .worms import WoRMSClient as WORMSClient  # maintain expected name
+from .worms import WoRMSClient  # also expose canonical name
 from .paleobiology import PaleobiologyClient
 
 __all__ = [
@@ -29,5 +30,6 @@ __all__ = [
     'PRIDEClient',
     'cBioPortalClient',
     'WORMSClient',
+    'WoRMSClient',
     'PaleobiologyClient'
 ]

--- a/omicverse/external/datacollect/api/specialized/blast.py
+++ b/omicverse/external/datacollect/api/specialized/blast.py
@@ -5,8 +5,8 @@ import time
 import xml.etree.ElementTree as ET
 from typing import Any, Dict, List, Optional
 
-from .base import BaseAPIClient
-from config.config import settings
+from ..base import BaseAPIClient
+from ...config.config import settings
 
 
 logger = logging.getLogger(__name__)

--- a/omicverse/external/datacollect/api/specialized/cbioportal.py
+++ b/omicverse/external/datacollect/api/specialized/cbioportal.py
@@ -3,8 +3,8 @@
 import logging
 from typing import Any, Dict, List, Optional, Union
 
-from .base import BaseAPIClient
-from config.config import settings
+from ..base import BaseAPIClient
+from ...config.config import settings
 
 logger = logging.getLogger(__name__)
 

--- a/omicverse/external/datacollect/api/specialized/iucn.py
+++ b/omicverse/external/datacollect/api/specialized/iucn.py
@@ -2,7 +2,7 @@
 
 import logging
 from typing import Dict, List, Optional, Any
-from src.api.base import BaseAPIClient
+from ..base import BaseAPIClient
 
 logger = logging.getLogger(__name__)
 

--- a/omicverse/external/datacollect/api/specialized/jaspar.py
+++ b/omicverse/external/datacollect/api/specialized/jaspar.py
@@ -3,8 +3,8 @@
 import logging
 from typing import Any, Dict, List, Optional
 
-from .base import BaseAPIClient
-from config.config import settings
+from ..base import BaseAPIClient
+from ...config.config import settings
 
 logger = logging.getLogger(__name__)
 

--- a/omicverse/external/datacollect/api/specialized/mpd.py
+++ b/omicverse/external/datacollect/api/specialized/mpd.py
@@ -1,7 +1,7 @@
 """Mouse Phenome Database API client."""
 
 from typing import Dict, List, Optional, Any
-from src.api.base import BaseAPIClient
+from ..base import BaseAPIClient
 
 
 class MPDClient(BaseAPIClient):

--- a/omicverse/external/datacollect/api/specialized/paleobiology.py
+++ b/omicverse/external/datacollect/api/specialized/paleobiology.py
@@ -1,7 +1,7 @@
 """Paleobiology Database API client for fossil data."""
 
 from typing import Dict, List, Optional, Any
-from src.api.base import BaseAPIClient
+from ..base import BaseAPIClient
 
 
 class PaleobiologyClient(BaseAPIClient):

--- a/omicverse/external/datacollect/api/specialized/pride.py
+++ b/omicverse/external/datacollect/api/specialized/pride.py
@@ -3,8 +3,8 @@
 import logging
 from typing import Any, Dict, List, Optional
 
-from .base import BaseAPIClient
-from config.config import settings
+from ..base import BaseAPIClient
+from ...config.config import settings
 
 
 logger = logging.getLogger(__name__)

--- a/omicverse/external/datacollect/api/specialized/worms.py
+++ b/omicverse/external/datacollect/api/specialized/worms.py
@@ -1,7 +1,7 @@
 """WoRMS (World Register of Marine Species) API client."""
 
 from typing import Dict, List, Optional, Any
-from src.api.base import BaseAPIClient
+from ..base import BaseAPIClient
 
 
 class WoRMSClient(BaseAPIClient):

--- a/omicverse/external/datacollect/api/string.py
+++ b/omicverse/external/datacollect/api/string.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Optional
 from urllib.parse import urlencode
 
 from .base import BaseAPIClient
-from config.config import settings
+from ..config.config import settings
 
 
 logger = logging.getLogger(__name__)

--- a/omicverse/external/datacollect/api/ucsc.py
+++ b/omicverse/external/datacollect/api/ucsc.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Optional
 import json
 
 from .base import BaseAPIClient
-from config.config import settings
+from ..config.config import settings
 
 
 logger = logging.getLogger(__name__)

--- a/omicverse/external/datacollect/api/uniprot.py
+++ b/omicverse/external/datacollect/api/uniprot.py
@@ -4,7 +4,7 @@ import logging
 from typing import Any, Dict, List, Optional
 
 from .base import BaseAPIClient
-from config import settings
+from ..config.config import settings
 
 
 logger = logging.getLogger(__name__)

--- a/omicverse/external/datacollect/api/worms.py
+++ b/omicverse/external/datacollect/api/worms.py
@@ -1,7 +1,7 @@
 """WoRMS (World Register of Marine Species) API client."""
 
 from typing import Dict, List, Optional, Any
-from src.api.base import BaseAPIClient
+from .base import BaseAPIClient
 
 
 class WoRMSClient(BaseAPIClient):

--- a/omicverse/external/datacollect/collectors/alphafold_collector.py
+++ b/omicverse/external/datacollect/collectors/alphafold_collector.py
@@ -8,7 +8,7 @@ from src.api.alphafold import AlphaFoldClient
 from src.models.structure import Structure, Chain
 from src.models.protein import Protein
 from .base import BaseCollector
-from config import settings
+from ..config.config import settings
 
 
 logger = logging.getLogger(__name__)

--- a/omicverse/external/datacollect/collectors/base.py
+++ b/omicverse/external/datacollect/collectors/base.py
@@ -8,8 +8,14 @@ import json
 
 from sqlalchemy.orm import Session
 
-from src.models.base import get_db
-from config import settings
+from ..config.config import settings
+
+# Optional DB session import; provide a safe fallback if models are not bundled
+try:
+    from ..models.base import get_db  # type: ignore
+except Exception:  # pragma: no cover - soft fallback for environments without DB
+    def get_db():  # type: ignore
+        raise ImportError("Database models not available; get_db cannot be used.")
 
 
 logger = logging.getLogger(__name__)

--- a/omicverse/external/datacollect/collectors/blast_collector.py
+++ b/omicverse/external/datacollect/collectors/blast_collector.py
@@ -7,7 +7,7 @@ from src.api.blast import BLASTClient
 from src.models.genomic import Gene
 from src.models.protein import Protein
 from .base import BaseCollector
-from config.config import settings
+from ..config.config import settings
 
 
 logger = logging.getLogger(__name__)

--- a/omicverse/external/datacollect/collectors/clinvar_collector.py
+++ b/omicverse/external/datacollect/collectors/clinvar_collector.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Optional, Union
 from src.api.clinvar import ClinVarClient
 from src.models.genomic import Variant, Gene
 from .base import BaseCollector
-from config.config import settings
+from ..config.config import settings
 
 
 logger = logging.getLogger(__name__)

--- a/omicverse/external/datacollect/collectors/dbsnp_collector.py
+++ b/omicverse/external/datacollect/collectors/dbsnp_collector.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Optional, Union
 from src.api.dbsnp import dbSNPClient
 from src.models.genomic import Variant, Gene
 from .base import BaseCollector
-from config.config import settings
+from ..config.config import settings
 
 
 logger = logging.getLogger(__name__)

--- a/omicverse/external/datacollect/collectors/ensembl_collector.py
+++ b/omicverse/external/datacollect/collectors/ensembl_collector.py
@@ -8,7 +8,7 @@ from src.api.ensembl import EnsemblClient
 from src.models.genomic import Gene, Variant
 from src.models.protein import Protein
 from .base import BaseCollector
-from config.config import settings
+from ..config.config import settings
 
 
 logger = logging.getLogger(__name__)

--- a/omicverse/external/datacollect/collectors/geo_collector.py
+++ b/omicverse/external/datacollect/collectors/geo_collector.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Optional, Union
 from src.api.geo import GEOClient
 from src.models.genomic import Gene, Expression
 from .base import BaseCollector
-from config.config import settings
+from ..config.config import settings
 
 
 logger = logging.getLogger(__name__)

--- a/omicverse/external/datacollect/collectors/gnomad_collector.py
+++ b/omicverse/external/datacollect/collectors/gnomad_collector.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, List, Optional
 from src.api.gnomad import GnomADClient
 from src.models.genomic import Gene, Variant
 from .base import BaseCollector
-from config.config import settings
+from ..config.config import settings
 
 
 logger = logging.getLogger(__name__)

--- a/omicverse/external/datacollect/collectors/gtopdb_collector.py
+++ b/omicverse/external/datacollect/collectors/gtopdb_collector.py
@@ -8,7 +8,7 @@ from src.models.genomic import Gene
 from src.models.protein import Protein
 from src.models.disease import Disease
 from .base import BaseCollector
-from config.config import settings
+from ..config.config import settings
 
 
 logger = logging.getLogger(__name__)

--- a/omicverse/external/datacollect/collectors/gwas_catalog_collector.py
+++ b/omicverse/external/datacollect/collectors/gwas_catalog_collector.py
@@ -7,7 +7,7 @@ from src.api.gwas_catalog import GWASCatalogClient
 from src.models.genomic import Gene, Variant
 from src.models.disease import Disease
 from .base import BaseCollector
-from config.config import settings
+from ..config.config import settings
 
 
 logger = logging.getLogger(__name__)

--- a/omicverse/external/datacollect/collectors/interpro_collector.py
+++ b/omicverse/external/datacollect/collectors/interpro_collector.py
@@ -8,7 +8,7 @@ from src.api.interpro import InterProClient
 from src.models.interpro import Domain, DomainLocation
 from src.models.protein import Protein
 from .base import BaseCollector
-from config.config import settings
+from ..config.config import settings
 
 
 logger = logging.getLogger(__name__)

--- a/omicverse/external/datacollect/collectors/kegg_collector.py
+++ b/omicverse/external/datacollect/collectors/kegg_collector.py
@@ -8,7 +8,7 @@ from src.models.pathway import Pathway
 from src.models.genomic import Gene
 from src.models.protein import Protein
 from .base import BaseCollector
-from config.config import settings
+from ..config.config import settings
 
 
 logger = logging.getLogger(__name__)

--- a/omicverse/external/datacollect/collectors/opentargets_collector.py
+++ b/omicverse/external/datacollect/collectors/opentargets_collector.py
@@ -8,7 +8,7 @@ from src.api.opentargets import OpenTargetsClient
 from src.models.genomic import Gene
 from src.models.disease import Disease
 from .base import BaseCollector
-from config.config import settings
+from ..config.config import settings
 
 
 logger = logging.getLogger(__name__)

--- a/omicverse/external/datacollect/collectors/opentargets_genetics_collector.py
+++ b/omicverse/external/datacollect/collectors/opentargets_genetics_collector.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, List, Optional
 from src.api.opentargets_genetics import OpenTargetsGeneticsClient
 from src.models.genomic import Gene, Variant
 from .base import BaseCollector
-from config.config import settings
+from ..config.config import settings
 
 
 logger = logging.getLogger(__name__)

--- a/omicverse/external/datacollect/collectors/pdb_collector.py
+++ b/omicverse/external/datacollect/collectors/pdb_collector.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from src.api.pdb_simple import SimplePDBClient
 from src.models.structure import Structure, Chain, Ligand
 from .base import BaseCollector
-from config import settings
+from ..config.config import settings
 
 
 logger = logging.getLogger(__name__)

--- a/omicverse/external/datacollect/collectors/pride_collector.py
+++ b/omicverse/external/datacollect/collectors/pride_collector.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, List, Optional
 from src.api.pride import PRIDEClient
 from src.models.protein import Protein
 from .base import BaseCollector
-from config.config import settings
+from ..config.config import settings
 
 
 logger = logging.getLogger(__name__)

--- a/omicverse/external/datacollect/collectors/reactome_collector.py
+++ b/omicverse/external/datacollect/collectors/reactome_collector.py
@@ -8,7 +8,7 @@ from src.models.pathway import Pathway
 from src.models.genomic import Gene
 from src.models.protein import Protein
 from .base import BaseCollector
-from config.config import settings
+from ..config.config import settings
 
 
 logger = logging.getLogger(__name__)

--- a/omicverse/external/datacollect/collectors/regulomedb_collector.py
+++ b/omicverse/external/datacollect/collectors/regulomedb_collector.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, List, Optional
 from src.api.regulomedb import RegulomeDBClient
 from src.models.genomic import Variant
 from .base import BaseCollector
-from config.config import settings
+from ..config.config import settings
 
 
 logger = logging.getLogger(__name__)

--- a/omicverse/external/datacollect/collectors/string_collector.py
+++ b/omicverse/external/datacollect/collectors/string_collector.py
@@ -8,7 +8,7 @@ from src.api.string import STRINGClient
 from src.models.protein import Protein
 from src.models.interaction import ProteinInteraction
 from .base import BaseCollector
-from config.config import settings
+from ..config.config import settings
 
 
 logger = logging.getLogger(__name__)

--- a/omicverse/external/datacollect/collectors/ucsc_collector.py
+++ b/omicverse/external/datacollect/collectors/ucsc_collector.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, List, Optional
 from src.api.ucsc import UCSCClient
 from src.models.genomic import Gene, Variant
 from .base import BaseCollector
-from config.config import settings
+from ..config.config import settings
 
 
 logger = logging.getLogger(__name__)

--- a/omicverse/external/datacollect/utils/database.py
+++ b/omicverse/external/datacollect/utils/database.py
@@ -7,8 +7,23 @@ from sqlalchemy import create_engine, event, text
 from sqlalchemy.orm import Session
 from sqlalchemy.pool import Pool
 
-from src.models.base import Base, init_db
-from config import settings
+from ..config.config import settings
+
+# Optional models import: make this module import-safe when DB models are absent
+try:
+    # When packaged standalone, models may live under datacollect.models
+    from ..models.base import Base, init_db  # type: ignore
+except Exception:  # pragma: no cover - soft fallback for environments without DB
+    class _PlaceholderMeta:
+        tables = {}
+
+    class _BasePlaceholder:
+        metadata = _PlaceholderMeta()
+
+    Base = _BasePlaceholder()  # type: ignore
+
+    def init_db():  # type: ignore
+        return None
 
 
 logger = logging.getLogger(__name__)

--- a/omicverse/external/datacollect/utils/logging.py
+++ b/omicverse/external/datacollect/utils/logging.py
@@ -9,7 +9,7 @@ from rich.console import Console
 from rich.logging import RichHandler
 from rich.traceback import install as install_rich_traceback
 
-from config import settings
+from ..config.config import settings
 
 
 # Install rich traceback handler


### PR DESCRIPTION
- Summary: Improves import reliability and client availability in omicverse.external.datacollect.
- Changes:
    - Fix relative imports across datacollect modules to avoid path issues.
    - Make httpx optional at import time; only required for async methods.
    - Lazy-load API clients inside collect_protein_data, collect_expression_data, collect_pathway_data to avoid early ImportErrors.
    - Exports:
    - Add `GnomADClient` (canonical) and legacy alias `gnomADClient`.
    - Expose `WORMSClient` as an alias of `WoRMSClient`.
- DB import-safety:
    - `utils/database.py`: fallback placeholder `Base`/`init_db` when models aren’t present.
    - `collectors/base.py`: safe fallback for `get_db` import.
- Rationale:
    - Prevents failures like “name 'UniProtClient' is not defined” by avoiding star-import crashes and ensuring clients are discoverable even with minimal dependencies.
    - Reduces setup friction in environments without full DB stack or async HTTP dependencies.
- Impact:
    - No breaking API changes; only added aliases and improved robustness.
    - Async features still require httpx; sync clients unaffected.
- Verification:
    - Local quick and complete tests run with:
    - `export MPLBACKEND=Agg`
    - `export PYTHONPATH="$(pwd)/omicverse:$PYTHONPATH"`
    - `python omicverse/omicverse/external/datacollect/test_ov_datacollect_quick.py`
    - `python omicverse/omicverse/external/datacollect/test_omicverse_datacollect_complete.py --verbose --fast`
- Optional deps: pip install httpx (for async), pip install anndata mudata (for conversions).
- Notes:
    - Resolves client availability issues in the suite and improves integration stability.
    - No changes to public APIs other than added aliases.