### PR TITLE
Fix pytest failures in test_dr_write.py

### DIFF
--- a/tests/llm/test_dr_write.py
+++ b/tests/llm/test_dr_write.py
@@ -13,7 +13,7 @@ def load_components():
         def validate_query(q):
             return True, ""
     oq.QueryManager = QM
-    sys.modules.setdefault("OvIntelligence.query_manager", oq)
+    sys.modules["OvIntelligence.query_manager"] = oq
     mf = types.ModuleType("omicverse.llm.model_factory")
     class DummyFactory:
         @staticmethod


### PR DESCRIPTION
Fixes the failing pytest tests in `tests/llm/test_dr_write.py` by properly setting up the mock for `OvIntelligence.query_manager.QueryManager`.

**Changes:**
- Fixed mock setup to use direct assignment instead of `setdefault`
- This ensures the mock validation function properly overrides the real one

**Root Cause:**
The tests were failing because `sys.modules.setdefault()` doesn't replace already-loaded modules, so the real query validation (which requires minimum 3 characters) was still being called instead of the mock.

Closes #405

Generated with [Claude Code](https://claude.ai/code)