### PR TITLE
Fix ov.utils.roe statistical issues: correct thresholds and Fisher's exact test

### DIFF
--- a/omicverse/utils/_roe.py
+++ b/omicverse/utils/_roe.py
@@ -1,9 +1,10 @@
 import pandas as pd
-from scipy.stats import chi2_contingency
+from scipy.stats import chi2_contingency, fisher_exact
 import seaborn as sns
 import matplotlib.pyplot as plt
 from matplotlib.colors import LinearSegmentedColormap
 from anndata import AnnData
+import numpy as np
 
 
 
@@ -42,29 +43,46 @@ def roe(
     # Perform chi-square test
     chi2, p, dof, expected = chi2_contingency(num_cell)
     print(f"chi2: {chi2}, dof: {dof}, pvalue: {p}")
+    
+    # Check if expected values are too low for chi-square test
+    use_fisher = any(item < expected_value_threshold for item in expected.flatten())
+    
+    if use_fisher:
+        # Use Fisher's exact test for 2x2 tables, or warn for larger tables
+        if num_cell.shape == (2, 2):
+            print(f"Some expected frequencies are less than {expected_value_threshold}, using Fisher's exact test")
+            # Convert to numpy array for fisher_exact
+            contingency_array = num_cell.values
+            _, p_fisher = fisher_exact(contingency_array)
+            print(f"Fisher's exact test p-value: {p_fisher}")
+            p = p_fisher  # Use Fisher's p-value instead of chi-square
+        else:
+            print(f"Some expected frequencies are less than {expected_value_threshold}. "
+                  f"Fisher's exact test is not available for tables larger than 2x2. "
+                  f"Results may be unreliable.")
+    
     # Check p-value
     if p <= pval_threshold:
-        if all(item > expected_value_threshold for item in expected.flatten()):
-            expected_data = pd.DataFrame(expected, index=num_cell.index, columns=num_cell.columns)
-            roe = num_cell / expected_data
-            adata.uns['roe_results'] = roe
-            adata.uns['expected_values'] = expected_data
-            adata.uns['sig_roe_results'] = roe
+        expected_data = pd.DataFrame(expected, index=num_cell.index, columns=num_cell.columns)
+        roe = num_cell / expected_data
+        adata.uns['roe_results'] = roe
+        adata.uns['expected_values'] = expected_data
+        
+        if use_fisher and num_cell.shape != (2, 2):
+            # Mark as unreliable if we couldn't use Fisher's test for larger tables
+            adata.uns['unreliable_roe_results'] = roe
         else:
-            print(
-                f"Some expected frequencies are less than {expected_value_threshold}, it is suggested to use other statistical methods, such as Fisher's exact test")
-            expected_data = pd.DataFrame(expected, index=num_cell.index, columns=num_cell.columns)
-            adata.uns['expected_values'] = expected_data
-            roe = num_cell / expected_data
-            adata.uns['roe_results'] = roe
-            adata.uns['unsig_roe_results'] = roe
+            adata.uns['sig_roe_results'] = roe
     else:
         print("P-value is greater than 0.05, there is no statistical significance")
-        roe_ratio = num_cell / expected
-        adata.uns['unsig_roe_results'] = roe_ratio
+        expected_data = pd.DataFrame(expected, index=num_cell.index, columns=num_cell.columns)
+        roe = num_cell / expected_data
+        adata.uns['unsig_roe_results'] = roe
 
     if 'sig_roe_results' in adata.uns:
         return adata.uns['sig_roe_results']
+    elif 'unreliable_roe_results' in adata.uns:
+        return adata.uns['unreliable_roe_results']
     else:
         return adata.uns['unsig_roe_results']
 
@@ -73,11 +91,16 @@ def roe(
 def roe_plot_heatmap(adata: AnnData, display_numbers: bool = False, center_value: float = 1.0,
                      color_scheme: str = 'cool',
                  custom_colors: list = None, save_path: str = None, batch_order: list = None):
-    # 检查是否有显著的结果
+    # Check for results in order of reliability
     if 'sig_roe_results' in adata.uns:
         roe = adata.uns['sig_roe_results']
+        title_suffix = ""
+    elif 'unreliable_roe_results' in adata.uns:
+        roe = adata.uns['unreliable_roe_results']
+        title_suffix = " (Statistical test unreliable - low expected frequencies)"
     else:
         roe = adata.uns['unsig_roe_results']
+        title_suffix = " (Not significant)"
 
     # 如果提供了批次顺序，则按批次排序
     if batch_order:
@@ -102,22 +125,22 @@ def roe_plot_heatmap(adata: AnnData, display_numbers: bool = False, center_value
     custom_cmap = LinearSegmentedColormap.from_list('custom_cmap', colors, N=256)
     custom_cmap.set_bad(color='white')
 
-    # 根据display_numbers参数选择显示方式
+    # Choose display method based on display_numbers parameter
     if display_numbers:
-        annot = roe.round(2)  # 保留两位小数
+        annot = roe.round(2)  # Keep two decimal places
         sns.heatmap(roe, annot=annot, cmap=custom_cmap, center=center_value, fmt='', ax=ax)
-        plt.title("ROE Results")
+        plt.title(f"ROE Results{title_suffix}")
     else:
         transformed_roe = transform_roe_values(roe)
         sns.heatmap(roe, annot=transformed_roe, cmap=custom_cmap, center=center_value, fmt='', cbar=False, ax=ax)
 
-        # 添加图例
+        # Add legend with corrected thresholds
         cbar_ax = fig.add_axes([0.93, 0.2, 0.03, 0.6])
         cbar = plt.colorbar(plt.cm.ScalarMappable(cmap=custom_cmap), cax=cbar_ax, orientation='vertical')
-        cbar.set_ticks([0.125, 0.375, 0.625, 0.875])
-        cbar.set_ticklabels(['+++', '++', '+', '±'])
+        cbar.set_ticks([0.1, 0.3, 0.5, 0.7, 0.9])
+        cbar.set_ticklabels(['—', '+/-', '+', '++', '+++'])
 
-    plt.title("Ro/e")
+    plt.title(f"Ro/e{title_suffix}")
     if save_path:
         plt.savefig(save_path)  # 保存图像
     else:
@@ -125,10 +148,17 @@ def roe_plot_heatmap(adata: AnnData, display_numbers: bool = False, center_value
 
 
 def transform_roe_values(roe):
-    # 将roe DataFrame转换为字符串格式，用于标注
+    # Transform roe DataFrame to string format for annotation, following Nature paper thresholds
     transformed_roe = roe.copy()
     transformed_roe = transformed_roe.applymap(
-        lambda x: '+++' if x >= 2 else ('++' if x >= 1.5 else ('+' if x >= 1 else '+/-')))
+        lambda x: '—' if x == 0 else (
+            '+++' if x > 1 else (
+                '++' if 0.8 < x <= 1 else (
+                    '+' if 0.2 <= x <= 0.8 else '+/-'
+                )
+            )
+        )
+    )
     return transformed_roe
 
 # roe(adata, sample_key='batch', cell_type_key='celltypist_cell_label_coarse')


### PR DESCRIPTION
This PR addresses the statistical issues identified in #247 regarding the ov.utils.roe function.

## Changes:
- Fixed threshold categorization to match Nature paper specifications
- Implemented Fisher's exact test for 2x2 tables when expected frequencies < 5
- Added proper warnings for unreliable results
- Updated visualization to reflect corrected thresholds

Fixes #247

Generated with [Claude Code](https://claude.ai/code)