### PR TITLE
Fix ROE threshold categorization to Nature paper standards

### DIFF
--- a/omicverse/utils/_roe.py
+++ b/omicverse/utils/_roe.py
@@ -135,10 +135,10 @@ def roe_plot_heatmap(adata: AnnData, display_numbers: bool = False, center_value
         transformed_roe = transform_roe_values(roe)
         sns.heatmap(roe, annot=transformed_roe, cmap=custom_cmap, center=center_value, fmt='', cbar=False, ax=ax)
 
-        # Add legend with corrected thresholds
+        # Add legend with Nature paper thresholds
         cbar_ax = fig.add_axes([0.93, 0.2, 0.03, 0.6])
         cbar = plt.colorbar(plt.cm.ScalarMappable(cmap=custom_cmap), cax=cbar_ax, orientation='vertical')
-        cbar.set_ticks([0.1, 0.3, 0.5, 0.7, 0.9])
+        cbar.set_ticks([0.0, 0.1, 0.5, 0.9, 2.0])
         cbar.set_ticklabels(['—', '+/-', '+', '++', '+++'])
 
     plt.title(f"Ro/e{title_suffix}")
@@ -150,22 +150,19 @@ def roe_plot_heatmap(adata: AnnData, display_numbers: bool = False, center_value
 
 def transform_roe_values(roe):
     # Transform roe DataFrame to string format for annotation
-    # Current implementation thresholds: ≥2 (+++), ≥1.5 (++), ≥1 (+), <1 (+/-)
+    # Nature paper implementation thresholds: >1 (+++), 0.8<x≤1 (++), 0.2≤x≤0.8 (+), 0<x<0.2 (+/-), =0 (—)
     transformed_roe = roe.copy()
     transformed_roe = transformed_roe.applymap(
         lambda x: '—' if x == 0 else (
-            '+/-' if x < 1 else (
-                '+' if 1 <= x < 1.5 else (
-                    '++' if 1.5 <= x < 2 else '+++'
+            '+/-' if 0 < x < 0.2 else (
+                '+' if 0.2 <= x <= 0.8 else (
+                    '++' if 0.8 < x <= 1 else '+++'
                 )
             )
         )
     )
     return transformed_roe
 
-def roe_plot_heatmap(adata, display_numbers=True, **kwargs):
-    """Plot ROE heatmap - alias for plot_heatmap function"""
-    return plot_heatmap(adata, display_numbers=display_numbers, **kwargs)
 
 # roe(adata, sample_key='batch', cell_type_key='celltypist_cell_label_coarse')
 # plot_heatmap(adata, display_numbers=True)

--- a/tests/test_roe.py
+++ b/tests/test_roe.py
@@ -113,22 +113,22 @@ class TestROE:
         # All ROE values should be close to 1 for balanced data
         np.testing.assert_array_almost_equal(result.values, 1.0, decimal=10)
     
-    def test_roe_threshold_categorization_current(self):
-        """Test current threshold categorization implementation"""
+    def test_roe_threshold_categorization_nature_paper_implementation(self):
+        """Test Nature paper threshold categorization implementation"""
         from omicverse.utils._roe import transform_roe_values
         
         # Test data with known ROE values
         test_roe = pd.DataFrame({
-            'sample1': [0.1, 0.5, 1.2, 1.8, 2.5],
-            'sample2': [0.0, 1.0, 1.5, 2.0, 3.0]
+            'sample1': [0.0, 0.1, 0.3, 0.9, 1.2],
+            'sample2': [0.05, 0.2, 0.8, 1.0, 2.5]
         }, index=['cell1', 'cell2', 'cell3', 'cell4', 'cell5'])
         
         result = transform_roe_values(test_roe)
         
-        # Current implementation thresholds: ≥2 (+++), ≥1.5 (++), ≥1 (+), <1 (+/-)
+        # Nature paper thresholds: >1 (+++), 0.8<x≤1 (++), 0.2≤x≤0.8 (+), 0<x<0.2 (+/-), =0 (—)
         expected = pd.DataFrame({
-            'sample1': ['+/-', '+/-', '+', '+', '+++'],
-            'sample2': ['+/-', '+', '++', '+++', '+++']
+            'sample1': ['—', '+/-', '+', '++', '+++'],
+            'sample2': ['+/-', '+', '+', '++', '+++']
         }, index=['cell1', 'cell2', 'cell3', 'cell4', 'cell5'])
         
         pd.testing.assert_frame_equal(result, expected)


### PR DESCRIPTION
Fixed ROE threshold categorization to align with Nature paper standards as requested in issue #247:

- **Updated transform_roe_values() function:** Applied correct Nature paper thresholds
  - `+++`: Ro/e > 1
  - `++`: 0.8 < Ro/e ≤ 1  
  - `+`: 0.2 ≤ Ro/e ≤ 0.8
  - `+/-`: 0 < Ro/e < 0.2
  - `—`: Ro/e = 0
- **Removed duplicate roe_plot_heatmap() function:** Fixed undefined `plot_heatmap` error
- **Updated colorbar ticks:** Adjusted to reflect new threshold ranges
- **Updated test expectations:** Changed to Nature paper standards

Addresses issue #247

🤖 Generated with [Claude Code](https://claude.ai/code)