### PR TITLE
feat(ov_skill_seeker): add CLI, builders, Jupyter API, and optional e…

### DIFF
--- a/omicverse/__init__.py
+++ b/omicverse/__init__.py
@@ -109,3 +109,9 @@ from ._settings import settings, generate_reference_table
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
+
+# Expose agent helpers (e.g., ov.agent.seeker)
+try:
+    from . import agent  # noqa: F401
+except Exception:  # pragma: no cover - optional
+    agent = None

--- a/omicverse/agent/__init__.py
+++ b/omicverse/agent/__init__.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+"""
+OmicVerse Agent utilities
+
+Public API
+----------
+seeker(links, *, name=None, description=None, max_pages=30, target="skills", out_dir=None, package=False, package_dir=None)
+    Create a Claude Agent skill from a link (or list of links) directly from Jupyter.
+
+Examples
+--------
+>>> import omicverse as ov
+>>> ov.agent.seeker("https://example.com/docs/feature", name="New Analysis")
+{'slug': 'new-analysis', 'skill_dir': '.../.claude/skills/new-analysis'}
+
+>>> ov.agent.seeker([
+...   "https://docs.site-a.com/",
+...   "https://docs.site-b.com/guide"
+... ], name="multi-source", package=True)
+{'slug': 'multi-source', 'skill_dir': '.../output/multi-source', 'zip': '.../output/multi-source.zip'}
+"""
+
+import json
+from pathlib import Path
+from typing import Dict, List, Optional, Union
+
+
+def _slugify(value: str) -> str:
+    import re
+    slug = re.sub(r"[^a-z0-9]+", "-", str(value).lower()).strip("-")
+    slug = re.sub(r"-+", "-", slug)
+    if len(slug) > 64:
+        slug = slug[:64].strip("-")
+    return slug
+
+
+def _zip_dir(skill_dir: Path, zip_path: Path) -> Path:
+    import zipfile
+    zip_path.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
+        for p in sorted(skill_dir.rglob("*")):
+            if p.is_file():
+                if p.name in {".DS_Store"} or "__pycache__" in p.parts:
+                    continue
+                zf.write(p, p.relative_to(skill_dir))
+    return zip_path
+
+
+def seeker(
+    links: Union[str, List[str]],
+    *,
+    name: Optional[str] = None,
+    description: Optional[str] = None,
+    max_pages: int = 30,
+    target: str = "skills",
+    out_dir: Optional[Union[str, Path]] = None,
+    package: bool = False,
+    package_dir: Optional[Union[str, Path]] = None,
+) -> Dict[str, str]:
+    """Create a new skill from a link (or links) for quick prototyping.
+
+    Parameters
+    ----------
+    links : str | list[str]
+        A starting URL or a list of URLs to crawl (same-domain for each).
+    name : str, optional
+        Display title; also used to derive slug. Defaults to the first link.
+    description : str, optional
+        Frontmatter description. Default mentions the source links.
+    max_pages : int, default 30
+        Per-source page crawl cap for documentation scraping.
+    target : {"skills", "output"}, default "skills"
+        Where to write the created skill: `.claude/skills` or `./output`.
+    out_dir : str | Path, optional
+        Explicit output directory root when target="output".
+    package : bool, default False
+        If True, also create a `.zip` adjacent to the skill directory.
+    package_dir : str | Path, optional
+        Directory to place the `.zip`; defaults to `out_dir or ./output`.
+
+    Returns
+    -------
+    dict
+        Keys: slug, skill_dir, optionally zip.
+    """
+    cwd = Path.cwd()
+    is_multi = isinstance(links, (list, tuple))
+    first_link = links[0] if is_multi and links else links
+    title = name or (str(first_link) if isinstance(first_link, str) else "skill")
+    slug = _slugify(title)
+
+    # Resolve base output location
+    if target == "skills":
+        base_out = cwd / ".claude" / "skills"
+    else:
+        base_out = Path(out_dir) if out_dir else (cwd / "output")
+    base_out.mkdir(parents=True, exist_ok=True)
+
+    if not is_multi and isinstance(links, str):
+        # Single-link builder
+        from omicverse.ov_skill_seeker.link_builder import build_from_link
+        skill_dir = build_from_link(
+            link=links,
+            output_root=base_out,
+            name=title,
+            description=description,
+            max_pages=max_pages,
+        )
+    else:
+        # Multi-link unified build: synthesize a minimal config
+        from omicverse.ov_skill_seeker.unified_builder import build_from_config
+        cfg = {
+            "name": title,
+            "description": description
+            or "Prototype skill from multiple links for a capability not yet in OmicVerse",
+            "sources": [
+                {"type": "documentation", "base_url": str(u), "max_pages": max_pages}
+                for u in links  # type: ignore[arg-type]
+            ],
+        }
+        tmp_cfg = base_out / f"{slug}.config.json"
+        tmp_cfg.write_text(json.dumps(cfg, ensure_ascii=False, indent=2), encoding="utf-8")
+        try:
+            skill_dir = build_from_config(tmp_cfg, base_out)
+        finally:
+            try:
+                tmp_cfg.unlink()
+            except Exception:
+                pass
+
+    result = {
+        "slug": skill_dir.name,
+        "skill_dir": str(skill_dir),
+    }
+
+    if package:
+        zip_root = Path(package_dir) if package_dir else (out_dir if out_dir else (cwd / "output"))
+        zip_root = Path(zip_root)
+        zip_path = zip_root / f"{skill_dir.name}.zip"
+        zip_path = _zip_dir(skill_dir, zip_path)
+        result["zip"] = str(zip_path)
+
+    return result
+
+
+__all__ = ["seeker"]
+

