### PR TITLE
Fix ValueError in VIA pruning_clustergraph: correct mask array size

### DIFF
--- a/omicverse/external/VIA/utils_via.py
+++ b/omicverse/external/VIA/utils_via.py
@@ -244,7 +244,7 @@ def pruning_clustergraph(adjacency, global_pruning_std=1, max_outgoing=30, prese
     n_comp, comp_labels = connected_components(csgraph=adjacency, directed=False, return_labels=True)
 
     sources, targets = cluster_graph_csr.nonzero()
-    mask = np.zeros(len(sources), dtype=bool)
+    mask = np.zeros(len(cluster_graph_csr.data), dtype=bool)
 
     cluster_graph_csr.data = cluster_graph_csr.data / (np.std(cluster_graph_csr.data))  # normalize
     threshold_global = np.mean(cluster_graph_csr.data) - global_pruning_std * np.std(cluster_graph_csr.data)


### PR DESCRIPTION
## Summary

Fixes #495 - ValueError in VIA.core.plot_atlas_view due to array shape mismatch.

## Changes

- Fixed mask array initialization in `pruning_clustergraph` function to use `len(cluster_graph_csr.data)` instead of `len(sources)`
- This ensures the mask array size matches the data array it's being applied to, preventing broadcasting errors

## Testing

The fix resolves the specific error where shapes (392,) and (10994,) couldn't broadcast. The user should test with their dataset to confirm the plot_atlas_view function now works correctly.

Generated with [Claude Code](https://claude.ai/code)