### PR TITLE
feat(skills): add slug support and display titles; parse YAML frontma…

### DIFF
--- a/.claude/skills/bulk-combat-correction/SKILL.md
+++ b/.claude/skills/bulk-combat-correction/SKILL.md
@@ -1,5 +1,6 @@
 ---
-name: Bulk RNA-seq batch correction with ComBat
+name: bulk-rna-seq-batch-correction-with-combat
+title: Bulk RNA-seq batch correction with ComBat
 description: Use omicverse's pyComBat wrapper to remove batch effects from merged bulk RNA-seq or microarray cohorts, export corrected matrices, and benchmark pre/post correction visualisations.
 ---
 

--- a/.claude/skills/bulk-deg-analysis/SKILL.md
+++ b/.claude/skills/bulk-deg-analysis/SKILL.md
@@ -1,5 +1,6 @@
 ---
-name: Bulk RNA-seq differential expression with omicverse
+name: bulk-rna-seq-differential-expression-with-omicverse
+title: Bulk RNA-seq differential expression with omicverse
 description: Guide Claude through omicverse's bulk RNA-seq DEG pipeline, from gene ID mapping and DESeq2 normalization to statistical testing, visualization, and pathway enrichment. Use when a user has bulk count matrices and needs differential expression analysis in omicverse.
 ---
 

--- a/.claude/skills/bulk-deseq2-analysis/SKILL.md
+++ b/.claude/skills/bulk-deseq2-analysis/SKILL.md
@@ -1,14 +1,13 @@
 ---
-name: Bulk RNA-seq DESeq2 analysis with omicverse
+name: bulk-rna-seq-deseq2-analysis-with-omicverse
+title: Bulk RNA-seq DESeq2 analysis with omicverse
 description: Walk Claude through PyDESeq2-based differential expression, including ID mapping, DE testing, fold-change thresholding, and enrichment visualisation.
 ---
 
 # Bulk RNA-seq DESeq2 analysis with omicverse
 
 ## Overview
-Use this skill when a user wants to reproduce the DESeq2 workflow showcased in [`t_deseq2.ipynb`](../../omicverse_guide/docs/Tu
-torials-bulk/t_deseq2.ipynb). It covers loading raw featureCounts matrices, mapping Ensembl IDs to symbols, running PyDESeq2 vi
-a `ov.bulk.pyDEG`, and exploring downstream enrichment plots.
+Use this skill when a user wants to reproduce the DESeq2 workflow showcased in [`t_deseq2.ipynb`](../../omicverse_guide/docs/Tutorials-bulk/t_deseq2.ipynb). It covers loading raw featureCounts matrices, mapping Ensembl IDs to symbols, running PyDESeq2 via `ov.bulk.pyDEG`, and exploring downstream enrichment plots.
 
 ## Instructions
 1. **Import and format the expression matrix**
@@ -25,8 +24,7 @@ a `ov.bulk.pyDEG`, and exploring downstream enrichment plots.
    - Collect sample labels into `treatment_groups` and `control_groups` lists that match column names exactly.
    - Execute `dds.deg_analysis(treatment_groups, control_groups, method='DEseq2')` to invoke PyDESeq2.
 5. **Filter and tune thresholds**
-   - Inspect result shape (`dds.result.shape`) and optionally filter low-expression genes, e.g. `dds.result.loc[dds.result['log2(B
-aseMean)'] > 1]`.
+   - Inspect result shape (`dds.result.shape`) and optionally filter low-expression genes, e.g. `dds.result.loc[dds.result['log2(BaseMean)'] > 1]`.
    - Set thresholds via `dds.foldchange_set(fc_threshold=-1, pval_threshold=0.05, logp_max=6)` to auto-pick fold-change cutoffs.
 6. **Visualise differential genes**
    - Draw volcano plots with `dds.plot_volcano(...)` and summarise key genes.

--- a/.claude/skills/bulk-stringdb-ppi/SKILL.md
+++ b/.claude/skills/bulk-stringdb-ppi/SKILL.md
@@ -1,5 +1,6 @@
 ---
-name: STRING protein interaction analysis with omicverse
+name: string-protein-interaction-analysis-with-omicverse
+title: STRING protein interaction analysis with omicverse
 description: Help Claude query STRING for protein interactions, build PPI graphs with pyPPI, and render styled network figures for bulk gene lists.
 ---
 

