### PR TITLE
Fix UnboundLocalError in research_manager.py

### DIFF
--- a/omicverse/llm/dr/research_manager.py
+++ b/omicverse/llm/dr/research_manager.py
@@ -83,8 +83,6 @@ class ResearchManager:
                     EmbedWebRetriever = None  # type: ignore
 
                 if vs_flag == "web":
-                    import os
-
                     backend = "tavily" if os.getenv("TAVILY_API_KEY") else ("brave" if os.getenv("BRAVE_API_KEY") else "duckduckgo")
                 elif vs_flag in {"web:tavily", "web:embed:tavily"}:
                     backend = "tavily"


### PR DESCRIPTION
Remove duplicate 'import os' statement that was causing variable shadowing issues. The os module is already imported at the top of the file.

Fixes pytest failures:
- test_research_generates_findings
- test_scope_returns_brief
- test_write_composes_report
- test_run_pipeline

Closes #396

Generated with [Claude Code](https://claude.ai/code)