### PR TITLE
Add Alignment Features

### DIFF
--- a/omicverse/bulk/__init__.py
+++ b/omicverse/bulk/__init__.py
@@ -44,8 +44,13 @@ from ._chm13 import get_chm13_gene,find_chm13_gene
 from ._Deseq2 import pyDEG,deseq2_normalize,estimateSizeFactors,estimateDispersions,Matrix_ID_mapping,data_drop_duplicates_index
 from ._tcga import pyTCGA
 from ._combat import batch_correction
+from ._alignment import Alignment, AlignmentConfig
 
 __all__ = [
+
+    # Alignment
+    "Alignment", "AlignmentConfig"
+
     # Gene co-expression analysis
     'pyWGCNA',
     'readWGCNA',

--- a/omicverse/bulk/_alignment.py
+++ b/omicverse/bulk/_alignment.py
@@ -1,0 +1,387 @@
+# omicverse/bulk/alignment.py
+# Contributor: Zhi Luo
+
+"""
+Alignment pipeline for bulk RNA-seq in OmicVerse.
+
+This class is a thin, composable wrapper around existing step modules in your repo:
+- sra_prefetch / sra_fasterq   : SRA download & conversion
+- qc_fastp / qc_tools          : FASTQ QC & trimming
+- count_step / count_tools     : gene-level counting via featureCounts
+- (optional) your aligner step : HISAT2/STAR wrapper if available
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable, Literal, Sequence, Tuple, Optional, Dict, Any
+
+# Import your existing step modules (assumes they are importable in the package env)
+# If your modules live at project root, adjust relative imports accordingly.
+try:
+    from . import geo_meta_fetcher as _geo
+except Exception:
+    import geo_meta_fetcher as _geo
+
+try:
+    from . import entrez_direct as _ed
+except Exception:
+    import entrez_direct as _ed
+
+try:
+    from . import sra_prefetch as _sra_prefetch
+except Exception:
+    import sra_prefetch as _sra_prefetch
+    
+try:
+    from . import sra_fasterq as _sra_fasterq
+except Exception:
+    import sra_fasterq as _sra_fasterq
+
+try:
+    from . import qc_fastp as _qc_fastp
+except Exception:
+    import qc_fastp as _qc_fastp
+
+try:
+    from . import star_step as _star_step
+except Exception:
+    import star_step as _star_step
+
+try:
+    from . import count_step as _count_step
+except Exception:
+    import count_step as _count_step
+
+try: 
+    from . import tools_check as _tools_check
+except Exception:
+    import tools_check as _tools_check
+
+@dataclass
+class AlignmentConfig:
+    # IO roots
+    work_root: Path = Path("work")
+    meta_root: Path = Path("work/meta")
+    prefetch_root: Path = Path("work/prefetch")
+    fasterq_root: Path = Path("work/fasterq")
+    qc_root: Path = Path("work/fastp")
+    align_root: Path = Path("work/align")     # placeholder if you later add HISAT2/STAR
+    counts_root: Path = Path("work/counts")
+
+    star_index_root: Path = field(default_factory=lambda: Path("index"))        # 索引根目录（和 star_tools 设定一致）
+    star_align_root: Path  = field(default_factory=lambda: Path("work/star"))   # STAR 输出根目录
+    
+
+    # Resources
+    threads: int = 16
+    memory: str = "8G"
+    genome: Literal["human", "mouse", "custom"] = "human"
+    gtf: Optional[Path] = None                 # if provided, overrides genome GTF discovery
+
+    # Behavior
+    gzip_fastq: bool = True
+    fastp_enabled: bool = True
+    simple_counts: bool = True                 # only gene_id,count
+
+    # Metadata
+    by: Literal["auto","srr","accession"] = "auto"
+
+
+class Alignment:
+    """
+    A cohesive, user-facing API for the bulk RNA-seq alignment pipeline.
+    Each step delegates to your existing step modules, preserving their behavior,
+    while unifying inputs/outputs and logging.
+    """
+
+    def __init__(self, config: AlignmentConfig | None = None):
+        self.cfg = config or AlignmentConfig()
+        # normalize paths
+        for p in [
+            self.cfg.work_root, self.cfg.meta_root,self.cfg.prefetch_root, self.cfg.fasterq_root,
+            self.cfg.qc_root, self.cfg.align_root, self.cfg.counts_root,self.cfg.star_index_root,self.cfg.star_align_root
+        ]:
+            Path(p).mkdir(parents=True, exist_ok=True)
+
+     # ---------- Fetch Metadata ----------
+    def fetch_metadata(
+        self,
+        accession: str,
+        meta_dir: Optional[Path] = None,
+        out_dir: Optional[Path] = None,
+        organism_filter: Optional[str] = None,   # 例如 "Homo sapiens"
+        layout_filter: Optional[str] = None,     # "PAIRED" / "SINGLE"
+    ):
+        """
+        给一个 GEO accession（GSE/GSM），抓取 SOFT→保存 meta JSON，
+        再走 EDirect 生成 RunInfo CSV，并返回 SRR 列表与路径。
+        """
+        _tools_check.check()
+        # 1) 目录设置
+        meta_root = Path(meta_dir) if meta_dir else (Path(self.cfg.work_root) / "meta")
+        #sra_meta_root = Path(out_dir) if out_dir else (Path(self.cfg.work_root) / "meta")
+        meta_root.mkdir(parents=True, exist_ok=True)
+        #sra_meta_root.mkdir(parents=True, exist_ok=True)
+    
+        # 2) 生成/更新 JSON metadata（注意是 out_dir 参数）
+        _geo.geo_accession_to_meta_json(accession, out_dir=str(meta_root))
+    
+        # 3) 生成 RunInfo CSV（注意是 accession + meta_dir/out_dir）
+        info = _ed.gse_meta_to_runinfo_csv(
+            accession=accession,
+            meta_dir=str(meta_root),
+            out_dir=str(meta_root),
+            organism_filter=organism_filter,
+            layout_filter=layout_filter,
+        )
+        runinfo_csv = Path(info["csv"]) if info.get("csv") else None
+    
+        # 4) 提取 SRR 列表
+        srrs: list[str] = []
+        if runinfo_csv and runinfo_csv.exists():
+            import csv
+            with runinfo_csv.open("r", newline="") as f:
+                reader = csv.DictReader(f)
+                for row in reader:
+                    for key in ("Run", "acc", "Run Accession", "RunAccession"):
+                        if key in row and row[key]:
+                            srrs.append(row[key].strip())
+                            break
+            # 去重保序
+            seen = set(); srrs = [x for x in srrs if not (x in seen or seen.add(x))]
+    
+        # 5) 可选：结构化字段
+        try:
+            meta_struct = _geo.parse_geo_soft_to_struct(_geo.fetch_geo_text(accession))
+        except Exception:
+            meta_struct = None
+    
+        return {
+            "meta_json": meta_root / f"{accession}_meta.json",
+            "runinfo_csv": runinfo_csv,
+            "srr_list": srrs,
+            "edirect_info": info,   # 包含 term_used/rows 等
+            "meta_struct": meta_struct,
+        }
+
+    # ---------- SRA: prefetch ----------
+    def prefetch(self, srr_list: Sequence[str]) -> Sequence[Path]:
+        """
+        Prefetch SRAs to .sra files.
+        Returns: list of .sra paths.
+        """
+        # Delegate to your prefetch implementation. We assume it exposes a function like:
+        # _sra_prefetch.prefetch_batch(srr_list, out_root=..., threads=...)
+        if not hasattr(_sra_prefetch, "prefetch_batch"):
+            raise RuntimeError("sra_prefetch.prefetch_batch(...) not found. Please expose it.")
+        return _sra_prefetch.prefetch_batch(
+            srr_list=srr_list,
+            out_root=str(self.cfg.prefetch_root),
+            threads=self.cfg.threads
+        )
+
+    # ---------- SRA: fasterq-dump ----------
+    def fasterq(self, srr_list: Sequence[str]) -> Sequence[Tuple[str, Path, Path]]:
+        """
+        Convert SRA to paired FASTQ(.gz).
+        Returns: list of tuples (srr, fq1_path, fq2_path).
+        """
+        if not hasattr(_sra_fasterq, "fasterq_batch"):
+            raise RuntimeError("sra_fasterq.fasterq_batch(...) not found. Please expose it.")
+        return _sra_fasterq.fasterq_batch(
+            srr_list=srr_list,
+            out_root=str(self.cfg.fasterq_root),
+            threads=self.cfg.threads,
+            mem = self.cfg.memory,
+            gzip_output=self.cfg.gzip_fastq
+        )
+
+    # ---------- QC: fastp ----------
+    def fastp(self, fq_pairs: Sequence[Tuple[str, Path, Path]]) -> Sequence[Tuple[str, Path, Path]]:
+        """
+        Run fastp on paired FASTQ files.
+        Returns: list of tuples (srr, fq1_qc, fq2_qc).
+        """
+        if not self.cfg.fastp_enabled:
+            # pass-through without QC
+            return [(srr, fq1, fq2) for srr, fq1, fq2 in fq_pairs]
+
+        if not hasattr(_qc_fastp, "fastp_batch"):
+            raise RuntimeError("qc_fastp.fastp_batch(...) not found. Please expose it.")
+        return _qc_fastp.fastp_batch(
+            pairs=fq_pairs,
+            out_root=str(self.cfg.qc_root),
+            threads=self.cfg.threads
+        )
+
+    # ---------- Alignment (placeholder) ----------
+    def star_align(
+        self,
+        clean_fastqs: Sequence[Tuple[str, Path, Path]],
+        *,
+        gencode_release: str = "v44",
+        sjdb_overhang: Optional[int] = 149,
+        accession_for_species: Optional[str] = None,   # 所有样本同一 GSE 时可统一传；否则保持 None
+        max_workers: Optional[int] = None,             # 同时跑多少个样本；None=串行，日志更清晰
+    ) -> List[Tuple[str, str, Optional[str]]]:
+        """
+        批量跑 STAR（调用 batch 版 star_step），返回：
+          [(srr, bam_path, index_dir|None), ...]
+        - 幂等：若 <SRR>/Aligned.sortedByCoord.out.bam 已存在且>1MB，则 [SKIP]
+        - index_dir 若在 star_tools 返回中可解析则给出，否则为 None（与你后续 GTF 推断逻辑一致）
+        """
+        if not hasattr(_star_step, "make_star_step"):
+            raise RuntimeError("star_step.make_star_step(...) not found")
+
+        # 构造一步“可批量”的 step（与原有工厂接口完全一致）
+        step = _star_step.make_star_step(
+            index_root=str(self.cfg.star_index_root),
+            out_root=str(self.cfg.star_align_root),
+            threads=int(self.cfg.threads),
+            gencode_release=gencode_release,
+            sjdb_overhang=sjdb_overhang,
+            accession_for_species=accession_for_species,
+            max_workers=max_workers,   # None=串行；也可外部传 2/4 并发
+        )
+
+        # 规范输入为 [(srr, str(fq1), str(fq2)), ...]
+        pairs: List[Tuple[str, str, str]] = [
+            (srr, str(Path(fq1)), str(Path(fq2))) for srr, fq1, fq2 in clean_fastqs
+        ]
+
+        # 直接调用批量 command，得到 [(srr, bam, index_dir|None), ...]
+        products = step["command"](pairs, logger=None)
+        # 与随后 pipeline 的“三元组规范化”完全兼容
+        return products
+
+    # ---------- Counting via featureCounts ----------
+    def featurecounts(
+        self,
+        bam_triples: Sequence[Tuple[str, str | Path, Optional[str]]],   # [(srr, bam, index_dir|None)]
+        *,
+        gtf: Optional[str | Path] = None,         # 显式 GTF（优先级最高）
+        simple: Optional[bool] = None,            # None→cfg.featurecounts_simple
+        by: Optional[str] = None,                 # None→cfg.featurecounts_by
+        threads: Optional[int] = None,            # None→cfg.threads
+        max_workers: Optional[int] = None,        # 预留（count_tools 可并行时透传）
+    ) -> Dict[str, object]:
+        """
+        批量调用 featureCounts。返回：
+          { "tables": [(srr, table_path), ...], "matrix": <path|None>, "failed": [] }
+        幂等：<counts_root>/<SRR>/<SRR>.counts.txt 存在且>0则跳过计算。
+        """
+        if not hasattr(_count_step, "make_featurecounts_step"):
+            raise RuntimeError("count_step.make_featurecounts_step(...) not found")
+
+        out_root = Path(self.cfg.counts_root)
+        out_root.mkdir(parents=True, exist_ok=True)
+
+        # ---------- 内置 GTF 自动推断 ----------
+        def _infer_gtf_from_bams(triples: Sequence[Tuple[str, str | Path, Optional[str]]]) -> Optional[str]:
+            # 1) 优先：从每个样本携带的 index_dir 推断
+            for _srr, _bam, idx_dir in triples:
+                if not idx_dir:
+                    continue
+                idx = Path(idx_dir)
+                # (a) 本目录 / 父目录搜 *.gtf
+                for base in {idx, idx.parent}:
+                    for p in base.glob("*.gtf"):
+                        return str(p.resolve())
+                # (b) _cache 下搜 *.gtf
+                for base in {idx.parent, idx.parent.parent}:
+                    cache = base / "_cache"
+                    if cache.exists():
+                        hits = list(cache.rglob("*.gtf"))
+                        if hits:
+                            return str(hits[0].resolve())
+                # (c) 再向上一级补充一轮
+                for p in idx.parent.parent.glob("*.gtf"):
+                    return str(p.resolve())
+
+            # 2) 其次：从配置的 star_index_root 下兜底搜索
+            idx_root = Path(getattr(self.cfg, "star_index_root", "index"))
+            if idx_root.exists():
+                hits = list(idx_root.rglob("*.gtf"))
+                if hits:
+                    return str(hits[0].resolve())
+
+            # 3) 最后：环境变量 FC_GTF_HINT
+            env_hint = os.environ.get("FC_GTF_HINT")
+            if env_hint and Path(env_hint).exists():
+                return str(Path(env_hint).resolve())
+
+            return None
+
+        # 若未显式给 gtf，则自动推断
+        if gtf is None:
+            inferred = _infer_gtf_from_bams(bam_triples)
+            if inferred:
+                print(f"[INFO] featureCounts: inferred GTF -> {inferred}")
+                gtf = inferred
+            else:
+                raise RuntimeError(
+                    "[featureCounts] 无法自动找到 GTF，请显式传入 gtf= 或设置环境变量 FC_GTF_HINT。"
+                )
+
+        # ---------- 构建 step 工厂并幂等检查 ----------
+        step = _count_step.make_featurecounts_step(
+            out_root=str(out_root),
+            simple=(self.cfg.featurecounts_simple if simple is None else bool(simple)),
+            gtf=None,  # 运行时 gtf 通过 command(...) 传入，优先级最高
+            by=(by or self.cfg.featurecounts_by),
+            threads=int(threads or self.cfg.threads),
+            gtf_path=str(gtf),  # 作为工厂的后备（内部优先用 command 的 gtf）
+        )
+
+        def _table_path_for(srr: str) -> Path:
+            # 若你的 count_tools 产物实际是 .csv，这里改成 .csv 并同步改 outputs 模板
+            return out_root / srr / f"{srr}.counts.txt"
+
+        # 幂等：全部已有则跳过
+        outs_by_srr: List[Tuple[str, Path]] = [(str(srr), _table_path_for(str(srr))) for srr, _bam, _ in bam_triples]
+        if all(step["validation"]([str(p)]) for _, p in outs_by_srr):
+            print("[SKIP] featureCounts for all")
+            tables = [(srr, str(p)) for srr, p in outs_by_srr]
+            return {"tables": tables, "matrix": None, "failed": []}
+
+        # 组装 (srr, bam) 列表并运行
+        bam_pairs = [(str(srr), str(bam)) for (srr, bam, _idx) in bam_triples]
+        ret = step["command"](
+            bam_pairs,
+            logger=None,
+            gtf=str(gtf),  # 显式传入，优先级最高
+        )
+
+        tables = [(srr, str(_table_path_for(str(srr)))) for srr, _ in bam_pairs]
+        matrix_path = ret.get("matrix") if isinstance(ret, dict) else None
+        return {"tables": tables, "matrix": matrix_path, "failed": []}
+
+    # ---------- End-to-end convenience ----------
+    def run(self, srr_list: Sequence[str], *, with_align: bool = False, align_index: Optional[Path] = None) -> Dict[str, Any]:
+        """
+        Convenience runner: prefetch -> fasterq -> (fastp) -> [align] -> featureCounts
+
+        Returns a dict of paths keyed by step.
+        """
+        sras = self.prefetch(srr_list)
+        fastqs = self.fasterq(srr_list)
+        fastqs_qc = self.fastp(fastqs)
+
+        result: Dict[str, Any] = {
+            "prefetch": sras,
+            "fastq": fastqs,
+            "fastq_qc": fastqs_qc,
+        }
+
+        if with_align:
+            bams = self.align(fastqs_qc, index_root=align_index)
+        else:
+            # If you have a separate step that takes fastq->counts directly, wire it here.
+            # Otherwise you need an alignment step. We raise for clarity.
+            raise NotImplementedError("No aligner wired. Set with_align=True and implement .align().")
+
+        counts = self.featurecounts(bams, gtf=self.cfg.gtf)
+        result["bam"] = bams
+        result["counts"] = counts
+        return result

--- a/omicverse/bulk/count_step.py
+++ b/omicverse/bulk/count_step.py
@@ -1,0 +1,61 @@
+# count_step.py featureCounts 步骤
+from __future__ import annotations
+import os
+from pathlib import Path
+from typing import Sequence
+
+# 批量 wrapper：内部调用 featureCounts，支持 simple=True 只留 gene_id,count
+from .count_tools import feature_counts_batch
+
+def make_featurecounts_step(
+    out_root: str = "work/counts",
+    simple: bool = True,            # 只保留 gene_id,count
+    gtf: str | None = None,         # 留空表示“使用 ensure_star_index 时下载到的 GENCODE GTF”（内部可从 index_root 推断）
+    by: str = "auto",               # "srr" 或 "accession" 或 "auto"
+    threads: int = 8,
+    gtf_path: str | None = None,
+):
+    """
+    输入：BAM 列表（[(srr, bam), ...]）
+    输出：
+      - 每样本：work/counts/{SRR}/{SRR}.counts.txt（或 .csv）
+      - 可选：合并矩阵：work/counts/matrix.{by}.csv
+    验证：每样本计数文件存在且行数>0
+    """
+    def _cmd(bam_pairs: Sequence[tuple[str, str]], logger=None, gtf: str | None = None):
+        """
+        bam_pairs: [(srr, bam_path), ...]
+        gtf:       ✅ 新增：运行时也可显式传入 GTF（优先级最高）
+        """
+        os.makedirs(out_root, exist_ok=True)
+
+        # ✅ 统一选择 GTF： 运行时 gtf > 工厂入参 gtf_path > 环境变量 FC_GTF_HINT
+        gtf_use = gtf or gtf_path or os.environ.get("FC_GTF_HINT")
+        if not gtf_use or not os.path.exists(gtf_use):
+            raise RuntimeError(
+                "[featureCounts] GTF not provided and FC_GTF_HINT not set or file missing.\n"
+                f"  - gtf (runtime): {gtf}\n"
+                f"  - gtf_path (factory): {gtf_path}\n"
+                f"  - FC_GTF_HINT (env): {os.environ.get('FC_GTF_HINT')}"
+            )
+
+        # 调用你的批量计数函数（保持原有参数不变）
+        return feature_counts_batch(
+            bam_items=list(bam_pairs),   # [(srr, bam)]
+            out_dir=out_root,
+            gtf=gtf_use,
+            simple=simple,
+            by=by,
+            threads=threads,
+            max_workers=None,            # 如需并行可按需加
+        )
+
+
+    return {
+        "name": "featurecounts",
+        "command": _cmd,  # 接收 [(srr, bam), ...]
+        "outputs": [f"{out_root}" + "/{SRR}/{SRR}.counts.txt"],  # 取决于你内部命名：txt/csv 二选一
+        "validation": lambda fs: all(os.path.exists(f) and os.path.getsize(f) > 0 for f in fs),
+        "takes": "BAM_PATHS",
+        "yields": "COUNT_TABLES"
+    }

--- a/omicverse/bulk/count_tools.py
+++ b/omicverse/bulk/count_tools.py
@@ -1,0 +1,266 @@
+# count_tools.py featureCounts 批量版本
+from __future__ import annotations
+import os, subprocess
+from pathlib import Path
+from concurrent.futures import ProcessPoolExecutor, as_completed
+import pandas as pd
+
+
+def _feature_counts_one(bam_path: str, out_dir: str, gtf: str, threads: int = 8, simple: bool = True):
+    # -------------- 新增安全判断 --------------
+    if gtf is None:
+        gtf = os.environ.get("FC_GTF_HINT")
+    if not gtf or not os.path.exists(gtf):
+        raise RuntimeError(
+            f"[featureCounts] Missing valid GTF file for {bam_path}. "
+            "请确认 pipeline 已设置 FC_GTF_HINT 或传入 gtf 参数。"
+        )
+    # -----------------------------------------
+    
+    srr = Path(bam_path).stem.replace(".bam", "")
+    out_prefix = Path(out_dir) / srr
+    out_file = f"{out_prefix}.counts.txt"
+
+    if os.path.exists(out_file) and os.path.getsize(out_file) > 0:
+        return srr, out_file
+
+    cmd = [
+        "featureCounts",
+        "-T", str(threads),
+        "-a", gtf,
+        "-o", out_file,
+        bam_path
+    ]
+    subprocess.run(cmd, check=True)
+    
+    # 简化输出（自动识别计数列）
+    if simple and os.path.exists(out_file):
+        df = pd.read_csv(out_file, sep="\t", comment="#")
+        # featureCounts 的注释列
+        annot_cols = {"Geneid", "Chr", "Start", "End", "Strand", "Length"}
+        # 找出计数列（通常只有 1 列；列名是 BAM 名称/路径）
+        count_cols = [c for c in df.columns if c not in annot_cols]
+        if len(count_cols) == 0:
+            raise ValueError(f"No count columns found in {out_file}. Got columns: {list(df.columns)}")
+        if len(count_cols) > 1:
+            # 多 BAM 情况下这里按需处理；本函数是“单个 bam”，理论上==1
+            # 保险起见，取最后一列当计数列
+            counts_col = count_cols[-1]
+        else:
+            counts_col = count_cols[0]
+    
+        df_simple = df[["Geneid", counts_col]].rename(
+            columns={"Geneid": "gene_id", counts_col: srr}
+        )
+        df_simple.to_csv(out_file, sep="\t", index=False)
+    
+    return srr, out_file
+
+
+def feature_counts_batch(
+    bam_items: list[tuple[str, str]],  # [(srr, bam_path)]
+    out_dir: str,
+    gtf: str | None = None,
+    simple: bool = True,
+    by: str = "auto",
+    threads: int = 8,
+    max_workers: int | None = None
+):
+    """
+    Run featureCounts on multiple BAM files.
+    """
+    os.makedirs(out_dir, exist_ok=True)
+     # -------------- 新增安全判断 --------------
+    if gtf is None:
+        gtf = os.environ.get("FC_GTF_HINT")
+    if not gtf or not os.path.exists(gtf):
+        raise RuntimeError(
+            "[featureCounts_batch] GTF not provided and FC_GTF_HINT not found. "
+            "请在 pipeline 推断 GTF 或手动传入。"
+        )
+    # -----------------------------------------
+
+    results, errors = [], []
+
+    with ProcessPoolExecutor(max_workers=max_workers or min(8, os.cpu_count() // threads)) as ex:
+        futures = {
+            ex.submit(_feature_counts_one, bam, out_dir, gtf, threads, simple): srr
+            for srr, bam in bam_items
+        }
+        for fut in as_completed(futures):
+            srr = futures[fut]
+            try:
+                res = fut.result()
+                results.append(res)
+            except Exception as e:
+                print(f"[ERR] {srr}: {e}")
+
+    # 结果汇总（更健壮：支持 Geneid 或 gene_id，自动识别计数列）
+        # 结果汇总（保留 SRR→文件配对；在合并前就把计数列重命名为 SRR，避免重复列名）
+    pairs = [(srr, f) for (srr, f) in results if os.path.exists(f)]
+    if len(pairs) > 1:
+        merged_df = None
+        for srr, f in pairs:
+            # 跳过注释行，避免列名被干扰
+            df = pd.read_csv(f, sep="\t", comment="#")
+
+            # 基因列：优先 gene_id；否则 Geneid；都没有则用第 1 列
+            if "gene_id" in df.columns:
+                gene_col = "gene_id"
+            elif "Geneid" in df.columns:
+                gene_col = "Geneid"
+            else:
+                gene_col = df.columns[0]
+
+            # 计数列：去除元数据列后剩下的列（通常只有 1 列，为该样本计数）
+            meta_cols = {"Chr", "Start", "End", "Strand", "Length", gene_col}
+            count_cols = [c for c in df.columns if c not in meta_cols]
+            if not count_cols:
+                # 兜底：最后一列当作计数列
+                count_col = df.columns[-1]
+            else:
+                # 常见只有 1 列；若有多列，取最后一列（通常为计数）
+                count_col = count_cols[-1]
+
+            # 只保留 gene_id + 该样本计数列，并把计数列名改成 SRR（唯一）
+            df_simple = df[[gene_col, count_col]].copy()
+            df_simple.columns = ["gene_id", srr]
+
+            if merged_df is None:
+                merged_df = df_simple
+            else:
+                merged_df = merged_df.merge(df_simple, on="gene_id", how="outer")
+
+        # 现在 merged_df 的每个计数列名都是 SRR，天然唯一，无需再做后续的正则重命名
+        out_path = Path(out_dir) / f"matrix.{by}.csv"
+        merged_df.to_csv(out_path, index=False)
+        print(f"[OK] featureCounts merged matrix → {out_path}")
+    '''table_files = [f for _, f in results if os.path.exists(f)]
+    if len(table_files) > 1:
+        merged_df = None
+        for f in table_files:
+            # 关键：跳过注释行，避免列名被干扰
+            df = pd.read_csv(f, sep="\t", comment="#")
+    
+            # 基因列：优先 gene_id；否则用 Geneid；都没有就退而求其次第 1 列
+            if "gene_id" in df.columns:
+                gene_col = "gene_id"
+            elif "Geneid" in df.columns:
+                gene_col = "Geneid"
+            else:
+                gene_col = df.columns[0]  # 兜底
+    
+            # 计数列：排除注释列后余下的全是计数列（通常只有 1 列；列名是 BAM 路径/文件名）
+            annot_cols = {gene_col, "Chr", "Start", "End", "Strand", "Length"}
+            count_cols = [c for c in df.columns if c not in annot_cols]
+            if len(count_cols) == 0:
+                raise ValueError(f"No count columns found in {f}. Columns={list(df.columns)}")
+    
+            # 只留“基因 + 计数列”，并统一把基因列命名为 gene_id
+            df = df[[gene_col] + count_cols].rename(columns={gene_col: "gene_id"})
+    
+            if merged_df is None:
+                merged_df = df
+            else:
+                merged_df = merged_df.merge(df, on="gene_id", how="outer")
+    
+        import re
+
+        def _extract_srr(colname: str) -> str:
+            m = re.search(r'(SRR\d{5,})', colname)
+            if m:
+                return m.group(1)
+            return colname  # 如果没匹配到，保留原名
+        
+        # 对除 gene_id 外的列重命名
+        new_cols = [merged_df.columns[0]] + [_extract_srr(c) for c in merged_df.columns[1:]]
+        merged_df.columns = new_cols
+        
+        out_path = Path(out_dir) / f"matrix.{by}.csv"
+        merged_df.to_csv(out_path, index=False)
+        print(f"[OK] featureCounts merged matrix → {out_path}")'''
+    
+
+    return {
+        "tables": results,                 # 例如 [(srr, sample_table_path), ...]，按你现有结构
+        "matrix": str(out_path),
+        "failed": errors if 'errors' in locals() else [],
+    }
+
+def run_featurecounts_auto(
+    bam_files: List[str | Path],
+    index_dir: str | Path,
+    out_dir: str = "results",
+    accession_id: Optional[str] = None,   # e.g. "GSE157103"
+    srr_id: Optional[str] = None,         # e.g. "SRR12544419"（单样本时）
+    threads: int = 12,
+    output_csv: bool = True,
+    simple: bool = True,                # ✅ 新增：是否精简输出
+    featurecounts_bin: Optional[str] = None,  # 可留空，自动用 PATH 解析
+) -> Path:
+    """
+    - 自动从 STAR index 定位 GTF（并在需要时解压 .gtf.gz）
+    - 根据 accession 或 SRR 自动命名输出文件
+    - 默认将 featureCounts 的制表符输出转换为 CSV
+    """
+    bam_files = [str(Path(b)) for b in bam_files]
+    index_dir = Path(index_dir)
+    os.makedirs(out_dir, exist_ok=True)
+
+    # 1) 自动找 GTF
+    gtf_path = get_gtf_for_index(index_dir)  # ← 核心：无需手动提供
+
+    # 2) 智能命名
+    if accession_id and not srr_id:
+        prefix = f"{accession_id}_counts"
+    elif srr_id:
+        prefix = f"{srr_id}_counts"
+    else:
+        prefix = f"counts_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+    out_txt = Path(out_dir) / f"{prefix}.txt"   # 先让 featureCounts 按默认写 .txt（TSV）
+
+    # 3) 定位 featureCounts 可执行文件
+    if featurecounts_bin is None:
+        import shutil
+        featurecounts_bin = shutil.which("featureCounts") or "featureCounts"
+
+    # 4) 运行 featureCounts
+    cmd = [
+        featurecounts_bin,
+        "-T", str(threads),
+        "-t", "exon",
+        "-g", "gene_id",
+        "-a", str(gtf_path),
+        "-o", str(out_txt),
+    ] + bam_files
+    print(">>", " ".join(cmd))
+    proc = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+    if proc.returncode != 0:
+        print(proc.stdout)
+        print(proc.stderr)
+        raise subprocess.CalledProcessError(proc.returncode, cmd, output=proc.stdout, stderr=proc.stderr)
+
+    # 读取输出
+    df = pd.read_csv(out_txt, sep="\t", comment="#")
+
+    # 若 simple=True，仅保留 Geneid + counts 列
+    if simple:
+        gene_col = "Geneid" if "Geneid" in df.columns else df.columns[0]
+        # 去除注释列，只留基因和样本计数 用于下游 OV pair的比对格式
+        keep_cols = [gene_col] + [
+            c for c in df.columns
+            if c not in ["Chr", "Start", "End", "Strand", "Length"] and c != gene_col
+        ]
+        df = df[keep_cols]
+        print(f"[INFO] Simplified output: retained {len(keep_cols)} columns")
+
+    # 导出 CSV 或 TXT
+    if output_csv:
+        out_csv = out_txt.with_suffix(".csv")
+        df.to_csv(out_csv, index=False)
+        print(f"[OK] featureCounts output → {out_csv}")
+        return out_csv.resolve()
+    else:
+        df.to_csv(out_txt, sep="\t", index=False)
+        print(f"[OK] featureCounts output → {out_txt}")
+        return out_txt.resolve()

--- a/omicverse/bulk/data_prepare_pipline.py
+++ b/omicverse/bulk/data_prepare_pipline.py
@@ -1,0 +1,239 @@
+# pipeline.py
+from __future__ import annotations
+from pathlib import Path
+from typing import Iterable, Union
+import pandas as pd
+from .sra_prefetch import make_prefetch_step, run_prefetch_with_progress, _make_local_logger
+from .sra_fasterq import make_fasterq_step
+from .qc_fastp import make_fastp_step
+from .star_step import make_star_step
+from .count_step import make_featurecounts_step
+import .tools_check
+import os
+
+# 1) 声明式组合步骤（可根据项目需求自由调整参数）
+tools_check.check()
+STEPS = [
+    make_prefetch_step(),
+    make_fasterq_step(outdir_pattern="work/fasterq", threads_per_job=12, compress_after=True),
+    make_fastp_step(out_root="work/fastp", threads_per_job=12),
+    make_star_step(index_root="index", out_root="work/star", threads=12, gencode_release="v44", sjdb_overhang=149),  
+    make_featurecounts_step(out_root="work/counts", simple=True, gtf=None, by="auto", threads=8)
+]
+
+def _render_paths(patterns, **kwargs):
+    return [p.format(**kwargs) for p in patterns]
+def _safe_call_validation(validation_fn, outs, logger):
+    try:
+        return bool(validation_fn(outs))
+    except FileNotFoundError:
+        # ✅ 即使验证函数内部有人误写了 getsize 也不至于炸
+        logger.warning(f"[VALIDATION] missing file(s): {outs}")
+        return False
+    except Exception as e:
+        logger.warning(f"[VALIDATION] raised {type(e).__name__}: {e} | outs={outs}")
+        return False
+def _normalize_srr_list(
+    srrs_or_csv: Union[str, Path, Iterable[str], pd.DataFrame]
+) -> List[str]:
+    """
+    接受：SRR 列表 / CSV 路径 / DataFrame
+    - CSV 会优先尝试 'Run' 列（不区分大小写），其次 'run_accession'
+    - 自动去重但保持原始顺序
+    """
+    if isinstance(srrs_or_csv, (str, Path)):
+        csv_path = Path(srrs_or_csv)
+        if not csv_path.exists():
+            raise FileNotFoundError(f"CSV not found: {csv_path}")
+        df = pd.read_csv(csv_path)
+    elif isinstance(srrs_or_csv, pd.DataFrame):
+        df = srrs_or_csv
+    else:
+        # 可迭代对象（list/tuple/set/generator）
+        seq = list(srrs_or_csv)
+        # 去重保序
+        return list(dict.fromkeys(str(x).strip() for x in seq if str(x).strip()))
+
+    # 针对 DataFrame：找列
+    cols_lower = {c.lower(): c for c in df.columns}
+    col = None
+    for cand in ("run", "run_accession"):
+        if cand in cols_lower:
+            col = cols_lower[cand]
+            break
+    if col is None:
+        raise ValueError(
+            f"CSV must contain a 'Run' (or 'run_accession') column. Got columns: {list(df.columns)}"
+        )
+
+    values = [str(x).strip() for x in df[col].tolist()]
+    # 去重保序
+    return list(dict.fromkeys(v for v in values if v))
+    
+def run_pipeline(srr_list_or_csv):
+    # NEW: 兼容 CSV / DataFrame / 列表
+    srr_list = _normalize_srr_list(srr_list_or_csv)
+    if not srr_list:
+        raise ValueError("未解析到任何 SRR 编号。")
+    logger = _make_local_logger("PIPE")
+    # 数据在步骤之间的“携带形式”
+    fastq_paths = []       # [(srr, fq1, fq2)]
+    clean_fastqs = []      # [(srr, clean1, clean2)]
+    bam_paths = []         # [(srr, bam)]
+    count_tables = []      # 可选
+
+    # Step 0: prefetch（逐个 SRR）
+    #logger.info(f"[RUN] prefetch {srr_id} -> {output_path}")
+    prefetch_step = STEPS[0]
+
+    for srr in srr_list:
+        outs = _render_paths(prefetch_step["outputs"], SRR=srr)
+        # 使用安全验证
+        if _safe_call_validation(prefetch_step["validation"], outs, logger):
+            logger.info(f"[SKIP] prefetch {srr}")
+        else:
+            ok = prefetch_step["command"](srr, logger=logger)
+            if not ok:
+                logger.error(f"[FAIL] prefetch {srr}")
+                return False
+
+    # Step 1: fasterq（批处理）
+    fasterq_step = STEPS[1]
+    outs_by_srr = []
+    for srr in srr_list:
+        outs = _render_paths(fasterq_step["outputs"], SRR=srr)
+        outs_by_srr.append((srr, outs))
+    # 如果全部存在就跳过
+    if all(fasterq_step["validation"](outs) for _, outs in outs_by_srr):
+        logger.info("[SKIP] fasterq for all")
+        fastq_paths = [(srr, outs[0], outs[1]) for srr, outs in outs_by_srr]
+    else:
+        ret = fasterq_step["command"]([s for s,_ in outs_by_srr], logger=logger)
+        # 规范化到 [(srr, fq1, fq2)]：你可以从 ret["success"] 解构；这里简单按模板返回
+        fastq_paths = [(srr, outs[0], outs[1]) for srr, outs in outs_by_srr]
+
+    # Step 2: fastp（批处理）
+    fastp_step = STEPS[2]
+    outs_by_srr = []
+    for srr, fq1, fq2 in fastq_paths:
+        outs = _render_paths(fastp_step["outputs"], SRR=srr)
+        outs_by_srr.append((srr, fq1, fq2, outs))
+    if all(fastp_step["validation"](o) for *_, o in outs_by_srr):
+        logger.info("[SKIP] fastp for all")
+        clean_fastqs = [(srr, o[0], o[1]) for srr, _, _, o in outs_by_srr]
+    else:
+        ret = fastp_step["command"]([(srr, fq1, fq2) for srr, fq1, fq2, _ in outs_by_srr], logger=logger)
+        clean_fastqs = [(srr, o[0], o[1]) for srr, _, _, o in outs_by_srr]
+
+    # Step 3: STAR（逐样本/可并行，这里串行示例，便于日志清晰）
+    star_step = STEPS[3]
+    outs_by_srr = []
+    for srr, c1, c2 in clean_fastqs:
+        outs = _render_paths(star_step["outputs"], SRR=srr)
+        outs_by_srr.append((srr, c1, c2, outs))
+    
+    bam_paths = []  # 形如 [(srr, bam, idx_dir)]
+    for srr, c1, c2, outs in outs_by_srr:
+        if star_step["validation"](outs):
+            logger.info(f"[SKIP] STAR {srr}")
+            # 如果 validation 为真，说明 outs[0] 的 bam 已存在，但此时我们拿不到 index_dir。
+            # 最稳妥：把 index_dir 设为 None，后面统一再推断一次（见 Step 4 前的逻辑）。
+            bam_paths.append((srr, outs[0], None))  # NEW
+        else:
+            prods = star_step["command"]([(srr, c1, c2)], logger=logger)
+            # 要求 star_step["command"] 返回 [(srr, bam_path, index_dir)] 结构  ← NEW（见说明）
+            bam_paths.extend(prods)
+
+    # 统一规范为三元组 (srr, bam, index_dir|None)  —— 关键修补
+    _norm_bams = []
+    for rec in bam_paths:
+        if isinstance(rec, (list, tuple)):
+            if len(rec) == 3:
+                _norm_bams.append((rec[0], rec[1], rec[2]))
+            elif len(rec) == 2:
+                srr, bam = rec
+                _norm_bams.append((srr, bam, None))
+            else:
+                raise ValueError(f"Unexpected bam_paths record (len={len(rec)}): {rec}")
+        else:
+            raise ValueError(f"Unexpected bam_paths record type: {type(rec)} -> {rec}")
+    bam_paths = _norm_bams  # 现在结构统一了
+    
+    # --- NEW: 在进入 featureCounts 前，统一用任意一个非 None 的 index_dir 推断 GTF ---
+    def _find_gtf_from_index(index_dir: str | os.PathLike) -> str:
+        """
+        给 STAR 的 index_dir（通常是 .../index/<species>/<build>/STAR），
+        尝试在该结构的“缓存区/父目录”中找解压过的 .gtf。
+        规则：
+          1) 同目录或上级目录的 *.gtf
+          2) 上上级目录下的 _cache/**.gtf
+        """
+        from pathlib import Path
+        idx = Path(index_dir)
+        if not idx:
+            return None
+    
+        # 1) 本目录或父目录搜 *.gtf
+        for base in {idx, idx.parent}:
+            for p in base.glob("*.gtf"):
+                return str(p.resolve())
+    
+        # 2) 两级父目录下的 _cache 搜索（兼容 ensure_star_index 的下载布局）
+        for base in {idx.parent, idx.parent.parent}:
+            cache = base / "_cache"
+            if cache.exists():
+                hits = list(cache.rglob("*.gtf"))
+                if hits:
+                    return str(hits[0].resolve())
+    
+        # 兜底：再向上一层搜一圈 *.gtf
+        for p in idx.parent.parent.glob("*.gtf"):
+            return str(p.resolve())
+    
+        return None
+    
+    # 选一个 index_dir 推断 GTF
+    inferred_gtf = None
+    for _, __, idx_dir in bam_paths:
+        if idx_dir:
+            inferred_gtf = _find_gtf_from_index(idx_dir)
+            if inferred_gtf:
+                break
+    
+    if not inferred_gtf:
+        # 如果 STAR 是 “全部都走了 [SKIP]”，上面 idx_dir 可能全是 None。
+        # 这时可以从约定位置再试一次（你可以按自己的布局改这段兜底逻辑）。
+        # 例如：index/human/GRCh38/STAR 的上上级 _cache 里通常有 gtf
+        candidate = Path("index")
+        if candidate.exists():
+            for p in candidate.rglob("*.gtf"):
+                inferred_gtf = str(p.resolve())
+                break
+    
+    if not inferred_gtf:
+        logger.error("[featureCounts] 无法自动找到 GTF，请确认 ensure_star_index 已下载并解压注释文件。")
+        # 在这里 return 或抛异常都可以；为了和你现有逻辑匹配，这里抛异常：
+        raise RuntimeError("GTF not found. Please check STAR index/annotation preparation.")
+    
+    # Step 4: featureCounts（批处理）
+    fc_step = STEPS[4]
+    outs_by_srr = []
+    for srr, bam, _idx in bam_paths:  # 注意现在的 bam_paths 有 3 元组
+        outs = _render_paths(fc_step["outputs"], SRR=srr)
+        outs_by_srr.append((srr, bam, outs))
+    
+    if all(fc_step["validation"](o) for _, _, o in outs_by_srr):
+        logger.info("[SKIP] featureCounts for all")
+        count_tables = [o[0] for _, _, o in outs_by_srr]
+    else:
+        # 显式把 gtf 传给 featureCounts 的命令函数  ← NEW
+        ret = fc_step["command"]([(srr, bam) for srr, bam, _ in outs_by_srr],
+                                 logger=logger,
+                                 gtf=inferred_gtf)
+        count_tables = [o[0] for _, _, o in outs_by_srr]
+'''
+How to use
+import data_prepare_pipline
+srrs = ["SRR12544419", "SRR12544565", "SRR12544566"]
+data_prepare_pipline.run_pipeline(srrs)
+'''

--- a/omicverse/bulk/entrez_direct.py
+++ b/omicverse/bulk/entrez_direct.py
@@ -1,0 +1,158 @@
+import os, json, csv, time, shutil, subprocess
+from pathlib import Path
+from typing import Optional, List
+import pandas as pd
+
+# -------------------- EDirect helpers --------------------
+class RunInfoError(RuntimeError): ...
+def _which(cmd: str) -> Optional[str]:
+    """寻找 edirect 工具；优先 PATH，再看 ~/edirect/"""
+    p = shutil.which(cmd)
+    if p: return p
+    home = os.path.expanduser("~")
+    cand = os.path.join(home, "edirect", cmd)
+    return cand if os.path.exists(cand) else None
+
+def _run_edirect(term: str, timeout: int = 240) -> str:
+    """调用 esearch|efetch 返回 runinfo CSV 文本；失败抛异常"""
+    esearch = _which("esearch"); efetch = _which("efetch")
+    if not esearch or not efetch:
+        raise RunInfoError("Entrez Direct not found (esearch/efetch). Add $HOME/edirect to PATH.")
+    # 用 bash -lc 支持管道；对 term 加引号
+    cmd = f'''{esearch} -db sra -query "{term}" | {efetch} -format runinfo'''
+    proc = subprocess.run(["bash", "-lc", cmd], capture_output=True, text=True, timeout=timeout)
+    if proc.returncode != 0:
+        err = (proc.stderr or proc.stdout)[:400]
+        raise RunInfoError(f"EDirect failed for {term}: {err}")
+    return proc.stdout
+
+def _ok_csv(text: str) -> bool:
+    """必须至少两行且包含 Run 列"""
+    lines = [ln for ln in text.splitlines() if ln.strip()]
+    if len(lines) < 2: return False
+    header = next(csv.reader([lines[0]]))
+    return any(h.strip().lower() == "run" for h in header)
+
+# -------------------- JSON meta 解析 --------------------
+def _load_meta(accession: str, meta_dir: str | Path = "meta") -> dict:
+    p = Path(meta_dir) / f"{accession}_meta.json"
+    if not p.exists():
+        raise FileNotFoundError(f"Meta JSON not found: {p}. Generate it first with geo_accession_to_meta_json().")
+    return json.loads(p.read_text(encoding="utf-8"))
+
+def _candidates_from_meta(meta: dict) -> List[str]:
+    """
+    优先返回 PRJNA 列表（BioProject_all），无则返回 SRP 列表（SRAnum_all）。
+    若两者都没有，尝试 extracted 的单值字段。
+    """
+    ex = meta.get("extracted", {})
+    prjna_all = ex.get("BioProject_all") or []
+    srp_all   = ex.get("SRAnum_all") or []
+    # 兼容只有单值的情况
+    if ex.get("BioProject") and ex["BioProject"] not in prjna_all:
+        prjna_all = [ex["BioProject"]] + prjna_all
+    if ex.get("SRAnum") and ex["SRAnum"] not in srp_all:
+        srp_all = [ex["SRAnum"]] + srp_all
+    # 去重保序
+    seen, out = set(), []
+    for x in prjna_all + srp_all:
+        u = x.upper()
+        if u not in seen:
+            seen.add(u); out.append(u)
+    return out
+
+# -------------------- 主流程：GSE→读取 JSON→PRJNA/SRP→runinfo.csv --------------------
+def gse_meta_to_runinfo_csv(
+    accession: str,
+    meta_dir: str | Path = "meta",
+    out_dir: str | Path = "meta",
+    retries: int = 3,
+    backoff: float = 2.0,
+    organism_filter: Optional[str] = None,  # e.g., "Homo sapiens"
+    layout_filter: Optional[str] = None,    # "PAIRED" / "SINGLE"
+) -> dict:
+    """
+    读取 {meta_dir}/{GSE}_meta.json，提取 PRJNA（无则 SRP）依次尝试：
+      esearch -db sra -query <TERM> | efetch -format runinfo
+    成功后保存 {out_dir}/{GSE}_runinfo.csv，并返回信息字典。
+    """
+    gse = accession.strip().upper()
+    meta = _load_meta(gse, meta_dir=meta_dir)
+    terms = _candidates_from_meta(meta)
+    if not terms:
+        return {"available": False, "csv": None, "term_used": None, "rows": 0,
+                "error": "No PRJNA/SRP found in meta JSON"}
+
+    out_dir = Path(out_dir); out_dir.mkdir(parents=True, exist_ok=True)
+    out_csv = out_dir / f"{gse}_runinfo.csv"
+
+     # -------- 新增部分：如果文件已存在则跳过 --------
+    if out_csv.exists():
+        df = pd.read_csv(out_csv)
+        return {
+            "available": True,
+            "csv": str(out_csv.resolve()),
+            "term_used": "SKIPPED (already exists)",
+            "rows": int(len(df))
+        }
+    # ------------------------------------------------
+
+    last_err = None
+    for term in terms:
+        # 网络波动/限流重试
+        for attempt in range(1, retries + 1):
+            try:
+                text = _run_edirect(term)
+                if not _ok_csv(text):
+                    raise RunInfoError(f"Empty/malformed CSV for {term} (no Run column).")
+                df = pd.read_csv(pd.io.common.StringIO(text))
+                if df.empty:
+                    raise RunInfoError(f"No rows for {term}.")
+
+                # 可选过滤：物种 + 文库布局
+                if organism_filter:
+                    org_cols = [c for c in df.columns if c.lower() in ("scientificname", "organism")]
+                    if org_cols:
+                        mask = False
+                        for c in org_cols:
+                            mask = mask | df[c].astype(str).str.contains(organism_filter, case=False, na=False)
+                        df = df[mask]
+                if layout_filter and "LibraryLayout" in df.columns:
+                    df = df[df["LibraryLayout"].astype(str).str.upper() == layout_filter.upper()]
+
+                if df.empty:
+                    raise RunInfoError(f"Rows removed by filters for {term}.")
+
+                # 保存
+                df.to_csv(out_csv, index=False)
+                return {
+                    "available": True,
+                    "csv": str(out_csv.resolve()),
+                    "term_used": term,
+                    "rows": int(len(df))
+                }
+            except Exception as e:
+                last_err = e
+                if attempt < retries:
+                    time.sleep(backoff * attempt)
+        # 换下一个 term（例如多个 PRJNA 或回退 SRP）
+
+    return {"available": False, "csv": None, "term_used": None, "rows": 0,
+            "error": repr(last_err) if last_err else "Unknown error"}
+
+'''
+How to use
+
+# 假设你已用 geo_accession_to_meta_json("GSE157103", out_dir="meta") 生成了 meta/GSE157103_meta.json
+
+info = gse_meta_to_runinfo_csv(
+    "GSE157103",
+    meta_dir="meta",
+    out_dir="sra_meta",
+    organism_filter=None,   # 或 "Homo sapiens"
+    layout_filter=None      # 或 "PAIRED" / "SINGLE"
+)
+print(info)
+# -> {'available': True, 'csv': '/.../sra_meta/GSE157103_runinfo.csv',
+#     'term_used': 'PRJNA660067', 'rows':  ...}
+'''

--- a/omicverse/bulk/geo_meta_fetcher.py
+++ b/omicverse/bulk/geo_meta_fetcher.py
@@ -1,0 +1,167 @@
+import re
+import json
+from pathlib import Path
+from typing import Dict, List, Any, Tuple
+import requests
+
+HEADERS = {"User-Agent": "Mozilla/5.0 (Python GEO-to-SRA fetcher)"}
+
+# ---------- 1) 抓取 GEO SOFT 文本 ----------
+def fetch_geo_text(accession: str, timeout: int = 120) -> str:
+    """
+    读取 GEO Series/GSM 的 SOFT 文本视图（包含最完整的 Series_* 字段）
+    e.g. https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE157103&form=text&view=full
+    """
+    url = f"https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc={accession}&form=text&view=full"
+    r = requests.get(url, headers=HEADERS, timeout=timeout)
+    r.raise_for_status()
+    return r.text
+
+# ---------- 2) 解析为结构化数据 ----------
+PRJNA_RE = re.compile(r"\bPRJNA\d+\b", re.I)
+SRP_RE   = re.compile(r"\bSRP\d+\b", re.I)
+GSM_RE   = re.compile(r"\bGSM\d+\b", re.I)
+
+def _append(d: Dict[str, Any], key: str, val: str):
+    """将重复键（如 Series_sample_id）收集为 list。"""
+    if key not in d:
+        d[key] = val
+    else:
+        if not isinstance(d[key], list):
+            d[key] = [d[key]]
+        d[key].append(val)
+
+def parse_geo_soft_to_struct(text: str) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    """
+    解析 SOFT 文本中所有以 '!Series_' 开头的键值，并抽取关键信息。
+    返回 (series_all, extracted)
+    - series_all: 所有 !Series_* 的完整键值（重复键变 list）
+    - extracted: 你关心的字段，规范化后的汇总
+    """
+    series_all: Dict[str, Any] = {}
+
+    # 逐行解析 Series_* 的键值（如：!Series_platform_id = GPLxxxx）
+    for ln in text.splitlines():
+        if ln.startswith("!Series_"):
+            # 例：!Series_sample_id = GSM123456
+            parts = ln.split("=", 1)
+            if len(parts) == 2:
+                key = parts[0].lstrip("!").strip()   # 'Series_sample_id'
+                val = parts[1].strip()
+                _append(series_all, key, val)
+
+    # 从 Series_relation 与全文中提取 PRJNA / SRP
+    relations = series_all.get("Series_relation", [])
+    if isinstance(relations, str):
+        relations = [relations]
+
+    prjna_candidates: List[str] = []
+    srp_candidates: List[str] = []
+
+    # 1) 从 relation 行里抓
+    for item in relations:
+        prjna_candidates += PRJNA_RE.findall(item)
+        srp_candidates   += SRP_RE.findall(item)
+
+    # 2) 全文兜底再抓一遍
+    if not prjna_candidates:
+        prjna_candidates += PRJNA_RE.findall(text)
+    if not srp_candidates:
+        srp_candidates   += SRP_RE.findall(text)
+
+    # 去重、规范大写
+    def _uniq_upper(xs): 
+        seen, out = set(), []
+        for x in xs:
+            x = x.upper()
+            if x not in seen:
+                seen.add(x); out.append(x)
+        return out
+
+    prjna_list = _uniq_upper(prjna_candidates)
+    srp_list   = _uniq_upper(srp_candidates)
+
+    # Series 号
+    geo_acc = None
+    for ln in text.splitlines():
+        if ln.startswith("!Series_geo_accession"):
+            # !Series_geo_accession = GSE157103
+            geo_acc = ln.split("=", 1)[1].strip()
+            break
+
+    # 所有样本 GSM（有些 Series 不在 !Series_sample_id 列出，也兜底从全文扫描）
+    sample_ids: List[str] = []
+    ssid = series_all.get("Series_sample_id", [])
+    if isinstance(ssid, str):
+        ssid = [ssid]
+    sample_ids += ssid
+    sample_ids += GSM_RE.findall(text)
+    sample_ids = _uniq_upper(sample_ids)
+
+    # 物种与 taxid（Series 级汇总）
+    # 允许重复、可能多物种；规范为不重复的列表
+    organism_vals = series_all.get("Series_sample_organism", [])
+    if isinstance(organism_vals, str):
+        organism_vals = [organism_vals]
+    organism_vals = [v.strip() for v in organism_vals]
+
+    taxid_vals = series_all.get("Series_sample_taxid", [])
+    if isinstance(taxid_vals, str):
+        taxid_vals = [taxid_vals]
+    taxid_vals = [v.strip() for v in taxid_vals]
+
+    # 组装 extracted
+    extracted = {
+        "geo_acc": geo_acc,
+        "BioProject": prjna_list[0] if prjna_list else None,
+        "BioProject_all": prjna_list or [],
+        "SRAnum": srp_list[0] if srp_list else None,
+        "SRAnum_all": srp_list or [],
+        "sample_ids": sample_ids,
+        "sample_organism": sorted(list({x for x in organism_vals if x})),
+        "sample_taxid": sorted(list({x for x in taxid_vals if x})),
+    }
+
+    return series_all, extracted
+
+# ---------- 3) 一键函数：从 GSE 拉取并写 JSON ----------
+def geo_accession_to_meta_json(accession: str, out_dir: str | Path = ".") -> Path:
+    """
+    给 GSE/GSM accession，拉取 SOFT 文本，解析出：
+      - geo_acc、BioProject(PRJNA)、SRAnum(SRP)
+      - sample_ids（列表）
+      - sample_organism（去重列表）
+      - sample_taxid（去重列表）
+    同时把所有 !Series_* 键值以字典形式完整保存。
+    输出：{accession}_meta.json
+    """
+    out_path = Path(out_dir) / f"{accession}_meta.json"
+    if out_path.exists():
+        print("SKIPPED (already exists)")
+        return out_path
+    else:
+        text = fetch_geo_text(accession)
+        series_all, extracted = parse_geo_soft_to_struct(text)
+    
+        payload = {
+            "accession": accession,
+            "extracted": extracted,
+            "series_all": series_all  # 保留“所有信息”的结构化版本（重复键已合并为 list）
+        }
+    
+        out_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+        return out_path
+
+'''
+How to use
+# 1) 直接生成 meta JSON（包含完整 !Series_* 字段与提取的关键字段）
+p = geo_accession_to_meta_json("GSE157103", out_dir="meta")
+print("Saved:", p)
+
+# 2) 读取并取出 PRJNA / SRP，用于后续 EDirect:
+import json
+d = json.loads(Path(p).read_text(encoding="utf-8"))
+prjna = d["extracted"]["BioProject"] or (d["extracted"]["BioProject_all"][0] if d["extracted"]["BioProject_all"] else None)
+srp   = d["extracted"]["SRA"] or (d["extracted"]["SRAnum_all"][0] if d["extracted"]["SRAnum_all"] else None)
+print("PRJNA:", prjna, " SRP:", srp)
+'''

--- a/omicverse/bulk/qc_fastp.py
+++ b/omicverse/bulk/qc_fastp.py
@@ -1,0 +1,175 @@
+# qc_fastp.py fastp 步骤工厂
+from __future__ import annotations
+
+try:
+    from .qc_tools import fastp_clean_parallel
+except ImportError:
+    from qc_tools import fastp_clean_parallel
+
+import os, subprocess
+from pathlib import Path
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import Sequence, Tuple, List, Dict
+
+try:
+    from .tools_check import which_or_find, merged_env
+except ImportError:
+    from tools_check import which_or_find, merged_env
+
+
+def _run(cmd: list[str], env: dict | None = None):
+    print(">>", " ".join(cmd), flush=True)
+    subprocess.run(cmd, check=True, env=env)
+
+
+def _ensure_dir(p: Path) -> Path:
+    p.mkdir(parents=True, exist_ok=True)
+    return p
+
+
+def _ext(p: Path) -> str:
+    # 保持与输入一致：输入是 .gz 则输出也 .gz
+    return ".fastq.gz" if p.suffix == ".gz" or p.name.endswith(".fastq.gz") else ".fastq"
+
+def _fastp_one(
+    srr: str,
+    fq1: Path,
+    fq2: Path,
+    out_root: Path,
+    threads: int = 8,
+) -> Tuple[str, Path, Path, Path, Path]:
+    """
+    跑一个样本的 fastp（paired-end）。
+    返回：(srr, clean1, clean2, json, html)
+    """
+    env = merged_env()
+    fastp_bin = which_or_find("fastp")  # 解析可执行路径
+    out_dir = _ensure_dir(out_root / srr)
+
+    # 输出文件名（与输入后缀保持一致）
+    oext = _ext(fq1)
+    clean1 = out_dir / f"{srr}_clean_1{oext.replace('.fastq', '')}"
+    clean2 = out_dir / f"{srr}_clean_2{oext.replace('.fastq', '')}"
+    json = out_dir / f"{srr}.fastp.json"
+    html = out_dir / f"{srr}.fastp.html"
+
+    # 已存在就跳过（可按需改成强制覆盖）
+    if clean1.exists() and clean2.exists() and json.exists() and html.exists():
+        return srr, clean1, clean2, json, html
+
+    cmd = [
+        fastp_bin,
+        "-i", str(fq1),
+        "-I", str(fq2),
+        "-o", str(clean1),
+        "-O", str(clean2),
+        "-w", str(threads),
+        "-j", str(json),
+        "-h", str(html),
+        "--detect_adapter_for_pe",
+        "--thread", str(threads),   # 一些版本也接受 --thread
+        "--overrepresentation_analysis",
+    ]
+
+    # 如果输出是 .gz，fastp 会自动压缩（由后缀决定），不必额外 gzip
+    # 可选：加更严格过滤参数（示例）——按需启用：
+    # cmd += ["-q", "20", "-u", "30", "-l", "30"]  # 质量阈值/不合格比例/最短长度
+
+    _run(cmd, env=env)
+
+    # 简单校验
+    if not (clean1.exists() and clean1.stat().st_size > 0 and clean2.exists() and clean2.stat().st_size > 0):
+        raise RuntimeError(f"fastp outputs missing/empty for {srr} in {out_dir}")
+
+    return srr, clean1, clean2, json, html
+
+
+def fastp_batch(
+    pairs: Sequence[Tuple[str, Path, Path]],  # [(srr, fq1, fq2), ...]
+    out_root: str | Path,
+    threads: int = 12,          # 每个样本 fastp 工作线程
+    max_workers: int | None = None,  # 同时处理的样本数；None=和 threads 一样或自动
+) -> List[Tuple[str, Path, Path, Path, Path]]:
+    """
+    并发跑 fastp。
+    返回：[(srr, clean1, clean2, json, html), ...]（按输入顺序）
+    """
+    out_root = Path(out_root)
+    out_root.mkdir(parents=True, exist_ok=True)
+
+    if max_workers is None:
+        # 默认同时处理的样本数 = min(线程数, 核心数/2)（你也可以换成固定值）
+        import os, math
+        max_workers = max(1, min(threads, (os.cpu_count() or 8) // 2))
+
+    results: Dict[str, Tuple[str, Path, Path, Path, Path]] = {}
+    errors: List[Tuple[str, str]] = []
+
+    def _worker(item: Tuple[str, Path, Path]):
+        srr, fq1, fq2 = item
+        return _fastp_one(srr, Path(fq1), Path(fq2), out_root=out_root, threads=threads)
+
+    with ThreadPoolExecutor(max_workers=int(max_workers)) as ex:
+        futs = {ex.submit(_worker, it): it[0] for it in pairs}
+        for fut in as_completed(futs):
+            srr = futs[fut]
+            try:
+                ret = fut.result()
+                results[srr] = ret
+            except Exception as e:
+                errors.append((srr, str(e)))
+
+    if errors:
+        msg = "; ".join([f"{s}:{m}" for s, m in errors])
+        raise RuntimeError(f"fastp_batch failed for {len(errors)} samples: {msg}")
+
+    # 按输入顺序组织
+    order = {s: i for i, (s, _, _) in enumerate(pairs)}
+    out = [results[s] for s, _, _ in sorted(pairs, key=lambda x: order[x[0]])]
+    return out
+
+def make_fastp_step(
+    out_root: str = "work/fastp",
+    threads_per_job: int = 12,
+    max_workers: int | None = None,
+    backend: str = "process",
+):
+    """
+    输入：FASTQ 列表（[(srr, fq1, fq2), ...]）
+    输出：work/fastp/{SRR}_1.clean.fq.gz, {SRR}_2.clean.fq.gz
+    验证：清洗后的 fq 均存在且 size > 0
+    """
+    def _cmd(fastq_triplets: Sequence[tuple[str, str, str]], logger=None):
+        # 三元组模式直接传给 fastp_clean_parallel
+        # outdir 在三元组模式下不会被使用，但函数签名需要，给个合理值即可
+        os.makedirs(out_root, exist_ok=True)
+
+        # 取第一个样本的 fq1 所在目录作为占位 outdir；若列表为空或路径异常，则用 "."
+        if fastq_triplets:
+            first_fq1_dir = os.path.dirname(fastq_triplets[0][1]) or "."
+        else:
+            first_fq1_dir = "."
+
+        # 关键点：让 fastp_clean 的输出落在 {work_dir}/fastp/ 之下，
+        # 而 out_root = "{work_dir}/fastp"。因此取 work_dir = dirname(out_root)
+        work_dir = os.path.dirname(out_root) or "."
+
+        return fastp_clean_parallel(
+            samples=list(fastq_triplets),           # 三元组模式 [(srr, fq1, fq2), ...]
+            outdir=first_fq1_dir,                   # 三元组模式会忽略此参数
+            work_dir=work_dir,                      # 确保输出到 {work_dir}/fastp = out_root
+            fastp_threads=threads_per_job,
+            max_workers=max_workers,
+            retries=2,
+            backend=backend
+        )
+
+    return {
+        "name": "fastp",
+        "command": _cmd,  # 接收 [(srr, fq1, fq2), ...]
+        "outputs": [f"{out_root}" + "/{SRR}_1.clean.fq.gz",
+                    f"{out_root}" + "/{SRR}_2.clean.fq.gz"],
+        "validation": lambda fs: all(os.path.exists(f) and os.path.getsize(f) > 0 for f in fs),
+        "takes": "FASTQ_PATHS",
+        "yields": "CLEAN_FASTQ_PATHS"
+    }

--- a/omicverse/bulk/qc_tools.py
+++ b/omicverse/bulk/qc_tools.py
@@ -1,0 +1,132 @@
+# QCtools Fastp
+
+import os, sys, shutil, subprocess
+from pathlib import Path
+from typing import Tuple, Optional, List, Union
+from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor, as_completed
+from math import floor
+
+# --- 你已有的单样本清洗函数，保持不变（示意） ---
+def fastp_clean(fq1: str, fq2: Optional[str], sample: str, work_dir: str, threads: int = 4) -> Tuple[str, str]:
+    """
+    读取 fq1,fq2，输出到 {work_dir}/fastp/{sample}_1.clean.fq.gz / _2.clean.fq.gz
+    若已存在则跳过，返回输出路径。
+    """
+    outdir = Path(work_dir) / "fastp"
+    outdir.mkdir(parents=True, exist_ok=True)
+    out1 = outdir / f"{sample}_1.clean.fq.gz"
+    out2 = outdir / f"{sample}_2.clean.fq.gz"
+
+    if out1.exists() and out2.exists():
+        return str(out1), str(out2)
+
+    cmd = [
+        "fastp",
+        "-i", fq1,
+        "-I", fq2 if fq2 else fq1.replace("_1.fastq", "_2.fastq"),
+        "-o", str(out1),
+        "-O", str(out2),
+        "-w", str(threads),
+        "-j", str(outdir / f"{sample}.json"),
+        "-h", str(outdir / f"{sample}.html"),
+    ]
+    print(">>", " ".join(cmd))
+    subprocess.run(cmd, check=True)
+    return str(out1), str(out2)
+
+# ---------- 新增：顶层子任务执行器（可被进程池 pickling） ----------
+def _fastp_run_one_triplet(srr: str, fq1: str, fq2: Optional[str], work_dir: str, fastp_threads: int, retries: int):
+    """
+    三元组模式：直接用传入的 fq1/fq2。
+    返回：(sample, out1, out2, status)  status in {"OK","SKIP"}
+    """
+    outdir = Path(work_dir) / "fastp"
+    out1 = outdir / f"{srr}_1.clean.fq.gz"
+    out2 = outdir / f"{srr}_2.clean.fq.gz"
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    # 已存在直接跳过
+    if out1.exists() and out2.exists():
+        return (srr, str(out1), str(out2), "SKIP")
+
+    last_err = None
+    for _ in range(max(1, retries)):
+        try:
+            c1, c2 = fastp_clean(fq1, fq2, srr, work_dir, threads=fastp_threads)
+            return (srr, c1, c2, "OK")
+        except Exception as e:
+            last_err = e
+    raise last_err
+
+def _fastp_run_one_from_outdir(srr: str, outdir: str, work_dir: str, fastp_threads: int, retries: int):
+    """
+    SRR 列表模式：从 outdir/{SRR}_1.fastq / _2.fastq 推断输入。
+    """
+    fq1 = str(Path(outdir) / f"{srr}_1.fastq")
+    fq2 = str(Path(outdir) / f"{srr}_2.fastq")
+    return _fastp_run_one_triplet(srr, fq1, fq2, work_dir, fastp_threads, retries)
+
+# ---------- 这里是你的并行 API：最小改动以兼容两种输入 ----------
+def fastp_clean_parallel(
+    samples: List[Union[str, Tuple[str, str, Optional[str]]]],
+    outdir: str,
+    work_dir: str,
+    fastp_threads: int = 4,
+    max_workers: Optional[int] = None,
+    retries: int = 2,
+    backend: str = "process",
+):
+    """
+    并行批量运行 fastp_clean。
+    - 输入可为：
+        1) SRR 列表：["SRRxxxx", ...]  将从 outdir/{SRR}_1.fastq/_2.fastq 读取
+        2) 三元组列表：[ (srr, fq1, fq2), ... ]  直接使用指定的 FASTQ 路径
+    - 输出：{"success": [(srr, out1, out2, status), ...], "failed": [(srr, err), ...]}
+    """
+    total_cores = os.cpu_count() or 8
+    if max_workers is None:
+        max_workers = max(1, floor(total_cores / max(1, fastp_threads)))
+
+    print(f"[INFO] CPU cores={total_cores}, per fastp threads={fastp_threads}, max parallel={max_workers}")
+    print(f"[INFO] fastp path: {shutil.which('fastp')}")
+    print(f"[INFO] Python exec: {sys.executable}")
+
+    # 判定输入模式
+    def is_triplet(x):
+        return isinstance(x, (tuple, list)) and (2 <= len(x) <= 3)
+
+    use_triplets = len(samples) > 0 and is_triplet(samples[0])
+
+    Executor = ProcessPoolExecutor if backend == "process" else ThreadPoolExecutor
+    results, errors = [], []
+
+    with Executor(max_workers=max_workers) as ex:
+        if use_triplets:
+            # items: List[(srr, fq1, fq2)]
+            futs = {
+                ex.submit(_fastp_run_one_triplet, srr, fq1, (fq2 if len(item) > 2 else None),
+                          work_dir, fastp_threads, retries): srr
+                for item in samples
+                for srr, fq1, fq2 in [item if len(item) == 3 else (item[0], item[1], None)]
+            }
+        else:
+            # items: List[str]  (SRR)
+            futs = {
+                ex.submit(_fastp_run_one_from_outdir, srr, outdir, work_dir, fastp_threads, retries): srr
+                for srr in samples
+            }
+
+        for fut in as_completed(futs):
+            s = futs[fut]
+            try:
+                sample, out1, out2, status = fut.result()
+                results.append((sample, out1, out2, status))
+                print(f"[{status}] {sample} -> {out1}, {out2}")
+            except Exception as e:
+                errors.append((s, str(e)))
+                print(f"[ERR] {s}: {e}")
+
+    ok_n = sum(1 for r in results if r[3] == "OK")
+    skip_n = sum(1 for r in results if r[3] == "SKIP")
+    print(f"[SUMMARY] Completed={ok_n}, Skipped={skip_n}, Failed={len(errors)}")
+    return {"success": results, "failed": errors}

--- a/omicverse/bulk/sra_fasterq.py
+++ b/omicverse/bulk/sra_fasterq.py
@@ -1,0 +1,434 @@
+# sra_fasterq.py
+from __future__ import annotations
+import os, sys, shutil, time, subprocess,math
+from pathlib import Path
+from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor, as_completed
+from typing import Sequence, Tuple, List, Dict
+
+try:
+    from .tools_check import which_or_find, merged_env
+except ImportError:
+    from tools_check import which_or_find, merged_env
+    
+def _fqdump_one(srr: str, outdir: str, fqdump_bin: str, threads: int, mem_gb: int, do_gzip: bool):
+    os.makedirs(outdir, exist_ok=True)
+    env = merged_env()
+    # fasterq-dump 输出 .fastq（未压缩）
+    cmd = [
+        fqdump_bin, srr, "-p", "-O", outdir,
+        "-e", str(threads), "--mem", f"{mem_gb}G", "--split-files"
+    ]
+    print(">>", " ".join(cmd))
+    subprocess.run(cmd, check=True, env=env)
+
+    # 产物探测
+    fq1 = os.path.join(outdir, f"{srr}_1.fastq")
+    fq2 = os.path.join(outdir, f"{srr}_2.fastq")
+    if not (os.path.exists(fq1) and os.path.exists(fq2)):
+        raise FileNotFoundError(f"fasterq outputs missing for {srr} in {outdir}")
+
+    # 可选：gzip 压缩并做 md5 校验
+    if do_gzip:
+        import hashlib, gzip, shutil as _sh
+        for p in (fq1, fq2):
+            gz = p + ".gz"
+            if not os.path.exists(gz):
+                with open(p, "rb") as f_in, gzip.open(gz, "wb") as f_out:
+                    _sh.copyfileobj(f_in, f_out)
+                # 简单完整性：再打开一次读头若干字节
+                with gzip.open(gz, "rb") as f_chk:
+                    _ = f_chk.read(128)
+                os.remove(p)
+        fq1 += ".gz"; fq2 += ".gz"
+
+    return srr, fq1, fq2
+
+def _have(path: Path) -> bool:
+    return path.exists() and path.stat().st_size > 0
+
+def _candidate_fastq_paths(out_root: Path, srr: str, gzip_output: bool):
+    suffix = ".fastq.gz" if gzip_output else ".fastq"
+    fq1 = out_root / f"{srr}_1{suffix}"
+    fq2 = out_root / f"{srr}_2{suffix}"
+    return fq1, fq2
+
+def _run(cmd: list[str]):
+    print(">>", " ".join(cmd), flush=True)
+    return subprocess.run(cmd, check=True)
+
+
+def _work_one_fasterq(
+    srr: str,
+    out_root: Path,
+    threads_per_job: int,
+    mem_gb: int,
+    tmp_root: Path,
+    gzip_output: bool,
+    retries: int = 3,
+) -> tuple[str, Path, Path]:
+    
+    # 1) 子目录：每个 SRR 一个输出目录（更稳）
+    out_dir = out_root / srr
+    out_dir.mkdir(parents=True, exist_ok=True)
+    tmp_dir = tmp_root / srr
+    tmp_dir.mkdir(parents=True, exist_ok=True)
+    # Prefer local .sra if present
+    local_sra = Path("work/prefetch") / srr / f"{srr}.sra"
+    input_token = str(local_sra) if local_sra.exists() else srr
+    cand_dirs = (out_dir, out_root)
+    stems = {srr}
+    try:
+        stems.add(Path(input_token).stem)  # 当 input_token 是 .sra 路径时，可能是 "SRR" 或 "SRR.sra"
+    except Exception:
+        pass
+
+    def _find_pair(ext_gz: bool) -> tuple[Path, Path] | None:
+        suffix = ".fastq.gz" if ext_gz else ".fastq"
+        for base in cand_dirs:
+            for st in stems:
+                # 同时兼容 "SRR_1" 与 "SRR.sra_1"
+                for name1 in (f"{st}_1{suffix}", f"{st}.sra_1{suffix}"):
+                    name2 = name1.replace("_1", "_2", 1)
+                    a, b = base / name1, base / name2
+                    if _have(a) and _have(b):
+                        return a, b
+        return None
+
+    # ---------------- 早退 1：如果要求 gzip，且 .gz 成对已存在 -> 直接返回 ----------------
+    if gzip_output:
+        hit_gz = _find_pair(ext_gz=True)
+        if hit_gz:
+            fq_a, fq_b = hit_gz
+            print(f"[SKIP] {srr}: paired .fastq.gz 已存在，跳过 fasterq-dump。")
+            return srr, fq_a, fq_b
+
+    # ---------------- 早退 2：若 .fastq 成对已存在 ----------------
+    hit_plain = _find_pair(ext_gz=False)
+    if hit_plain:
+        fq_a, fq_b = hit_plain
+        if gzip_output:
+            # 只做 gzip（不再调用 fasterq-dump）
+            print(f"[INFO] {srr}: 检测到未压缩 .fastq，start gzip step.")
+            for src in (fq_a, fq_b):
+                if src.exists() and src.suffix == ".fastq":
+                    _run(["gzip", "-f", str(src)])
+            fq_a = fq_a.with_suffix(".fastq.gz")
+            fq_b = fq_b.with_suffix(".fastq.gz")
+            if not (_have(fq_a) and _have(fq_b)):
+                raise RuntimeError(f"gzip step did not produce gz files for {srr}")
+            print(f"[SKIP] {srr}: 已完成 gzip 压缩，跳过 fasterq-dump。")
+        else:
+            print(f"[SKIP] {srr}: paired .fastq exists，jump fasterq-dump。")
+        return srr, fq_a, fq_b
+
+
+    # Build fasterq-dump command
+
+    base_cmd = [
+        shutil.which("fasterq-dump") or "fasterq-dump",
+        input_token,
+        "-p",
+        "-O", str(out_dir),
+        "-e", str(threads_per_job),
+        "--mem", f"{mem_gb}G",
+        "--split-files",
+        "-t", str(tmp_dir),
+        "-f",
+    ]
+    print(">>>>>> ", " ".join(base_cmd), flush=True)
+
+    # Retry loop (most of your errors are rc=3 timeouts from S3)
+    sleep = 8
+    for attempt in range(1, retries + 1):
+        try:
+            _run(base_cmd)
+            break
+        except subprocess.CalledProcessError as e:
+            # If we used network accession and have a prefetched .sra, retry on the local file immediately
+            if input_token == srr and local_sra.exists():
+                input_token = str(local_sra)
+                base_cmd[1] = input_token
+                print(f"[WARN] Switching to local SRA for retry: {local_sra}", flush=True)
+
+            if attempt == retries:
+                raise
+            print(f"[WARN] fasterq-dump failed (try {attempt}/{retries}), sleep {sleep}s and retry...", flush=True)
+            time.sleep(sleep)
+            sleep *= 2
+
+    # Validate raw fastq results exist
+    # 产物定位：兼容输入为 .sra 时的 "SRR.sra_1.fastq" 命名 
+    # 候选目录：SRR 子目录 + 根目录
+    cand_dirs = (out_dir, out_root)
+
+    # 生成候选前缀：通常是 srr；若 input_token 是 ".sra" 路径，则补充它的 stem 作为候选
+    stems = {srr}
+    try:
+        stems.add(Path(input_token).stem)  # 可能是 "SRR123", 也可能是 "SRR123.sra"
+    except Exception:
+        pass
+
+    def _find_pair(ext_gz: bool) -> tuple[Path, Path] | None:
+        """在 cand_dirs × stems 中寻找成对的 _1/_2.fastq(.gz)"""
+        suffix = ".fastq.gz" if ext_gz else ".fastq"
+        for base in cand_dirs:
+            for st in stems:
+                # 兼容 "SRR_1" 与 "SRR.sra_1"
+                for name1 in (f"{st}_1{suffix}", f"{st}.sra_1{suffix}"):
+                    name2 = name1.replace("_1", "_2", 1)
+                    a, b = base / name1, base / name2
+                    if _have(a) and _have(b):
+                        return a, b
+        return None
+
+    hit = _find_pair(ext_gz=True) or _find_pair(ext_gz=False)
+
+    if not hit:
+        # 再检查是否出现单端（不符合预期）
+        for base in cand_dirs:
+            for st in stems:
+                for single in (base / f"{st}.sra.fastq", base / f"{st}.fastq"):
+                    if _have(single):
+                        raise RuntimeError(
+                            f"{srr} produced single-end file: {single} (no _1/_2). "
+                            f"Check library layout or remove --split-files."
+                        )
+        searched = ", ".join(str(d) for d in cand_dirs)
+        raise RuntimeError(f"fasterq outputs missing for {srr} (searched: {searched})")
+
+    fq_a, fq_b = hit
+    # 若需要 gzip 且目前是 .fastq，就地压缩
+    if gzip_output and fq_a.suffix == ".fastq":
+        for src in (fq_a, fq_b):
+            if src.exists() and src.suffix == ".fastq":
+                _run(["gzip", "-f", str(src)])
+        fq_a = fq_a.with_suffix(".fastq.gz")
+        fq_b = fq_b.with_suffix(".fastq.gz")
+        if not (_have(fq_a) and _have(fq_b)):
+            raise RuntimeError(f"gzip step did not produce gz files for {srr}")
+
+    return srr, fq_a, fq_b
+
+def fasterq_batch(
+    srr_list: Sequence[str],
+    out_root: str | Path,
+    threads: int = 8,          # ← “同时处理多少个 SRR”（映射到 max_workers）
+    gzip_output: bool = True,  # 是否对 fastq 输出 gzip 压缩
+    mem: str = "8G",
+    tmp_root: str | Path = "work/tmp",
+    backend: str = "process",
+    threads_per_job: int = 24,       # 每个 SRR 内部的 fasterq-dump 线程数
+) ->list[tuple[str, Path, Path]]:
+    """
+    适配器：把类传来的参数映射到 fasterq_dump_parallel，并把 dict 结果转成 list[tuple]
+    """
+    # 解析 mem (支持 "4G"/"8G" 这种形式；不匹配时默认 8G)
+    try:
+        mem_gb = int(str(mem).upper().rstrip("G"))
+    except Exception:
+        mem_gb = 8
+
+    res = fasterq_dump_parallel(
+        srr_list=list(srr_list),
+        out_root=str(out_root),
+        threads_per_job=threads_per_job,
+        mem_gb=mem_gb,
+        max_workers=int(threads),      # ← 并发度
+        gzip_output=bool(gzip_output),
+        backend=backend,
+        tmp_root=str(tmp_root),
+    )
+
+    by_srr = res.get("by_srr", {})
+    errs = res.get("failed", [])
+
+    if errs:
+        # 你也可以选择仅告警不抛错
+        msgs = "; ".join([f"{s}: {m}" for s, m in errs])
+        raise RuntimeError(f"fasterq_batch failed for {len(errs)} samples: {msgs}")
+
+    # 转换为 [(srr, Path, Path)]，并按输入顺序排序
+    out_pairs = []
+    for srr in srr_list:
+        if srr in by_srr:
+            fq1, fq2 = by_srr[srr]
+            out_pairs.append((srr, Path(fq1), Path(fq2)))
+
+    
+    return out_pairs
+
+def fasterq_dump_parallel(
+    srr_list: list[str],
+    out_root: str = "work/fasterq",
+    threads_per_job: int = 24,
+    mem_gb: int = 8,
+    max_workers: int | None = None,
+    gzip_output: bool = True,
+    backend: str = "process",
+    tmp_root: str = "work/tmp"
+)-> Dict[str, object]:
+    
+    total_cores = os.cpu_count() or 8
+    out_root = Path(out_root)
+    tmp_root = Path(tmp_root)
+    out_root.mkdir(parents=True, exist_ok=True)
+    tmp_root.mkdir(parents=True, exist_ok=True)
+
+    # 解析二进制绝对路径（关键！）
+    fqdump_bin = which_or_find("fasterq-dump")
+    print(f"[INFO] fasterq-dump: {fqdump_bin}")
+
+    if max_workers is None:
+        import math, os as _os
+        max_workers = max(1, math.floor((_os.cpu_count() or 8) / max(1, threads_per_job)))
+
+    Executor = ProcessPoolExecutor if backend == "process" else ThreadPoolExecutor
+    by_srr: Dict[str, Tuple[str, str]] = {}
+    errs: List[Tuple[str, str]] = []
+    
+    Path(tmp_root).mkdir(parents=True, exist_ok=True)
+    Path(out_root).mkdir(parents=True, exist_ok=True)
+
+    with Executor(max_workers=max_workers) as ex:
+        #futs = {
+        #    ex.submit(_fqdump_one, srr, out_root, fqdump_bin, threads_per_job, mem_gb, gzip_output): srr
+        #    for srr in srr_list
+        futs = {
+            ex.submit(
+                _work_one_fasterq,
+                srr, out_root, threads_per_job, mem_gb, tmp_root, gzip_output
+            ): srr for srr in srr_list
+        }
+        for fut in as_completed(futs):
+            srr = futs[fut]
+            try:
+                srr_id, fq1p, fq2p = fut.result()  # older return
+            except TypeError:
+                # new return (srr, fq1, fq2)
+                srr_id, fq1p, fq2p = fut.result()
+            except Exception as e:
+                errs.append((srr, str(e)))
+                continue
+            by_srr[srr_id] = (str(fq1p), str(fq2p))
+
+    if errs:
+        print("[SUMMARY] fasterq errors:", errs)
+    return {"by_srr": by_srr, "failed": errs}
+
+def _parse_mem_gb(mem_per_job: str | int) -> int:
+    """
+    兼容传入 '4G' / '8g' / 4 / '4' 等形式，统一返回整数 GB。
+    """
+    if isinstance(mem_per_job, int):
+        return mem_per_job
+    s = str(mem_per_job).strip().lower()
+    if s.endswith("gb"):
+        s = s[:-2]
+    elif s.endswith("g"):
+        s = s[:-1]
+    return int(float(s))
+
+
+'''
+def fasterq_batch(
+    srr_list: Sequence[str],
+    out_root: str | Path,
+    threads: int = 24,
+    gzip_output: bool = True,
+    mem: str = "8G",
+    tmp_root: str = "work/tmp",
+    retries: int = 2,
+) -> list[Tuple[str, Path, Path]]:
+    """
+    批量执行 fasterq-dump。
+    参数：
+        srr_list : SRR 编号列表
+        out_root : 输出目录（FASTQ 文件存放位置）
+        threads  : 每个样本使用的线程数
+        gzip_output : 是否对输出进行 gzip 压缩
+        mem : fasterq-dump 内存参数（默认 4G）
+        tmp_root : 临时目录
+        retries : 单样本失败重试次数
+    返回：
+        [(srr, fq1_path, fq2_path), ...]
+    """
+    out_root = Path(out_root)
+    out_root.mkdir(parents=True, exist_ok=True)
+
+    results = []
+    for srr in srr_list:
+        srr, fq1, fq2, status = fasterq_dump_parallel(
+            srr=srr,
+            outdir=str(out_root),
+            threads=threads,
+            mem=mem,
+            retries=retries,
+            tmp_root=str(tmp_root),
+        )
+
+        # 如果需要压缩输出（可选）
+        if gzip_output:
+            import gzip, shutil
+            for fq in [fq1, fq2]:
+                fq_path = Path(fq)
+                if not fq_path.with_suffix(fq_path.suffix + ".gz").exists():
+                    with open(fq_path, "rb") as f_in, gzip.open(str(fq_path) + ".gz", "wb") as f_out:
+                        shutil.copyfileobj(f_in, f_out)
+                    fq_path.unlink()
+            fq1 = str(Path(fq1).with_suffix(".fastq.gz"))
+            fq2 = str(Path(fq2).with_suffix(".fastq.gz"))
+
+        results.append((srr, Path(fq1), Path(fq2)))
+
+    return results
+    '''
+
+def make_fasterq_step(
+    outdir_pattern: str = "work/fasterq",   # 产出目录（与之前一致）
+    threads_per_job: int = 24,
+    mem_per_job: str = "4G",               # 兼容旧写法，内部转成 int GB
+    max_workers: int | None = None,
+    retries: int = 2,                      # 新实现未用到，先保留以免破坏接口
+    tmp_root: str = "work/tmp",            # 同上
+    backend: str = "process",
+    compress_after: bool = True,           # 映射到 gzip_output
+    compress_threads: int = 8,             # 新实现未用到，先保留
+):
+    """
+    输入：srr_list（由 pipeline 传入）
+    输出：work/fasterq/{SRR}_1.fastq.gz, {SRR}_2.fastq.gz
+    验证：两端均存在且 size > 0
+    """
+    def _cmd(srr_list: List[str], logger=None) -> List[Tuple[str, str, str]]:
+        os.makedirs(outdir_pattern, exist_ok=True)
+
+        # 映射参数到新的 fasterq_dump_parallel
+        mem_gb = _parse_mem_gb(mem_per_job)
+
+        ret = fasterq_dump_parallel(
+            srr_list=srr_list,
+            out_root=outdir_pattern,         # 对应 outdir_pattern
+            threads_per_job=threads_per_job,
+            mem_gb=mem_gb,                   # 统一成 int GB
+            max_workers=max_workers,
+            gzip_output=compress_after,      # compress_after -> gzip_output
+            backend=backend,
+        )
+        # 规范化输出为 [(srr, fq1, fq2), ...]，供 pipeline 使用
+        by_srr = ret.get("by_srr", {})
+        products = [(srr, paths[0], paths[1]) for srr, paths in by_srr.items()]
+        # 若需要，你也可以在此打印 ret["failed"] 以便日志观察
+        if logger and ret.get("failed"):
+            for srr, err in ret["failed"]:
+                logger.error(f"[fasterq] {srr} failed: {err}")
+        return products
+
+    return {
+        "name": "fasterq",
+        "command": _cmd,  # 接收 srr_list
+        "outputs": [f"{outdir_pattern}" + "/{SRR}_1.fastq.gz",
+                    f"{outdir_pattern}" + "/{SRR}_2.fastq.gz"],
+        "validation": lambda fs: all(os.path.exists(f) and os.path.getsize(f) > 0 for f in fs),
+        "takes": "SRR_LIST",
+        "yields": "FASTQ_PATHS"
+    }

--- a/omicverse/bulk/sra_prefetch.py
+++ b/omicverse/bulk/sra_prefetch.py
@@ -1,0 +1,232 @@
+# sra_prefetch.py Prefetch步骤工厂
+from __future__ import annotations
+import os, time, subprocess, logging
+import threading
+from pathlib import Path
+from typing import Callable, Optional, Sequence
+try:
+    from tqdm.auto import tqdm 
+except Exception:
+    from tqdm import tqdm
+    
+from concurrent.futures import ThreadPoolExecutor, as_completed
+try:
+    from .sra_tools import (get_sra_metadata, human_readable_speed, estimate_remaining_time, record_to_log, get_downloaded_file_size, run_prefetch_with_progress)
+except ImportError:
+    from sra_tools import (get_sra_metadata, human_readable_speed, estimate_remaining_time, record_to_log, get_downloaded_file_size, run_prefetch_with_progress)
+# ---------- 工具函数（按你的实现/命名保留） ----------
+def find_sra_file(srr_id: str, output_root: Path) -> Path | None:
+    """
+    在一系列候选位置查找 {srr_id}.sra：
+      1) output_root/SRR/SRR.sra
+      2) output_root/SRR.sra
+      3) srapath 返回的缓存路径
+      4) 常见本地缓存目录 (~/.ncbi/public/sra, ~/ncbi/public/sra)
+    找到就返回 Path，否则 None。
+    """
+    candidates = [
+        output_root / srr_id / f"{srr_id}.sra",
+        output_root / f"{srr_id}.sra",
+    ]
+    for p in candidates:
+        if p.exists():
+            return p
+
+    # 3) srapath
+    try:
+        cp = subprocess.run(["srapath", srr_id],
+                            capture_output=True, text=True, check=True)
+        for line in cp.stdout.splitlines():
+            p = Path(line.strip())
+            if p.exists():
+                return p
+    except Exception:
+        pass
+
+    # 4) 常见缓存根
+    home = Path.home()
+    for root in [home/".ncbi/public/sra", home/"ncbi/public/sra"]:
+        p = root / f"{srr_id}.sra"
+        if p.exists():
+            return p
+    return None
+def ensure_link_at(output_path: Path, real_file: Path, logger=None, prefer="symlink") -> Path:
+    """
+    确保在 output_path 有一个可用的文件指向 real_file：
+      - 优先创建符号链接；不支持时退回硬链接/复制
+    返回 output_path
+    """
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    if output_path.exists():
+        # 已有就直接用
+        return output_path
+
+    try:
+        if prefer == "symlink":
+            output_path.symlink_to(real_file)
+        elif prefer == "hardlink":
+            os.link(real_file, output_path)
+        else:
+            shutil.copy2(real_file, output_path)
+        if logger:
+            logger.info(f"[LINK] {output_path} -> {real_file}")
+    except Exception as e:
+        # 兼容不支持软链接的环境：退回拷贝
+        if logger:
+            logger.warning(f"[LINK] failed ({e}), fallback to copy")
+        shutil.copy2(real_file, output_path)
+    return output_path
+    
+def _make_local_logger(name: str, level=logging.INFO) -> logging.Logger:
+    log_dir = Path("log")
+    log_dir.mkdir(parents=True, exist_ok=True) 
+    logger = logging.getLogger(f"sraprefetch.{name}")
+    if not logger.handlers:
+        logger.setLevel(level)
+        fh = logging.FileHandler(log_dir/f"{name}.log", mode="a")
+        sh = logging.StreamHandler()
+        fmt = logging.Formatter(f"[%(asctime)s] [{name}] %(levelname)s: %(message)s")
+        for h in (fh, sh):
+            h.setFormatter(fmt)
+            logger.addHandler(h)
+    return logger
+
+   ################################################
+  #                                              #
+ #      兼容Alignment Class与PipLine工厂         #
+#                                             #
+##############################################
+
+# ---------- For Alignment Class ----------
+def _monitor_file_size(path: Path, pbar: tqdm, stop_event: threading.Event, interval: float = 1.0):
+    """外部监控文件大小并刷新 tqdm"""
+    last = 0
+    while not stop_event.is_set():
+        try:
+            size = path.stat().st_size if path.exists() else 0
+            inc = max(0, size - last)
+            if inc:
+                pbar.update(inc)
+                last = size
+        except Exception:
+            pass
+        time.sleep(interval)
+    # 收尾再刷一次
+    try:
+        size = path.stat().st_size if path.exists() else last
+        if size > last:
+            pbar.update(size - last)
+    except Exception:
+        pass
+    pbar.close()
+    
+def prefetch_batch(
+    srr_list: Sequence[str], 
+    out_root: str | Path, 
+    threads: int = 4, # 同时下载的 SRR 数
+    retries: int = 3, 
+    link_mode: str = "symlink",
+    cache_root: str | Path = "sra_cache",
+):
+    """
+    Adapter to integrate with Alignment.prefetch().
+    For each SRR:
+      1) call run_prefetch_with_progress(srr, logger, retries, output_root="sra_cache")
+      2) locate the real .sra in the cache
+      3) place a link/copy at <out_root>/<SRR>/<SRR>.sra
+      并发下载 SRA：对 srr_list 中的样本并行执行 prefetch。
+      threads 控制“同时下载任务数”
+      下载后在 cache_root 中找到 .sra，再链接/复制到 out_root/<SRR>/<SRR>.sra
+    返回：按输入顺序对齐的目标 .sra 路径列表
+    """
+    out_root = Path(out_root)
+    cache_root = out_root 
+    out_root.mkdir(parents=True, exist_ok=True)
+    
+    logger = _make_local_logger("prefetch")
+    # 单个任务
+    def _worker(pos: int, srr: str) -> tuple[str, Path]:
+        
+        # 监控的目标文件（与你原函数保持一致的落盘位置）
+        srr_dir = cache_root / srr
+        srr_dir.mkdir(parents=True, exist_ok=True)
+        sra_file = srr_dir / f"{srr}.sra"
+
+        '''# 尝试使用多行进度条位置；不支持时自动降级
+        pbar_kwargs = dict(
+            desc=f"📥 {srr}",
+            total=None,  # 若能拿到预估大小可替换为具体值
+            unit="B", unit_scale=True, unit_divisor=1024,
+            dynamic_ncols=True, leave=False, mininterval=0.5
+        )
+        try:
+            pbar = tqdm(position=pos, **pbar_kwargs)
+        except TypeError:
+            pbar = tqdm(**pbar_kwargs)
+            
+        stop_evt = threading.Event()
+        mon = threading.Thread(target=_monitor_file_size, args=(sra_file, pbar, stop_evt), daemon=True)
+        mon.start()
+        '''
+        # 下载
+        ok = run_prefetch_with_progress(
+            srr_id=srr, logger=logger, retries=retries, output_root=str(cache_root)
+        )
+        # 停止监控并收尾
+        #stop_evt.set()
+        #mon.join()
+        
+        if not ok:
+            raise RuntimeError(f"Prefetch failed for {srr}")
+
+        real = find_sra_file(srr_id=srr, output_root=cache_root)
+        if not real or not Path(real).exists():
+            raise RuntimeError(f"Prefetch done but cannot locate .sra for {srr}")
+
+        dest = out_root / srr / f"{srr}.sra"
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        ensure_link_at(Path(real), dest, prefer=link_mode, logger=logger)
+        return srr, dest
+
+    results_map: dict[str, Path] = {}
+    failures: list[tuple[str, Exception]] = []
+
+    # Multiple Download 
+    with ThreadPoolExecutor(max_workers=int(threads)) as pool:
+        fut_map = {pool.submit(_worker, pos,srr): srr for pos, srr in enumerate(srr_list)}
+        for fut in as_completed(fut_map):
+            srr = fut_map[fut]
+            try:
+                srr_id, dest_path = fut.result()
+                results_map[srr_id] = dest_path
+                logger.info(f"[prefetch] OK: {srr_id} -> {dest_path}")
+            except Exception as e:
+                failures.append((srr, e))
+                logger.error(f"[prefetch] FAIL: {srr}: {e}")
+
+    if failures:
+        failed = ", ".join([f"{srr}({repr(err)})" for srr, err in failures])
+        raise RuntimeError(f"Prefetch failed for {len(failures)} samples: {failed}")
+    # 保持与输入顺序一致
+    return [results_map[s] for s in srr_list if s in results_map]
+
+# ---------- “步骤工厂”：需要时在编排模块里调用 ----------
+def make_prefetch_step(output_pattern: str = "sra_cache/{SRR}/{SRR}.sra", validation=None):
+    def _safe_valid(fs: list[str]) -> bool:
+        # fs 只会有一个：期望路径，但我们用 find_sra_file 来兜底
+        try:
+            f = Path(fs[0])
+            if f.exists() and f.stat().st_size > 1_000_000:
+                return True
+            # 用定位函数检查真实缓存位置
+            real = find_sra_file(f.stem, f.parent.parent)  # stem=SRRxxxxxx, parent.parent=output_root
+            return bool(real and real.exists() and real.stat().st_size > 1_000_000)
+        except Exception:
+            return False
+
+    return {
+        "name": "prefetch",
+        "command": run_prefetch_with_progress,
+        "outputs": [output_pattern],
+        "validation": validation or _safe_valid,
+    }

--- a/omicverse/bulk/sra_tools.py
+++ b/omicverse/bulk/sra_tools.py
@@ -1,0 +1,931 @@
+import os,sys,time, shutil, hashlib, subprocess, requests,argparse
+import pandas as pd
+import concurrent.futures
+from pathlib import Path
+from typing import Tuple, Optional, List, Union
+from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor, as_completed
+from math import floor
+
+if 'ipykernel' in sys.modules:
+    from tqdm.notebook import tqdm
+else:
+    from tqdm import tqdm
+from filelock import FileLock
+import logging
+
+
+# ================= Safer single-sample worker =================
+def _sra_tools_version() -> str | None:
+    p = shutil.which("fasterq-dump")
+    if not p:
+        return None
+    try:
+        out = subprocess.check_output(["fasterq-dump", "--version"], text=True, stderr=subprocess.STDOUT)
+        # expected like: fasterq-dump : 3.0.8
+        for line in out.splitlines():
+            if "fasterq-dump" in line and ":" in line:
+                return line.split(":")[1].strip()
+    except Exception:
+        pass
+    return None
+
+def _exists_fastqs(outdir: str, srr: str) -> bool:
+    return (Path(outdir)/f"{srr}_1.fastq").exists() and (Path(outdir)/f"{srr}_2.fastq").exists()
+
+def _run(cmd: list[str], log: Path):
+    log.parent.mkdir(parents=True, exist_ok=True)
+    with log.open("a") as fh:
+        fh.write(">> " + " ".join(cmd) + "\n")
+        subprocess.run(cmd, check=True, stdout=fh, stderr=fh)
+
+def _try_direct_fasterq(srr: str, outdir: str, threads: int, mem: str, parallel: bool, tmpdir: str | None, log: Path):
+    cmd = ["fasterq-dump", srr, "-O", outdir, "-e", str(threads), "--mem", str(mem), "--split-files", "--force", "--progress"]
+    if parallel:
+        cmd.insert(2, "-p")
+    if tmpdir:
+        cmd += ["--temp", tmpdir]
+    _run(cmd, log)
+
+def _prefetch_and_convert(srr: str, outdir: str, threads: int, mem: str, parallel: bool, tmpdir: str | None, log: Path):
+    # prefetch to cache, then validate, then dump from local
+    _run(["prefetch", srr, "--progress"], log)
+    # optional validate (helpful for corrupt/incomplete)
+    try:
+        _run(["vdb-validate", srr], log)
+    except Exception:
+        # don't hard-fail: some records may warn; we still attempt dump
+        pass
+    # Now convert
+    _try_direct_fasterq(srr, outdir, threads, mem, parallel, tmpdir, log)
+
+def _fasterq_run_one_resilient(
+    srr: str,
+    outdir: str,
+    threads: int = 24,
+    mem: str = "4G",
+    retries: int = 2,
+    tmp_root: str = "work/tmp"  # place for --temp
+):
+    """
+    Resilient fasterq-dump:
+    1) skip if outputs exist
+    2) try direct download
+    3) on error: prefetch -> (validate) -> local fasterq-dump
+    4) on repeated error: lower threads, disable -p, fresh tmp
+    """
+    os.makedirs(outdir, exist_ok=True)
+    fq1 = os.path.join(outdir, f"{srr}_1.fastq")
+    fq2 = os.path.join(outdir, f"{srr}_2.fastq")
+    log = Path(outdir) / f"{srr}.fasterq.log"
+
+    if _exists_fastqs(outdir, srr):
+        return (srr, fq1, fq2, "SKIP")
+
+    ver = _sra_tools_version()
+    if ver is None:
+        raise FileNotFoundError("fasterq-dump not found in PATH")
+    try:
+        major = int(ver.split(".")[0])
+        if major < 2:
+            print(f"[WARN] SRA-tools version looks very old: {ver}", file=sys.stderr)
+    except Exception:
+        pass
+
+    last_err = None
+    # 1st pass: direct (parallel on), then fallback (prefetch), then degraded (no -p, fewer threads)
+    plans = [
+        ("direct_parallel", dict(parallel=True,  t=threads, mem=mem)),
+        ("prefetch_parallel", dict(parallel=True,  t=threads, mem=mem)),
+        ("prefetch_serial",   dict(parallel=False, t=max(1, threads//2), mem=mem)),
+    ]
+
+    for name, cfg in plans:
+        for attempt in range(1, retries+1):
+            try:
+                # isolate temp per attempt to avoid stale temp issues
+                tmpdir = os.path.join(tmp_root, f"{srr}.{name}.try{attempt}")
+                Path(tmpdir).mkdir(parents=True, exist_ok=True)
+
+                if "prefetch" in name:
+                    _prefetch_and_convert(srr, outdir, cfg["t"], cfg["mem"], cfg["parallel"], tmpdir, log)
+                else:
+                    _try_direct_fasterq(srr, outdir, cfg["t"], cfg["mem"], cfg["parallel"], tmpdir, log)
+
+                if not _exists_fastqs(outdir, srr):
+                    raise RuntimeError("Outputs missing after fasterq-dump.")
+                return (srr, fq1, fq2, "OK")
+            except Exception as e:
+                last_err = e
+                time.sleep(2 * attempt)  # brief backoff
+        # next plan
+
+    raise RuntimeError(f"[{srr}] fasterq-dump ultimately failed: {last_err}")
+
+# =================Utilities: gzip with integrity check  ====================
+def _gzip_available() -> tuple[str, bool]:
+    """
+    Return (exe_path, is_pigz) for pigz or gzip; prefer pigz.
+    """
+    pigz = shutil.which("pigz")
+    if pigz:
+        return pigz, True
+    gz = shutil.which("gzip")
+    if gz:
+        return gz, False
+    raise FileNotFoundError("Neither pigz nor gzip is available in PATH.")
+
+def _gzip_test_ok(path_gz: Path) -> bool:
+    """
+    Test gzip integrity via 'gzip -t' or 'pigz -t'. Return True if OK.
+    """
+    exe, is_pigz = _gzip_available()
+    cmd = [exe, "-t", str(path_gz)]
+    try:
+        subprocess.run(cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        return True
+    except Exception:
+        return False
+
+def _gzip_compress(path_fastq: str, threads: int = 4) -> str:
+    """
+    Compress a .fastq to .fastq.gz using pigz (if available) or gzip.
+    Replaces the input file (no second copy). Verifies with gzip -t.
+    Returns the .gz path (string). Raises on failure.
+    """
+    exe, is_pigz = _gzip_available()
+    p = Path(path_fastq)
+    if not p.exists():
+        raise FileNotFoundError(f"File to compress not found: {p}")
+    # If already gz, just test and return
+    if p.suffix == ".gz":
+        if not _gzip_test_ok(p):
+            raise RuntimeError(f"Gzip integrity test failed: {p}")
+        return str(p)
+
+    # compress in place
+    cmd = [exe]
+    if is_pigz:
+        cmd += ["-p", str(max(1, threads))]
+    cmd += ["-f", str(p)]
+    subprocess.run(cmd, check=True)
+
+    gz = Path(str(p) + ".gz")
+    if not gz.exists():
+        raise RuntimeError(f"Gzip did not produce: {gz}")
+
+    if not _gzip_test_ok(gz):
+        # attempt to remove bad output to avoid confusion
+        try:
+            gz.unlink(missing_ok=True)
+        finally:
+            raise RuntimeError(f"Gzip integrity test failed: {gz}")
+
+    return str(gz)
+
+# ================= 获取 SRA 文件元信息（大小 + MD5） =================
+def get_sra_metadata(srr_id):
+    ena_url = f"https://www.ebi.ac.uk/ena/portal/api/filereport?accession={srr_id}&result=read_run&fields=run_accession,fastq_bytes,fastq_md5"
+    try:
+        response = requests.get(ena_url)
+        lines = response.text.strip().split('\n')
+        if len(lines) < 2:
+            raise ValueError("返回数据格式异常")
+        data_line = lines[1]
+        cols = data_line.split('\t')
+        size_str, md5_str = cols[1], cols[2]
+        sizes = [int(x) for x in size_str.split(';') if x.isdigit()]
+        md5s = [x.strip() for x in md5_str.split(';') if x.strip()]
+        return {'size': sum(sizes), 'md5s': md5s}
+    except Exception as e:
+        print(f"获取SRA元信息失败: {str(e)}")
+        return {'size': None, 'md5s': []}
+
+def calculate_md5(filepath, chunk_size=8192):
+    md5 = hashlib.md5()
+    try:
+        with open(filepath, 'rb') as f:
+            while chunk := f.read(chunk_size):
+                md5.update(chunk)
+        return md5.hexdigest()
+    except Exception as e:
+        print(f"计算MD5失败: {e}")
+        return None
+
+def human_readable_speed(speed_bps):
+    units = ['B/s', 'KB/s', 'MB/s', 'GB/s']
+    unit_index = 0
+    while speed_bps >= 1024 and unit_index < 3:
+        speed_bps /= 1024
+        unit_index += 1
+    return f"{speed_bps:.1f} {units[unit_index]}"
+
+def estimate_remaining_time(current, total, speed):
+    if total is None or speed == 0:
+        return "--:--"
+    remaining = (total - current) / speed
+    return time.strftime("%H:%M:%S", time.gmtime(remaining))
+
+def get_downloaded_file_size(output_root: Path, srr_id: str):
+    tmp_file = output_root / srr_id / f"{srr_id}.sra.tmp"
+    return tmp_file.stat().st_size if tmp_file.exists() else 0
+
+def record_to_log(srr_id: str, status: str):
+    log_file = "success.log" if status == "success" else "fail.log"
+    with open(log_file, "a") as f:
+        f.write(srr_id + "\n")
+
+def setup_logger(srr_id):
+    logger = logging.getLogger(srr_id)
+    logger.setLevel(logging.DEBUG)
+    log_dir = Path("log")
+    log_dir.mkdir(exist_ok=True)
+    file_handler = logging.FileHandler(log_dir / f"{srr_id}.log", mode="w")
+    file_handler.setLevel(logging.DEBUG)
+    file_handler.setFormatter(logging.Formatter(f"[%(asctime)s] [{srr_id}] %(levelname)s: %(message)s"))
+
+    if not logger.handlers:
+        logger.addHandler(file_handler)
+        stream_handler = logging.StreamHandler()
+        stream_handler.setFormatter(logging.Formatter(f"[%(asctime)s] [{srr_id}] %(levelname)s: %(message)s"))
+        logger.addHandler(stream_handler)
+
+    return logger
+
+# ====================Prefetch Setting==============================
+def resolve_sra_path(srr_id: str) -> Path | None:
+    """
+    用 srapath 解析 SRR 对应的真实 .sra 路径（可能在 ~/.ncbi/public/sra/）。
+    返回 Path 或 None。
+    """
+    try:
+        out = subprocess.check_output(["srapath", srr_id], text=True).strip().splitlines()
+    except Exception:
+        return None
+    for line in out:
+        p = Path(line.strip())
+        if p.suffix.lower() == ".sra" and p.exists():
+            return p
+    for line in out:
+        p = Path(line.strip()) / f"{srr_id}.sra"
+        if p.exists():
+            return p
+    return None
+
+def ensure_symlink(target: Path, real: Path) -> None:
+    """
+    在 target 位置建立到 real 的软链（若不支持软链则复制），确保 target 所在目录存在。
+    """
+    target.parent.mkdir(parents=True, exist_ok=True)
+    # 已经是同一个目标则直接返回
+    if target.exists() or target.is_symlink():
+        try:
+            if target.resolve() == real.resolve():
+                return
+        except Exception:
+            pass
+        try:
+            target.unlink()
+        except FileNotFoundError:
+            pass
+    try:
+        target.symlink_to(real)
+    except OSError:
+        shutil.copy2(real, target)
+
+def check_step_completed(step: dict, srr_id: str, logger=None) -> tuple[bool, list[str]]:
+    """
+    通用的“此步骤是否完成”检查：
+      - 基于 step["outputs"] 渲染出期望产物路径
+      - 调用 step["validation"](outputs) 判断
+      - 针对 prefetch 步骤做稳健化：如果期望 .sra 不在指定 cache，
+        则用 srapath 找真实文件，存在则补建软链/复制到期望位置，再判定完成
+    返回：(done: bool, outputs: List[str])
+    """
+    outs = _render_paths(step["outputs"], SRR=srr_id)
+
+    # 先直接跑 validation（你之前已有 _safe_call_validation 也可以复用）
+    try:
+        done = step["validation"](outs)
+    except Exception as e:
+        if logger:
+            logger.warning(f"[WARN] validation raised: {e}")
+        done = all(Path(p).exists() for p in outs)
+
+    # 额外稳健化：prefetch 步骤（通常只有 1 个 .sra 期望路径）
+    # 约定：prefetch 的 outputs 模板里包含 “.sra”
+    is_prefetch = any(str(p).endswith(".sra") for p in outs)
+    if not done and is_prefetch:
+        # outs[0] 就是期望的 sra_cache/SRR/SRR.sra
+        expected = Path(outs[0])
+        real = resolve_sra_path(srr_id)
+        if real and real.exists():
+            # 补建软链/复制
+            ensure_symlink(expected, real)
+            # 重新判定
+            try:
+                done = step["validation"]([str(expected)])
+            except Exception:
+                done = expected.exists() and expected.stat().st_size > 1_000_000
+            if done and logger:
+                logger.info(f"[FIX] {srr_id}: found real .sra at {real}, linked to {expected}")
+
+    return done, outs
+
+def run_prefetch_with_progress(srr_id, logger, retries=3, output_root: str | Path = "sra_cache"):
+    """
+    稳健的 prefetch：
+      1) 目标路径：sra_cache/<SRR>/<SRR>.sra
+      2) 已存在则先 vdb-validate，通过即跳过
+      3) 使用 --verify yes --resume yes 下载
+      4) 下载结束统一 vdb-validate 作为最终校验
+    说明：ENA 的 fastq_md5 是 FASTQ 的 MD5，不适用于 .sra；因此不再用其做 .sra 校验
+    """
+    # 根目录与目标路径
+    output_root = Path(output_root)
+    srr_dir = output_root / srr_id
+    output_path = srr_dir / f"{srr_id}.sra"
+    srr_dir.mkdir(exist_ok=True, parents=True)
+    # （可选）仅作显示用途的预估总大小；拿不到也不影响流程
+    try:
+        meta = get_sra_metadata(srr_id)
+        total_size = meta.get("size") if isinstance(meta, dict) else None
+        if not isinstance(total_size, int) or total_size <= 0:
+            total_size = None
+    except Exception:
+        total_size = None
+
+    # 如果文件已存在，先做官方校验；通过就跳过
+    if output_path.exists():
+        try:
+            subprocess.run(["vdb-validate", str(output_path)],
+                           check=True,
+                           stdout=subprocess.DEVNULL,
+                           stderr=subprocess.DEVNULL)
+            logger.info(f"{srr_id}.sra 已存在且通过 vdb-validate，跳过下载")
+            record_to_log(srr_id, "success")
+            return True
+        except subprocess.CalledProcessError:
+            logger.info(f"{srr_id}.sra 存在但未通过 vdb-validate，将尝试重新下载")
+
+    # 进度条（拿不到 total_size 就显示为“未知总量”）
+    downloaded_size = get_downloaded_file_size(output_root, srr_id)
+    bar_total = total_size if isinstance(total_size, int) and total_size > 0 else None
+    pbar = tqdm(
+        desc=f"\U0001F4E5 Prefetch {srr_id}",
+        total=total_size,
+        initial=downloaded_size if bar_total else 0,
+        unit='B', unit_scale=True, unit_divisor=1024,
+        dynamic_ncols=True, leave=False, mininterval=0.25,
+    )
+
+    last_err = None
+    for attempt in range(retries):
+        try:
+            # 清理锁文件（偶发残留）
+            ext_lock = output_path.with_suffix('.sra.lock')
+            if ext_lock.exists():
+                ext_lock.unlink()
+                logger.warning(f"清除外部锁文件: {ext_lock}")
+            inner_lock = srr_dir / f"{srr_id}.sra.lock"
+            if inner_lock.exists():
+                inner_lock.unlink()
+                logger.warning(f"清除内部锁文件: {inner_lock}")
+            
+            start_time = time.time()
+            # 启动 prefetch
+            proc = subprocess.Popen(
+                [
+                    "prefetch", srr_id,
+                    "--output-directory", str(output_root),
+                    #"--verify", "yes",     # 官方完整性校验
+                    #"--resume", "yes",     # 断点续传
+                    #"--progress"           # 控制台进度（也会写到 stdout）
+                ],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                bufsize=1,
+                universal_newlines=True
+            )
+
+            # 轮询更新进度
+            
+            while True:
+                # 读 stdout（可选：记录到 logger）
+                last_size = downloaded_size
+                prev_size = last_size
+                current_size = get_downloaded_file_size(output_root, srr_id)
+                
+                if proc.stdout:
+                    line = proc.stdout.readline()
+                    if line:
+                        logger.debug(line.strip())
+
+                # 更新进度：读取 .tmp 文件大小（prefetch 的写入临时）
+                cur_size = current_size
+
+                if cur_size > last_size:
+                    delta = cur_size - last_size
+                    pbar.update(delta)  # 没 total 时不累加 total，只显示 desc
+                    # 可选显示速度/ETA（total 不确定时仅显示速度）
+                    speed = delta / 0.25
+                    
+                    eta_str = estimate_remaining_time(cur_size, bar_total, speed) if bar_total else ""
+                    pbar.set_postfix_str(
+                        f"{human_readable_speed(speed)}" + (f" | 剩余: {eta_str}" if eta_str else "")
+                    )
+                    last_size = cur_size
+
+                if proc.poll() is not None:
+                    break
+
+                time.sleep(0.25)
+
+            # 读取剩余输出，检查退出码
+            stdout_rest, _ = proc.communicate()
+            if proc.returncode != 0:
+                logger.error(f"prefetch 失败 (退出码 {proc.returncode})\n{stdout_rest}")
+                raise subprocess.CalledProcessError(proc.returncode, proc.args)
+
+            # 至此 prefetch 正常退出，关闭进度条
+            pbar.close()
+
+            # 确认目标文件存在
+            #if not output_path.exists():
+             #   logger.error(f"{srr_id}.sra 未找到：{output_path}")
+             #   last_err = FileNotFoundError(str(output_path))
+              #  continue
+
+            # 结束后统一做 vdb-validate（**你要的校验就加在这里**）
+            val = subprocess.run(["vdb-validate", str(output_path)], capture_output=True, text=True)
+            if val.returncode == 0:
+                logger.info(f"{srr_id}.sra 下载成功并通过 vdb-validate")
+                record_to_log(srr_id, "success")
+                return True
+            else:
+                logger.warning(
+                    f"{srr_id}.sra 下载完成但 vdb-validate 失败；输出：\n{val.stdout}\n{val.stderr}"
+                )
+                last_err = RuntimeError("vdb-validate failed")
+                # 失败则进入下一轮重试（如果还有）
+
+        except subprocess.CalledProcessError as e:
+            last_err = e
+            logger.error(f"Prefetch失败 (尝试 {attempt}/{retries}): {e}")
+            time.sleep(5)
+
+    # 全部重试失败
+    pbar.close()
+    logger.error(f"{srr_id} 最终失败：{last_err}")
+    record_to_log(srr_id, "fail")
+    return False
+
+COMMAND_STEPS = [
+    {
+        'name': 'prefetch',
+        'command': run_prefetch_with_progress,
+        'outputs': ['{SRR}/{SRR}.sra'],
+        'validation': lambda fs: all(os.path.getsize(f) > 1_000_000 for f in fs)
+    }
+]
+
+def process_srr(srr_id, max_retry=3):
+    logger = setup_logger(srr_id)
+    if os.path.exists("success.log") and srr_id in Path("success.log").read_text().splitlines():
+        logger.info(f"{srr_id} 已在 success.log 中记录，跳过")
+        return True
+
+    logger.info(f"开始处理 {srr_id}")
+    start_time = time.time()
+    try:
+        for step in COMMAND_STEPS:
+            step_name = step['name']
+            lock_file = f"{srr_id}_{step_name}.lock"
+            with FileLock(lock_file + ".lock"):
+                if not step['command'](srr_id, logger):
+                    raise RuntimeError("Prefetch步骤失败")
+                if not check_step_completed(step, srr_id, logger):
+                    raise RuntimeError(f"最终验证失败: {step_name}")
+
+        duration = time.time() - start_time
+        logger.info(f"{srr_id} 下载完成，总耗时: {duration:.1f} 秒")
+        record_to_log(srr_id, "success")
+        return True
+    except Exception as e:
+        logger.exception(f"{srr_id} 处理失败: {e}")
+        record_to_log(srr_id, "fail")
+        return False
+
+
+# ================= 获取 SRA  =================
+def raw_data_downloader(sample_csv="sample_list.csv", start=0, end=100, max_workers=10, resume=True):
+    try:
+        df = pd.read_csv(sample_csv)
+        srr_list = df["Run"].tolist()
+        if resume and os.path.exists("success.log"):
+            completed = set(Path("success.log").read_text().splitlines())
+            srr_list = [s for s in srr_list if s not in completed]
+        if end:
+            srr_list = srr_list[start:end]
+        else:
+            srr_list = srr_list[start:]
+        print(f"待处理样本数: {len(srr_list)}")
+    except Exception as e:
+        print(f"读取样本列表失败: {str(e)}")
+        return
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+        futures = {executor.submit(process_srr, srr): srr for srr in srr_list}
+        with tqdm(total=len(srr_list), desc="处理进度") as pbar:
+            for future in concurrent.futures.as_completed(futures):
+                srr_id = futures[future]
+                try:
+                    success = future.result()
+                    status = "成功" if success else "失败"
+                    print(f"{srr_id}: {status}")
+                except Exception as e:
+                    print(f"{srr_id}: 异常终止 - {str(e)}")
+                finally:
+                    pbar.update(1)
+
+
+
+# ================= Bash Run  =================
+
+def run(cmd):
+    print(">>", " ".join(cmd))
+    subprocess.run(cmd, check=True)
+
+# ================= 数据前处理 fasterq-dump  ================= 
+#
+def pyfasterq_dump(srr, outdir):
+    """
+    Convert SRA accession to FASTQ using fasterq-dump with parallel threads and memory limit.
+    Produces paired-end FASTQ files in the specified output directory.
+    """
+    os.makedirs(outdir, exist_ok=True)
+
+    cmd = [
+        "fasterq-dump", srr,        # SRA accession ID
+        "-p",                       # enable parallel processing
+        "-O", outdir,               # output directory
+        "-e", "24",                 # use 24 threads
+        "--mem", "4G",              # allocate 4 GB memory
+        "--split-files"             # separate paired-end reads
+    ]
+
+    print(">> Running:", " ".join(cmd))
+    subprocess.run(cmd, check=True)
+
+    # Construct expected output filenames
+    fq1 = os.path.join(outdir, f"{srr}_1.fastq")
+    fq2 = os.path.join(outdir, f"{srr}_2.fastq")
+    return [fq1, fq2]
+
+
+# ======== 顶层 worker（可被pickle）========
+
+'''
+def _fasterq_run_one(srr: str,
+                     outdir: str,
+                     threads: int = 24,
+                     mem: str = "4G",
+                     retries: int = 2):
+    """
+    单个 SRR 的 fasterq-dump 任务。
+    若已存在 {srr}_1.fastq / {srr}_2.fastq 则跳过。
+    """
+    import os, time, subprocess, shutil
+
+    os.makedirs(outdir, exist_ok=True)
+    fq1 = os.path.join(outdir, f"{srr}_1.fastq")
+    fq2 = os.path.join(outdir, f"{srr}_2.fastq")
+
+    # 已有产物：跳过
+    if os.path.exists(fq1) and os.path.exists(fq2):
+        return (srr, fq1, fq2, "SKIP")
+
+    last_err = None
+    for attempt in range(1, retries + 1):
+        try:
+            cmd = [
+                "fasterq-dump", srr,
+                "-p",
+                "-O", outdir,
+                "-e", str(threads),
+                "--mem", str(mem),
+                "--split-files"
+            ]
+            print(">>", " ".join(cmd))
+            # 确认二进制可见
+            if not shutil.which("fasterq-dump"):
+                raise FileNotFoundError("fasterq-dump not found in PATH")
+
+            subprocess.run(cmd, check=True)
+
+            # 基本校验
+            if not (os.path.exists(fq1) and os.path.exists(fq2)):
+                raise RuntimeError(f"Missing outputs after fasterq-dump: {fq1}, {fq2}")
+            return (srr, fq1, fq2, "OK")
+        except Exception as e:
+            last_err = e
+            if attempt < retries:
+                time.sleep(2 * attempt)
+    # 重试用尽
+    raise RuntimeError(f"[{srr}] fasterq-dump failed after {retries} attempts: {last_err}")
+'''
+def _fasterq_run_one_resilient(
+    srr: str,
+    outdir: str,
+    threads: int = 24,
+    mem: str = "4G",
+    retries: int = 2,
+    tmp_root: str = "work/tmp",
+    compress_after: bool = True,          # NEW: auto-compress after dump
+    compress_threads: int = 8             # NEW: pigz threads if available
+):
+    """
+    Resilient fasterq-dump:
+      1) skip if outputs already exist (.fastq or .fastq.gz)
+      2) try direct stream
+      3) fallback: prefetch -> (validate) -> local fasterq-dump
+      4) degrade: fewer threads, no -p
+      5) optional: gzip compress outputs + integrity check + remove .fastq
+    Returns (srr, fq1_out, fq2_out, status) where fq*_out may be .fastq.gz
+    """
+    os.makedirs(outdir, exist_ok=True)
+    fq1 = os.path.join(outdir, f"{srr}_1.fastq")
+    fq2 = os.path.join(outdir, f"{srr}_2.fastq")
+    fq1_gz = fq1 + ".gz"
+    fq2_gz = fq2 + ".gz"
+    log = Path(outdir) / f"{srr}.fasterq.log"
+
+    def _outputs_exist() -> bool:
+        # consider either uncompressed or compressed pairs as "existing"
+        return ((Path(fq1).exists() and Path(fq2).exists()) or
+                (Path(fq1_gz).exists() and Path(fq2_gz).exists()))
+
+    # If already produced (gz or fq), skip
+    if _outputs_exist():
+        # normalize return to gz paths if present, else fq paths
+        out1 = fq1_gz if Path(fq1_gz).exists() else fq1
+        out2 = fq2_gz if Path(fq2_gz).exists() else fq2
+        return (srr, out1, out2, "SKIP")
+
+    ver = _sra_tools_version()
+    if ver is None:
+        raise FileNotFoundError("fasterq-dump not found in PATH")
+
+    last_err = None
+    plans = [
+        ("direct_parallel",   dict(parallel=True,  t=threads,                mem=mem)),
+        ("prefetch_parallel", dict(parallel=True,  t=threads,                mem=mem)),
+        ("prefetch_serial",   dict(parallel=False, t=max(1, threads // 2),   mem=mem)),
+    ]
+
+    for name, cfg in plans:
+        for attempt in range(1, retries + 1):
+            try:
+                tmpdir = os.path.join(tmp_root, f"{srr}.{name}.try{attempt}")
+                Path(tmpdir).mkdir(parents=True, exist_ok=True)
+
+                if "prefetch" in name:
+                    _prefetch_and_convert(srr, outdir, cfg["t"], cfg["mem"], cfg["parallel"], tmpdir, log)
+                else:
+                    _try_direct_fasterq(srr, outdir, cfg["t"], cfg["mem"], cfg["parallel"], tmpdir, log)
+
+                # basic existence check (uncompressed)
+                if not (Path(fq1).exists() and Path(fq2).exists()):
+                    # some single-end runs produce only _1; consider extending if needed
+                    raise RuntimeError("Outputs missing after fasterq-dump.")
+
+                # Post-step compression
+                out1, out2 = fq1, fq2
+                if compress_after:
+                    out1 = _gzip_compress(fq1, threads=compress_threads)
+                    out2 = _gzip_compress(fq2, threads=compress_threads)
+                    # after _gzip_compress, .fastq is removed and .gz integrity tested
+
+                return (srr, out1, out2, "OK")
+
+            except Exception as e:
+                last_err = e
+                time.sleep(2 * attempt)
+
+    raise RuntimeError(f"[{srr}] fasterq-dump ultimately failed: {last_err}")
+
+# ======== 并行调度器（对外 API）========
+def pyfasterq_dump_parallel(
+    srr_list: list[str],
+    outdir: str,
+    threads_per_job: int = 24,     # 传给 fasterq-dump 的 -e
+    mem_per_job: str = "4G",       # 传给 fasterq-dump 的 --mem
+    max_workers: int | None = None,
+    retries: int = 2,
+    tmp_root: str = "work/tmp",
+    compress_after: bool = True,      
+    compress_threads: int = 8,         
+    backend: str = "process",      # "process" 或 "thread"
+):
+    """
+    批量并行执行 fasterq-dump（与单个 pyfasterq_dump 逻辑一致）。
+    - 自动跳过已存在 {SRR}_1.fastq / {SRR}_2.fastq
+    - 支持失败重试
+    - max_workers 缺省为 (CPU核数 // threads_per_job)
+
+    返回:
+      {"success": [(srr, fq1, fq2, status), ...], "failed": [(srr, errmsg), ...]}
+    """
+    
+
+    total_cores = os.cpu_count() or 8
+    if max_workers is None:
+        max_workers = max(1, floor(total_cores / max(1, threads_per_job)))
+
+    print(f"[INFO] CPU cores={total_cores}, per-job threads={threads_per_job}, max parallel={max_workers}")
+    print(f"[INFO] fasterq-dump path: {shutil.which('fasterq-dump')}")
+    print(f"[INFO] Python exec: {sys.executable}")
+
+    Executor = ProcessPoolExecutor if backend == "process" else ThreadPoolExecutor
+
+    results, errors = [], []
+    with Executor(max_workers=max_workers) as ex:
+        futs = {
+            ex.submit(_fasterq_run_one_resilient,
+                      srr, outdir,
+                      threads_per_job, mem_per_job,
+                      retries, tmp_root,
+                      compress_after, compress_threads): srr
+            for srr in srr_list
+        }
+        for fut in as_completed(futs):
+            srr = futs[fut]
+            try:
+                res = fut.result()  # (srr, fq1_out, fq2_out, status) | .gz if compressed
+                results.append(res)
+                print(f"[{res[3]}] {srr} -> {res[1]}, {res[2]}")
+            except Exception as e:
+                errors.append((srr, str(e)))
+                print(f"[ERR] {srr}: {e}")
+
+    print(f"[SUMMARY] OK={len([r for r in results if r[3]=='OK'])}, "
+          f"SKIP={len([r for r in results if r[3]=='SKIP'])}, "
+          f"Failed={len(errors)}")
+    return {"success": results, "failed": errors}
+
+'''
+how to use
+
+srrs = ["SRR12544419", "SRR12544565", "SRR12544566"]
+
+ret = pyfasterq_dump_parallel(
+    srr_list=srrs,
+    outdir="work",
+    threads_per_job=24,     # passed to fasterq-dump -e
+    mem_per_job="4G",
+    # max_workers=8,        # optional; defaults to cores // threads_per_job
+    retries=2,
+    tmp_root="work/tmp",
+    backend="process",
+    compress_after=True,     # turn on gzip
+    compress_threads=8       # pigz -p 8 (if pigz available)
+)
+
+# outputs for each SRR are .fastq.gz paths (if compressed)
+
+'''
+
+# ===============数据质控===================
+
+def require_tool(name, hint=""):
+    import shutil
+    path = shutil.which(name)
+    if path:
+        print(f"[OK] {name} found at {path}")
+        return path
+    else:
+        raise FileNotFoundError(f"{name} not found. {hint}")
+
+
+def fastp_clean(fq1, fq2, sample, out_dir, threads = "12" ):
+    # 单一数据的处理 对于多数据并行使用 fastp_clean_parallel(),
+    outdir = os.path.join(out_dir, "fastp"); os.makedirs(outdir, exist_ok=True)
+    #require_tool("fastp", "Try: conda install -c bioconda fastp")
+    if fq2:  # paired
+        out1 = os.path.join(outdir, f"{sample}_1.clean.fq.gz")
+        out2 = os.path.join(outdir, f"{sample}_2.clean.fq.gz")
+        run(["fastp","-i",fq1,"-I",fq2,
+             "-o",out1,"-O",out2,
+             "-w",threads,
+             "-j",os.path.join(outdir,f"{sample}.json"),
+             "-h",os.path.join(outdir,f"{sample}.html")])
+        # verify outputs
+        if not (os.path.exists(out1) and os.path.exists(out2)):
+            raise RuntimeError(f"fastp finished but outputs missing: {out1}, {out2}")
+        return out1, out2
+    else:
+        out1 = os.path.join(outdir, f"{sample}.clean.fq.gz")
+        run(["fastp","-i",fq1,
+             "-o",out1,
+             "-w",threads,
+             "-j",os.path.join(outdir,f"{sample}.json"),
+             "-h",os.path.join(outdir,f"{sample}.html")])
+        if not os.path.exists(out1):
+            raise RuntimeError(f"fastp finished but output missing: {out1}")
+        return out1, ""
+
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from math import floor
+
+# ---- 顶层可pickle的worker ----
+def _fastp_run_one(sample: str, outdir: str, work_dir: str, fastp_threads: int, retries: int = 2):
+    """
+    单样本清洗的子进程任务。需要在模块顶层定义，便于 ProcessPoolExecutor pickle。
+    依赖同模块中的 fastp_clean(fq1, fq2, sample, work_dir, threads=...).
+    """
+    import os, time
+
+    fq1 = os.path.join(outdir, f"{sample}_1.fastq")
+    fq2 = os.path.join(outdir, f"{sample}_2.fastq")
+    if not os.path.exists(fq1):
+        raise FileNotFoundError(f"[{sample}] FASTQ not found: {fq1}")
+    if fq2 and not os.path.exists(fq2):
+        raise FileNotFoundError(f"[{sample}] FASTQ not found: {fq2}")
+
+    # 已完成则跳过（与 fastp_clean 输出命名保持一致）
+    out1 = os.path.join(work_dir, f"{sample}_1.clean.fq.gz")
+    out2 = os.path.join(work_dir, f"{sample}_2.clean.fq.gz")
+    if os.path.exists(out1) and os.path.exists(out2):
+        return sample, out1, out2, "SKIP"
+
+    last_err = None
+    for attempt in range(1, retries + 1):
+        try:
+            # 直接调用你已有的 fastp_clean（确保它是模块级函数）
+            fq1_clean, fq2_clean = fastp_clean(fq1, fq2, sample, work_dir, threads=fastp_threads)
+            if not os.path.exists(fq1_clean) or not os.path.exists(fq2_clean):
+                raise RuntimeError(f"[{sample}] Missing output after fastp_clean.")
+            return sample, fq1_clean, fq2_clean, "OK"
+        except Exception as e:
+            last_err = e
+            if attempt < retries:
+                time.sleep(2 * attempt)
+    # 重试用尽
+    raise RuntimeError(f"[{sample}] fastp_clean failed after {retries} attempts: {last_err}")
+
+# ---- 并行调度器（对外API）----
+def fastp_clean_parallel(
+    samples: list[str],
+    outdir: str,
+    work_dir: str,
+    fastp_threads: int = 4,
+    max_workers: int | None = None,
+    retries: int = 2,
+    backend: str = "process",   # 可选 "process" 或 "thread"
+):
+    """
+    并行批量运行 fastp_clean（对单个样本仍可用原 fastp_clean）。
+
+    参数
+    ----
+    samples: SRR 列表
+    outdir: 原始 FASTQ 所在目录
+    work_dir: 清洗输出目录（fastp_clean里会用到）
+    fastp_threads: 传给 fastp 的 -w
+    max_workers: 并发度（默认=CPU核数/fastp_threads）
+    retries: 每个样本失败重试次数
+    backend: "process"（默认）或 "thread"；若仍遇到pickling问题可临时用 "thread"
+    """
+    import os, sys, shutil
+    from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor, as_completed
+    from math import floor
+
+    total_cores = os.cpu_count() or 8
+    if max_workers is None:
+        max_workers = max(1, floor(total_cores / fastp_threads))
+
+    print(f"[INFO] CPU cores={total_cores}, per fastp threads={fastp_threads}, max parallel={max_workers}")
+    print(f"[INFO] fastp path: {shutil.which('fastp')}")
+    print(f"[INFO] Python exec: {sys.executable}")
+
+    Executor = ProcessPoolExecutor if backend == "process" else ThreadPoolExecutor
+
+    results, errors = [], []
+    with Executor(max_workers=max_workers) as ex:
+        futs = {
+            ex.submit(_fastp_run_one, s, outdir, work_dir, fastp_threads, retries): s
+            for s in samples
+        }
+        for fut in as_completed(futs):
+            s = futs[fut]
+            try:
+                sample, out1, out2, status = fut.result()
+                results.append((sample, out1, out2, status))
+                print(f"[{status}] {sample} -> {out1}, {out2}")
+            except Exception as e:
+                errors.append((s, str(e)))
+                print(f"[ERR] {s}: {e}")
+
+    print(f"[SUMMARY] Completed={len([r for r in results if r[3]=='OK'])}, "
+          f"Skipped={len([r for r in results if r[3]=='SKIP'])}, "
+          f"Failed={len(errors)}")
+    return {"success": results, "failed": errors}

--- a/omicverse/bulk/star_step.py
+++ b/omicverse/bulk/star_step.py
@@ -1,0 +1,224 @@
+# star_step.py  —— 批量 STAR 步骤（与现有 star_tools 保持兼容）
+from __future__ import annotations
+from pathlib import Path
+from typing import Sequence, Tuple, List, Optional
+import os, shutil
+from concurrent.futures import ThreadPoolExecutor, as_completed
+import subprocess
+from .star_tools import star_align_auto     # 复用你的实现
+from .tools_check import which_or_find, merged_env
+
+
+def _bam_ok(p: Path) -> bool:
+    """BAM>1MB 即认为有效；若有 .bai 更好，但不强制。"""
+    try:
+        return p.exists() and p.stat().st_size > 1_000_000
+    except Exception:
+        return False
+
+
+def _normalize_bam(bam_path: Path, sample_dir: Path, srr: str) -> Path:
+    """
+    归一化 BAM 命名为 <SRR>/Aligned.sortedByCoord.out.bam
+    - 若 star_align_auto 产出例如: run.Aligned.sortedByCoord.out.bam，则移动/重命名到规范名称
+    - 同步处理 .bai（若存在）
+    归一化：
+      1) 确保标准名 <SRR>/Aligned.sortedByCoord.out.bam 存在（必要时移动原产物）
+      2) 暴露 SRR 命名句柄 <SRR>/<srr>.sorted.bam （优先软链接；失败则复制）
+      3) 返回 SRR 命名句柄（供下游 featureCounts 使用，列名唯一）
+    """
+    sample_dir.mkdir(parents=True, exist_ok=True)
+    target = sample_dir / "Aligned.sortedByCoord.out.bam"
+    target_bai = target.with_suffix(".bam.bai")
+
+    # 如果不是标准名，先把 bam_path 挪到标准名
+    if bam_path.resolve() != target.resolve():
+        # 先把旧索引名定位出来（若存在）
+        src_bai = bam_path.with_suffix(".bam.bai")
+        # 移动 BAM
+        bam_path.parent.mkdir(parents=True, exist_ok=True)
+        if target.exists() and target.stat().st_size == 0:
+            target.unlink()
+        if not target.exists():
+            shutil.move(str(bam_path), str(target))
+        # 移动 BAI
+        if src_bai.exists():
+            if target_bai.exists():
+                target_bai.unlink()
+            shutil.move(str(src_bai), str(target_bai))
+
+    # 确保有索引（如果还没有）
+    if not target_bai.exists():
+        samtools = which_or_find("samtools")
+        subprocess.run([samtools, "index", str(target)], check=True)
+
+    # 创建/刷新 SRR 命名的软链接
+    srr_bam = sample_dir / f"{srr}.sorted.bam"
+    srr_bai = sample_dir / f"{srr}.sorted.bam.bai"
+    try:
+        if srr_bam.is_symlink() or srr_bam.exists():
+            srr_bam.unlink()
+        if srr_bai.is_symlink() or srr_bai.exists():
+            srr_bai.unlink()
+        # 相对链接更稳（目录内）
+        srr_bam.symlink_to(target.name)
+        srr_bai.symlink_to(target_bai.name)
+    except OSError:
+        # 某些文件系统/权限不支持 symlink，则复制一份
+        shutil.copy2(str(target), str(srr_bam))
+        shutil.copy2(str(target_bai), str(srr_bai))
+
+    return srr_bam
+
+
+def _try_parse_index_dir(ret) -> Optional[Path]:
+    """
+    star_align_auto 的返回可能是:
+      - str(bam)
+      - (bam,)
+      - (bam, index_dir)
+      - [bam, index_dir, ...]
+    这里尽量解析 index_dir；实在确定不了就返回 None。
+    """
+    if isinstance(ret, (list, tuple)):
+        if len(ret) >= 2:
+            cand = Path(ret[1])
+            if cand.exists() and cand.is_dir():
+                return cand
+    return None
+
+
+def _align_one(
+    srr: str,
+    fq1: str | Path,
+    fq2: str | Path,
+    index_root: str,
+    out_root: str,
+    threads: int,
+    gencode_release: str,
+    sjdb_overhang: Optional[int],
+    accession_for_species: Optional[str],
+) -> Tuple[str, str, Optional[str]]:
+    """
+    单样本对齐；返回 (srr, bam_path, index_dir|None)
+    """
+    sample_dir = Path(out_root) / srr
+    sample_dir.mkdir(parents=True, exist_ok=True)
+    # 规范化预期产物路径（用于幂等跳过 & 下游验证）
+    expected_bam = sample_dir / "Aligned.sortedByCoord.out.bam"
+
+    # 幂等：已有就跳过
+    if _bam_ok(expected_bam):
+        print(f"[SKIP] STAR {srr}: {expected_bam}")
+        # 补齐 SRR 命名句柄（若不存在）
+        srr_bam = _normalize_bam(expected_bam, sample_dir, srr)
+        return srr, str(srr_bam), None
+
+    # 仍兼容你原来的 out_prefix="run."
+    out_prefix = sample_dir / "run."
+    acc = accession_for_species or srr
+
+    # 调你的现有封装
+    ret = star_align_auto(
+        accession=acc,
+        fq1=str(fq1),
+        fq2=str(fq2),
+        index_root=index_root,
+        out_prefix=str(out_prefix),
+        threads=threads,
+        gencode_release=gencode_release,
+        sjdb_overhang=sjdb_overhang,
+        sample=srr,
+    )
+
+    # 解析 bam_path
+    if isinstance(ret, (list, tuple)):
+        bam_path = Path(ret[0])
+    else:
+        bam_path = Path(ret)
+
+    if not bam_path.exists():
+        raise FileNotFoundError(f"[STAR] BAM not found for {srr}: {bam_path}")
+
+    # 归一化命名为 <SRR>/Aligned.sortedByCoord.out.bam
+    bam_path = _normalize_bam(bam_path, sample_dir, srr)   # ← 传 srr
+    idx_dir = _try_parse_index_dir(ret)
+    return srr, str(bam_path), (str(idx_dir) if idx_dir else None)
+
+
+def make_star_step(
+    index_root: str = "index",
+    out_root: str = "work/star",
+    threads: int = 12,
+    gencode_release: str = "v44",
+    sjdb_overhang: int | None = 149,
+    accession_for_species: str | None = None,  # 若每个样本同一 GSE，可统一传
+    max_workers: int | None = None,            # ← 新增：批量并发数（None=串行）
+):
+    """
+    输入：[(srr, fq1_clean, fq2_clean), ...]
+    输出：work/star/{SRR}/Aligned.sortedByCoord.out.bam（每样本独立子目录）
+    验证：BAM 存在且 > 1MB
+    """
+    def _cmd(clean_fastqs: Sequence[Tuple[str, str | Path, str | Path]], logger=None) -> List[Tuple[str, str, Optional[str]]]:
+        os.makedirs(out_root, exist_ok=True)
+
+        # 若未指定并发，默认串行（保持日志顺序清晰）
+        if not max_workers or max_workers <= 1:
+            products = []
+            for srr, fq1, fq2 in clean_fastqs:
+                rec = _align_one(
+                    srr=srr, fq1=fq1, fq2=fq2,
+                    index_root=index_root, out_root=out_root,
+                    threads=threads, gencode_release=gencode_release,
+                    sjdb_overhang=sjdb_overhang,
+                    accession_for_species=accession_for_species,
+                )
+                products.append(rec)  # (srr, bam, index_dir|None)
+            return products
+
+        # 并发模式（每样本一个任务）
+        from concurrent.futures import ThreadPoolExecutor, as_completed
+        products: List[Tuple[str, str, Optional[str]]] = []
+        errors: List[Tuple[str, str]] = []
+
+        def _worker(item):
+            srr, fq1, fq2 = item
+            return _align_one(
+                srr=srr, fq1=fq1, fq2=fq2,
+                index_root=index_root, out_root=out_root,
+                threads=threads, gencode_release=gencode_release,
+                sjdb_overhang=sjdb_overhang,
+                accession_for_species=accession_for_species,
+            )
+
+        with ThreadPoolExecutor(max_workers=int(max_workers)) as ex:
+            futs = {ex.submit(_worker, it): it[0] for it in clean_fastqs}
+            for fut in as_completed(futs):
+                srr = futs[fut]
+                try:
+                    products.append(fut.result())
+                except Exception as e:
+                    msg = str(e)
+                    errors.append((srr, msg))
+                    if logger:
+                        logger.error(f"[STAR] {srr} failed: {msg}")
+
+        if errors:
+            # 你也可以选择继续返回成功的部分
+            err_msg = "; ".join([f"{s}:{m}" for s, m in errors])
+            raise RuntimeError(f"STAR failed for {len(errors)} samples: {err_msg}")
+
+        # 保持与输入顺序一致
+        order = {s: i for i, (s, _, _) in enumerate(clean_fastqs)}
+        products.sort(key=lambda x: order[x[0]])
+        return products
+
+    return {
+        "name": "star",
+        "command": _cmd,  # 接收[(srr, fq1_clean, fq2_clean), ...]，返回[(srr, bam, index_dir|None), ...]
+        "outputs": [f"{out_root}" + "/{SRR}/Aligned.sortedByCoord.out.bam"],  # 与你的验证一致
+        "validation": lambda fs: all(os.path.exists(f) and os.path.getsize(f) > 1_000_000 for f in fs),
+        "takes": "CLEAN_FASTQ_PATHS",
+        "yields": "BAM_PATHS"  # 实际返回三元组，后续仍按你已有规范化逻辑处理
+    }

--- a/omicverse/bulk/star_tools.py
+++ b/omicverse/bulk/star_tools.py
@@ -1,0 +1,698 @@
+from __future__ import annotations
+import os, time,re, sys, gzip, shutil, subprocess, json, requests
+import pandas as pd
+from pathlib import Path
+from typing import Tuple, Optional, List, Union
+from tqdm import tqdm
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from .geo_meta_fetcher import parse_geo_soft_to_struct, fetch_geo_text
+
+
+
+# ================= 获GEO取数据信息  ================= 
+
+HEADERS = {"User-Agent": "Mozilla/5.0 (Python requests)"}
+
+def fetch_geo_text(accession: str) -> str:
+    """
+    accession: GSE12345 or GSMxxxx. (For SRR, you typically have no GEO record; pass the GSE.)
+    """
+    
+    url = f"https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc={accession}&form=text&view=full"
+    r = requests.get(url, headers=HEADERS, timeout=120)
+    r.raise_for_status()
+    return r.text
+# ================= 检测数据来源  ================= 
+
+def detect_species_build_from_geo(accession: str) -> Tuple[str, str]:
+    """
+    Returns (species_key, build_key), e.g. ('human', 'GRCh38')
+    - If build is not stated, choose a robust default by species.
+    """
+    txt = fetch_geo_text(accession)
+    # try to find organism lines
+    org_lines = re.findall(r"!(?:Series|Sample|Platform)_(?:sample_)?organism.*=\s*(.+)", txt)
+    org = "|".join(set([o.strip() for o in org_lines])) if org_lines else ""
+
+    # normalize organism
+    org_lower = org.lower()
+    if "homo sapiens" in org_lower or "human" in org_lower:
+        species, build = "human", "GRCh38"
+    elif "mus musculus" in org_lower or "mouse" in org_lower:
+        species, build = "mouse", "GRCm39"
+    else:
+        # default fallbacks; customize as needed
+        species, build = "human", "GRCh38"
+
+    # Try to detect genome build strings in free text (rare in GEO)
+    build_hits = re.findall(r"(GRCh\d+|hg\d+|GRCm\d+|mm\d+)", txt, flags=re.I)
+    if build_hits:
+        # pick the first reasonable hit
+        b = build_hits[0].upper()
+        # normalize a few common aliases
+        if b.startswith("HG"):
+            # hg38->GRCh38, hg19->GRCh37
+            build = "GRCh38" if "38" in b else ("GRCh37" if "19" in b else build)
+        elif b.startswith("MM"):
+            build = "GRCm39" if "39" in b else ("GRCm38" if "10" in b else build)
+        else:
+            build = b
+    return species, build
+
+# ================= ·download helper ================= 
+'''
+def download_file(url, dest, chunk=1 << 20, max_retries=5):
+    """
+    Robust file downloader with HTTP Range resume support.
+    - If an incomplete .part file exists, it will resume from where it stopped.
+    - Retries on connection drop (ChunkedEncodingError, Timeout, etc.).
+    """
+    headers = {
+    "User-Agent": "Python-Resumable-Downloader/1.0",
+    "Accept-Encoding": "identity",   # 避免服务器对主体再 gzip，保证 Range 的字节对齐
+    }
+    dest = os.path.abspath(dest)
+    tmp = dest + ".part"
+    os.makedirs(os.path.dirname(dest), exist_ok=True)
+
+    # Figure out where to resume
+    resume_byte_pos = os.path.getsize(tmp) if os.path.exists(tmp) else 0
+    mode = "ab" if resume_byte_pos > 0 else "wb"
+
+    
+    if resume_byte_pos > 0:
+        headers["Range"] = f"bytes={resume_byte_pos}-"
+
+    # Do streaming with retries
+    for attempt in range(1, max_retries + 1):
+        try:
+            with requests.get(url, stream=True, headers=headers, timeout=600) as r:
+                r.raise_for_status()
+
+                total = int(r.headers.get("Content-Length", 0)) + resume_byte_pos
+                pbar = tqdm(
+                    total=total, initial=resume_byte_pos, unit="B", unit_scale=True,
+                    desc=os.path.basename(dest)
+                )
+
+                with open(tmp, mode) as f:
+                    for chunk_bytes in r.iter_content(chunk_size=chunk):
+                        if not chunk_bytes:
+                            continue
+                        f.write(chunk_bytes)
+                        pbar.update(len(chunk_bytes))
+                pbar.close()
+
+            # Rename only if full download succeeded
+            os.replace(tmp, dest)
+            print(f"[OK] {os.path.basename(dest)} downloaded successfully ({total/1e6:.1f} MB)")
+            return dest
+
+        except (requests.exceptions.ChunkedEncodingError,
+                requests.exceptions.ConnectionError,
+                requests.exceptions.ReadTimeout) as e:
+            print(f"⚠️ Attempt {attempt}/{max_retries} failed: {e}")
+            print("   Retrying in 10 s …")
+            import time; time.sleep(10)
+            # next iteration will resume again
+            continue
+
+    raise RuntimeError(f"❌ Failed to download {url} after {max_retries} attempts")
+'''
+def gunzip_to(src_gz: Path, dst: Path):
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    with gzip.open(src_gz, "rb") as gzin, open(dst, "wb") as out:
+        shutil.copyfileobj(gzin, out)
+
+class ResumeError(RuntimeError): pass
+
+def head_info(url, timeout=30):
+    r = requests.head(url, headers=HEADERS, allow_redirects=True, timeout=timeout)
+    r.raise_for_status()
+    h = r.headers
+    return {
+        "length": int(h.get("Content-Length") or 0),
+        "accept_ranges": (h.get("Accept-Ranges") or "").lower() == "bytes",
+        "etag": h.get("ETag"),
+        "last_modified": h.get("Last-Modified"),
+        "final_url": r.url,
+    }
+
+def curl_available():
+    return shutil.which("curl") is not None
+
+def download_file(url: str, dest: str, chunk: int = 1<<20, max_retries: int = 8, use_curl_fallback: bool = True):
+    """
+    具备断点续传、元信息校验、重试与可选 curl 回退的稳健下载器。
+    - 部分下载写到 dest.part，元信息写到 dest.meta.json
+    - 支持 Range 续传（206）。若服务端忽略 Range（200），可选走 curl -C - 回退。
+    """
+    dest = os.path.abspath(dest)
+    tmp = dest + ".part"
+    meta = dest + ".meta.json"
+    os.makedirs(os.path.dirname(dest), exist_ok=True)
+
+    # 1) 获取服务器元信息
+    info = head_info(url)
+    total = info["length"]
+    supports_range = info["accept_ranges"]
+    etag = info["etag"]
+    last_mod = info["last_modified"]
+
+    # 2) 读取本地元信息
+    local = {"downloaded": 0, "total": total, "etag": etag, "last_modified": last_mod}
+    if os.path.exists(meta):
+        try:
+            local = json.load(open(meta, "r"))
+        except Exception:
+            pass
+
+    # 如果服务器文件特征（etag/last-mod/总长）与本地不一致，删除旧片段
+    mismatch = (
+        (local.get("etag") and etag and local["etag"] != etag) or
+        (local.get("last_modified") and last_mod and local["last_modified"] != last_mod) or
+        (local.get("total", 0) and total and local["total"] != total)
+    )
+    if mismatch:
+        for p in (tmp, dest, meta):
+            if os.path.exists(p):
+                os.remove(p)
+        local = {"downloaded": 0, "total": total, "etag": etag, "last_modified": last_mod}
+
+    # 若已有完整文件，直接返回
+    if os.path.exists(dest) and (total == 0 or os.path.getsize(dest) == total):
+        return dest
+
+    # 初始化/刷新 meta
+    local["total"] = total
+    local["etag"] = etag
+    local["last_modified"] = last_mod
+    json.dump(local, open(meta, "w"))
+
+    # 当前已下载字节
+    downloaded = os.path.getsize(tmp) if os.path.exists(tmp) else 0
+    if downloaded > total > 0:
+        # 异常状态，清理重新来
+        os.remove(tmp)
+        downloaded = 0
+
+    # 3) 如果不支持 Range，且需要续传，考虑 curl 回退或重下
+    if downloaded > 0 and not supports_range:
+        if use_curl_fallback and curl_available():
+            print("⚠️ Server does not advertise Range support. Falling back to curl -C - …")
+            return curl_resume(url, dest, meta)
+        else:
+            print("⚠️ Server does not support resume; restarting from scratch.")
+            if os.path.exists(tmp):
+                os.remove(tmp)
+            downloaded = 0
+
+    # 4) 带 Range 的下载循环
+    headers = dict(HEADERS)
+    if downloaded > 0:
+        headers["Range"] = f"bytes={downloaded}-"
+
+    for attempt in range(1, max_retries + 1):
+        try:
+            with requests.get(url, headers=headers, stream=True, timeout=600) as r:
+                # 期望 206（续传）；如果返回 200 且我们想续传 → 服务器忽略 Range
+                if downloaded > 0 and r.status_code == 200:
+                    if use_curl_fallback and curl_available():
+                        print("⚠️ Server ignored Range (200). Falling back to curl -C - …")
+                        return curl_resume(url, dest, meta)
+                    else:
+                        print("⚠️ Server ignored Range; restarting from scratch.")
+                        if os.path.exists(tmp): os.remove(tmp)
+                        downloaded = 0
+
+                r.raise_for_status()
+
+                # 进度条
+                total_disp = total if total else None
+                pbar = tqdm(total=total_disp, initial=downloaded, unit="B", unit_scale=True,
+                            desc=os.path.basename(dest))
+
+                # 以追加或写入模式打开
+                with open(tmp, "ab" if downloaded else "wb") as f:
+                    for chunk_bytes in r.iter_content(chunk_size=chunk):
+                        if not chunk_bytes:
+                            continue
+                        f.write(chunk_bytes)
+                        downloaded += len(chunk_bytes)
+                        pbar.update(len(chunk_bytes))
+                        # 每写一段就刷新 meta（防止崩溃后能继续）
+                        local["downloaded"] = downloaded
+                        json.dump(local, open(meta, "w"))
+                pbar.close()
+
+            # 完成：原子替换
+            os.replace(tmp, dest)
+            print(f"[OK] {os.path.basename(dest)} downloaded ({downloaded/1e6:.1f} MB)")
+            return dest
+
+        except (requests.exceptions.ChunkedEncodingError,
+                requests.exceptions.ConnectionError,
+                requests.exceptions.ReadTimeout) as e:
+            print(f"⚠️ Attempt {attempt}/{max_retries} failed: {e}")
+            time.sleep(min(30, 5 * attempt))  # 逐步退避
+
+    raise ResumeError(f"Failed to download after {max_retries} attempts: {url}")
+
+def curl_resume(url: str, dest: str, meta_path: str):
+    """使用 curl -L -C - 断点续传作为回退方案。"""
+    tmp = dest + ".part"
+    # curl 直接对最终文件续传，因此我们对齐逻辑：先把 .part 挪成最终名（若存在）
+    if os.path.exists(tmp) and not os.path.exists(dest):
+        os.rename(tmp, dest)
+
+    cmd = ["curl", "-L", "-C", "-", "-o", dest, url]
+    print(">>", " ".join(cmd))
+    ret = subprocess.run(cmd)
+    if ret.returncode != 0:
+        raise ResumeError("curl failed to resume download.")
+    # 校验尺寸并补 meta
+    try:
+        info = head_info(url)
+        meta = {"downloaded": os.path.getsize(dest), "total": info["length"],
+                "etag": info["etag"], "last_modified": info["last_modified"]}
+        json.dump(meta, open(meta_path, "w"))
+    except Exception:
+        pass
+    print(f"[OK] {os.path.basename(dest)} downloaded via curl")
+    return dest
+
+# ================= ·检测STAR INDEX是否存在 ================= 
+def get_gtf_for_index(index_dir: Path) -> Path:
+    """
+    根据 STAR index 目录自动定位 GTF：
+    1) 若存在 reference.json（建议在 ensure_star_index 构建索引时写入），直接读取；
+    2) 按约定路径扫描：index/<species>/<build>/STAR → 缓存在 index/_cache/<species>/<build>/*.gtf(.gz)
+    3) 兜底：在 index 根目录向下递归找最近的 .gtf 或 .gtf.gz
+
+    返回：解压后的 .gtf 的绝对路径（若原文件是 .gtf.gz，会自动解压并返回解压路径）
+    """
+    index_dir = Path(index_dir).resolve()
+    # 1) 优先用 reference.json（如果你在 ensure_star_index 里写过这个档案）
+    ref_json = index_dir.parent / "reference.json"
+    if ref_json.exists():
+        try:
+            meta = json.loads(ref_json.read_text())
+            gtf = Path(meta.get("gtf", ""))
+            if gtf.exists():
+                if gtf.suffix == ".gz":
+                    # 解压到同级无后缀路径（可按需改到 cache）
+                    dst = gtf.with_suffix("") 
+                    if not dst.exists():
+                        _gunzip_to(gtf, dst)
+                    return dst.resolve()
+                return gtf.resolve()
+        except Exception:
+            pass
+
+    # 2) 依约定推导 cache 目录：index/<species>/<build>/STAR
+    #    → index/_cache/<species>/<build>
+    #    index_dir.parts: [..., "index", species, build, "STAR"]
+    parts = index_dir.parts
+    # 尝试定位 "index" 的位置
+    try:
+        i = parts.index("index")
+        species = parts[i+1]
+        build   = parts[i+2]
+        cache_dir = Path(*parts[:i+1]) / "_cache" / species / build
+    except Exception:
+        # 若不符合约定结构，fallback 到 index 的三层上级再去找 _cache
+        cache_dir = index_dir
+        for _ in range(3):
+            if cache_dir.name == "STAR":
+                cache_dir = cache_dir.parent.parent / "_cache" / cache_dir.parent.name / cache_dir.parent.parent.name
+                break
+            cache_dir = cache_dir.parent
+
+    gtf = None
+    # 2a) cache 下找 .gtf or .gtf.gz
+    if cache_dir and cache_dir.exists():
+        gz_list  = sorted(cache_dir.glob("*.gtf.gz"))
+        gtf_list = sorted(cache_dir.glob("*.gtf"))
+        if gtf_list:
+            gtf = gtf_list[0]
+        elif gz_list:
+            gtf_gz = gz_list[0]
+            dst = cache_dir / re.sub(r"\.gz$", "", gtf_gz.name)
+            if not dst.exists():
+                _gunzip_to(gtf_gz, dst)
+            gtf = dst
+
+    # 3) 兜底：在 index 根目录附近递归找
+    if gtf is None:
+        root = index_dir
+        for _ in range(4):  # 往上最多四层
+            root = root.parent
+        candidates = list(root.rglob("*.gtf")) or list(root.rglob("*.gtf.gz"))
+        if not candidates:
+            raise FileNotFoundError(
+                f"Cannot locate GTF for STAR index at: {index_dir}\n"
+                f"Please ensure ensure_star_index() downloaded GENCODE and cache exists under index/_cache/<species>/<build>/"
+            )
+        gtf_cand = candidates[0]
+        if str(gtf_cand).endswith(".gtf.gz"):
+            dst = gtf_cand.with_suffix("")
+            if not dst.exists():
+                _gunzip_to(gtf_cand, dst)
+            gtf = dst
+        else:
+            gtf = gtf_cand
+
+    return Path(gtf).resolve()
+def ensure_star_index(
+    species: str,
+    build: str,
+    index_root: Path = Path("index"),
+    gencode_release: str = "v44",
+    threads: int = 12,
+    sjdb_overhang: Optional[int] = 149,) -> Path:
+    """
+    Ensures STAR index exists for (species, build).
+    Downloads GENCODE genome+GTF, builds index if missing.
+    Returns the STAR index dir path.
+    """
+    # Normalize
+    species = species.lower()
+    build = build.upper()
+    
+    # normalize common aliases 确保名称大小写规范
+    if build in ("GRCH38", "HG38"):
+        build = "GRCh38"
+    elif build in ("GRCH37", "HG19"):
+        build = "GRCh37"
+    elif build in ("GRCM39", "MM39"):
+        build = "GRCm39"
+    elif build in ("GRCM38", "MM10"):
+        build = "GRCm38"
+
+    # Where to place the index
+    idx_dir = index_root / species / build / "STAR"
+    genome_params = idx_dir / "genomeParameters.txt"
+    if genome_params.exists():
+        return idx_dir
+
+    # Choose GENCODE URLs (adjust if you prefer Ensembl / iGenomes)
+    if species == "human" and build == "GRCh38":
+        # GENCODE primary assembly (no ALT contigs)
+        base = f"https://ftp.ebi.ac.uk/pub/databases/gencode/Gencode_human/release_{gencode_release.lstrip('v')}"
+        fasta_url = f"{base}/GRCh38.primary_assembly.genome.fa.gz"
+        gtf_url   = f"{base}/gencode.{gencode_release}.annotation.gtf.gz"
+    elif species == "mouse" and build in ("GRCm39","GRCM39"):
+        base = f"https://ftp.ebi.ac.uk/pub/databases/gencode/Gencode_mouse/release_{gencode_release.lstrip('v')}"
+        fasta_url = f"{base}/GRCm39.primary_assembly.genome.fa.gz"
+        gtf_url   = f"{base}/gencode.{gencode_release}.annotation.gtf.gz"
+    else:
+        raise ValueError(f"No URL templates for species={species}, build={build}. Add one above.")
+
+    # Download to a cache folder
+    cache = index_root / "_cache" / species / build
+    fa_gz = cache / Path(fasta_url).name
+    gtf_gz = cache / Path(gtf_url).name
+    fa = cache / fa_gz.with_suffix("").name  # .fa
+    gtf = cache / gtf_gz.with_suffix("").name  # .gtf
+
+    print(f"[INFO] Preparing reference for {species}/{build} (GENCODE {gencode_release})")
+    if not fa_gz.exists():
+        download_file(fasta_url, fa_gz)
+    if not gtf_gz.exists():
+        download_file(gtf_url, gtf_gz)
+
+    if not fa.exists():
+        print(f"[INFO] Decompressing {fa_gz.name} → {fa.name}")
+        gunzip_to(fa_gz, fa)
+    if not gtf.exists():
+        print(f"[INFO] Decompressing {gtf_gz.name} → {gtf.name}")
+        gunzip_to(gtf_gz, gtf)
+
+    # Build STAR index
+    idx_dir.mkdir(parents=True, exist_ok=True)
+    cmd = [
+        "STAR",
+        "--runThreadN", str(threads),
+        "--runMode", "genomeGenerate",
+        "--genomeDir", str(idx_dir),
+        "--genomeFastaFiles", str(fa),
+        "--sjdbGTFfile", str(gtf),
+    ]
+    if sjdb_overhang is not None:
+        cmd += ["--sjdbOverhang", str(sjdb_overhang)]  # readLength-1 (150bp reads → 149)
+
+    print(">>", " ".join(cmd))
+    subprocess.run(cmd, check=True)
+
+    if not genome_params.exists():
+        raise RuntimeError(f"STAR index build completed but {genome_params} not found.")
+
+    ref_json = idx_dir.parent / "reference.json"  # index/<species>/<build>/reference.json
+    try:
+        ref_json.write_text(json.dumps({
+            "species": species,
+            "build": build,
+            "gencode_release": gencode_release,
+            "fasta": str(fa.resolve()),
+            "gtf":   str(gtf.resolve()),
+            "download_time": time.strftime("%Y-%m-%d %H:%M:%S"),
+            "sources": {"fasta_url": fasta_url, "gtf_url": gtf_url}
+        }, indent=2))
+        print(f"[INFO] Reference metadata written → {ref_json}")
+    except Exception as e:
+        print(f"[WARN] Could not write reference.json: {e}")
+    return idx_dir
+
+# ================= RUN STAR =======================
+'''
+def run_star(
+    fq1: Path,
+    fq2: Optional[Path],
+    index_dir: Path,
+    out_prefix: Path,
+    threads: int = 12,
+    extra_args: Optional[list] = None,
+):
+    if not (index_dir / "genomeParameters.txt").exists():
+        raise RuntimeError(f"STAR index incomplete: {index_dir}")
+
+    cmd = [
+        "STAR",
+        "--runThreadN", str(threads),
+        "--genomeDir", str(index_dir),
+        "--readFilesIn", str(fq1)
+    ]
+    if fq2:
+        cmd += [str(fq2)]
+
+    # macOS uses 'gunzip -c' (or 'gzcat'); use gunzip universally for .gz
+    if str(fq1).endswith(".gz") or (fq2 and str(fq2).endswith(".gz")):
+        cmd += ["--readFilesCommand", "gunzip", "-c"]
+
+    cmd += ["--outSAMtype", "BAM", "SortedByCoordinate",
+            "--outFileNamePrefix", str(out_prefix)]
+    if extra_args:
+        cmd += list(extra_args)
+
+    print(">>", " ".join(cmd))
+    subprocess.run(cmd, check=True)
+
+def star_align_auto(
+    accession: str,
+    fq1: str,
+    fq2: Optional[str],
+    index_root: str = "index",
+    out_prefix: str = "work/star/sample.",
+    threads: int = 12,
+    gencode_release: str = "v44",
+    sjdb_overhang: Optional[int] = 149,
+):
+    species, build = detect_species_build_from_geo(accession)
+    print(f"[INFO] Detected: species={species}, build={build}")
+
+    idx = ensure_star_index(
+        species, build,
+        index_root=Path(index_root),
+        gencode_release=gencode_release,
+        threads=threads,
+        sjdb_overhang=sjdb_overhang
+    )
+
+    run_star(
+        fq1=Path(fq1),
+        fq2=Path(fq2) if fq2 else None,
+        index_dir=idx,
+        out_prefix=Path(out_prefix),
+        threads=threads
+    )
+    print("[OK] STAR alignment finished.")
+'''
+def _infer_sample_id_from_fq(fq1: Path) -> str:
+    s = fq1.name
+    m = re.search(r"(SRR\d+)", s, re.I)
+    if m:
+        return m.group(1)
+    # 常见命名 S1_1.fastq / S1.R1.fq.gz / S1.clean.fq.gz
+    s = re.sub(r"\.f(ast)?q(\.gz)?$", "", s)
+    s = re.sub(r"(_|\.)(R?1|R?2|clean)$", "", s, flags=re.I)
+    return s
+
+def run_star(
+    fq1: Path,
+    fq2: Optional[Path],
+    index_dir: Path,
+    out_prefix: Path,
+    threads: int = 12,
+    extra_args: Optional[List[str]] = None,
+    sample: Optional[str] = None,
+) -> Path:
+    """
+    运行 STAR，比对结果写入：<base>/<sample>/<sample>.* 并返回 BAM 路径。
+    - out_prefix：可以传你原来的 "work/star/sample."（我们会基于它构造真正的 per-sample 前缀）
+    - sample：可显式传 SRR；不传则从 fq1 文件名自动推断
+    """
+    # 检查是否已有结果
+
+    sample = sample or _infer_sample_id_from_fq(fq1)
+    # 以 out_prefix 的父目录为 base，例如 "work/star/sample." -> base="work/star"
+    base_dir = out_prefix.parent
+    out_dir = base_dir / sample
+    out_dir.mkdir(parents=True, exist_ok=True)
+    star_prefix = out_dir / f"{sample}."  # <sample>.*
+    bam_path = out_dir / f"{sample or out_prefix.stem}.Aligned.sortedByCoord.out.bam"
+    if bam_path.exists() and bam_path.stat().st_size > 1024 * 1024:  # >1MB
+        print(f"[SKIP] Detected existing alignment → {bam_path}")
+        return bam_path
+
+    if not (index_dir / "genomeParameters.txt").exists():
+        raise RuntimeError(f"STAR index incomplete: {index_dir}")
+
+    cmd = [
+        "STAR",
+        "--runThreadN", str(threads),
+        "--genomeDir", str(index_dir),
+        "--readFilesIn", str(fq1)
+    ]
+    if fq2:
+        cmd += [str(fq2)]
+
+    # 通用 .gz 解压（macOS 用 gunzip -c）
+    if str(fq1).endswith(".gz") or (fq2 and str(fq2).endswith(".gz")):
+        cmd += ["--readFilesCommand", "gunzip", "-c"]
+
+    cmd += [
+        "--outSAMtype", "BAM", "SortedByCoordinate",
+        "--outFileNamePrefix", str(star_prefix),
+        "--outTmpDir", str(out_dir / "tmp"),
+        "--outSAMattrRGline", f"ID:{sample}", f"SM:{sample}", "PL:ILLUMINA"
+    ]
+    if extra_args:
+        cmd += list(extra_args)
+
+    print(">>", " ".join(cmd))
+    subprocess.run(cmd, check=True)
+
+    bam = star_prefix.with_name(f"{sample}.Aligned.sortedByCoord.out.bam")
+    return bam
+
+def star_align_auto(
+    accession: str,
+    fq1: str,
+    fq2: Optional[str],
+    index_root: str = "index",
+    out_prefix: str = "work/star/sample.",  # 基底目录仍沿用这个写法
+    threads: int = 12,
+    gencode_release: str = "v44",
+    sjdb_overhang: Optional[int] = 149,
+    sample: Optional[str] = None,           # 新增：可显式传 SRR
+) -> Path:
+    species, build = detect_species_build_from_geo(accession)
+    print(f"[INFO] Detected: species={species}, build={build}")
+
+    idx = ensure_star_index(
+        species, build,
+        index_root=Path(index_root),
+        gencode_release=gencode_release,
+        threads=threads,
+        sjdb_overhang=sjdb_overhang
+    )
+
+    bam = run_star(
+        fq1=Path(fq1),
+        fq2=Path(fq2) if fq2 else None,
+        index_dir=idx,
+        out_prefix=Path(out_prefix),
+        threads=threads,
+        sample=sample  # 传递 SRR（不传则自动从 fq1 推断）
+    )
+    print(f"[OK] STAR alignment finished. BAM -> {bam}")
+    return bam, idx
+
+def _star_align_one(
+    accession: str,
+    fq1: str,
+    fq2: str,
+    index_dir: Path,
+    out_prefix: str,
+    threads: int,
+    sample: str,
+):
+    """
+    执行单个 STAR 对齐任务。
+    """
+    os.makedirs(Path(out_prefix).parent, exist_ok=True)
+    bam_out = str(Path(out_prefix).with_suffix(".Aligned.sortedByCoord.out.bam"))
+
+    if os.path.exists(bam_out) and os.path.getsize(bam_out) > 0:
+        return sample, bam_out
+
+    cmd = [
+        "STAR",
+        "--runThreadN", str(threads),
+        "--genomeDir", str(index_dir),
+        "--readFilesIn", fq1, fq2,
+        "--outSAMtype", "BAM", "SortedByCoordinate",
+        "--outFileNamePrefix", out_prefix,
+        "--readFilesCommand", "zcat" if fq1.endswith(".gz") else "cat",
+        "--outSAMunmapped", "Within"
+    ]
+    subprocess.run(cmd, check=True)
+    return sample, bam_out
+
+
+def star_align_auto_parallel(
+    samples: list[tuple[str, str, str]],  # [(srr, fq1, fq2)]
+    accession: Optional[str],
+    index_root: str,
+    out_root: str,
+    threads: int = 12,
+    gencode_release: str = "v44",
+    sjdb_overhang: int = 149,
+    max_workers: Optional[int] = None
+):
+    """
+    并行运行 STAR 对齐。
+    """
+    species, build = detect_species_build_from_geo(accession or samples[0][0])
+
+    index_dir = ensure_star_index(species, build, gencode_release, index_root, threads)
+    os.makedirs(out_root, exist_ok=True)
+
+    results = []
+    with ProcessPoolExecutor(max_workers=max_workers or min(8, os.cpu_count() // threads)) as ex:
+        futures = {}
+        for srr, fq1, fq2 in samples:
+            out_prefix = Path(out_root) / srr / "run."
+            out_prefix.parent.mkdir(parents=True, exist_ok=True)
+            fut = ex.submit(_star_align_one, accession, fq1, fq2, index_dir, str(out_prefix), threads, srr)
+            futures[fut] = srr
+
+        for fut in as_completed(futures):
+            srr = futures[fut]
+            try:
+                res = fut.result()
+                results.append(res)
+            except Exception as e:
+                print(f"[ERR] {srr}: {e}")
+
+    return results

--- a/omicverse/bulk/tools_check.py
+++ b/omicverse/bulk/tools_check.py
@@ -1,0 +1,85 @@
+import sys, os, shutil,glob
+from pathlib import Path
+
+def resolve_tool(name: str):
+    """
+    Return absolute path to a tool if found by PATH or adjacent to current Python (conda env bin).
+    """
+    p = shutil.which(name)
+    if p:
+        return p
+    # fallback: same env/bin as current Python
+    env_bin = Path(sys.executable).parent
+    candidate = env_bin / name
+    if candidate.exists() and os.access(candidate, os.X_OK):
+        return str(candidate)
+    return None
+
+def check(): # auto-fix PATH to include this conda env bin (in case kernelspec PATH is wrong)
+    env_bin = str(Path(sys.executable).parent)
+    if env_bin not in os.environ.get("PATH", ""):
+        os.environ["PATH"] = env_bin + os.pathsep + os.environ.get("PATH", "")
+    esearch        = resolve_tool("esearch")
+    SRATOOL        = resolve_tool("prefetch")
+    FASTP          = resolve_tool("fastp")
+    STAR_BIN       = resolve_tool("STAR")
+    FEATURECOUNTS  = resolve_tool("featureCounts")
+    
+    if SRATOOL is None:
+        raise EnvironmentError("sra-tools not found. Try: conda install -c bioconda sra-tools")
+    if STAR_BIN is None:
+        raise EnvironmentError("STAR not found. Try: conda install -c bioconda star")
+    if FEATURECOUNTS is None:
+        print("⚠️ featureCounts not found. Install via: conda install -c bioconda subread")
+    if FASTP is None:
+        print("⚠️ fastp not found. QC will be skipped in fastp_clean().")
+    if esearch is None:
+        raise EnvironmentError("STAR not found. Try: conda install -c bioconda entrez-direct")
+
+    print("Tools check finished!")
+
+def which_or_find(cmd: str) -> str:
+    """
+    返回 cmd 的绝对路径。先用 shutil.which，
+    再在常见目录和 sratoolkit* 目录下尝试。
+    找不到则抛错并给出可读提示。
+    """
+    p = shutil.which(cmd)
+    if p:
+        return p
+
+    # 常见路径兜底：当前 Python env 的 bin、常见系统路径、用户 HOME 下的 sratoolkit 解压目录
+    candidates = []
+    # 1) 当前解释器所在 env 的 bin（对 conda 很有效）
+    py_bin = Path(os.path.realpath(os.sys.executable)).parent
+    candidates += [str(py_bin / cmd)]
+
+    # 2) 系统常见路径
+    candidates += [f"/usr/local/bin/{cmd}", f"/usr/bin/{cmd}", f"/bin/{cmd}"]
+
+    # 3) 用户目录下手动解压的 sratoolkit
+    for g in glob.glob(str(Path.home() / "sratoolkit*/bin")):
+        candidates.append(str(Path(g) / cmd))
+
+    for c in candidates:
+        if os.path.exists(c) and os.access(c, os.X_OK):
+            return c
+
+    raise FileNotFoundError(
+        f"'{cmd}' not found in PATH. "
+        f"Try: `conda install -c bioconda sra-tools` "
+        f"or ensure your Jupyter kernel is the same env as your shell.\n"
+        f"Python: {os.sys.executable}\nPATH: {os.environ.get('PATH','')}\n"
+    )
+
+def merged_env(extra: dict | None = None) -> dict:
+    """
+    生成一个对 subprocess 友好的环境变量字典。
+    可在这里加 SRAToolkit/代理配置等。
+    """
+    env = os.environ.copy()
+    # 若你有特定的 VDB 配置，可在此注入，例如：
+    # env.setdefault("VDB_CONFIG", str(Path.home() / ".ncbi/user-settings.mkfg"))
+    if extra:
+        env.update(extra)
+    return env


