### PR TITLE
Fix geneset_aucell KeyError with custom AUC_threshold values

### DIFF
--- a/omicverse/external/CEFCON/_aucell.py
+++ b/omicverse/external/CEFCON/_aucell.py
@@ -76,7 +76,7 @@ def create_rankings(ex_mtx: pd.DataFrame, seed=None) -> pd.DataFrame:
     )
 
 
-def derive_auc_threshold(ex_mtx: pd.DataFrame) -> pd.DataFrame:
+def derive_auc_threshold(ex_mtx: pd.DataFrame, AUC_threshold: float = None) -> pd.DataFrame:
     """
     Derive AUC thresholds for an expression matrix.
 
@@ -85,15 +85,19 @@ def derive_auc_threshold(ex_mtx: pd.DataFrame) -> pd.DataFrame:
     
     Arguments:
         ex_mtx: The expression profile matrix. The rows should correspond to different cells, the columns to different genes (n_cells x n_genes).
+        AUC_threshold: Specific AUC threshold to include in the quantile calculation. If None, returns default quantiles.
     
     Returns:
         A dataframe with AUC threshold for different quantiles over the number cells: a fraction of 0.01 designates that when using this value as the AUC threshold for 99% of the cells all ranked genes used for AUC calculation will have had a detected expression in the single-cell experiment.
 
     """
+    quantiles = [0.01, 0.05, 0.10, 0.50, 1]
+    if AUC_threshold is not None and AUC_threshold not in quantiles:
+        quantiles.append(AUC_threshold)
+        quantiles.sort()
+    
     return (
-        pd.Series(np.count_nonzero(ex_mtx, axis=1)).quantile(
-            [0.01, 0.05, 0.10, 0.50, 1]
-        )
+        pd.Series(np.count_nonzero(ex_mtx, axis=1)).quantile(quantiles)
         / ex_mtx.shape[1]
     )
 

--- a/omicverse/single/_aucell.py
+++ b/omicverse/single/_aucell.py
@@ -112,7 +112,7 @@ def fast_rank(X_sparse, seed=42):
 
 
 
-def derive_auc_threshold(ex_mtx: csr_matrix) -> pd.DataFrame:
+def derive_auc_threshold(ex_mtx: csr_matrix, AUC_threshold: float = None) -> pd.DataFrame:
     """
     Derive AUC thresholds for an expression matrix.
 
@@ -121,15 +121,19 @@ def derive_auc_threshold(ex_mtx: csr_matrix) -> pd.DataFrame:
     
     Arguments:
         ex_mtx: The expression profile matrix. The rows should correspond to different cells, the columns to different genes (n_cells x n_genes).
+        AUC_threshold: Specific AUC threshold to include in the quantile calculation. If None, returns default quantiles.
     
     Returns:
         A dataframe with AUC threshold for different quantiles over the number cells: a fraction of 0.01 designates that when using this value as the AUC threshold for 99% of the cells all ranked genes used for AUC calculation will have had a detected expression in the single-cell experiment.
 
     """
+    quantiles = [0.01, 0.05, 0.10, 0.50, 1]
+    if AUC_threshold is not None and AUC_threshold not in quantiles:
+        quantiles.append(AUC_threshold)
+        quantiles.sort()
+    
     return (
-        pd.Series(np.count_nonzero(ex_mtx.toarray(), axis=1)).quantile(
-            [0.01, 0.05, 0.10, 0.50, 1]
-        )
+        pd.Series(np.count_nonzero(ex_mtx.toarray(), axis=1)).quantile(quantiles)
         / ex_mtx.shape[1]
     )
 

--- a/omicverse/single/_scgsea.py
+++ b/omicverse/single/_scgsea.py
@@ -53,7 +53,7 @@ def geneset_aucell_tmp(adata, geneset_name, geneset, AUC_threshold=0.01, seed=42
         from ctxcore.genesig import GeneSignature
 
     matrix = adata.X.copy()
-    percentiles = derive_auc_threshold(matrix)
+    percentiles = derive_auc_threshold(matrix, AUC_threshold)
     auc_threshold = percentiles[AUC_threshold]
 
     n_cells = matrix.shape[0]
@@ -108,7 +108,7 @@ def geneset_aucell(adata,geneset_name,geneset,AUC_threshold=0.01,seed=42):
 
 
     matrix = adata.X.copy()
-    percentiles = derive_auc_threshold(matrix)
+    percentiles = derive_auc_threshold(matrix, AUC_threshold)
     auc_threshold = percentiles[AUC_threshold]
 
     np_rnk_sparse=fast_rank(matrix, seed= seed)
@@ -151,7 +151,7 @@ def pathway_aucell(adata,pathway_names,pathways_dict,AUC_threshold=0.01,seed=42)
         from ctxcore.genesig import GeneSignature
 
     matrix = adata.X.copy()
-    percentiles = derive_auc_threshold(matrix)
+    percentiles = derive_auc_threshold(matrix, AUC_threshold)
     auc_threshold = percentiles[AUC_threshold]
 
     np_rnk_sparse=fast_rank(matrix, seed= seed)
@@ -197,7 +197,7 @@ def pathway_aucell_tmp(adata, pathway_names, pathways_dict, AUC_threshold=0.01, 
         from ctxcore.genesig import GeneSignature
 
     matrix = adata.X.copy()
-    percentiles = derive_auc_threshold(matrix)
+    percentiles = derive_auc_threshold(matrix, AUC_threshold)
     auc_threshold = percentiles[AUC_threshold]
     
     n_cells = matrix.shape[0]
@@ -251,7 +251,7 @@ def pathway_aucell_enrichment(adata,pathways_dict,AUC_threshold=0.01,seed=42,num
 
     # Use sparse matrix for both derive_auc_threshold and aucell
     matrix_sparse = adata.X.copy()
-    percentiles = derive_auc_threshold(matrix_sparse)
+    percentiles = derive_auc_threshold(matrix_sparse, AUC_threshold)
     auc_threshold = percentiles[AUC_threshold]
 
     # Pass sparse matrix directly to aucell with index and columns
@@ -293,7 +293,7 @@ def pathway_aucell_enrichment_tmp(adata, pathways_dict, AUC_threshold=0.01, seed
 
     # Use sparse matrix for derive_auc_threshold
     matrix_sparse = adata.X.copy()
-    percentiles = derive_auc_threshold(matrix_sparse)
+    percentiles = derive_auc_threshold(matrix_sparse, AUC_threshold)
     auc_threshold = percentiles[AUC_threshold]
 
     # Process in chunks using sparse matrix slicing


### PR DESCRIPTION
Fixes issue where custom AUC_threshold values not in the hard-coded quantiles list would cause a KeyError.

## Changes
- Updated `derive_auc_threshold()` to accept optional AUC_threshold parameter
- When custom threshold provided, it gets added to quantiles list to prevent KeyError
- Updated all function calls to pass the AUC_threshold parameter
- Backward compatible - existing code continues to work

Fixes #254

Generated with [Claude Code](https://claude.ai/code)