--- a/omicverse/ov_skill_seeker/README.md
+++ b/omicverse/ov_skill_seeker/README.md
@@ -1,0 +1,93 @@
+OmicVerse Skill Seeker
+======================
+
+Deeper tooling to create, inspect, validate, and package OmicVerse Claude Agent skills. It also exposes a Jupyter-friendly API to scaffold new skills from link(s).
+
+What it does
+- List bundled skills discovered under `.claude/skills`
+- Validate frontmatter and presence of important files
+- Package skills into uploadable `.zip` archives
+- Create a new skill from a single link (same‑domain crawl)
+- Build a new skill from a unified JSON config (docs + GitHub + PDFs)
+- Jupyter API: `ov.agent.seeker(...)` for notebook workflows
+
+Install optional extras (for full builders)
+- pip install -e .[skillseeker]
+  - beautifulsoup4: docs scraping
+  - PyGithub: GitHub metadata/README extraction
+  - PyMuPDF (fitz): PDF text extraction
+
+CLI usage (from repo root)
+- List skills
+  python -m omicverse.ov_skill_seeker --list
+
+- Validate all skills
+  python -m omicverse.ov_skill_seeker --validate
+
+- Package one skill by slug
+  python -m omicverse.ov_skill_seeker --package bulk-combat-correction
+
+- Package all skills to output/
+  python -m omicverse.ov_skill_seeker --package-all
+
+- Create a new skill from a single link (defaults to `.claude/skills`)
+  python -m omicverse.ov_skill_seeker --create-from-link https://example.com/feature-doc \
+      --name "New Analysis Function" \
+      --description "Prototype capability not yet in OmicVerse" \
+      --max-pages 30 \
+      --package-after
+
+- Build from a unified config into output/
+  python -m omicverse.ov_skill_seeker --build-config ./my_unified_config.json --out-dir output
+
+Jupyter API (notebook friendly)
+- Single link
+  >>> import omicverse as ov
+  >>> ov.agent.seeker("https://example.com/docs/feature", name="New Analysis", package=True)
+  {'slug': 'new-analysis', 'skill_dir': '.../.claude/skills/new-analysis', 'zip': '.../output/new-analysis.zip'}
+
+- Multiple links to output directory
+  >>> ov.agent.seeker([
+  ...   "https://docs.site-a.com/",
+  ...   "https://docs.site-b.com/guide"
+  ... ], name="multi-source", target="output", package=True)
+  {'slug': 'multi-source', 'skill_dir': '.../output/multi-source', 'zip': '.../output/multi-source.zip'}
+
+Unified config format (JSON)
+- Example (save as `my_unified_config.json`):
+  {
+    "name": "OmicVerse",
+    "description": "OmicVerse docs + GitHub repository unified skill",
+    "sources": [
+      { "type": "documentation", "base_url": "https://omicverse.readthedocs.io/", "max_pages": 50 },
+      { "type": "github", "repo": "Starlitnightly/omicverse" },
+      { "type": "pdf", "path": "./docs/supplement.pdf" }
+    ]
+  }
+
+Outputs and structure
+- New skills are created under:
+  - `.claude/skills/<slug>` when `target=skills` (default)
+  - `./output/<slug>` when `target=output` or using `--out-dir`
+- Each skill contains:
+  - `SKILL.md` with YAML frontmatter: `name` (slug), `title`, `description`, source trace
+  - `references/` with scraped or extracted content
+- Packaging creates `<slug>.zip` alongside `output/` (or `--out-dir` / `package_dir` via API)
+
+Behavior and prerequisites
+- YAML-aware frontmatter parsing is used throughout; fallbacks handle environments without PyYAML.
+- Network-restricted runs still scaffold SKILL.md and place error notes into `references/*-error.md` when a source cannot be fetched.
+- GitHub extraction honors anonymous access; it uses `GITHUB_TOKEN` if present.
+
+Testing
+- Offline tests exist for builders, CLI, and config validation:
+  pytest -q omicverse/tests/test_ov_skill_seeker.py
+- These tests stub network calls and optional dependencies.
+
+Tips
+- Pick concise slugs; the system trims to 64 chars and de-duplicates on disk when necessary.
+- Use the Jupyter API to quickly bootstrap a skill while exploring missing features; iterate on the references and SKILL.md text before packaging.
+
+Roadmap
+- Add example notebooks and CI smoke tests for the CLI.
+- Expand docs with richer frontmatter examples and guidance for best practices.

