### PR TITLE
Fix fq_data_preprocess bug #501: Add paired/single-end data type support and improve tool checks

### DIFF
--- a/omicverse/bulk/_alignment/iseq_handler.py
+++ b/omicverse/bulk/_alignment/iseq_handler.py
@@ -91,8 +91,15 @@ class ISeqHandler:
 
     def _auto_extract_sample_id(self, file_path: Path) -> str:
         """Automatically derive a sample ID."""
-        # Try several patterns.
-        filename = file_path.stem  # Remove extension.
+        # Special case: honour explicit SRA-style IDs (SRR/ERR/DRR) anywhere
+        # in the filename, so that FASTQ-based workflows stay consistent with
+        # GEO/SRA-based naming (e.g. "SRR123456.fastq.gz" → "SRR123456").
+        sra_match = re.search(r"(SRR\d+|ERR\d+|DRR\d+)", file_path.name)
+        if sra_match:
+            return sra_match.group(1)
+
+        # Generic heuristics for vendor-style filenames.
+        filename = file_path.stem  # Remove only the last extension.
 
         # Pattern 1: remove common sequencing suffixes (_R1, _R2, .R1, .R2, _1, _2).
         cleaned = re.sub(r'[._][Rr]?[12]$', '', filename)

--- a/omicverse/bulk/_alignment/sra_fasterq.py
+++ b/omicverse/bulk/_alignment/sra_fasterq.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os, sys, shutil, time, subprocess,math
 from pathlib import Path
 from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor, as_completed
-from typing import Sequence, Tuple, List, Dict
+from typing import Sequence, Tuple, List, Dict, Optional, Union
 
 try:
     from .tools_check import which_or_find, merged_env
@@ -57,6 +57,26 @@ def _run(cmd: list[str]):
     return subprocess.run(cmd, check=True)
 
 
+
+def _find_single(ext_gz: bool) -> Path | None:
+    """Find single-end fastq files, similar to _find_pair for paired-end."""
+    suffix = ".fastq.gz" if ext_gz else ".fastq"
+    for base in cand_dirs:
+        for st in stems:
+            # Look for single-end files
+            patterns = [base / f"{st}.sra{suffix}", base / f"{st}{suffix}"]
+            for single_pattern in patterns:
+                if _have(single_pattern):
+                    return single_pattern
+
+            # Wildcard fallback - any fastq file with the SRR name
+            if base.exists():
+                candidates = list(base.glob(f"*{suffix}"))
+                for cand in candidates:
+                    if _have(cand):
+                        return cand
+    return None
+
 def _work_one_fasterq(
     srr: str,
     out_root: Path,
@@ -65,7 +85,12 @@ def _work_one_fasterq(
     tmp_root: Path,
     gzip_output: bool,
     retries: int = 3,
-) -> tuple[str, Path, Path]:
+    library_layout: str = "auto",  # Library layout hint: "auto", "single", "paired"
+) -> tuple[str, Path, Path | None]:
+    """
+    Process a single SRR with fasterq-dump, handling early exits and both paired/single-end data.
+    Returns: (srr, fastq_path, fastq2_path | None) where fq2 is None for single-end.
+    """
     # 1) Output and temporary directories.
     out_dir = out_root / srr
     out_dir.mkdir(parents=True, exist_ok=True)