### PR DESCRIPTION
#  RNA-seq Bulk Alignment Pipeline — Class 集成与批处理支持

## 摘要（Summary）
本 PR 将原有分散脚本封装为 `omicverse.bulk.Alignment` 统一入口，打通 **SRA → FASTQ → QC(fastp) → STAR → featureCounts** 全链条，支持**并发**、**幂等跳过**与**一致的产出结构**，并新增：
- `Alignment.fetch_metadata()`：GEO/ENA 元数据获取与 RunInfo 生成  
- `Alignment.prefetch()`：多路 SRA 并发下载（带进度、断点与官方校验）  
- `Alignment.fasterq()`：`fasterq-dump` 并行（按 SRR 隔离输出与 tmp）  
- `Alignment.fastp()`：批处理 QC，缓存检测与报告收集  
- `Alignment.star_align()`：批量 STAR（索引自动选择/缓存、BAM 幂等、SRR 命名软链接）  
- `Alignment.featurecounts()`：批量计数与**自动合并矩阵**（自动推断 GTF；返回矩阵路径）

> 产物命名标准化：  
> - STAR 目录中保留官方名 `Aligned.sortedByCoord.out.bam`，同时**额外暴露** `SRR.sorted.bam`（软链接/拷贝）以避免合并矩阵时列名冲突。  
> - featureCounts 单样本表统一为 `<counts_root>/<SRR>/<SRR>.counts.txt`；合并矩阵为 `<counts_root>/matrix.<by>.csv`。

