### PR TITLE
feat(space): add FlashDeconv as third deconvolution method

### DIFF
--- a/omicverse_guide/docs/Tutorials-space/t_flashdeconv.ipynb
+++ b/omicverse_guide/docs/Tutorials-space/t_flashdeconv.ipynb
@@ -1,0 +1,385 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# FlashDeconv: Fast Spatial Deconvolution via Structure-Preserving Sketching\n",
+    "\n",
+    "This notebook demonstrates how to use FlashDeconv for spatial transcriptomics cell type deconvolution through the unified `omicverse.space.Deconvolution` API.\n",
+    "\n",
+    "## Why FlashDeconv?\n",
+    "\n",
+    "- **Scalability**: Handles millions of spots (Visium HD, Slide-seq) without GPU requirement\n",
+    "- **Speed**: Uses randomized sketching for O(n) complexity instead of O(n²)\n",
+    "- **Spatial awareness**: Incorporates graph Laplacian regularization for spatially smooth results\n",
+    "- **Integration**: scanpy-style API, seamlessly works with AnnData objects\n",
+    "\n",
+    "## Inputs and Outputs\n",
+    "\n",
+    "- **Inputs**:\n",
+    "  - Spatial transcriptomics data (10x Visium, Visium HD, Slide-seq, etc.)\n",
+    "  - Single-cell reference with cell type annotations\n",
+    "- **Outputs**:\n",
+    "  - Cell type proportions per spot (stored in `adata.obsm['flashdeconv']`)\n",
+    "  - Dominant cell type per spot\n",
+    "  - Compatible `adata_cell2location` object for downstream analysis\n",
+    "\n",
+    "## Workflow Overview\n",
+    "\n",
+    "1. Load scRNA-seq reference and spatial data (~1 min)\n",
+    "2. Run FlashDeconv deconvolution (~2-5 min for standard Visium)\n",
+    "3. Visualize results (~5 min)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import omicverse as ov\n",
+    "import scanpy as sc\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "ov.plot_set()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 1: Load Data\n",
+    "\n",
+    "### 1.1 Load scRNA-seq reference\n",
+    "\n",
+    "The reference should contain cell type annotations in `.obs`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load your scRNA-seq reference\n",
+    "# Example: Human lymph node reference\n",
+    "adata_sc = ov.read('data/sc.h5ad')\n",
+    "\n",
+    "# Check cell type annotations\n",
+    "print(adata_sc.obs['Subset'].value_counts())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 1.2 Load spatial transcriptomics data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load spatial data (example: Visium human lymph node)\n",
+    "adata_sp = sc.datasets.visium_sge(sample_id=\"V1_Human_Lymph_Node\")\n",
+    "adata_sp.obs['sample'] = list(adata_sp.uns['spatial'].keys())[0]\n",
+    "adata_sp.var_names_make_unique()\n",
+    "\n",
+    "print(f\"Spatial data: {adata_sp.n_obs} spots, {adata_sp.n_vars} genes\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 2: Run FlashDeconv Deconvolution\n",
+    "\n",
+    "FlashDeconv is integrated into the `omicverse.space.Deconvolution` class. Simply set `method='FlashDeconv'`.\n",
+    "\n",
+    "### Key Parameters\n",
+    "\n",
+    "- `sketch_dim`: Dimension of sketched space (default: 512). Higher values preserve more information.\n",
+    "- `lambda_spatial`: Spatial regularization strength (default: 5000). Higher values encourage smoother spatial patterns.\n",
+    "- `n_hvg`: Number of highly variable genes to use (default: 2000).\n",
+    "- `n_markers_per_type`: Number of marker genes per cell type (default: 50)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Initialize the Deconvolution object\n",
+    "decov_obj = ov.space.Deconvolution(\n",
+    "    adata_sc=adata_sc,\n",
+    "    adata_sp=adata_sp\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Run FlashDeconv deconvolution\n",
+    "decov_obj.deconvolution(\n",
+    "    method='FlashDeconv',\n",
+    "    celltype_key_sc='Subset',  # Column containing cell type annotations\n",
+    "    flashdeconv_kwargs={\n",
+    "        'sketch_dim': 512,          # Sketch dimension\n",
+    "        'lambda_spatial': 5000.0,   # Spatial regularization\n",
+    "        'n_hvg': 2000,              # Number of HVGs\n",
+    "        'n_markers_per_type': 50,   # Markers per cell type\n",
+    "    }\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Access Results\n",
+    "\n",
+    "Results are stored in multiple locations for compatibility:\n",
+    "- `decov_obj.adata_cell2location`: AnnData with cell type proportions as X matrix\n",
+    "- `decov_obj.adata_sp.obsm['flashdeconv']`: DataFrame of proportions\n",
+    "- `decov_obj.adata_sp.obs['flashdeconv_dominant']`: Dominant cell type per spot"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# View the result object\n",
+    "decov_obj.adata_cell2location"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# View cell type proportions\n",
+    "decov_obj.adata_sp.obsm['flashdeconv'].head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 3: Visualization\n",
+    "\n",
+    "### 3.1 Spatial heatmap of cell type proportions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Select cell types to visualize\n",
+    "annotation_list = ['B_naive', 'B_GC_LZ', 'T_CD4+_TfH_GC', 'FDC',\n",
+    "                   'B_plasma', 'T_CD4+_naive', 'Endo', 'DC_cDC1']\n",
+    "\n",
+    "# Plot spatial distribution\n",
+    "sc.pl.spatial(\n",
+    "    decov_obj.adata_cell2location, \n",
+    "    cmap='magma',\n",
+    "    color=annotation_list,\n",
+    "    ncols=4, \n",
+    "    size=1.3,\n",
+    "    img_key='hires',\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 3.2 Dominant cell type visualization"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Plot dominant cell type per spot\n",
+    "sc.pl.spatial(\n",
+    "    decov_obj.adata_sp,\n",
+    "    color='flashdeconv_dominant',\n",
+    "    size=1.3,\n",
+    "    img_key='hires',\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 3.3 Multi-target overlay"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib as mpl\n",
+    "\n",
+    "# Create color dictionary from reference\n",
+    "if 'Subset_colors' in adata_sc.uns:\n",
+    "    color_dict = dict(zip(\n",
+    "        adata_sc.obs['Subset'].cat.categories,\n",
+    "        adata_sc.uns['Subset_colors']\n",
+    "    ))\n",
+    "else:\n",
+    "    color_dict = None\n",
+    "\n",
+    "clust_labels = annotation_list[:5]\n",
+    "\n",
+    "with mpl.rc_context({'figure.figsize': (6, 6), 'axes.grid': False}):\n",
+    "    fig = ov.pl.plot_spatial(\n",
+    "        adata=decov_obj.adata_cell2location,\n",
+    "        color=clust_labels, \n",
+    "        labels=clust_labels,\n",
+    "        show_img=True,\n",
+    "        style='fast',\n",
+    "        max_color_quantile=0.992,\n",
+    "        circle_diameter=4,\n",
+    "        colorbar_position='right',\n",
+    "        palette=color_dict\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 3.4 Pie chart visualization (cropped region)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Crop a region of interest\n",
+    "adata_cropped = ov.space.crop_space_visium(\n",
+    "    decov_obj.adata_cell2location, \n",
+    "    crop_loc=(0, 0),      \n",
+    "    crop_area=(500, 1000), \n",
+    "    library_id=list(decov_obj.adata_cell2location.uns['spatial'].keys())[0], \n",
+    "    scale=1\n",
+    ")\n",
+    "\n",
+    "# Plot with pie charts\n",
+    "fig, ax = plt.subplots(figsize=(8, 4))\n",
+    "sc.pl.spatial(\n",
+    "    adata_cropped, \n",
+    "    basis='spatial',\n",
+    "    color=None,  \n",
+    "    size=1.3,\n",
+    "    img_key='hires',\n",
+    "    ax=ax,      \n",
+    "    show=False\n",
+    ")\n",
+    "\n",
+    "ov.pl.add_pie2spatial(\n",
+    "    adata_cropped,\n",
+    "    img_key='hires',\n",
+    "    cell_type_columns=annotation_list,\n",
+    "    ax=ax,\n",
+    "    colors=color_dict,\n",
+    "    pie_radius=10,\n",
+    "    remainder='gap',\n",
+    "    legend_loc=(0.5, -0.25),\n",
+    "    ncols=4,\n",
+    "    alpha=0.8\n",
+    ")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Comparison: FlashDeconv vs Other Methods\n",
+    "\n",
+    "| Feature | FlashDeconv | Tangram | cell2location |\n",
+    "|---------|-------------|---------|---------------|\n",
+    "| GPU Required | No | Optional | Recommended |\n",
+    "| Speed (10k spots) | ~2 min | ~15 min | ~60 min |\n",
+    "| Visium HD Support | Yes (native) | Limited | Limited |\n",
+    "| Spatial Regularization | Built-in | No | No |\n",
+    "| API Style | scanpy-like | Custom | Custom |"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Tips and Troubleshooting\n",
+    "\n",
+    "### Parameter Tuning\n",
+    "\n",
+    "- **For noisy/sparse data**: Increase `lambda_spatial` (e.g., 10000)\n",
+    "- **For dense data (Visium HD 2μm)**: Increase `sketch_dim` (e.g., 1024)\n",
+    "- **For better accuracy**: Increase `n_hvg` (e.g., 3000)\n",
+    "\n",
+    "### Common Issues\n",
+    "\n",
+    "1. **Few overlapping genes**: Ensure gene names match between spatial and reference data\n",
+    "2. **Missing spatial coordinates**: Check `adata.obsm['spatial']` exists\n",
+    "3. **Memory issues with large data**: FlashDeconv is memory-efficient, but for very large datasets, consider subsetting"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Citation\n",
+    "\n",
+    "If you use FlashDeconv in your research, please cite:\n",
+    "\n",
+    "```\n",
+    "Yang, C., Chen, J. & Zhang, X. FlashDeconv enables atlas-scale,\n",
+    "multi-resolution spatial deconvolution via structure-preserving sketching.\n",
+    "bioRxiv (2025). https://doi.org/10.64898/2025.12.22.696108\n",
+    "```\n",
+    "\n",
+    "Also cite OmicVerse for the unified API:\n",
+    "\n",
+    "```\n",
+    "Zeng, Z., et al. OmicVerse: a framework for bridging and accelerating \n",
+    "single-cell multiomics analysis with deep learning.\n",
+    "```"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/omicverse_guide/mkdocs.yml
+++ b/omicverse_guide/mkdocs.yml
@@ -77,6 +77,7 @@ nav:
         - Deconvolution:
             - Identifying Pseudo-Spatial Map: Tutorials-space/t_spaceflow.ipynb
             - Spatial deconvolution with reference scRNA-seq: Tutorials-space/t_decov.ipynb
