### PR TITLE
fix: remove redundant EMOJI warning assignment causing KeyError

### DIFF
--- a/omicverse/single/_deg_ct.py
+++ b/omicverse/single/_deg_ct.py
@@ -209,7 +209,6 @@ class DEG:
         if self.adata_test.shape[0] == 0:
             raise ValueError(f"No cells found for DEG analysis")
         elif self.adata_test.shape[0] > max_cells:
-            EMOJI['warning']="⚠️"
             print(f"{EMOJI['warning']} Total cells: {self.adata_test.shape[0]} is too large, will be downsampled to {max_cells}")
             print(f"If you want to keep all cells, please set max_cells to None")
             try:


### PR DESCRIPTION
Fixes #360

The warning emoji is already defined in the EMOJI dictionary in _settings.py.
The code was attempting to access EMOJI['warning'] before assigning it on the
same line, causing a KeyError. Removed the redundant assignment.

Generated with [Claude Code](https://claude.ai/code)