### PR TITLE
Fix embedding_celltype function for pandas 2.0+ compatibility

### DIFF
--- a/omicverse/pl/_single.py
+++ b/omicverse/pl/_single.py
@@ -416,12 +416,9 @@ def embedding_celltype(adata:AnnData,figsize:tuple=(6,4),basis:str='umap',
     """
 
     adata.obs[celltype_key]=adata.obs[celltype_key].astype('category')
-    if pd.__version__>="2.0.0":
-        cell_num_pd=pd.DataFrame(adata.obs[celltype_key].value_counts())
-        cell_num_pd[celltype_key]=cell_num_pd['count']
-    else:
-        cell_num_pd=pd.DataFrame(adata.obs[celltype_key].value_counts())
-        
+    cell_counts=adata.obs[celltype_key].value_counts()
+    cell_num_pd=pd.DataFrame({celltype_key: cell_counts.values}, index=cell_counts.index)
+    
     if '{}_colors'.format(celltype_key) in adata.uns.keys():
         cell_color_dict=dict(zip(adata.obs[celltype_key].cat.categories.tolist(),
                         adata.uns['{}_colors'.format(celltype_key)]))


### PR DESCRIPTION
- Fixed pandas DataFrame construction in embedding_celltype function
- Replaced inconsistent value_counts() handling with unified approach
- This resolves issue where only one cell type was displayed instead of all cell types
- celltype_range and embedding_range parameters now work correctly

Fixes #204