---

## 变更范围（Scope）
- 新增/调整的模块（示例，实际以本 PR diff 为准）：
  - `bulk/alignment.py`（核心类与适配）
  - `bulk/sra_prefetch.py`（并发 prefetch 与进度条最小侵入改造）
  - `bulk/sra_fasterq.py`（批处理 fasterq；幂等与重试）
  - `bulk/qc_fastp.py`（fastp 批处理与产物检测）
  - `bulk/star_step.py`（基于现有 `star_tools` 的批处理适配；SRR 软链接）
  - `bulk/count_step.py` / `bulk/count_tools.py`（批量 featureCounts 与合并矩阵；列名统一为 SRR）
  - `bulk/tools_check.py`（`which_or_find`、`merged_env` 等工具）
- `bulk/__init__.py` 导出 `Alignment`, `AlignmentConfig`

---

## 依赖（Dependencies）

### 系统 & 生信工具
- **sra-tools**（需要 `prefetch`, `vdb-validate`, `fasterq-dump`）
- **samtools**（BAM index）
- **STAR**
- **subread**（提供 `featureCounts`）
- **fastp**
- 建议：`pigz`（gzip 加速）、`aria2`（下载加速，可选）

### Python 包
- 必需：`pandas`, `tqdm`, `numpy`, `requests`, `lxml`
- 可能用到（视 meta 抓取实现）：`biopython`

