### PR TITLE
Fix pandas compatibility in bulk2single_plot_cellprop

### DIFF
--- a/omicverse/bulk2single/_utils.py
+++ b/omicverse/bulk2single/_utils.py
@@ -71,7 +71,7 @@ def bulk2single_plot_cellprop(generate_single_data:anndata.AnnData,
     generate_single_data.obs[celltype_key]=generate_single_data.obs[celltype_key].astype('category')
     key_name=list(generate_single_data.obs[celltype_key].cat.categories)
     ct_name = list(ct_stat.index)
-    ct_num = list(ct_stat['count'])
+    ct_num = list(ct_stat.iloc[:, 0])
     if '{}_colors'.format(celltype_key) in generate_single_data.uns.keys():
         color=generate_single_data.uns['{}_colors'.format(celltype_key)]
         color_dict=dict(zip(key_name,color))


### PR DESCRIPTION
Fixes #179

- Fixed pandas compatibility issue where `ct_stat['count']` failed in pandas 1.5.3
- Changed to use `ct_stat.iloc[:, 0]` for universal compatibility
- Ensures function works with all pandas versions

Generated with [Claude Code](https://claude.ai/code)