--- a/.claude/skills/bulk-to-single-deconvolution/SKILL.md
+++ b/.claude/skills/bulk-to-single-deconvolution/SKILL.md
@@ -1,5 +1,6 @@
 ---
-name: Bulk RNA-seq deconvolution with Bulk2Single
+name: bulk-rna-seq-deconvolution-with-bulk2single
+title: Bulk RNA-seq deconvolution with Bulk2Single
 description: Turn bulk RNA-seq cohorts into synthetic single-cell datasets using omicverse's Bulk2Single workflow for cell fraction estimation, beta-VAE generation, and quality control comparisons against reference scRNA-seq.
 ---
 

--- a/.claude/skills/bulk-trajblend-interpolation/SKILL.md
+++ b/.claude/skills/bulk-trajblend-interpolation/SKILL.md
@@ -1,5 +1,6 @@
 ---
-name: BulkTrajBlend trajectory interpolation
+name: bulktrajblend-trajectory-interpolation
+title: BulkTrajBlend trajectory interpolation
 description: Extend scRNA-seq developmental trajectories with BulkTrajBlend by generating intermediate cells from bulk RNA-seq, training beta-VAE and GNN models, and interpolating missing states.
 ---
 

--- a/.claude/skills/bulk-wgcna-analysis/SKILL.md
+++ b/.claude/skills/bulk-wgcna-analysis/SKILL.md
@@ -1,14 +1,13 @@
 ---
-name: Bulk WGCNA analysis with omicverse
+name: bulk-wgcna-analysis-with-omicverse
+title: Bulk WGCNA analysis with omicverse
 description: Assist Claude in running PyWGCNA through omicverse—preprocessing expression matrices, constructing co-expression modules, visualising eigengenes, and extracting hub genes.
 ---
 
 # Bulk WGCNA analysis with omicverse
 
 ## Overview
-Activate this skill for users who want to reproduce the WGCNA workflow from [`t_wgcna.ipynb`](../../omicverse_guide/docs/Tutori
-als-bulk/t_wgcna.ipynb). It guides you through loading expression data, configuring PyWGCNA, constructing weighted gene co-expre
-ssion networks, and inspecting modules of interest.
+Activate this skill for users who want to reproduce the WGCNA workflow from [`t_wgcna.ipynb`](../../omicverse_guide/docs/Tutorials-bulk/t_wgcna.ipynb). It guides you through loading expression data, configuring PyWGCNA, constructing weighted gene co-expression networks, and inspecting modules of interest.
 
 ## Instructions
 1. **Prepare the environment**

--- a/.claude/skills/plotting-visualization/SKILL.md
+++ b/.claude/skills/plotting-visualization/SKILL.md
@@ -1,5 +1,6 @@
 ---
-name: OmicVerse visualization for bulk, color systems, and single-cell data
+name: omicverse-visualization-for-bulk-color-systems-and-single-cell-d
+title: OmicVerse visualization for bulk, color systems, and single-cell data
 description: Guide users through OmicVerse plotting utilities showcased in the bulk, color system, and single-cell visualization tutorials, including venn/volcano charts, palette selection, and advanced embedding layouts.
 ---
 

--- a/.claude/skills/single-annotation/SKILL.md
+++ b/.claude/skills/single-annotation/SKILL.md
@@ -1,5 +1,6 @@
 ---
-name: Single-cell annotation skills with omicverse
+name: single-cell-annotation-skills-with-omicverse
+title: Single-cell annotation skills with omicverse
 description: Guide Claude through SCSA, MetaTiME, CellVote, CellMatch, GPTAnno, and weighted KNN transfer workflows for annotating single-cell modalities.
 ---
 

--- a/.claude/skills/single-cellphone-db/SKILL.md
+++ b/.claude/skills/single-cellphone-db/SKILL.md
@@ -1,5 +1,6 @@
 ---
-name: Single-cell CellPhoneDB communication mapping
+name: single-cell-cellphonedb-communication-mapping
+title: Single-cell CellPhoneDB communication mapping
 description: Run omicverse's CellPhoneDB v5 wrapper on annotated single-cell data to infer ligand-receptor networks and produce CellChat-style visualisations.
 ---
 

--- a/.claude/skills/single-clustering/SKILL.md
+++ b/.claude/skills/single-clustering/SKILL.md
@@ -1,5 +1,6 @@
 ---
