### PR TITLE
Fix pytest failures by using valid query lengths

### DIFF
--- a/tests/llm/test_dr_write.py
+++ b/tests/llm/test_dr_write.py
@@ -47,7 +47,7 @@ def make_rm():
 
 def test_write_composes_report():
     rm = make_rm()
-    brief = ProjectBrief(title="T", objectives=["topic"], constraints=[])
+    brief = ProjectBrief(title="Test Title", objectives=["topic"], constraints=[])
     findings = [Finding(topic="topic", text="summary", sources=[SourceCitation(source_id="1", content="ref")])]
     report = rm.write(brief, findings)
     assert "topic" in report
@@ -56,8 +56,8 @@ def test_write_composes_report():
 
 def test_run_pipeline(monkeypatch):
     rm = make_rm()
-    monkeypatch.setattr(rm.scope_manager, "generate_brief", lambda: ProjectBrief(title="T", objectives=["topic"], constraints=[]))
-    report = rm.run("T")
+    monkeypatch.setattr(rm.scope_manager, "generate_brief", lambda: ProjectBrief(title="Test Title", objectives=["topic"], constraints=[]))
+    report = rm.run("Test Query")
     assert "topic" in report
     assert "text about topic" in report
     assert "[1]" in report


### PR DESCRIPTION
Fixes #403

This PR resolves the pytest failures by ensuring test queries meet the minimum length requirement of 3 characters.

**Changes:**
- Changed title from 'T' to 'Test Title' in test_write_composes_report
- Changed request from 'T' to 'Test Query' in test_run_pipeline

**Root cause:** QueryManager.validate_query() requires queries to be at least 3 characters long, but tests were using single-character strings.

Generated with [Claude Code](https://claude.ai/code)