**见本 PR 附带的 `environment.yml`（bioconda 优先）**。

---

## 目录结构（Outputs Layout）
运行后默认输出如下（以 `work/` 为根）：
```
work/
 ├── prefetch/         # prefetch 的 .sra
 │   └── SRRxxxxxx/SRRxxxxxx.sra
 ├── fasterq/
 │   └── SRRxxxxxx/
 │       ├── SRRxxxxxx_1.fastq.gz
 │       └── SRRxxxxxx_2.fastq.gz
 ├── fastp/
 │   └── SRRxxxxxx/
 │       ├── SRRxxxxxx_clean_1.fastq.gz
 │       ├── SRRxxxxxx_clean_2.fastq.gz
 │       ├── SRRxxxxxx.fastp.json
 │       └── SRRxxxxxx.fastp.html
 ├── star/
 │   └── SRRxxxxxx/
 │       ├── Aligned.sortedByCoord.out.bam      # 官方文件名（保留）
 │       ├── Aligned.sortedByCoord.out.bam.bai
 │       ├── SRRxxxxxx.sorted.bam               # SRR 命名（软链接/拷贝）
 │       └── SRRxxxxxx.sorted.bam.bai
 └── counts/
     ├── SRRxxxxxx/SRRxxxxxx.counts.txt
     └── matrix.auto.csv                        # 合并矩阵（行=gene_id, 列=SRR）
```

