### PR TITLE
fix: configure dask query-planning for crop_space_visium

### DIFF
--- a/omicverse/space/_tools.py
+++ b/omicverse/space/_tools.py
@@ -78,6 +78,9 @@ def crop_space_visium(adata, crop_loc, crop_area,
         ...     scale=1.0
         ... )
     """
+    # Configure dask to use query-planning before importing squidpy
+    import dask
+    dask.config.set({"dataframe.query-planning": True})
     import squidpy as sq
     adata1 = adata.copy()
     img = sq.im.ImageContainer(


### PR DESCRIPTION
Fixes #435

## Summary

The `crop_space_visium` function was failing with a `NotImplementedError` because squidpy imports spatialdata which requires dask with query-planning enabled.

## Changes
- Added dask configuration to enable query-planning before importing squidpy
- This ensures compatibility with recent versions of dask that no longer support the legacy implementation

## Test plan
- Test that `crop_space_visium` function works without the NotImplementedError
- Verify the function still performs spatial cropping correctly

🤖 Generated with [Claude Code](https://claude.ai/code)