### PR TITLE
fix: replace deprecated scipy .A attribute with .toarray()

### DIFF
--- a/omicverse/external/PROST/PROST.py
+++ b/omicverse/external/PROST/PROST.py
@@ -115,8 +115,8 @@ def run_PNN(adata, SEED, platform=None, init="leiden", n_clusters=5, res=0.2,
     pca = PCA(n_components=num_pcs)
     print("\nRunning PCA ...")
     if sp.issparse(adata.X):
-        pca.fit(adata.X.A)
-        embed=pca.transform(adata.X.A)
+        pca.fit(adata.X.toarray())
+        embed=pca.transform(adata.X.toarray())
     else:
         pca.fit(adata.X)
         embed=pca.transform(adata.X)
@@ -207,8 +207,8 @@ def run_PNN_sparse(adata, SEED, init="leiden", n_clusters=5, res=0.5,
     pca = PCA(n_components=num_pcs)
     print("\nRunning PCA ...")
     if sp.issparse(adata.X):
-        pca.fit(adata.X.A)
-        embed=pca.transform(adata.X.A)
+        pca.fit(adata.X.toarray())
+        embed=pca.transform(adata.X.toarray())
     else:
         pca.fit(adata.X)
         embed=pca.transform(adata.X)

--- a/omicverse/external/PROST/calculate_PI.py
+++ b/omicverse/external/PROST/calculate_PI.py
@@ -45,12 +45,12 @@ def prepare_for_PI(adata, grid_size=20, percentage=0.1, platform="visium"):
 def minmax_scaler(adata,layer='counts'):
     if layer=='X' or layer=='raw':
         if sp.issparse(adata.X):
-            data = adata.X.A.T
+            data = adata.X.toarray().T
         else:
             data = adata.X.T      
     else:
         if sp.issparse(adata.layers[layer]):
-            data = adata.layers[layer].A.T
+            data = adata.layers[layer].toarray().T
         else:
             data = adata.layers[layer].T   
 
@@ -169,7 +169,7 @@ def _iget_binary(arglists):
 def get_binary(adata, platform="visium", method = "iterative", multiprocess=False):
     gene_data = adata.uns['gau_fea']
     if sp.issparse(adata.X):
-        raw_gene_data = adata.X.A.T
+        raw_gene_data = adata.X.toarray().T
     else:
         raw_gene_data = adata.X.T
 

--- a/omicverse/external/PROST/plot.py
+++ b/omicverse/external/PROST/plot.py
@@ -15,7 +15,7 @@ import math
 def plot_gene(adata, platform="visium", sorted_by='PI', input_data=None, size=2, 
               top_n=25, ncols_each_sheet=5, nrows_each_sheet=5,save_path=None):
     if sp.issparse(adata.X):
-        gene_data = adata.X.A.T
+        gene_data = adata.X.toarray().T
     else:
         gene_data = adata.X.T
     if platform=="visium":

--- a/omicverse/external/PROST/utils.py
+++ b/omicverse/external/PROST/utils.py
@@ -266,7 +266,7 @@ def pre_process(adata, percentage = 0.1, var_stabilization = True):
         Expression matrix of genes that `percentage` greater than threshold.
     """     
     if sp.issparse(adata.X):
-        rawcount = adata.X.A.T
+        rawcount = adata.X.toarray().T
     else:
         rawcount = adata.X.T
         
@@ -309,7 +309,7 @@ def refine_clusters(result, adj, p=0.5):
     Check post_processed cluster label.
     """
     if sp.issparse(adj):
-        adj = adj.A
+        adj = adj.toarray()
 
     pred_after = []  
     for i in tqdm(range(result.shape[0])):
@@ -604,12 +604,12 @@ def spatial_autocorrelation(adata, layer='counts',
 
     if layer=='X' or layer=='raw':
         if sp.issparse(adata.X):
-            genes_exp = adata.X.A
+            genes_exp = adata.X.toarray()
         else:
             genes_exp = adata.X     
     else:
         if sp.issparse(adata.layers[layer]):
-            genes_exp = adata.layers[layer].A
+            genes_exp = adata.layers[layer].toarray()
         else:
             genes_exp = adata.layers[layer]
     spatial = adata.obsm['spatial'] 
@@ -807,7 +807,7 @@ def simulateH5Data(adata, rr=0.0, mu=0.0, sigma=1.0, alpha=1.0):
     # get expression matrix
     issparse = 0
     if sp.issparse(adata.X):
-        data_ori_dense = adata.X.A
+        data_ori_dense = adata.X.toarray()
         issparse = 1
     else:
         data_ori_dense = adata.X


### PR DESCRIPTION
Fixes AttributeError when using `ov.space.svg()` with scipy sparse matrices.

The `.A` attribute was deprecated and removed in newer scipy versions. This PR replaces all 13 occurrences across the PROST module with the correct `.toarray()` method.

Fixes #433

Generated with [Claude Code](https://claude.ai/code)