---

## 环境变量 / 配置（Configuration）
- `NCBI_SETTINGS`（可选）：SRA 工具配置路径  
- `TMPDIR`（可选）：大文件临时目录  
- `FC_GTF_HINT`（可选）：当无法从 STAR index 推断 GTF 时，提供 GTF 路径提示

`AlignmentConfig` 关键字段（有默认）：
- `work_root`, `prefetch_root`, `fasterq_root`, `fastp_root`,   `star_index_root`, `star_align_root`, `counts_root`
- `threads`（并发控制，与内部每任务线程需平衡）
- `memory`（传递给 fasterq 的 `--mem`，如 `"8G"`）
- `gzip_fastq`（fasterq 输出是否压缩）

---

## 端到端用法（Usage）
```python
from omicverse.bulk import Alignment, AlignmentConfig

cfg = AlignmentConfig(
    work_root="work",
    prefetch_root="work/prefetch",
    fasterq_root="work/fasterq",
    fastp_root="work/fastp",
    star_index_root="index",
    star_align_root="work/star",
    counts_root="work/counts",
    threads=16,
    memory="8G",
    gzip_fastq=True,
)

aln = Alignment(cfg)

meta = aln.fetch_metadata("GSE157103")
sra_paths = aln.prefetch(meta["srr_list"], max_concurrent=4)
fq_pairs = aln.fasterq(meta["srr_list"])
qc_results = aln.fastp(fq_pairs)
pairs_for_star = [(srr, c1, c2) for (srr, c1, c2, _, _) in qc_results]

bam_triples = aln.star_align(
    pairs_for_star,
    gencode_release="v44",
    sjdb_overhang=149,
    accession_for_species=None,
    max_workers=2,
)

fc_out = aln.featurecounts(
    bam_triples,
    simple=True,
    by="auto",
    threads=8,
)
print("merged matrix:", fc_out.get("matrix"))
```