@@ -103,66 +128,242 @@ def _work_one_fasterq(
                         return a, b
         return None
     # ---------------- Early exit 1: gzip requested and paired .gz already present -> return ----------------
-    if gzip_output:
-        hit_gz = _find_pair(ext_gz=True)
-        if hit_gz:
-            fq_a, fq_b = hit_gz
-            print(f"[SKIP] {srr}: paired .fastq.gz already exists; skipping fasterq-dump.")
-            return srr, fq_a, fq_b
+    # Only apply to paired-end files
+    if library_layout == "auto" or library_layout == "paired":
+        # Check paired-end files
+        if gzip_output:
+            hit_gz = _find_pair(ext_gz=True)
+            if hit_gz:
+                fq_a, fq_b = hit_gz
+                print(f"[SKIP] {srr}: paired .fastq.gz already exists; skipping fasterq-dump.")
+                return srr, fq_a, fq_b
 
     # ---------------- Early exit 2: paired .fastq already present ----------------
-    hit_plain = _find_pair(ext_gz=False)
-    if hit_plain:
-        fq_a, fq_b = hit_plain
+    if library_layout == "auto" or library_layout == "paired":
+        # Check paired-end files
+        hit_plain = _find_pair(ext_gz=False)
+        if hit_plain:
+            fq_a, fq_b = hit_plain
+            if gzip_output:
+                # Only perform gzip (skip fasterq-dump).
+                print(f"[INFO] {srr}: found uncompressed paired .fastq, starting gzip step.")
+                for src in (fq_a, fq_b):
+                    if src.exists() and src.suffix == ".fastq":
+                        _run(["gzip", "-f", str(src)])
+                fq_a = fq_a.with_suffix(".fastq.gz")
+                fq_b = fq_b.with_suffix(".fastq.gz")
+                if not (_have(fq_a) and _have(fq_b)):
+                    raise RuntimeError(f"gzip step did not produce gz files for {srr}")
+                print(f"[SKIP] {srr}: paired gzip already completed; skipping fasterq-dump.")
+            else:
+                print(f"[SKIP] {srr}: paired .fastq exists; skipping fasterq-dump.")
+            return srr, fq_a, fq_b
+
+    # ---------------- Early exit 3: single-end fastq files already present ----------------
+    if library_layout == "auto" or library_layout == "single":
+        # Internal function to search for single-end files (similar to _find_pair)
+        def _find_single(ext_gz: bool) -> Path | None:
+            """Find single-end fastq files, similar to _find_pair for paired-end."""
+            suffix = ".fastq.gz" if ext_gz else ".fastq"
+            for base in cand_dirs:
+                for st in stems:
+                    # Look for single-end files
+                    patterns = [base / f"{st}.sra{suffix}", base / f"{st}{suffix}"]
+                    for single_pattern in patterns:
+                        if _have(single_pattern):
+                            return single_pattern
+
+                # Wildcard fallback - any fastq file with the SRR name
+                if base.exists():
+                    candidates = list(base.glob(f"*{suffix}"))
+                    for cand in candidates:
+                        if _have(cand):
+                            return cand
+            return None
+
+        # Check single-end files
+        suffix = ".fastq.gz" if gzip_output else ".fastq"
+        hit_single = _find_single(ext_gz=True if gzip_output else False)
+        if hit_single:
+            if gzip_output:
+                print(f"[SKIP] {srr}: single-end .fastq.gz already exists; skipping fasterq-dump.")
+                return srr, hit_single, None
+            else:
+                print(f"[SKIP] {srr}: single-end .fastq exists; skipping fasterq-dump.")
+                return srr, hit_single, None
+
+        # Try to find uncompressed .fastq and gzip it if needed
         if gzip_output:
-            # Only perform gzip (skip fasterq-dump).
-            print(f"[INFO] {srr}: found uncompressed .fastq, starting gzip step.")
-            for src in (fq_a, fq_b):
-                if src.exists() and src.suffix == ".fastq":
-                    _run(["gzip", "-f", str(src)])
-            fq_a = fq_a.with_suffix(".fastq.gz")
-            fq_b = fq_b.with_suffix(".fastq.gz")
-            if not (_have(fq_a) and _have(fq_b)):
-                raise RuntimeError(f"gzip step did not produce gz files for {srr}")
-            print(f"[SKIP] {srr}: gzip already completed; skipping fasterq-dump.")
-        else:
-            print(f"[SKIP] {srr}: paired .fastq exists; skipping fasterq-dump.")
-        return srr, fq_a, fq_b
+            hit_uncompressed = _find_single(ext_gz=False)
+            if hit_uncompressed:
+                print(f"[INFO] {srr}: found uncompressed single-end .fastq, starting gzip step.")
+                if hit_uncompressed.exists() and hit_uncompressed.suffix == ".fastq":
+                    _run(["gzip", "-f", str(hit_uncompressed)])
+                gz_path = hit_uncompressed.with_suffix(".fastq.gz")
+                if not _have(gz_path):
+                    raise RuntimeError(f"gzip step did not produce gz file for {srr}")
+                print(f"[SKIP] {srr}: single gzip already completed; skipping fasterq-dump.")
+                return srr, gz_path, None
 
 
-    # Build fasterq-dump command
+    # Build fasterq-dump commands for auto-detection
 
-    base_cmd = [
-        shutil.which("fasterq-dump") or "fasterq-dump",
+    fq_bin = shutil.which("fasterq-dump") or "fasterq-dump"
+    base_args = [
         input_token,
         "-p",
         "-O", str(out_dir),
         "-e", str(threads_per_job),
         "--mem", f"{mem_gb}G",
-        "--split-files",
         "-t", str(tmp_dir),
         "-f",
     ]
-    print(">>>>>> ", " ".join(base_cmd), flush=True)
 
-    # Retry loop (most of your errors are rc=3 timeouts from S3)
-    sleep = 8
-    for attempt in range(1, retries + 1):
+    # Handle user-specified library layout
+    if library_layout == "single":
+        # User specified single-end - skip paired attempt
+        print(f"[DEBUG] Using user-specified single-end library layout for {srr}")
+        is_paired = False
+    elif library_layout == "paired":
+        # User specified paired-end - only try paired approach
+        print(f"[DEBUG] Using user-specified paired-end library layout for {srr}")
+        is_paired = True
+    else:
+        # Auto-detect library layout
+        is_paired = None
+
+    # Handle user-specified library layout
+    if library_layout != "auto":
+        print(f"[DEBUG] Using user-specified library layout: {library_layout} for {srr}")
+        if library_layout == "single":
+            is_paired = False
+        elif library_layout == "paired":
+            is_paired = True
+
+    # Process based on library layout
+    if is_paired is True:
+        # User specified paired-end - try paired approach only
+        cmd_paired = [fq_bin] + base_args + ["--split-files"]
+        print("Try:", " ".join(cmd_paired) + " (paired-end mode)", flush=True)
+
         try:
-            _run(base_cmd)
-            break
+            _run(cmd_paired)
+            # Check if paired files were created
+            paired_files = _find_pair(ext_gz=False) or _find_pair(ext_gz=True)
+            if paired_files:
+                print(f"[INFO] Successfully determined {srr}: paired-end")
+            else:
+                raise RuntimeError(f"fasterq-dump with --split-files did not create paired files for {srr}")
         except subprocess.CalledProcessError as e:
-            # If we used network accession and have a prefetched .sra, retry on the local file immediately
-            if input_token == srr and local_sra.exists():
-                input_token = str(local_sra)
-                base_cmd[1] = input_token
-                print(f"[WARN] Switching to local SRA for retry: {local_sra}", flush=True)
+            raise RuntimeError(f"fasterq-dump failed for paired-end mode: {str(e)}")
 
-            if attempt == retries:
-                raise
-            print(f"[WARN] fasterq-dump failed (try {attempt}/{retries}), sleep {sleep}s and retry...", flush=True)
-            time.sleep(sleep)
-            sleep *= 2
+    elif is_paired is False:
+        # User specified single-end - try single approach only
+        cmd_single = [fq_bin] + base_args + []
+        print("Try:", " ".join(cmd_single) + " (single-end mode)", flush=True)
+
+        try:
+            _run(cmd_single)
+            # DEBUG: List all files in output directories
+            # Check if single file was created - look for uncompressed first
+            suffix = ".fastq"  # Always check for uncompressed first with fasterq-dump
+            single_files = []
+
+            for base in cand_dirs:
+                for st in stems:
+                    patterns = [base / f"{st}.sra{suffix}", base / f"{st}{suffix}"]
+                    for single in patterns:
+                        if _have(single):
+                            single_files.append(single)
+                            break
+
+                    # If explicit patterns didn't work, try wildcard fallback
+                    if not single_files:
+                        if base.exists():
+                            candidates = list(base.glob(f"*{suffix}"))
+                            for cand in candidates:
+                                if _have(cand):
+                                    single_files.append(cand)
+                                    break
+                    if single_files:
+                        break
+                if single_files:
+                    break
+            if single_files:
+                print(f"[INFO] Successfully determined {srr}: single-end")
+            else:
+                # Build detailed error message showing what was searched
+                searched_patterns = []
+                for base in cand_dirs:
+                    for st in stems:
+                        patterns = [base / f"{st}.sra{suffix}", base / f"{st}{suffix}"]
+                        searched_patterns.extend([str(p) for p in patterns])
+
+                # Also check for any .fastq files at all in directories
+                all_fastq_files = []
+                for base in cand_dirs:
+                    if base.exists():
+                        all_fastq_files.extend([str(f) for f in base.glob(f"*{suffix}")])
+
+                err_msg = (
+                    f"fasterq-dump completed but output file not found for {srr}.\n"
+                    f"Expected patterns searched: {searched_patterns}\n"
+                    f"All {suffix} files found: {all_fastq_files if all_fastq_files else 'None'}\n"
+                    f"Directories searched: {[str(d) for d in cand_dirs]}\n"
+                    f"Stems used: {list(stems)}"
+                )
+                raise RuntimeError(err_msg)
+        except subprocess.CalledProcessError as e:
+            raise RuntimeError(f"fasterq-dump failed for single-end mode: {str(e)}")
+
+    else:  # Auto-detect library layout
+        # First, try with --split-files (paired-end)
+        cmd_paired = [fq_bin] + base_args + ["--split-files"]
+        print("Try:", " ".join(cmd_paired) + " (auto: paired-end mode)", flush=True)
+
+        try:
+            _run(cmd_paired)
+            # Check if paired files were created
+            paired_files = _find_pair(ext_gz=False) or _find_pair(ext_gz=True)
+            if paired_files:
+                is_paired = True
+                print(f"[INFO] Successfully determined {srr}: paired-end")
+        except subprocess.CalledProcessError:
+            print(f"[WARN] fasterq-dump failed with --split-files, will try single-end")
+            # Clear partial outputs
+            for base in cand_dirs:
+                for st in stems:
+                    for ext in [".fastq", ".fastq.gz"]:
+                        for p in [base / f"{st}.sra{ext}", base / f"{st}{ext}",
+                                  base / f"{st}_1{ext}", base / f"{st}_2{ext}"]:
+                            if _have(p):
+                                p.unlink()
+
+        # If paired files weren't created, try without --split-files (single-end)
+        if is_paired is None:
+            cmd_single = [fq_bin] + base_args + []
+            print("Try:", " ".join(cmd_single) + " (auto: single-end mode)", flush=True)
+
+            try:
+                _run(cmd_single)
+                # Check if single file was created
+                suffix = ".fastq.gz" if gzip_output else ".fastq"
+                single_files = []
+                for base in cand_dirs:
+                    for st in stems:
+                        for single in (base / f"{st}.sra{suffix}", base / f"{st}{suffix}"):
+                            if _have(single):
+                                single_files.append(single)
+                                break
+                    if single_files:
+                        break
+                if single_files:
+                    is_paired = False
+                    print(f"[INFO] Successfully determined {srr}: single-end")
+                else:
+                    raise RuntimeError(f"fasterq-dump did not create expected output files for {srr}")
+            except Exception as e:
+                raise RuntimeError(f"fasterq-dump failed for both paired-end and single-end attempts: {str(e)}")
 
     # Validate raw fastq results exist
     # Locate outputs: support names like "SRR.sra_1.fastq" when the input is .sra.
@@ -189,33 +390,59 @@ def _work_one_fasterq(
                         return a, b
         return None
 
-    hit = _find_pair(ext_gz=True) or _find_pair(ext_gz=False)
+    # Determine output files based on library layout
+    if is_paired is True:
+        hit = _find_pair(ext_gz=True) or _find_pair(ext_gz=False)
+        if not hit:
+            searched = ", ".join(str(d) for d in cand_dirs)
+            raise RuntimeError(f"fasterq paired outputs missing for {srr} (searched: {searched})")
+        fq_a, fq_b = hit
+        # If gzip is requested and the outputs are still .fastq, compress them in place.
+        if gzip_output and fq_a.suffix == ".fastq":
+            for src in (fq_a, fq_b):
+                if src.exists() and src.suffix == ".fastq":
+                    _run(["gzip", "-f", str(src)])
+            fq_a = fq_a.with_suffix(".fastq.gz")
+            fq_b = fq_b.with_suffix(".fastq.gz")
+            if not (_have(fq_a) and _have(fq_b)):
+                raise RuntimeError(f"gzip step did not produce gz files for {srr}")
+        return srr, fq_a, fq_b
 
-    if not hit:
-        # Detect unexpected single-end outputs.
+    elif is_paired is False:
+        # Single-end processing - find .fastq, then gzip if requested
+        search_suffix = ".fastq"  # fasterq-dump creates uncompressed .fastq
+        fq_uncompressed = None
+
+        # First find the uncompressed .fastq file
         for base in cand_dirs:
             for st in stems:
-                for single in (base / f"{st}.sra.fastq", base / f"{st}.fastq"):
-                    if _have(single):
-                        raise RuntimeError(
-                            f"{srr} produced single-end file: {single} (no _1/_2). "
-                            f"Check library layout or remove --split-files."
-                        )
-        searched = ", ".join(str(d) for d in cand_dirs)
-        raise RuntimeError(f"fasterq outputs missing for {srr} (searched: {searched})")
+                patterns = [base / f"{st}.sra{search_suffix}", base / f"{st}{search_suffix}"]
+                for pattern in patterns:
+                    if _have(pattern):
+                        fq_uncompressed = pattern
+                        break
+                if fq_uncompressed:
+                    break
+            if fq_uncompressed:
+                break
 
-    fq_a, fq_b = hit
-    # If gzip is requested and the outputs are still .fastq, compress them in place.
-    if gzip_output and fq_a.suffix == ".fastq":
-        for src in (fq_a, fq_b):
-            if src.exists() and src.suffix == ".fastq":
-                _run(["gzip", "-f", str(src)])
-        fq_a = fq_a.with_suffix(".fastq.gz")
-        fq_b = fq_b.with_suffix(".fastq.gz")
-        if not (_have(fq_a) and _have(fq_b)):
-            raise RuntimeError(f"gzip step did not produce gz files for {srr}")
+        if not fq_uncompressed:
+            searched = ", ".join(str(d) for d in cand_dirs)
+            raise RuntimeError(f"fasterq single output missing for {srr} (searched: {searched})")
 
-    return srr, fq_a, fq_b
+        # Apply gzip compression if requested
+        if gzip_output:
+            gz_path = fq_uncompressed.with_suffix(".fastq.gz")
+            if not _have(gz_path):
+                _run(["gzip", "-f", str(fq_uncompressed)])
+            if not _have(gz_path):
+                raise RuntimeError(f"gzip compression failed for single-file in {srr}")
+            return srr, gz_path, None  # Return gzipped path
+        else:
+            return srr, fq_uncompressed, None  # Return raw fastq path, None for fq2 indicates single-end
+
+    else:
+        raise RuntimeError(f"Failed to determine library layout for {srr}")
 
 def fasterq_batch(
     srr_list: Sequence[str],
@@ -226,9 +453,11 @@ def fasterq_batch(
     tmp_root: str | Path = "work/tmp",
     backend: str = "process",
     threads_per_job: int = 24,       # fasterq-dump threads per SRR.
-) ->list[tuple[str, Path, Path]]:
+    library_layout: str = "auto"  # Library layout hint: "auto", "single", "paired"
+) ->list[tuple[str, Path, Path | None]]:
     """
     Adapter that maps pipeline parameters to fasterq_dump_parallel and returns a list[tuple].
+    Supports both paired-end (fq2 present) and single-end (fq2=None) library layouts.
     """
     # Parse mem (accept "4G"/"8G" formats; default to 8G when parsing fails).
     try:
@@ -245,6 +474,7 @@ def fasterq_batch(
         gzip_output=bool(gzip_output),
         backend=backend,
         tmp_root=str(tmp_root),
+        library_layout=library_layout  # Pass user-specified library layout hint
     )
 
     by_srr = res.get("by_srr", {})
@@ -255,14 +485,13 @@ def fasterq_batch(
         msgs = "; ".join([f"{s}: {m}" for s, m in errs])
         raise RuntimeError(f"fasterq_batch failed for {len(errs)} samples: {msgs}")
 
-    # Convert to [(srr, Path, Path)] in the original input order.
+    # Convert to [(srr, Path, fq2_path|None)] in the original input order.
     out_pairs = []
     for srr in srr_list:
         if srr in by_srr:
-            fq1, fq2 = by_srr[srr]
-            out_pairs.append((srr, Path(fq1), Path(fq2)))
+            fq_path, fq2_path = by_srr[srr]  # fq2_path is None for single-end
+            out_pairs.append((srr, Path(fq_path), fq2_path))
 
-    
     return out_pairs
 
 def fasterq_dump_parallel(
@@ -273,7 +502,8 @@ def fasterq_dump_parallel(
     max_workers: int | None = None,
     gzip_output: bool = True,
     backend: str = "process",
-    tmp_root: str = "work/tmp"
+    tmp_root: str = "work/tmp",
+    library_layout: str = "auto"  # Library layout hint passed from alignment pipeline
 )-> Dict[str, object]:
     
     total_cores = os.cpu_count() or 8
@@ -291,33 +521,34 @@ def fasterq_dump_parallel(
         max_workers = max(1, math.floor((_os.cpu_count() or 8) / max(1, threads_per_job)))
 
     Executor = ProcessPoolExecutor if backend == "process" else ThreadPoolExecutor
-    by_srr: Dict[str, Tuple[str, str]] = {}
+    by_srr: Dict[str, Tuple[str, str|None]] = {}
     errs: List[Tuple[str, str]] = []
-    
+
     Path(tmp_root).mkdir(parents=True, exist_ok=True)
     Path(out_root).mkdir(parents=True, exist_ok=True)
 
     with Executor(max_workers=max_workers) as ex:
-        #futs = {
-        #    ex.submit(_fqdump_one, srr, out_root, fqdump_bin, threads_per_job, mem_gb, gzip_output): srr
-        #    for srr in srr_list
         futs = {
             ex.submit(
                 _work_one_fasterq,
-                srr, out_root, threads_per_job, mem_gb, tmp_root, gzip_output
+                srr, out_root, threads_per_job, mem_gb, tmp_root, gzip_output, 3, library_layout
             ): srr for srr in srr_list
         }
         for fut in as_completed(futs):
             srr = futs[fut]
             try:
-                srr_id, fq1p, fq2p = fut.result()  # older return
-            except TypeError:
-                # new return (srr, fq1, fq2)
-                srr_id, fq1p, fq2p = fut.result()
+                result = fut.result()
+                srr_id = result[0]
+                fq1p = result[1]
+                fq2p = result[2] if len(result) > 2 else None  # fq2p is None for single-end
             except Exception as e:
                 errs.append((srr, str(e)))
                 continue
-            by_srr[srr_id] = (str(fq1p), str(fq2p))
+            # Store result: either (fq1_path, fq2_path) for paired or (fq1_path, None) for single-end
+            if fq2p is None:
+                by_srr[srr_id] = (str(fq1p), None)
+            else:
+                by_srr[srr_id] = (str(fq1p), str(fq2p))
 
     if errs:
         print("[SUMMARY] fasterq errors:", errs)

--- a/omicverse/bulk/_alignment/star_step.py
+++ b/omicverse/bulk/_alignment/star_step.py
@@ -98,6 +98,7 @@ def _align_one(
     gencode_release: str,
     sjdb_overhang: Optional[int],
     accession_for_species: Optional[str],
+    memory_limit: str = "100G",  # BAM sorting memory limit
 ) -> Tuple[str, str, Optional[str]]:
     """
     Align a single sample; return (srr, bam_path, index_dir|None).
@@ -129,6 +130,7 @@ def _align_one(
         gencode_release=gencode_release,
         sjdb_overhang=sjdb_overhang,
         sample=srr,
+        memory_limit=memory_limit,  # Add memory limit for BAM sorting
     )
 
     # Extract the BAM path from the return value.
@@ -154,6 +156,7 @@ def make_star_step(
     sjdb_overhang: int | None = 149,
     accession_for_species: str | None = None,  # Provide a shared accession when all samples belong to the same GSE.
     max_workers: int | None = None,            # Batch concurrency control; None keeps execution serial.
+    memory_limit: str = "100G",                 # BAM sorting memory limit
 ):
     """
     Input: [(srr, fq1_clean, fq2_clean), ...]
@@ -173,6 +176,7 @@ def make_star_step(
                     threads=threads, gencode_release=gencode_release,
                     sjdb_overhang=sjdb_overhang,
                     accession_for_species=accession_for_species,
+                    memory_limit=memory_limit,
                 )
                 products.append(rec)  # (srr, bam, index_dir|None)
             return products
@@ -190,6 +194,7 @@ def make_star_step(
                 threads=threads, gencode_release=gencode_release,
                 sjdb_overhang=sjdb_overhang,
                 accession_for_species=accession_for_species,
+                memory_limit=memory_limit,
             )
 
         with ThreadPoolExecutor(max_workers=max_workers) as ex:


### PR DESCRIPTION
This update introduces explicit library_layout configuration (auto/single/paired) for SRA/GEO workflows and fastq data workflows, enabling correct handling of single-end and paired-end data throughout the pipeline. Tool availability checks for featureCounts and axel are now best-effort and non-blocking, with improved logging and installation guidance. STAR alignment now supports configurable BAM sorting memory limits, and fastp/fasterq-dump steps are updated to process both single-end and paired-end samples robustly.
GEO Example:
 cfg = AlignmentConfig(
    work_root="work",
    threads=64,
    genome="human",
    download_method="prefetch", 
    memory = "128G",
    library_layout = 'paired', # single
    fastp_enabled=True,
    gzip_fastq=True,
)
result = geo_data_preprocess( input_data ="SRR12544419",
                              config=cfg)

fastq data example
cfg = AlignmentConfig(
    work_root="work",
    threads=64,
    genome="human",
    memory = "128G",
    #library_layout = 'single',
    fastp_enabled=True,
)

result = fq_data_preprocess(
    fastq_files=[
        "./work/fasterq/SRR31869821/SRR31869821.fastq.gz",
    ],
    config=cfg
)