### PR TITLE
Fix KeyError in ov.pl.embedding when use_raw=True

### DIFF
--- a/omicverse/utils/_scatterplot.py
+++ b/omicverse/utils/_scatterplot.py
@@ -1256,8 +1256,12 @@ def _get_color_source_vector(
     
     # Safe checks for obs and var
     in_obs = _safe_check_obs_columns(adata, value_to_plot)
-    in_var = _safe_check_var_names(adata, value_to_plot)
-    
+    # When use_raw is True, check raw.var_names; otherwise check var_names
+    if use_raw and adata.raw is not None:
+        in_var = _safe_check_var_names(adata.raw, value_to_plot)
+    else:
+        in_var = _safe_check_var_names(adata, value_to_plot)
+
     # Handle gene symbols - convert to actual gene names if needed
     if (
         gene_symbols is not None
@@ -1266,11 +1270,15 @@ def _get_color_source_vector(
     ):
         # We should probably just make an index for this, and share it over runs
         try:
-            value_to_plot = adata.var.index[adata.var[gene_symbols] == value_to_plot][0]
-            in_var = _safe_check_var_names(adata, value_to_plot)  # Update after conversion
+            if use_raw and adata.raw is not None:
+                value_to_plot = adata.raw.var.index[adata.raw.var[gene_symbols] == value_to_plot][0]
+                in_var = _safe_check_var_names(adata.raw, value_to_plot)  # Update after conversion
+            else:
+                value_to_plot = adata.var.index[adata.var[gene_symbols] == value_to_plot][0]
+                in_var = _safe_check_var_names(adata, value_to_plot)  # Update after conversion
         except (IndexError, KeyError):
             pass  # Will be handled in the error case below
-    
+
     # Determine the source of the data
     if in_obs:
         # Data is in adata.obs (metadata)


### PR DESCRIPTION
### Summary

This PR fixes issue #496 where `ov.pl.embedding` throws a KeyError when using `use_raw=True` with genes that exist in `adata.raw` but have been filtered out from the processed `adata`.

### Changes

- Modified `_get_color_source_vector` in `omicverse/utils/_scatterplot.py` to check `adata.raw.var_names` when `use_raw=True`
- Updated gene symbols conversion logic to use `adata.raw.var` when `use_raw=True`

### Testing

The fix ensures that `ov.pl.embedding(adata, color=markers, use_raw=True, ...)` works correctly with genes like "IGHD" that exist in the raw data but have been filtered out.

Fixes #496

---

Generated with [Claude Code](https://claude.ai/code)