### PR TITLE
Fix sparse matrix handling in remove_cc_genes and corr2_coeff

### DIFF
--- a/omicverse/external/CEFCON/utils.py
+++ b/omicverse/external/CEFCON/utils.py
@@ -106,8 +106,8 @@ def data_preparation(input_expData: Union[str, sc.AnnData, pd.DataFrame],
         adata_l.uns['name'] = l
 
         ## [5] Additional edges with high spearman correlation
-        if isinstance(adata_l.X, sparse.csr_matrix):
-            gene_exp = pd.DataFrame(adata_l.X.A.T, index=priori_network_nodes)
+        if sparse.issparse(adata_l.X):
+            gene_exp = pd.DataFrame(adata_l.X.toarray().T, index=priori_network_nodes)
         else:
             gene_exp = pd.DataFrame(adata_l.X.T, index=priori_network_nodes)
 

--- a/omicverse/external/graphvelo/utils.py
+++ b/omicverse/external/graphvelo/utils.py
@@ -534,7 +534,7 @@ def mack_score(
             nbrs_idx, _ = knn(adata.obsm[basis_for_knn], n_neighbors)
         else:
             logging.info(f"Compute knn in original basis...")
-            X_for_knn = adata.X.A if sp.issparse(adata.X) else adata.X
+            X_for_knn = adata.X.toarray() if sp.issparse(adata.X) else adata.X
             nbrs_idx, _ = knn(X_for_knn, n_neighbors)
     
     # Ensure nbrs_idx is a 2D NumPy array.

--- a/omicverse/pp/_preprocess.py
+++ b/omicverse/pp/_preprocess.py
@@ -370,6 +370,12 @@ def corr2_coeff(a, b):
     """
     resol = 10 ** (-15)
 
+    # Convert sparse matrices to dense arrays if necessary
+    if issparse(a):
+        a = a.toarray()
+    if issparse(b):
+        b = b.toarray()
+
     a_ma = a - a.mean(1)[:, None]
     b_mb = b - b.mean(1)[:, None]
     ssa = (a_ma ** 2).sum(1)
@@ -395,9 +401,9 @@ def remove_cc_genes(adata:anndata.AnnData, organism:str='human', corr_threshold:
     cc_genes = list(set(cycling_genes['G1/S']) | set(cycling_genes['G2/M']))
     cc_genes = [ x for x in cc_genes if x in adata.var_names ]
     # Compute corr
-    cc_expression = adata[:, cc_genes].X.A.T
+    cc_expression = adata[:, cc_genes].X.toarray().T if issparse(adata[:, cc_genes].X) else adata[:, cc_genes].X.T
     hvgs = adata.var_names[adata.var['highly_variable_features']]
-    hvgs_expression = adata[:, hvgs].X.A.T
+    hvgs_expression = adata[:, hvgs].X.toarray().T if issparse(adata[:, hvgs].X) else adata[:, hvgs].X.T
     cc_corr = corr2_coeff(hvgs_expression, cc_expression)
 
     # Discard genes having the maximum correlation with one of the cc > corr_threshold

--- a/tests/test_cellvote_pbmc3k.py
+++ b/tests/test_cellvote_pbmc3k.py
@@ -4,6 +4,7 @@ from typing import Dict, List
 import numpy as np
 import pandas as pd
 import pytest
+from scipy.sparse import issparse
 
 
 def _load_pbmc3k():
@@ -40,7 +41,7 @@ def _ensure_clusters(adata, key="leiden"):
 
 def _compute_simple_markers(adata, cluster_key: str, topn: int = 15) -> Dict[str, List[str]]:
     markers = {}
-    X = adata.X.A if hasattr(adata.X, "A") else adata.X
+    X = adata.X.toarray() if issparse(adata.X) else adata.X
     for ct in adata.obs[cluster_key].cat.categories:
         idx_in = np.where(adata.obs[cluster_key].values == ct)[0]
         idx_out = np.where(adata.obs[cluster_key].values != ct)[0]


### PR DESCRIPTION
## Summary

Fixed sparse matrix handling issues in `remove_cc_genes` and `corr2_coeff` functions. The problem was the use of `.X.A` which is specific to numpy matrix objects and doesn't exist on scipy sparse matrices.

## Changes

- `omicverse/pp/_preprocess.py`:
  - `corr2_coeff`: Add sparse matrix check and conversion to dense
  - `remove_cc_genes`: Replace `.X.A.T` with proper sparse handling
- `omicverse/external/CEFCON/utils.py`: Use `issparse()` and `.toarray()`
- `tests/test_cellvote_pbmc3k.py`: Replace hasattr check with `issparse()`
- `omicverse/external/graphvelo/utils.py`: Replace `.A` with `.toarray()`

## Testing

All changes ensure compatibility with both sparse and dense matrices.

Fixes #461

🤖 Generated with [Claude Code](https://claude.ai/code)