### PR TITLE
fix: numpy 2.0 compatibility - replace deprecated functions

### DIFF
--- a/omicverse/external/scdiffusion/guided_diffusion/resample.py
+++ b/omicverse/external/scdiffusion/guided_diffusion/resample.py
@@ -129,7 +129,7 @@ class LossSecondMomentResampler(LossAwareSampler):
         self._loss_history = np.zeros(
             [diffusion.num_timesteps, history_per_term], dtype=np.float64
         )
-        self._loss_counts = np.zeros([diffusion.num_timesteps], dtype=np.int)
+        self._loss_counts = np.zeros([diffusion.num_timesteps], dtype=np.int64)
 
     def weights(self):
         if not self._warmed_up():

--- a/omicverse/nocd/utils.py
+++ b/omicverse/nocd/utils.py
@@ -134,7 +134,7 @@ def adjacency_split_naive(A, p_val, neg_mul=1, max_num_val=None):
     candidate_zeros = np.random.choice(np.arange(num_nodes, dtype=np.int32),
                                        size=(2 * num_val_nonedges, 2), replace=True)
     cne1, cne2 = candidate_zeros[:, 0], candidate_zeros[:, 1]
-    to_keep = (1 - A[cne1, cne2]).astype(np.bool).A1
+    to_keep = (1 - A[cne1, cne2]).astype(bool).A1
     val_zeros = candidate_zeros[to_keep][:num_val_nonedges]
     if to_keep.sum() < num_val_nonedges:
         raise ValueError("Couldn't produce enough non-edges")

--- a/omicverse/pl/_embedding.py
+++ b/omicverse/pl/_embedding.py
@@ -79,7 +79,7 @@ def embedding_atlas(adata,basis,color,
         img = tf.shade(tf.spread(agg,px=0),color_key=[color_key[i] for i in df['label'].cat.categories], 
                        how='eq_hist')
     elif (type(labels[0]) is int) or (type(labels[0]) is float) or (type(labels[0]) is np.float32)\
-    or (type(labels[0]) is np.float64) or (type(labels[0]) is np.int):
+    or (type(labels[0]) is np.float64) or (type(labels[0]) is np.int64):
         # 聚合数据
         agg = cvs.points(df, 'x', 'y',ds.mean('label'),
                         )

--- a/omicverse/single/_SCSA.py
+++ b/omicverse/single/_SCSA.py
@@ -11,7 +11,7 @@ import gzip
 import os
 
 import numpy as np
-from numpy import asfarray,arange,minimum,abs,mat,sum,power,mean,array,std,log2,log10
+from numpy import asarray,arange,minimum,abs,mat,sum,power,mean,array,std,log2,log10
 import pandas as pd
 from pandas import DataFrame,read_csv,ExcelWriter
 from pickle import dump,load
@@ -99,7 +99,7 @@ class Annotator(object):
     @staticmethod
     def p_adjust_bh(p):
         """Benjamini-Hochberg p-value correction for multiple hypothesis testing."""
-        p = asfarray(p)
+        p = asarray(p, dtype=float)
         by_descend = p.argsort()[::-1]
         by_orig = by_descend.argsort()
         steps = float(len(p)) / arange(len(p), 0, -1)

--- a/omicverse/single/_sccaf.py
+++ b/omicverse/single/_sccaf.py
@@ -939,7 +939,7 @@ def plot_link(ad, ymat, old_id, basis='tsne', ax=None, line_color='#ffa500', lin
                     fontsize=legend_fontsize)
 
     df = ymat.copy()
-    df = df.where(np.triu(np.ones(df.shape)).astype(np.bool))
+    df = df.where(np.triu(np.ones(df.shape)).astype(bool))
     df = df.stack().reset_index()
     df.columns = ['i', 'j', 'val']
     for k in np.arange(df.shape[0]):


### PR DESCRIPTION
Fixes #437

## Summary

This PR fixes numpy 2.0 compatibility issues by replacing deprecated functions that were removed in numpy 2.0.

## Changes

- Replace `asfarray` with `asarray` in `_SCSA.py`
- Update `np.int` to `np.int64` in various files
- Update `np.bool` to `bool` in various files

## Test Plan

The import error should no longer occur when using numpy >= 2.0

Generated with [Claude Code](https://claude.ai/code)