### PR TITLE
fix: remove global seaborn theme override causing heatmap legend issues

### DIFF
--- a/omicverse/llm/geneformer/classifier.py
+++ b/omicverse/llm/geneformer/classifier.py
@@ -53,7 +53,6 @@ from pathlib import Path
 
 import numpy as np
 import pandas as pd
-import seaborn as sns
 import transformers
 from tqdm.auto import tqdm, trange
 from transformers import Trainer
@@ -67,8 +66,6 @@ from . import (
 from . import classifier_utils as cu
 from . import evaluation_utils as eu
 from . import perturber_utils as pu
-
-sns.set()
 
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
Remove `sns.set()` call from classifier.py that was globally overriding matplotlib themes and interfering with other plotting functions like `netVisual_heatmap_marsilea`. The call was unnecessary as this module doesn't create seaborn plots directly - plotting functions properly handle their own styling in evaluation_utils.py.

Fixes #368

Generated with [Claude Code](https://claude.ai/code)