---

## 复现实验（Repro Checklist）
- [ ] 同一批次 SRR **重复运行**：所有阶段出现 `[SKIP]`，不重复生成产物  
- [ ] fasterq 失败重试有效（网络不稳时自动切换本地 `.sra` 输入）  
- [ ] STAR 产物包含**官方名**与**SRR 命名软链接**，二者指向同一数据  
- [ ] featureCounts 合并矩阵列名为 **SRR**，无重复列名冲突  
- [ ] `counts/matrix.auto.csv` 行数 ≥ 单样本 gene 行数上限，且 `gene_id` 非空  

---

## 并发与性能（Tuning）
- **机器核数 N**：`max_workers × per-sample threads ≤ N`（含超线程时适当打折）  
- `prefetch`：外层并发（例 `max_concurrent=4`），单个下载内部 0.25s 轮询进度  
- `fasterq-dump`：建议 `--mem 8–16G`、`threads_per_job 12–24`；并发样本数谨慎  
- `STAR`：**内存敏感**；大型基因组建议单样本 8–16 线程，并发 1–2  
- `featureCounts`：`-T` 适中（8–16），I/O 是主要瓶颈  

---

## 向后兼容性（Compatibility）
- 原有脚本可继续**独立调用**；类方法只是薄适配，不改变原业务逻辑  
- STAR 输出增加了 SRR 软链接，不影响原有消费方；有助于矩阵列名唯一化  