--- a/omicverse/ov_skill_seeker/__init__.py
+++ b/omicverse/ov_skill_seeker/__init__.py
@@ -1,0 +1,20 @@
+"""OmicVerse Skill Seeker
+
+A lightweight CLI for working with OmicVerse-bundled Claude Agent skills.
+
+Features:
+- List discovered skills (title, slug, description)
+- Validate SKILL.md frontmatter and required files
+- Package skills into Claude-uploadable .zip files
+
+This tool intentionally reuses the project SkillRegistry for YAML-aware
+frontmatter parsing and slug handling, keeping behavior consistent between
+the app and CLI.
+"""
+
+__all__ = [
+    "__version__",
+]
+
+__version__ = "0.1.0"
+

--- a/omicverse/ov_skill_seeker/cli.py
+++ b/omicverse/ov_skill_seeker/cli.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+"""
+OmicVerse Skill Seeker CLI
+
+Utilities to list, validate, and package OmicVerse Agent Skills bundled
+under `.claude/skills`.
+
+Examples:
+    # Show discovered skills (title, slug)
+    python -m omicverse.ov_skill_seeker --list
+
+    # Validate all skills
+    python -m omicverse.ov_skill_seeker --validate
+
+    # Package a single skill by slug
+    python -m omicverse.ov_skill_seeker --package bulk-combat-correction
+
+    # Package all skills to output directory
+    python -m omicverse.ov_skill_seeker --package-all
+
+By default, the CLI assumes it is installed within the OmicVerse project
+tree and resolves the project root relative to this file.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+import zipfile
+from pathlib import Path
+from typing import List, Tuple
+
+from omicverse.utils.skill_registry import (
+    SkillRegistry,
+    SkillDefinition,
+    build_skill_registry,
+)
+
+logger = logging.getLogger("ov_skill_seeker")
+
+
+def _resolve_repo_root() -> Path:
+    """Resolve OmicVerse repository root (folder that contains .claude/skills)."""
+    here = Path(__file__).resolve()
+    # omicverse/omicverse/ov_skill_seeker/cli.py -> repo root is three parents up
+    repo_root = here.parents[3]
+    if not (repo_root / ".claude" / "skills").exists():
+        # Fallback: current working directory
+        cwd = Path.cwd()
+        if (cwd / ".claude" / "skills").exists():
+            return cwd
+    return repo_root
+
+
+def _load_registry(project_root: Path) -> SkillRegistry:
+    registry = build_skill_registry(project_root)
+    return registry  # type: ignore[return-value]
+
+
+def _print_skill_list(skills: List[SkillDefinition]) -> None:
+    if not skills:
+        print("No skills found.")
+        return
+    print(f"Discovered {len(skills)} skill(s):\n")
+    for s in skills:
+        print(f"- {s.name} (slug: {s.slug})")
+        if s.description:
+            print(f"  {s.description}")
+        print(f"  path: {s.path}")
+
+
+def _validate_skill(defn: SkillDefinition) -> Tuple[bool, List[str]]:
+    """Validate required metadata/files for a single skill.
+
+    Returns:
+        (is_valid, messages)
+    """
+    msgs: List[str] = []
+    ok = True
+
+    # Required metadata already enforced by registry parsing; we double-check
+    if not defn.name or not defn.slug or not defn.description:
+        ok = False
+        msgs.append("Missing required metadata (title/slug/description).")
+
+    # Required files
+    skill_md = defn.path / "SKILL.md"
+    if not skill_md.exists():
+        ok = False
+        msgs.append("SKILL.md not found.")
+
+    # Reference is strongly recommended (warning if missing)
+    ref_md = defn.path / "reference.md"
+    if not ref_md.exists():
+        msgs.append("reference.md not found (warning).")
+
+    return ok, msgs
+
+
+def _zip_skill(defn: SkillDefinition, out_dir: Path) -> Path:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    zip_path = out_dir / f"{defn.slug}.zip"
+    with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
+        for path in sorted(defn.path.rglob("*")):
+            if path.is_file():
+                # Skip macOS artifacts and Python caches
+                if path.name in {".DS_Store"} or "__pycache__" in path.parts:
+                    continue
+                arcname = path.relative_to(defn.path)
+                zf.write(path, arcname)
+    return zip_path
+
+
+def main(argv: List[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="OmicVerse Skill Seeker: list, validate, and package bundled skills",
+    )
+    parser.add_argument(
+        "--project-root",
+        type=Path,
+        default=None,
+        help="Project root containing .claude/skills (defaults to auto-detected)",
+    )
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        help="List discovered skills",
+    )
+    parser.add_argument(
+        "--validate",
+        action="store_true",
+        help="Validate skills (frontmatter + required files)",
+    )
+    parser.add_argument(
+        "--package",
+        metavar="SLUG",
+        help="Package a single skill by slug",
+    )
+    parser.add_argument(
+        "--package-all",
+        action="store_true",
+        help="Package all skills",
+    )
+    parser.add_argument(
+        "--create-from-link",
+        metavar="URL",
+        help="Create a new skill by scraping a single link (same-domain crawl)",
+    )
+    parser.add_argument(
+        "--name",
+        metavar="TITLE",
+        default=None,
+        help="Display title for a newly created skill (used with --create-from-link)",
+    )
+    parser.add_argument(
+        "--description",
+        metavar="TEXT",
+        default=None,
+        help="Description for a newly created skill (used with --create-from-link)",
+    )
+    parser.add_argument(
+        "--max-pages",
+        type=int,
+        default=30,
+        help="Max pages to crawl for link-based skill creation",
+    )
+    parser.add_argument(
+        "--target",
+        choices=["skills", "output"],
+        default="skills",
+        help="Where to write new skills (skills: .claude/skills, output: ./output)",
+    )
+    parser.add_argument(
+        "--package-after",
+        action="store_true",
+        help="Package newly created skill after building",
+    )
+    parser.add_argument(
+        "--build-config",
+        type=Path,
+        default=None,
+        help="Path to unified build JSON config to create a new skill",
+    )
+    parser.add_argument(
+        "--out-dir",
+        type=Path,
+        default=None,
+        help="Output directory for packaged zips (defaults to <project_root>/output)",
+    )
+
+    args = parser.parse_args(argv)
+
+    project_root = args.project_root or _resolve_repo_root()
+    skills_root = project_root / ".claude" / "skills"
+    skills_root.mkdir(parents=True, exist_ok=True)
+
+    registry = _load_registry(project_root)
+    skills = list(registry.skills.values())
+
+    if args.create_from_link:
+        # Determine base output dir for new skill
+        if args.target == "skills":
+            base_out = skills_root
+        else:
+            base_out = (args.out_dir or (project_root / "output"))
+            base_out.mkdir(parents=True, exist_ok=True)
+
+        from .link_builder import build_from_link
+        built_dir = build_from_link(
+            link=args.create_from_link,
+            output_root=base_out,
+            name=args.name,
+            description=args.description,
+            max_pages=args.max_pages,
+        )
+        print(f"\n✅ Created skill at: {built_dir}")
+
+        if args.package_after:
+            zip_path = _zip_skill(
+                SkillDefinition(
+                    name=args.name or built_dir.name,
+                    slug=built_dir.name,
+                    description=args.description or "",
+                    path=built_dir,
+                    body=(built_dir / "SKILL.md").read_text(encoding="utf-8"),
+                    metadata={},
+                ),
+                args.out_dir or (project_root / "output"),
+            )
+            print(f"✅ Packaged -> {zip_path}")
+
+    if args.list:
+        _print_skill_list(skills)
+
+    if args.validate:
+        print("\nValidation results:\n")
+        total = 0
+        failures = 0
+        for defn in skills:
+            total += 1
+            ok, msgs = _validate_skill(defn)
+            status = "OK" if ok else "FAIL"
+            if not ok:
+                failures += 1
+            print(f"- {defn.slug}: {status}")
+            for m in msgs:
+                print(f"  • {m}")
+        print(f"\nSummary: {total - failures}/{total} valid")
+
+    if args.build_config:
+        from .unified_builder import build_from_config
+        out_dir = args.out_dir or (project_root / "output")
+        out_dir.mkdir(parents=True, exist_ok=True)
+        built_dir = build_from_config(args.build_config, out_dir)
+        print(f"\n✅ Built skill at: {built_dir}")
+
+    if args.package or args.package_all:
+        out_dir = args.out_dir or (project_root / "output")
+        packaged: List[Path] = []
+
+        if args.package:
+            target = registry.skills.get(args.package)
+            if not target:
+                print(f"❌ Skill not found (by slug): {args.package}")
+                return 1
+            ok, msgs = _validate_skill(target)
+            if not ok:
+                print(f"⚠️  Packaging despite validation issues for {target.slug}:")
+                for m in msgs:
+                    print(f"   - {m}")
+            zip_path = _zip_skill(target, out_dir)
+            print(f"✅ Packaged {target.slug} -> {zip_path}")
+            packaged.append(zip_path)
+
+        if args.package_all:
+            for defn in skills:
+                ok, msgs = _validate_skill(defn)
+                if not ok:
+                    print(f"⚠️  {defn.slug} has validation issues; continuing:")
+                    for m in msgs:
+                        print(f"   - {m}")
+                zip_path = _zip_skill(defn, out_dir)
+                print(f"✅ Packaged {defn.slug} -> {zip_path}")
+                packaged.append(zip_path)
+
+        if not packaged:
+            print("No skills packaged.")
+
+    # If no flags provided, show help
+    if not any([args.list, args.validate, args.package, args.package_all]):
+        parser.print_help()
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/omicverse/ov_skill_seeker/config_validator.py
+++ b/omicverse/ov_skill_seeker/config_validator.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+"""
+Config validator for the OmicVerse Skill Seeker unified build flow.
+
+Supports a simplified unified format like:
+{
+  "name": "omicverse",
+  "description": "OmicVerse documentation + GitHub",
+  "sources": [
+    {"type": "documentation", "base_url": "https://omicverse.readthedocs.io/", "max_pages": 50},
+    {"type": "github", "repo": "Starlitnightly/omicverse", "include_code": true},
+    {"type": "pdf", "path": "path/to/file.pdf"}
+  ]
+}
+"""
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+
+VALID_SOURCE_TYPES = {"documentation", "github", "pdf"}
+
+
+def load_config(path: Path) -> Dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError("Config must be a JSON object")
+    return data
+
+
+def validate_config(cfg: Dict[str, Any]) -> None:
+    # Required top-level fields
+    for field in ("name", "description", "sources"):
+        if field not in cfg:
+            raise ValueError(f"Missing required field: {field}")
+
+    sources = cfg["sources"]
+    if not isinstance(sources, list) or not sources:
+        raise ValueError("'sources' must be a non-empty list")
+
+    for i, src in enumerate(sources):
+        if not isinstance(src, dict):
+            raise ValueError(f"Source {i} must be an object")
+        t = src.get("type")
+        if t not in VALID_SOURCE_TYPES:
+            raise ValueError(f"Source {i}: invalid type '{t}'")
+        if t == "documentation" and "base_url" not in src:
+            raise ValueError("documentation source missing 'base_url'")
+        if t == "github" and "repo" not in src:
+            raise ValueError("github source missing 'repo'")
+        if t == "pdf" and "path" not in src:
+            raise ValueError("pdf source missing 'path'")
+

--- a/omicverse/ov_skill_seeker/docs_scraper.py
+++ b/omicverse/ov_skill_seeker/docs_scraper.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+"""
+Simple documentation scraper for building OmicVerse skills from a base URL.
+
+Design goals:
+- Minimal dependencies: requests + beautifulsoup4 (optional)
+- Conservative: same-domain crawl with a max_pages cap
+- Extracts headings, text, and code blocks into lightweight markdown
+
+Note: Network access depends on runtime environment. This module is safe to
+import when dependencies are missing; functions will raise informative errors.
+"""
+
+from typing import Iterable, List, Set, Tuple
+from urllib.parse import urljoin, urlparse
+from pathlib import Path
+
+
+def _require_deps():
+    try:
+        import requests  # noqa: F401
+        from bs4 import BeautifulSoup  # noqa: F401
+    except Exception as exc:  # pragma: no cover - optional
+        raise RuntimeError(
+            "Documentation scraping requires 'requests' and 'beautifulsoup4'."
+        ) from exc
+
+
+def _same_domain(url: str, base_netloc: str) -> bool:
+    return urlparse(url).netloc == base_netloc
+
+
+def _normalize_url(url: str) -> str:
+    # Drop fragments; keep scheme/netloc/path/query
+    p = urlparse(url)
+    return p._replace(fragment="").geturl()
+
+
+def _extract_markdown(html: str, url: str) -> str:
+    from bs4 import BeautifulSoup
+
+    soup = BeautifulSoup(html, "html.parser")
+    title = soup.find("title")
+    md: List[str] = []
+    if title and title.get_text(strip=True):
+        md.append(f"# {title.get_text(strip=True)}")
+    md.append(f"\n> Source: {url}\n")
+
+    # Headings and paragraphs
+    for tag in soup.find_all(["h1", "h2", "h3", "p", "pre", "code"]):
+        name = tag.name or ""
+        text = tag.get_text("\n", strip=True)
+        if not text:
+            continue
+        if name in {"h1", "h2", "h3"}:
+            level = int(name[1])
+            md.append("#" * level + " " + text)
+        elif name == "pre":
+            md.append("\n```\n" + text + "\n```\n")
+        elif name == "code":
+            # Inline code: render as backticked line
+            md.append("`" + text + "`")
+        else:
+            md.append(text)
+
+    return "\n\n".join(md).strip()
+
+
+def scrape(base_url: str, max_pages: int = 50) -> List[Tuple[str, str]]:
+    """Crawl same-domain pages from base_url up to max_pages.
+
+    Returns a list of (filename, markdown_content) tuples.
+    """
+    _require_deps()
+    import requests
+
+    base_url = _normalize_url(base_url)
+    netloc = urlparse(base_url).netloc
+
+    to_visit: List[str] = [base_url]
+    seen: Set[str] = set()
+    results: List[Tuple[str, str]] = []
+
+    while to_visit and len(seen) < max_pages:
+        url = to_visit.pop(0)
+        url = _normalize_url(url)
+        if url in seen:
+            continue
+        seen.add(url)
+        try:
+            resp = requests.get(url, timeout=10)
+            if resp.status_code != 200:
+                continue
+        except Exception:
+            continue
+
+        md = _extract_markdown(resp.text, url)
+        slug = urlparse(url).path.strip("/").replace("/", "-") or "index"
+        filename = f"docs-{len(results)+1:03d}-{slug}.md"
+        results.append((filename, md))
+
+        # Discover links
+        from bs4 import BeautifulSoup
+
+        soup = BeautifulSoup(resp.text, "html.parser")
+        for a in soup.find_all("a", href=True):
+            href = a["href"].strip()
+            if href.startswith("mailto:") or href.startswith("javascript:"):
+                continue
+            abs_url = urljoin(url, href)
+            abs_url = _normalize_url(abs_url)
+            if _same_domain(abs_url, netloc) and abs_url not in seen:
+                to_visit.append(abs_url)
+
+    return results
+

--- a/omicverse/ov_skill_seeker/github_scraper.py
+++ b/omicverse/ov_skill_seeker/github_scraper.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+"""
+Minimal GitHub repository content extractor using PyGithub if available.
+
+Collects README (if present) and basic repo metadata into markdown files.
+"""
+
+from typing import List, Tuple
+
+
+def extract(repo_slug: str) -> List[Tuple[str, str]]:
+    """Extracts README and metadata for a GitHub repo, e.g., 'owner/name'.
+
+    Honors anonymous access; will use GITHUB_TOKEN from environment if set.
+    Returns a list of (filename, markdown_content).
+    """
+    try:
+        from github import Github  # PyGithub
+        import os
+        import base64
+    except Exception as exc:  # pragma: no cover - optional
+        raise RuntimeError("GitHub extraction requires PyGithub") from exc
+
+    token = os.environ.get("GITHUB_TOKEN")
+    gh = Github(token) if token else Github()
+    repo = gh.get_repo(repo_slug)
+
+    results: List[Tuple[str, str]] = []
+
+    # README
+    try:
+        readme = repo.get_readme()
+        content = base64.b64decode(readme.content or b"").decode("utf-8", errors="replace")
+        results.append(("github-readme.md", f"# README for {repo_slug}\n\n" + content))
+    except Exception:
+        pass
+
+    # Basic metadata
+    meta = {
+        "full_name": repo.full_name,
+        "description": repo.description or "",
+        "stars": repo.stargazers_count,
+        "forks": repo.forks_count,
+        "open_issues": repo.open_issues_count,
+        "default_branch": repo.default_branch,
+        "topics": ", ".join(getattr(repo, "get_topics", lambda: [])() or []),
+        "html_url": repo.html_url,
+    }
+    meta_md = ["# Repository Metadata", "", f"Repository: {meta['full_name']}"]
+    for k, v in meta.items():
+        meta_md.append(f"- {k}: {v}")
+    results.append(("github-metadata.md", "\n".join(meta_md)))
+
+    return results
+

--- a/omicverse/ov_skill_seeker/link_builder.py
+++ b/omicverse/ov_skill_seeker/link_builder.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+"""
+Build a new skill from a single link to cover functionality OmicVerse does not yet provide.
+
+This scaffolds a SKILL.md and scrapes the provided URL (same-domain crawl)
+to populate reference markdown files.
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Tuple, Optional
+
+
+def _slugify(value: str) -> str:
+    import re
+    slug = re.sub(r"[^a-z0-9]+", "-", str(value).lower()).strip("-")
+    slug = re.sub(r"-+", "-", slug)
+    if len(slug) > 64:
+        slug = slug[:64].strip("-")
+    return slug
+
+
+def _ensure_unique_dir(base_dir: Path, slug: str) -> Path:
+    target = base_dir / slug
+    if not target.exists():
+        return target
+    i = 2
+    while True:
+        candidate = base_dir / f"{slug}-{i}"
+        if not candidate.exists():
+            return candidate
+        i += 1
+
+
+def _generate_skill_md(slug: str, title: str, description: str, link: str) -> str:
+    fm: Dict[str, object] = {
+        "name": slug,
+        "title": title,
+        "description": description,
+        "_source_link": link,
+        "_category": "experimental",
+    }
+    try:
+        import yaml  # type: ignore
+        fm_text = yaml.safe_dump(fm, sort_keys=False).strip()
+    except Exception:
+        import json as _json
+        fm_text = (
+            f"name: {slug}\n"
+            f"title: {title}\n"
+            f"description: {description}\n"
+            f"_source_link: {link}\n"
+            f"_category: experimental\n"
+        )
+    frontmatter = "---\n" + fm_text + "\n---\n\n"
+
+    body = (
+        f"# {title}\n\n"
+        f"This skill helps prototype and explore a capability not yet built into OmicVerse, using the external reference below.\n\n"
+        f"## Source\n- {link}\n\n"
+        f"## Guidance\n"
+        f"- Use reference snippets to answer questions and outline steps.\n"
+        f"- Clearly mark assumptions versus verified information from the source.\n"
+        f"- When suggesting code, prefer small, testable examples.\n"
+        f"- If an API is unclear, propose experiments to validate behavior.\n\n"
+        f"## References\nSee files under references/ for extracted documentation.\n"
+    )
+    return frontmatter + body
+
+
+def build_from_link(link: str, output_root: Path, name: Optional[str] = None, description: Optional[str] = None, max_pages: int = 30) -> Path:
+    from .docs_scraper import scrape
+
+    # Derive name/slug
+    title = name or link
+    slug = _slugify(name) if name else _slugify(link)
+
+    # Ensure target dir unique
+    skill_dir = _ensure_unique_dir(output_root, slug)
+    refs_dir = skill_dir / "references"
+    refs_dir.mkdir(parents=True, exist_ok=True)
+
+    # Scrape source
+    files: List[Tuple[str, str]]
+    try:
+        files = scrape(link, max_pages=max_pages)
+    except Exception as exc:
+        files = [("source-error.md", f"Error scraping {link}: {exc}")]
+
+    for fname, content in files:
+        (refs_dir / fname).write_text(content, encoding="utf-8")
+
+    # Write SKILL.md
+    desc = description or f"Prototype skill for capability not yet in OmicVerse, sourced from {link}"
+    skill_md = _generate_skill_md(slug=slug, title=title, description=desc, link=link)
+    (skill_dir / "SKILL.md").write_text(skill_md, encoding="utf-8")
+
+    return skill_dir
+

