### PR TITLE
Fix PrincipalCurve.fit() parameter name from 'w' to 'weights'

### DIFF
--- a/omicverse/single/_pyslingshot.py
+++ b/omicverse/single/_pyslingshot.py
@@ -512,7 +512,7 @@ class Slingshot:
             curve.fit(
                 self.data,
                 max_iter=1,
-                w=self.cell_weights[:, l_idx]
+                weights=self.cell_weights[:, l_idx]
             )
 
             if self.debug_plot_lineages:


### PR DESCRIPTION
## Summary
- Fixed TypeError in pyslingshot trajectory inference
- Changed parameter `w` to `weights` in `curve.fit()` call at line 515

## Details
The `PrincipalCurve.fit()` method from the `pcurvepy2` library expects a `weights` parameter, not `w`. This was causing a TypeError when users tried to run slingshot trajectory inference.

Fixes #462

🤖 Generated with [Claude Code](https://claude.ai/code)