---

## 测试（Test Plan）
- [ ] 小样本（2–3 SRR）本地端到端测试  
- [ ] 中等批量（8–12 SRR）并发参数  
- [ ] 断点续跑（kill 后重启）产物与日志一致性  
- [ ] 手动删除某一步产物，仅重做该步（其余 `[SKIP]`）  
- [ ] 仅保留 STAR 官方 BAM 名时，`_normalize_bam` 能补齐 `SRR.sorted.bam` 软链接  
- [ ] `FC_GTF_HINT` 指向 GTF 时，可绕过自动推断  

---

## 未来工作（Next）
- [ ] 增加 **CLI**（`ov-bulk align ...`）封装类方法  
- [ ] 支持 **STAR 索引自动下载/构建**（gencode/ensembl）与缓存记录  
- [ ] 整合 **salmon**/**kallisto** 作为可选轻量计数  
- [ ] 增加 **md5/sha256** 与产物 manifest，便于审计与复现  
- [ ] GitHub Actions 做最小 CI：lint + 单元测试 + 小数据集集成测试  

---

## 故障排查（Troubleshooting）
- **MergeError: duplicate columns** → 已在 `count_tools.py` 中合并前将计数列名改为 **SRR**  
- **fasterq 退出码 3 / 输出缺失** → 网络不稳或 S3 超时；已加入重试与切换本地 `.sra`  
- **STAR 内存不足** → 降低 `threads` 或减少 `max_workers`；必要时调整 `--limitGenomeGenerateRAM`  
- **找不到 GTF** → 显式传 `gtf=` 或设 `FC_GTF_HINT`；或确保 STAR index 上级 `_cache/` 下有 gtf  
- **权限/软链接问题** → 若文件系统不支持 symlink，代码自动回退为拷贝策略  

---

## Checklist（提交前）
- [ ] 代码通过 `flake8`/`black`（或项目既有规范）  
- [ ] 大文件未纳入仓库（.sra/.bam/.fastq.gz 等）  
- [ ] 文档与示例路径与默认配置一致  
- [ ] 在 `CHANGELOG.md` 或本 PR 中清楚记录变更与迁移说明