### PR TITLE
Fix KeyError in bulktb.gnn_generate() when NOCD classes are missing

### DIFF
--- a/omicverse/bulk2single/_bulktrajblend.py
+++ b/omicverse/bulk2single/_bulktrajblend.py
@@ -380,6 +380,11 @@ class BulkTrajBlend(object):
             else:
                 pair_dict_r[str(nocd_class)]=now_celltype
                 repeat_celltype[now_celltype]+=1
+        
+        # Ensure all keys from 0 to K-1 exist in pair_dict_r to prevent KeyError
+        for j in range(self.nocd_obj.K):
+            if str(j) not in pair_dict_r:
+                pair_dict_r[str(j)] = f'unknown_{j}'
 
         def li_range(li,max_len):
             r=[0]*max_len   


### PR DESCRIPTION
This PR fixes the KeyError: '2' issue in the `bulktb.gnn_generate()` function reported in issue #182.

## Problem
The error occurred when the function tried to access `pair_dict_r[str(j)]` for all `j` in `range(self.nocd_obj.K)`, but some keys were missing from the dictionary when certain NOCD classes weren't present in the results.

## Solution
Added a safety check to ensure all keys from 0 to K-1 exist in `pair_dict_r`, assigning 'unknown_X' labels to missing classes.

## Changes
- Added validation loop in `gnn_generate()` method
- Missing NOCD classes now get 'unknown_X' labels
- Preserves all existing functionality

Fixes #182

Generated with [Claude Code](https://claude.ai/code)