-name: Single-cell clustering and batch correction with omicverse
+name: single-cell-clustering-and-batch-correction-with-omicverse
+title: Single-cell clustering and batch correction with omicverse
 description: Guide Claude through omicverse's single-cell clustering workflow, covering preprocessing, QC, multimethod clustering, topic modeling, cNMF, and cross-batch integration as demonstrated in t_cluster.ipynb and t_single_batch.ipynb.
 ---
 

--- a/.claude/skills/single-downstream-analysis/SKILL.md
+++ b/.claude/skills/single-downstream-analysis/SKILL.md
@@ -1,5 +1,6 @@
 ---
-name: Single-cell downstream analysis
+name: single-cell-downstream-analysis
+title: Single-cell downstream analysis
 description: Checklist-style reference for OmicVerse downstream tutorials covering AUCell scoring, metacell DEG, and related exports.
 ---
 

--- a/.claude/skills/single-multiomics/SKILL.md
+++ b/.claude/skills/single-multiomics/SKILL.md
@@ -1,5 +1,6 @@
 ---
-name: Single-cell multi-omics integration
+name: single-cell-multi-omics-integration
+title: Single-cell multi-omics integration
 description: Quick-reference sheet for OmicVerse tutorials spanning MOFA, GLUE pairing, SIMBA integration, TOSICA transfer, and StaVIA cartography.
 ---
 

--- a/.claude/skills/single-preprocessing/SKILL.md
+++ b/.claude/skills/single-preprocessing/SKILL.md
@@ -1,5 +1,6 @@
 ---
-name: Single-cell preprocessing with omicverse
+name: single-cell-preprocessing-with-omicverse
+title: Single-cell preprocessing with omicverse
 description: Walk through omicverse's single-cell preprocessing tutorials to QC PBMC3k data, normalise counts, detect HVGs, and run PCA/embedding pipelines on CPU, CPU–GPU mixed, or GPU stacks.
 ---
 

--- a/.claude/skills/single-to-spatial-mapping/SKILL.md
+++ b/.claude/skills/single-to-spatial-mapping/SKILL.md
@@ -1,5 +1,6 @@
 ---
-name: Single2Spatial spatial mapping
+name: single2spatial-spatial-mapping
+title: Single2Spatial spatial mapping
 description: Map scRNA-seq atlases onto spatial transcriptomics slides using omicverse's Single2Spatial workflow for deep-forest training, spot-level assessment, and marker visualisation.
 ---
 

--- a/.claude/skills/single-trajectory/SKILL.md
+++ b/.claude/skills/single-trajectory/SKILL.md
@@ -1,5 +1,6 @@
 ---
-name: Single-trajectory analysis
+name: single-trajectory-analysis
+title: Single-trajectory analysis
 description: Guide to reproducing OmicVerse trajectory workflows spanning PAGA, Palantir, VIA, velocity coupling, and fate scoring notebooks.
 ---
 

--- a/.claude/skills/spatial-tutorials/SKILL.md
+++ b/.claude/skills/spatial-tutorials/SKILL.md
@@ -1,5 +1,6 @@
 ---
-name: Spatial transcriptomics tutorials with omicverse
+name: spatial-transcriptomics-tutorials-with-omicverse
+title: Spatial transcriptomics tutorials with omicverse
 description: Guide users through omicverse's spatial transcriptomics tutorials covering preprocessing, deconvolution, and downstream modelling workflows across Visium, Visium HD, Stereo-seq, and Slide-seq datasets.
 ---
 

--- a/.claude/skills/tcga-preprocessing/SKILL.md
+++ b/.claude/skills/tcga-preprocessing/SKILL.md
@@ -1,14 +1,13 @@
 ---
-name: TCGA bulk data preprocessing with omicverse
+name: tcga-bulk-data-preprocessing-with-omicverse
+title: TCGA bulk data preprocessing with omicverse
 description: Guide Claude through ingesting TCGA sample sheets, expression archives, and clinical carts into omicverse, initialising survival metadata, and exporting annotated AnnData files.
 ---
 
 # TCGA bulk data preprocessing with omicverse
 
 ## Overview