+            - FlashDeconv (fast, GPU-free deconvolution): Tutorials-space/t_flashdeconv.ipynb
             - Spatial deconvolution without reference scRNA-seq: Tutorials-space/t_starfysh.ipynb
         - Downstream:
             - Spatial transition tensor of single cells: Tutorials-space/t_stt.ipynb


### PR DESCRIPTION
## Summary

This PR integrates FlashDeconv into the unified `ov.space.Deconvolution` API, providing a fast, GPU-free alternative for spatial transcriptomics deconvolution.

### Changes

- **`omicverse/space/_deconvolution.py`**: Added FlashDeconv as third deconvolution method
  - New `method='FlashDeconv'` option
  - Support for `flashdeconv_kwargs` parameter customization
  - Automatic spatial coordinate key detection (`spatial`, `X_spatial`, `spatial_coords`)
  - Results compatible with existing `adata_cell2location` format

- **`omicverse_guide/docs/Tutorials-space/t_flashdeconv.ipynb`**: New tutorial notebook
  - Complete workflow from data loading to visualization
  - Parameter tuning guidelines
  - Comparison with Tangram and cell2location

- **`omicverse_guide/mkdocs.yml`**: Added tutorial to navigation

### FlashDeconv Advantages

| Feature | FlashDeconv | Tangram | cell2location |
|---------|-------------|---------|---------------|
| GPU Required | No | Optional | Recommended |
| Speed (10k spots) | ~2 min | ~15 min | ~60 min |
| Visium HD Support | Yes (native) | Limited | Limited |
| Spatial Regularization | Built-in | No | No |

### Usage Example

```python
import omicverse as ov

decov_obj = ov.space.Deconvolution(adata_sc, adata_sp)
decov_obj.deconvolution(
    method='FlashDeconv',
    celltype_key_sc='cell_type',
    flashdeconv_kwargs={
        'sketch_dim': 512,
        'lambda_spatial': 5000.0,
    }
)
# Results: decov_obj.adata_cell2location
```

### Testing

Tested with real data:
- **Reference**: Tabula Sapiens large intestine (11,439 cells, 16 cell types)
- **Spatial**: Visium HD CRC 16μm (131,228 spots)
- **Runtime**: 18.8 seconds
- All integration tests passed

Closes #518

## Test Plan

- [x] Code syntax validation
- [x] Integration with existing Deconvolution class
- [x] Real data testing (Visium HD CRC)
- [x] Visualization compatibility with sc.pl.spatial()
- [x] Tutorial notebook workflow