### PR TITLE
fix: Add PyArrow compatibility layer for PyExtensionType

### DIFF
--- a/omicverse/__init__.py
+++ b/omicverse/__init__.py
@@ -31,6 +31,15 @@ Examples:
     >>> ov.pl.umap(adata, color='leiden')
 """
 
+# Fix PyArrow compatibility issue
+# PyExtensionType was renamed to ExtensionType in newer versions
+try:
+    import pyarrow
+    if hasattr(pyarrow, 'ExtensionType') and not hasattr(pyarrow, 'PyExtensionType'):
+        pyarrow.PyExtensionType = pyarrow.ExtensionType
+except ImportError:
+    pass
+
 try:
     from importlib.metadata import version
 except ModuleNotFoundError:


### PR DESCRIPTION
PyExtensionType was renamed to ExtensionType in newer PyArrow versions.
This fix adds a compatibility shim to maintain backward compatibility
with dependencies that still reference the old API.

Fixes #391

Generated with [Claude Code](https://claude.ai/code)