-Follow this skill to recreate the preprocessing routine from [`t_tcga.ipynb`](../../omicverse_guide/docs/Tutorials-bulk/t_tcga.i
-pynb). It automates loading TCGA downloads, generating raw/normalised matrices, initialising metadata, and running survival analy
-ses through `ov.bulk.pyTCGA`.
+Follow this skill to recreate the preprocessing routine from [`t_tcga.ipynb`](../../omicverse_guide/docs/Tutorials-bulk/t_tcga.ipynb). It automates loading TCGA downloads, generating raw/normalised matrices, initialising metadata, and running survival analyses through `ov.bulk.pyTCGA`.
 
 ## Instructions
 1. **Gather required downloads**
@@ -16,8 +15,7 @@ ses through `ov.bulk.pyTCGA`.
      - `gdc_sample_sheet.<date>.tsv` from the TCGA Sample Sheet export.
      - The decompressed `gdc_download_xxxxx` directory containing expression archives.
      - The `clinical.cart.<date>` directory with clinical XML/JSON files.
-   - Mention that sample data are available under [`omicverse_guide/docs/Tutorials-bulk/data/TCGA_OV/`](../../omicverse_guide/do
-cs/Tutorials-bulk/data/TCGA_OV/).
+   - Mention that sample data are available under [`omicverse_guide/docs/Tutorials-bulk/data/TCGA_OV/`](../../omicverse_guide/docs/Tutorials-bulk/data/TCGA_OV/).
 2. **Initialise the TCGA helper**
    - Import `omicverse as ov` (and `scanpy as sc` if plotting) then call `ov.plot_set()`.
    - Instantiate `aml_tcga = ov.bulk.pyTCGA(sample_sheet_path, download_dir, clinical_dir)`.
@@ -32,8 +30,7 @@ cs/Tutorials-bulk/data/TCGA_OV/).
    - Plot gene-level survival curves with `aml_tcga.survival_analysis('GENE', layer='deseq_normalize', plot=True)`.
    - To process all genes, call `aml_tcga.survial_analysis_all()`; warn that it may take time.
 6. **Export results**
-   - Save enriched metadata to a new AnnData file (`aml_tcga.adata.write_h5ad('.../ov_tcga_survial_all.h5ad', compression='gzip'
-)`).
+   - Save enriched metadata to a new AnnData file (`aml_tcga.adata.write_h5ad('.../ov_tcga_survial_all.h5ad', compression='gzip')`).
    - Suggest exporting summary tables (e.g., survival statistics) if users need to share outputs outside Python.
 7. **Troubleshooting tips**
    - Ensure TCGA archives are fully extracted; missing XML/TSV files trigger parsing errors.

--- a/OvIntelligence/app.py
+++ b/OvIntelligence/app.py
@@ -53,7 +53,8 @@ def get_rag_system(config: dict):
     skill_registry = build_skill_registry(project_root)
     if skill_registry and skill_registry.skills:
         st.session_state['available_skills'] = {
-            skill.name: {
+            skill.slug: {
+                "title": skill.name,
                 "description": skill.description,
                 "path": str(skill.path),
             }
@@ -434,8 +435,9 @@ def show_configuration(rag_system):
             available_skills = st.session_state.get('available_skills', {})
             st.markdown("**Discovered skills:**")
             if available_skills:
-                for name, meta in available_skills.items():
-                    st.markdown(f"- **{name}** — {meta.get('description', 'No description provided.')}")
+                for slug, meta in available_skills.items():
+                    title = meta.get('title') or slug
+                    st.markdown(f"- **{title}** — {meta.get('description', 'No description provided.')}")
             else:
                 st.markdown("- _None discovered_.")
         if st.button("Save Configuration"):

--- a/OvIntelligence/requirements.txt
+++ b/OvIntelligence/requirements.txt
@@ -12,3 +12,4 @@ sentence-transformers
 gpt4all
 tiktoken
 pyngrok
+PyYAML


### PR DESCRIPTION
…tter for slug/title, key registry by slug; update app UI; fix link wraps; add PyYAML to app requirements\n\n- SkillDefinition now includes slug (identifier) and uses name as display title\n- Registry loads skills with slug keys; robust slug fallback if missing\n- SkillMatch.as_dict exposes slug for UI/telemetry\n- App sidebar lists discovered skills with display title; stores metadata keyed by slug\n- SKILL.md frontmatters migrated: name -> slug, added title fields\n- Fixed mid-word line breaks in several SKILL.md docs\n- Added PyYAML to OvIntelligence requirements to enable YAML parsing