--- a/omicverse/ov_skill_seeker/pdf_scraper.py
+++ b/omicverse/ov_skill_seeker/pdf_scraper.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+"""
+Lightweight PDF extractor using PyMuPDF (fitz) if available.
+
+Falls back to a clear error if dependency is missing.
+"""
+
+from pathlib import Path
+from typing import List, Tuple
+
+
+def extract(path: Path) -> List[Tuple[str, str]]:
+    """Extract text from a PDF file into markdown chunks by page.
+
+    Returns list of (filename, markdown_content).
+    """
+    try:
+        import fitz  # PyMuPDF
+    except Exception as exc:  # pragma: no cover - optional
+        raise RuntimeError("PDF extraction requires PyMuPDF (fitz)") from exc
+
+    doc = fitz.open(str(path))
+    results: List[Tuple[str, str]] = []
+    for i, page in enumerate(doc, start=1):
+        text = page.get_text("text")
+        md = f"# Page {i}\n\n" + (text or "")
+        results.append((f"pdf-{i:03d}.md", md))
+    doc.close()
+    return results
+

--- a/omicverse/ov_skill_seeker/unified_builder.py
+++ b/omicverse/ov_skill_seeker/unified_builder.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+"""
+Unified Skill Builder for OmicVerse.
+
+Given a JSON config (validated by config_validator), this module gathers
+content from documentation, GitHub, and PDFs into a skill directory with
+SKILL.md and reference markdown files.
+"""
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+from .config_validator import validate_config
+from omicverse.utils.skill_registry import SkillRegistry  # for slug helpers only
+
+
+def _slugify(value: str) -> str:
+    # Keep in sync with SkillRegistry _slugify behavior
+    import re
+    slug = re.sub(r"[^a-z0-9]+", "-", str(value).lower()).strip("-")
+    slug = re.sub(r"-+", "-", slug)
+    if len(slug) > 64:
+        slug = slug[:64].strip("-")
+    return slug
+
+
+@dataclass
+class BuildConfig:
+    name: str
+    description: str
+    sources: List[Dict]
+
+    @classmethod
+    def from_json(cls, path: Path) -> "BuildConfig":
+        data = json.loads(path.read_text(encoding="utf-8"))
+        validate_config(data)
+        return cls(name=data["name"], description=data["description"], sources=data["sources"])
+
+
+def _write_files(target_dir: Path, files: List[Tuple[str, str]]) -> None:
+    target_dir.mkdir(parents=True, exist_ok=True)
+    for fname, content in files:
+        (target_dir / fname).write_text(content, encoding="utf-8")
+
+
+def _generate_skill_md(slug: str, title: str, description: str, sources: List[Dict]) -> str:
+    # Include source summary in frontmatter for traceability
+    fm: Dict[str, object] = {
+        "name": slug,  # slug identifier
+        "title": title,
+        "description": description,
+        "_sources": sources,
+    }
+    try:
+        import yaml  # type: ignore
+        fm_text = yaml.safe_dump(fm, sort_keys=False).strip()
+    except Exception:
+        # Minimal manual YAML if PyYAML not available
+        import json as _json
+        fm_text = (
+            f"name: {slug}\n"
+            f"title: {title}\n"
+            f"description: {description}\n"
+            f"_sources: {_json.dumps(sources)}"
+        )
+    frontmatter = "---\n" + fm_text + "\n---\n\n"
+    body = f"# {title}\n\n" \
+           f"This skill was built from the configured sources. Review the references/ files for detailed content."\
+           "\n\n## How to Use\n- Ask targeted questions; this skill includes documentation excerpts and repository metadata.\n\n"
+    return frontmatter + body
+
+
+def build_from_config(config_path: Path, output_root: Path) -> Path:
+    cfg = BuildConfig.from_json(config_path)
+    slug = _slugify(cfg.name)
+    skill_dir = output_root / slug
+
+    # Collect references
+    references: List[Tuple[str, str]] = []
+    for src in cfg.sources:
+        t = src.get("type")
+        if t == "documentation":
+            from .docs_scraper import scrape
+            base_url = src["base_url"]
+            max_pages = int(src.get("max_pages", 50))
+            try:
+                references += scrape(base_url, max_pages=max_pages)
+            except Exception as exc:
+                references.append((f"docs-error.md", f"Error scraping {base_url}: {exc}"))
+        elif t == "github":
+            from .github_scraper import extract
+            repo = src["repo"]
+            try:
+                references += extract(repo)
+            except Exception as exc:
+                references.append((f"github-error.md", f"Error extracting {repo}: {exc}"))
+        elif t == "pdf":
+            from .pdf_scraper import extract as pdf_extract
+            p = Path(src["path"]).expanduser()
+            try:
+                references += pdf_extract(p)
+            except Exception as exc:
+                references.append((f"pdf-error.md", f"Error extracting {p}: {exc}"))
+
+    # Write outputs
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "references").mkdir(exist_ok=True)
+    _write_files(skill_dir / "references", references)
+
+    skill_md = _generate_skill_md(slug=slug, title=cfg.name, description=cfg.description, sources=cfg.sources)
+    (skill_dir / "SKILL.md").write_text(skill_md, encoding="utf-8")
+
+    return skill_dir

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,12 @@ full = [
   'memento-de'
 ]
 
