### PR TITLE
Fix TypeError in plot_flowsig_network: correctly pass subset_key to multipartite_layout

### DIFF
--- a/omicverse/pl/_flowsig.py
+++ b/omicverse/pl/_flowsig.py
@@ -302,7 +302,13 @@ def plot_flowsig_network(flow_network,
         layers = {"layer1": list(set(sender_li)), 
                    "layer3": list(set(receptor_li)),
                    "layer2": list(set(gem_li)),}
-    pos = nx.multipartite_layout(flow_network, subset_key=layers,align='horizontal',scale=2.0)
+    
+    # Assign layer information to node attributes
+    for layer_name, node_list in layers.items():
+        for node in node_list:
+            flow_network.nodes[node]['layer'] = layer_name
+    
+    pos = nx.multipartite_layout(flow_network, subset_key='layer', align='horizontal', scale=2.0)
 
     #fig, ax = plt.subplots(figsize=(8,8)) 
     sub_G=flow_network.subgraph(sender_li+receptor_li+gem_plot).copy()


### PR DESCRIPTION
This PR fixes the TypeError reported in issue #304 where `ov.pl.plot_flowsig_network` was failing with "unhashable type: 'dict'" error.

## Problem
The `nx.multipartite_layout()` function was receiving a dictionary directly via the `subset_key` parameter, but NetworkX expects this to be a string referring to a node attribute name.

## Solution
- Modified the code to first assign layer information as node attributes
- Then pass the attribute name ('layer') to `subset_key` instead of the dictionary

Fixes #304

Generated with [Claude Code](https://claude.ai/code)