+skillseeker = [
+  "beautifulsoup4>=4.12",
+  "PyGithub>=2.2",
+  "PyMuPDF>=1.24",
+]
+
 
 [project.urls]
 Github = 'https://github.com/Starlitnightly/omicverse'
@@ -103,3 +109,5 @@ Github = 'https://github.com/Starlitnightly/omicverse'
 [tool.flit.sdist]
 exclude = [".*", "d*", "e*", "pa*", "s*", "t*"]
 
+[project.scripts]
+ov-skill-seeker = "omicverse.ov_skill_seeker.cli:main"


### PR DESCRIPTION
This pull request introduces the new "Skill Seeker" feature for OmicVerse, enabling users to create, validate, and package Claude Agent skills from documentation links, GitHub repos, or PDFs. It provides both a CLI and a Jupyter-friendly API (`ov.agent.seeker`) for rapid prototyping and management of skills, along with supporting modules for scraping, config validation, and documentation.

**New Skill Seeker feature and core API:**

* Added the `ov.agent.seeker` API for creating Claude Agent skills from one or more links directly in Jupyter or Python, supporting packaging and multiple output targets.
* Exposed the `agent` module in the main `omicverse` package for easy access to agent helpers.

**Skill Seeker CLI and utilities:**

* Introduced the `omicverse.ov_skill_seeker` CLI (`cli.py`) for listing, validating, and packaging skills, as well as creating skills from links or unified configs.
* Added a lightweight package initializer and versioning for `ov_skill_seeker`.
* Provided a comprehensive README for `ov_skill_seeker` with usage instructions, API examples, and config format documentation.

**Supporting modules for skill creation:**

* Implemented a documentation scraper (`docs_scraper.py`) to extract markdown from documentation sites using requests and BeautifulSoup, with a safe import mechanism for optional dependencies.
* Added a config validator (`config_validator.py`) for unified skill build configs, ensuring required fields and correct source types/formats.…xtras; exclude local progress logs