### PR TITLE
Add Codex OAuth support to ov.Agent

### DIFF
--- a/omicverse/__init__.py
+++ b/omicverse/__init__.py
@@ -34,6 +34,7 @@ Examples:
     >>>
     >>> # Smart Agent approach
     >>> agent = ov.Agent(model="gpt-4o-mini", api_key="your-key")
+    >>> codex_agent = ov.Agent(model="gpt-5.3-codex", auth_mode="openai_oauth")
     >>> adata = agent.run("quality control with nUMI>500, mito<0.2", adata)
     >>> adata = agent.run("preprocess with 2000 HVGs", adata)
     >>> adata = agent.run("leiden clustering resolution=1.0", adata)

--- a/omicverse/jarvis/cli.py
+++ b/omicverse/jarvis/cli.py
@@ -23,11 +23,15 @@ OPENAI_CODEX_DEFAULT_MODEL = "gpt-5.3-codex"
 _LEGACY_OPENAI_CODEX_BASE_URL = "https://api.openai.com/v1"
 _OPENAI_CODEX_MODELS = {
     "gpt-5.3-codex",
+    "gpt-5.3-codex-spark",
     "gpt-5.2-codex",
     "gpt-5.2",
     "gpt-5.1",
+    "gpt-5.1-codex",
     "gpt-5.1-codex-mini",
     "gpt-5.1-codex-max",
+    "gpt-5.4",
+    "gpt-5.4-mini",
 }
 
 

--- a/omicverse/jarvis/model_registry.py
+++ b/omicverse/jarvis/model_registry.py
@@ -187,9 +187,12 @@ _FALLBACK_PROVIDER_DISPLAY_NAMES: Dict[str, str] = {
 _CHAT_EXTRA_PROVIDER_MODELS: Dict[str, Dict[str, str]] = {
     "openai": {
         "gpt-5.3-codex": "OpenAI Codex GPT-5.3",
+        "gpt-5.3-codex-spark": "OpenAI Codex GPT-5.3 Spark",
         "gpt-5.2-codex": "OpenAI Codex GPT-5.2",
+        "gpt-5.1-codex": "OpenAI Codex GPT-5.1",
         "gpt-5.1-codex-mini": "OpenAI Codex GPT-5.1 Mini",
         "gpt-5.1-codex-max": "OpenAI Codex GPT-5.1 Max",
+        "gpt-5.4-mini": "OpenAI GPT-5.4 Mini",
     },
     "ollama": {
         "qwen3:8b": "Ollama Qwen3 8B",

--- a/omicverse/jarvis/openai_oauth.py
+++ b/omicverse/jarvis/openai_oauth.py
@@ -373,6 +373,24 @@ class OpenAIOAuthManager:
 
         return access_token or None
 
+    def ensure_access_token_with_codex_fallback(
+        self,
+        *,
+        refresh_if_needed: bool = True,
+        import_codex_if_missing: bool = True,
+    ) -> Optional[str]:
+        """Return a usable access token, importing Codex CLI auth when available."""
+
+        access_token = self.ensure_access_token(refresh_if_needed=refresh_if_needed)
+        if access_token or not import_codex_if_missing:
+            return access_token
+
+        imported = self.import_codex_auth()
+        if not imported:
+            return None
+
+        return self.ensure_access_token(refresh_if_needed=refresh_if_needed)
+
     @staticmethod
     def _create_callback_server(event: threading.Event) -> ThreadingHTTPServer:
         for port in (OPENAI_CALLBACK_PORT, 0):

--- a/omicverse/jarvis/setup_wizard.py
+++ b/omicverse/jarvis/setup_wizard.py
@@ -138,11 +138,15 @@ _PROVIDER_MODEL_CHOICES: Dict[str, List[str]] = {
 
 _OPENAI_CODEX_MODEL_CHOICES: List[str] = [
     "gpt-5.3-codex",
+    "gpt-5.3-codex-spark",
     "gpt-5.2-codex",
     "gpt-5.2",
     "gpt-5.1",
+    "gpt-5.1-codex",
     "gpt-5.1-codex-mini",
     "gpt-5.1-codex-max",
+    "gpt-5.4",
+    "gpt-5.4-mini",
 ]
 
 _COPY: Dict[Language, Dict[str, str]] = {

--- a/omicverse/utils/agent_config.py
+++ b/omicverse/utils/agent_config.py
@@ -29,6 +29,8 @@ class LLMConfig:
     model: str = "gemini-2.5-flash"
     api_key: Optional[str] = None
     endpoint: Optional[str] = None
+    auth_mode: str = "environment"
+    auth_file: Optional[Path] = None
     reasoning_effort: str = "high"  # "low" | "medium" | "high" for GPT-5
 
 
@@ -164,6 +166,8 @@ class AgentConfig:
                 model=kw.get("model", "gemini-2.5-flash"),
                 api_key=kw.get("api_key"),
                 endpoint=kw.get("endpoint"),
+                auth_mode=kw.get("auth_mode", "environment"),
+                auth_file=Path(kw["auth_file"]).expanduser() if kw.get("auth_file") else None,
             ),
             reflection=ReflectionConfig(
                 enabled=kw.get("enable_reflection", True),

--- a/omicverse/utils/model_config.py
+++ b/omicverse/utils/model_config.py
@@ -79,8 +79,16 @@ register_provider(ProviderInfo(
     model_prefixes=("gpt-", "o1", "o3", "o4"),
     models={
         "gpt-5": "OpenAI GPT-5 (Latest)",
+        "gpt-5.3-codex": "OpenAI Codex GPT-5.3",
+        "gpt-5.3-codex-spark": "OpenAI Codex GPT-5.3 Spark",
         "gpt-5.2": "OpenAI GPT-5.2",
+        "gpt-5.2-codex": "OpenAI Codex GPT-5.2",
+        "gpt-5.1": "OpenAI GPT-5.1",
+        "gpt-5.1-codex": "OpenAI Codex GPT-5.1",
+        "gpt-5.1-codex-mini": "OpenAI Codex GPT-5.1 Mini",
+        "gpt-5.1-codex-max": "OpenAI Codex GPT-5.1 Max",
         "gpt-5.4": "OpenAI GPT-5.4",
+        "gpt-5.4-mini": "OpenAI GPT-5.4 Mini",
         "gpt-5.4-pro": "OpenAI GPT-5.4 Pro",
         "gpt-5-mini": "OpenAI GPT-5 Mini",
         "gpt-5-nano": "OpenAI GPT-5 Nano",
@@ -468,6 +476,13 @@ _RAW_MODEL_ALIASES = {
     "glm-4.5v": "zhipu/glm-4.5v",
     # OpenAI o4
     "openai/o4-mini": "o4-mini",
+    "gpt-5.3-codex-latest": "gpt-5.3-codex",
+    "openai/gpt-5.3-codex": "gpt-5.3-codex",
+    "openai/gpt-5.3-codex-spark": "gpt-5.3-codex-spark",
+    "openai/gpt-5.2-codex": "gpt-5.2-codex",
+    "openai/gpt-5.1-codex": "gpt-5.1-codex",
+    "openai/gpt-5.1-codex-mini": "gpt-5.1-codex-mini",
+    "openai/gpt-5.1-codex-max": "gpt-5.1-codex-max",
 }
 
 MODEL_ALIASES: Dict[str, str] = {key.lower(): value for key, value in _RAW_MODEL_ALIASES.items()}

--- a/omicverse/utils/smart_agent.py
+++ b/omicverse/utils/smart_agent.py
@@ -139,9 +139,163 @@ from .skill_registry import (
 # Import filesystem context management for context engineering
 # Reference: https://blog.langchain.com/how-agents-can-use-filesystems-for-context-engineering/
 from .filesystem_context import FilesystemContextManager
+from ..jarvis.config import load_auth
+from ..jarvis.openai_oauth import OPENAI_CODEX_BASE_URL, OpenAIOAuthManager
 
 
 logger = logging.getLogger(__name__)
+
+_LEGACY_OPENAI_CODEX_BASE_URL = "https://api.openai.com/v1"
+OPENAI_CODEX_DEFAULT_MODEL = "gpt-5.3-codex"
+_OPENAI_OAUTH_SUPPORTED_MODELS = {
+    "gpt-5.3-codex",
+    "gpt-5.3-codex-spark",
+    "gpt-5.2-codex",
+    "gpt-5.2",
+    "gpt-5.1",
+    "gpt-5.1-codex",
+    "gpt-5.1-codex-mini",
+    "gpt-5.1-codex-max",
+    "gpt-5.4",
+    "gpt-5.4-mini",
+}
+_OPENAI_EXPLICIT_OAUTH_MODELS = {
+    model_name
+    for model_name in _OPENAI_OAUTH_SUPPORTED_MODELS
+    if "codex" in model_name
+}
+
+
+def _normalize_auth_mode(auth_mode: Optional[str]) -> str:
+    if auth_mode == "openai_api_key":
+        return "saved_api_key"
+    if auth_mode == "openai_codex":
+        return "openai_oauth"
+    return str(auth_mode or "environment")
+
+
+def _is_openai_oauth_supported_model(model: str) -> bool:
+    return str(model or "").strip().lower() in {
+        name.lower() for name in _OPENAI_OAUTH_SUPPORTED_MODELS
+    }
+
+
+def _is_explicit_openai_oauth_model(model: str) -> bool:
+    return str(model or "").strip().lower() in {
+        name.lower() for name in _OPENAI_EXPLICIT_OAUTH_MODELS
+    }
+
+
+def _normalize_model_for_routing(model: str) -> str:
+    normalized = str(model or "").strip()
+    if not normalized:
+        return normalized
+    try:
+        return ModelConfig.normalize_model_id(normalized)
+    except Exception:
+        return normalized
+
+
+def _is_custom_openai_endpoint(endpoint: Optional[str]) -> bool:
+    normalized = str(endpoint or "").strip().rstrip("/")
+    return bool(normalized) and normalized not in {
+        _LEGACY_OPENAI_CODEX_BASE_URL,
+        OPENAI_CODEX_BASE_URL,
+    }
+
+
+def _extract_openai_codex_account_id(token: Optional[str]) -> str:
+    try:
+        return OmicVerseLLMBackend._extract_openai_codex_account_id(str(token or ""))
+    except Exception:
+        return ""
+
+
+def _resolve_saved_provider_api_key(provider_name: str, auth_path: Optional[Path]) -> Optional[str]:
+    auth = load_auth(auth_path)
+    providers = dict(auth.get("providers") or {})
+
+    if provider_name == "openai":
+        top_level = str(auth.get("OPENAI_API_KEY") or "").strip()
+        if top_level:
+            return top_level
+
+    provider_auth = dict(providers.get(provider_name) or {})
+    api_key = str(provider_auth.get("api_key") or "").strip()
+    return api_key or None
+
+
+def _resolve_agent_llm_credentials(
+    *,
+    model: str,
+    api_key: Optional[str],
+    endpoint: Optional[str],
+    auth_mode: Optional[str],
+    auth_file: Optional[Union[str, Path]],
+) -> Tuple[str, Optional[str], Optional[str], str]:
+    """Resolve model/auth settings, including OpenAI Codex OAuth fallback."""
+
+    normalized_mode = _normalize_auth_mode(auth_mode)
+    resolved_model = model
+    normalized_model = _normalize_model_for_routing(model)
+    resolved_api_key = api_key
+    api_key_source = "explicit" if resolved_api_key else None
+    resolved_endpoint = endpoint
+    resolved_auth_path = Path(auth_file).expanduser() if auth_file else None
+
+    provider = ModelConfig.get_provider_from_model(normalized_model or resolved_model, resolved_endpoint)
+    wants_codex_oauth = provider == "openai" and (
+        normalized_mode == "openai_oauth"
+        or _is_explicit_openai_oauth_model(normalized_model)
+        or str(resolved_endpoint or "").rstrip("/") == OPENAI_CODEX_BASE_URL
+    )
+
+    if provider == "openai" and normalized_mode == "saved_api_key" and not resolved_api_key:
+        resolved_api_key = _resolve_saved_provider_api_key("openai", resolved_auth_path)
+        api_key_source = "saved_api_key" if resolved_api_key else None
+
+    if not wants_codex_oauth:
+        return resolved_model, resolved_api_key, resolved_endpoint, normalized_mode
+
+    normalized_mode = "openai_oauth"
+    preserve_model_id = _is_custom_openai_endpoint(resolved_endpoint)
+    if not resolved_endpoint or resolved_endpoint.rstrip("/") == _LEGACY_OPENAI_CODEX_BASE_URL:
+        resolved_endpoint = OPENAI_CODEX_BASE_URL
+        preserve_model_id = False
+    if _is_openai_oauth_supported_model(normalized_model):
+        if not preserve_model_id:
+            resolved_model = normalized_model
+    elif not preserve_model_id:
+        resolved_model = OPENAI_CODEX_DEFAULT_MODEL
+
+    if resolved_api_key:
+        if _extract_openai_codex_account_id(resolved_api_key):
+            return resolved_model, resolved_api_key, resolved_endpoint, normalized_mode
+        if api_key_source == "explicit":
+            raise ValueError(
+                "OpenAI Codex models require a ChatGPT OAuth access token with "
+                "chatgpt_account_id. Run `omicverse jarvis --codex-login` or "
+                "pass a valid OpenAI OAuth access token."
+            )
+        resolved_api_key = None
+
+    manager = OpenAIOAuthManager(resolved_auth_path)
+    resolved_api_key = manager.ensure_access_token_with_codex_fallback(
+        refresh_if_needed=True,
+        import_codex_if_missing=True,
+    )
+    if resolved_api_key and _extract_openai_codex_account_id(resolved_api_key):
+        return resolved_model, resolved_api_key, resolved_endpoint, normalized_mode
+    if resolved_api_key:
+        raise ValueError(
+            "Saved OpenAI Codex login is missing chatgpt_account_id. "
+            "Run `omicverse jarvis --codex-login` again."
+        )
+
+    raise ValueError(
+        "No saved OpenAI Codex login found. Run `omicverse jarvis --codex-login` "
+        "or pass a valid OpenAI OAuth access token."
+    )
 
 
 # ProactiveCodeTransformer is now in ovagent/analysis_executor.py — keep a
@@ -161,7 +315,7 @@ class OmicVerseAgent:
         result_adata = agent.run("quality control with nUMI>500, mito<0.2", adata)
     """
     
-    def __init__(self, model: str = "gpt-5.2", api_key: Optional[str] = None, endpoint: Optional[str] = None, enable_reflection: bool = True, reflection_iterations: int = 1, enable_result_review: bool = True, use_notebook_execution: bool = True, max_prompts_per_session: int = 5, notebook_storage_dir: Optional[str] = None, keep_execution_notebooks: bool = True, notebook_timeout: int = 600, strict_kernel_validation: bool = True, enable_filesystem_context: bool = True, context_storage_dir: Optional[str] = None, approval_mode: str = "never", agent_mode: str = "agentic", max_agent_turns: int = 15, security_level: Optional[str] = None, *, config: Optional[AgentConfig] = None, reporter: Optional[Reporter] = None, verbose: bool = True):
+    def __init__(self, model: str = "gpt-5.2", api_key: Optional[str] = None, endpoint: Optional[str] = None, auth_mode: str = "environment", auth_file: Optional[str] = None, enable_reflection: bool = True, reflection_iterations: int = 1, enable_result_review: bool = True, use_notebook_execution: bool = True, max_prompts_per_session: int = 5, notebook_storage_dir: Optional[str] = None, keep_execution_notebooks: bool = True, notebook_timeout: int = 600, strict_kernel_validation: bool = True, enable_filesystem_context: bool = True, context_storage_dir: Optional[str] = None, approval_mode: str = "never", agent_mode: str = "agentic", max_agent_turns: int = 15, security_level: Optional[str] = None, *, config: Optional[AgentConfig] = None, reporter: Optional[Reporter] = None, verbose: bool = True):
         """
         Initialize the OmicVerse Smart Agent.
 
@@ -173,6 +327,10 @@ class OmicVerseAgent:
             API key for the model provider. If not provided, will use environment variable
         endpoint : str, optional
             Custom API endpoint. If not provided, will use default for the provider
+        auth_mode : str, optional
+            Authentication mode. Use ``"openai_oauth"`` to reuse Jarvis/Codex login state.
+        auth_file : str, optional
+            Path to the saved Jarvis auth file. Defaults to ``~/.ovjarvis/auth.json``.
         enable_reflection : bool, optional
             Enable reflection step to review and improve generated code (default: True)
         reflection_iterations : int, optional
@@ -225,6 +383,8 @@ class OmicVerseAgent:
                 model=model,
                 api_key=api_key,
                 endpoint=endpoint,
+                auth_mode=auth_mode,
+                auth_file=auth_file,
                 enable_reflection=enable_reflection,
                 reflection_iterations=reflection_iterations,
                 enable_result_review=enable_result_review,
@@ -254,6 +414,24 @@ class OmicVerseAgent:
         self._emit = _emit
 
         _emit(EventLevel.INFO, "Initializing OmicVerse Smart Agent (internal backend)...", "init")
+
+        llm_cfg = self._config.llm
+        model, api_key, endpoint, resolved_auth_mode = _resolve_agent_llm_credentials(
+            model=llm_cfg.model,
+            api_key=llm_cfg.api_key,
+            endpoint=llm_cfg.endpoint,
+            auth_mode=llm_cfg.auth_mode,
+            auth_file=llm_cfg.auth_file,
+        )
+        llm_cfg.model = model
+        llm_cfg.api_key = api_key
+        llm_cfg.endpoint = endpoint
+        llm_cfg.auth_mode = resolved_auth_mode
+        model = llm_cfg.model
+        api_key = llm_cfg.api_key
+        endpoint = llm_cfg.endpoint
+        self.auth_mode = llm_cfg.auth_mode
+        self.auth_file = str(llm_cfg.auth_file) if llm_cfg.auth_file else None
         
         # When using a custom endpoint (proxy), keep the model name as-is.
         # Proxies expect the exact model name the user typed.
@@ -286,16 +464,16 @@ class OmicVerseAgent:
         self._use_llm_skill_matching: bool = True  # Use LLM-based skill matching (Claude Code approach)
         self._managed_api_env: Dict[str, str] = {}
         # Reflection configuration
-        self.enable_reflection = enable_reflection
-        self.reflection_iterations = max(1, min(3, reflection_iterations))  # Clamp to 1-3
+        self.enable_reflection = self._config.reflection.enabled
+        self.reflection_iterations = self._config.reflection.iterations
         # Result review configuration
-        self.enable_result_review = enable_result_review
+        self.enable_result_review = self._config.reflection.result_review
         # Notebook execution configuration
-        self.use_notebook_execution = use_notebook_execution
-        self.max_prompts_per_session = max_prompts_per_session
+        self.use_notebook_execution = self._config.execution.use_notebook
+        self.max_prompts_per_session = self._config.execution.max_prompts_per_session
         self._notebook_executor = None
         # Filesystem context configuration (set early to avoid AttributeError)
-        self.enable_filesystem_context = enable_filesystem_context
+        self.enable_filesystem_context = self._config.context.enabled
         self._filesystem_context: Optional[FilesystemContextManager] = None
         # Token usage tracking at agent level
         self.last_usage = None
@@ -3901,7 +4079,7 @@ def list_supported_models(show_all: bool = False) -> str:
     """
     return ModelConfig.list_supported_models(show_all)
 
-def Agent(model: str = "gpt-5.2", api_key: Optional[str] = None, endpoint: Optional[str] = None, enable_reflection: bool = True, reflection_iterations: int = 1, enable_result_review: bool = True, use_notebook_execution: bool = True, max_prompts_per_session: int = 5, notebook_storage_dir: Optional[str] = None, keep_execution_notebooks: bool = True, notebook_timeout: int = 600, strict_kernel_validation: bool = True, enable_filesystem_context: bool = True, context_storage_dir: Optional[str] = None, approval_mode: str = "never", agent_mode: str = "agentic", max_agent_turns: int = 15, security_level: Optional[str] = None, *, config: Optional[AgentConfig] = None, reporter: Optional[Reporter] = None, verbose: bool = True) -> OmicVerseAgent:
+def Agent(model: str = "gpt-5.2", api_key: Optional[str] = None, endpoint: Optional[str] = None, auth_mode: str = "environment", auth_file: Optional[str] = None, enable_reflection: bool = True, reflection_iterations: int = 1, enable_result_review: bool = True, use_notebook_execution: bool = True, max_prompts_per_session: int = 5, notebook_storage_dir: Optional[str] = None, keep_execution_notebooks: bool = True, notebook_timeout: int = 600, strict_kernel_validation: bool = True, enable_filesystem_context: bool = True, context_storage_dir: Optional[str] = None, approval_mode: str = "never", agent_mode: str = "agentic", max_agent_turns: int = 15, security_level: Optional[str] = None, *, config: Optional[AgentConfig] = None, reporter: Optional[Reporter] = None, verbose: bool = True) -> OmicVerseAgent:
     """
     Create an OmicVerse Smart Agent instance.
 
@@ -3916,6 +4094,10 @@ def Agent(model: str = "gpt-5.2", api_key: Optional[str] = None, endpoint: Optio
         API key for the model provider. If not provided, will use environment variable
     endpoint : str, optional
         Custom API endpoint. If not provided, will use default for the provider
+    auth_mode : str, optional
+        Authentication mode. Use ``"openai_oauth"`` to reuse saved Jarvis/Codex login state.
+    auth_file : str, optional
+        Path to the saved Jarvis auth file. Defaults to ``~/.ovjarvis/auth.json``.
     enable_reflection : bool, optional
         Enable reflection step to review and improve generated code (default: True)
     reflection_iterations : int, optional
@@ -3961,6 +4143,9 @@ def Agent(model: str = "gpt-5.2", api_key: Optional[str] = None, endpoint: Optio
     >>> # Create agent instance with full validation (default, session-based execution)
     >>> agent = ov.Agent(model="gpt-5", api_key="your-key")
     >>>
+    >>> # Reuse a saved ChatGPT/Codex login
+    >>> agent = ov.Agent(model="gpt-5.3-codex", auth_mode="openai_oauth")
+    >>>
     >>> # Create agent with multiple reflection iterations
     >>> agent = ov.Agent(model="gpt-5", api_key="your-key", reflection_iterations=2)
     >>>
@@ -3999,6 +4184,8 @@ def Agent(model: str = "gpt-5.2", api_key: Optional[str] = None, endpoint: Optio
         model=model,
         api_key=api_key,
         endpoint=endpoint,
+        auth_mode=auth_mode,
+        auth_file=auth_file,
         enable_reflection=enable_reflection,
         reflection_iterations=reflection_iterations,
         enable_result_review=enable_result_review,

--- a/tests/utils/test_agent_codex_auth.py
+++ b/tests/utils/test_agent_codex_auth.py
@@ -1,0 +1,274 @@
+import importlib.machinery
+import importlib.util
+import json
+import sys
+import types
+from base64 import urlsafe_b64encode
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+PACKAGE_ROOT = PROJECT_ROOT / "omicverse"
+
+
+def _load_smart_agent_module():
+    original_modules = {
+        name: sys.modules.get(name)
+        for name in ["omicverse", "omicverse.utils", "omicverse.utils.smart_agent"]
+    }
+
+    for name in ["omicverse", "omicverse.utils", "omicverse.utils.smart_agent"]:
+        sys.modules.pop(name, None)
+
+    omicverse_pkg = types.ModuleType("omicverse")
+    omicverse_pkg.__path__ = [str(PACKAGE_ROOT)]
+    omicverse_pkg.__spec__ = importlib.machinery.ModuleSpec(
+        "omicverse", loader=None, is_package=True
+    )
+    sys.modules["omicverse"] = omicverse_pkg
+
+    utils_pkg = types.ModuleType("omicverse.utils")
+    utils_pkg.__path__ = [str(PACKAGE_ROOT / "utils")]
+    utils_pkg.__spec__ = importlib.machinery.ModuleSpec(
+        "omicverse.utils", loader=None, is_package=True
+    )
+    sys.modules["omicverse.utils"] = utils_pkg
+    omicverse_pkg.utils = utils_pkg
+
+    spec = importlib.util.spec_from_file_location(
+        "omicverse.utils.smart_agent",
+        PACKAGE_ROOT / "utils" / "smart_agent.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["omicverse.utils.smart_agent"] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+
+    for name, existing in original_modules.items():
+        if existing is None:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = existing
+
+    return module
+
+
+smart_agent = _load_smart_agent_module()
+
+
+def _make_oauth_token(account_id: str = "acct_test") -> str:
+    def _encode(payload):
+        raw = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+        return urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+
+    header = _encode({"alg": "none", "typ": "JWT"})
+    payload = _encode(
+        {
+            "https://api.openai.com/auth": {
+                "chatgpt_account_id": account_id,
+            }
+        }
+    )
+    return f"{header}.{payload}.signature"
+
+
+def test_resolve_agent_llm_credentials_uses_saved_codex_auth(monkeypatch):
+    class DummyManager:
+        def __init__(self, auth_path=None):
+            self.auth_path = auth_path
+
+        def ensure_access_token_with_codex_fallback(self, **kwargs):
+            return _make_oauth_token()
+
+    monkeypatch.setattr(smart_agent, "OpenAIOAuthManager", DummyManager)
+
+    model, api_key, endpoint, auth_mode = smart_agent._resolve_agent_llm_credentials(
+        model="gpt-5.2",
+        api_key=None,
+        endpoint=None,
+        auth_mode="openai_oauth",
+        auth_file=None,
+    )
+
+    assert model == "gpt-5.2"
+    assert api_key == _make_oauth_token()
+    assert endpoint == smart_agent.OPENAI_CODEX_BASE_URL
+    assert auth_mode == "openai_oauth"
+
+
+def test_resolve_agent_llm_credentials_auto_enables_codex_oauth(monkeypatch):
+    class DummyManager:
+        def __init__(self, auth_path=None):
+            self.auth_path = auth_path
+
+        def ensure_access_token_with_codex_fallback(self, **kwargs):
+            return _make_oauth_token("acct_alias")
+
+    monkeypatch.setattr(smart_agent, "OpenAIOAuthManager", DummyManager)
+
+    model, api_key, endpoint, auth_mode = smart_agent._resolve_agent_llm_credentials(
+        model="gpt-5.3-codex",
+        api_key=None,
+        endpoint=None,
+        auth_mode="environment",
+        auth_file=None,
+    )
+
+    assert model == "gpt-5.3-codex"
+    assert api_key == _make_oauth_token("acct_alias")
+    assert endpoint == smart_agent.OPENAI_CODEX_BASE_URL
+    assert auth_mode == "openai_oauth"
+
+
+def test_resolve_agent_llm_credentials_auto_enables_codex_oauth_for_alias(monkeypatch):
+    class DummyManager:
+        def __init__(self, auth_path=None):
+            self.auth_path = auth_path
+
+        def ensure_access_token_with_codex_fallback(self, **kwargs):
+            return _make_oauth_token("acct_alias_auto")
+
+    monkeypatch.setattr(smart_agent, "OpenAIOAuthManager", DummyManager)
+
+    model, api_key, endpoint, auth_mode = smart_agent._resolve_agent_llm_credentials(
+        model="openai/gpt-5.3-codex",
+        api_key=None,
+        endpoint=None,
+        auth_mode="environment",
+        auth_file=None,
+    )
+
+    assert model == "gpt-5.3-codex"
+    assert api_key == _make_oauth_token("acct_alias_auto")
+    assert endpoint == smart_agent.OPENAI_CODEX_BASE_URL
+    assert auth_mode == "openai_oauth"
+
+
+def test_resolve_agent_llm_credentials_keeps_standard_openai_path(monkeypatch):
+    class DummyManager:
+        def __init__(self, auth_path=None):
+            raise AssertionError("Codex OAuth manager should not be used for standard OpenAI auth")
+
+    monkeypatch.setattr(smart_agent, "OpenAIOAuthManager", DummyManager)
+
+    model, api_key, endpoint, auth_mode = smart_agent._resolve_agent_llm_credentials(
+        model="gpt-5.2",
+        api_key="api-key",
+        endpoint=None,
+        auth_mode="environment",
+        auth_file=None,
+    )
+
+    assert model == "gpt-5.2"
+    assert api_key == "api-key"
+    assert endpoint is None
+    assert auth_mode == "environment"
+
+
+def test_resolve_agent_llm_credentials_keeps_supported_oauth_chat_models(monkeypatch):
+    class DummyManager:
+        def __init__(self, auth_path=None):
+            self.auth_path = auth_path
+
+        def ensure_access_token_with_codex_fallback(self, **kwargs):
+            return _make_oauth_token("acct_chat")
+
+    monkeypatch.setattr(smart_agent, "OpenAIOAuthManager", DummyManager)
+
+    model, api_key, endpoint, auth_mode = smart_agent._resolve_agent_llm_credentials(
+        model="gpt-5.4",
+        api_key=None,
+        endpoint=None,
+        auth_mode="openai_oauth",
+        auth_file=None,
+    )
+
+    assert model == "gpt-5.4"
+    assert api_key == _make_oauth_token("acct_chat")
+    assert endpoint == smart_agent.OPENAI_CODEX_BASE_URL
+    assert auth_mode == "openai_oauth"
+
+
+def test_resolve_agent_llm_credentials_normalizes_supported_oauth_alias(monkeypatch):
+    class DummyManager:
+        def __init__(self, auth_path=None):
+            self.auth_path = auth_path
+
+        def ensure_access_token_with_codex_fallback(self, **kwargs):
+            return _make_oauth_token("acct_spark")
+
+    monkeypatch.setattr(smart_agent, "OpenAIOAuthManager", DummyManager)
+
+    model, api_key, endpoint, auth_mode = smart_agent._resolve_agent_llm_credentials(
+        model="openai/gpt-5.3-codex-spark",
+        api_key=None,
+        endpoint=None,
+        auth_mode="openai_oauth",
+        auth_file=None,
+    )
+
+    assert model == "gpt-5.3-codex-spark"
+    assert api_key == _make_oauth_token("acct_spark")
+    assert endpoint == smart_agent.OPENAI_CODEX_BASE_URL
+    assert auth_mode == "openai_oauth"
+
+
+def test_resolve_agent_llm_credentials_rejects_standard_api_key_for_codex():
+    with pytest.raises(ValueError, match="valid OpenAI OAuth access token"):
+        smart_agent._resolve_agent_llm_credentials(
+            model="gpt-5.3-codex",
+            api_key="sk-test",
+            endpoint=None,
+            auth_mode="openai_oauth",
+            auth_file=None,
+        )
+
+
+def test_resolve_agent_llm_credentials_falls_back_when_saved_api_key_is_not_oauth(monkeypatch):
+    class DummyManager:
+        def __init__(self, auth_path=None):
+            self.auth_path = auth_path
+
+        def ensure_access_token_with_codex_fallback(self, **kwargs):
+            return _make_oauth_token("acct_fallback")
+
+    monkeypatch.setattr(
+        smart_agent,
+        "_resolve_saved_provider_api_key",
+        lambda provider_name, auth_path: "sk-test",
+    )
+    monkeypatch.setattr(smart_agent, "OpenAIOAuthManager", DummyManager)
+
+    model, api_key, endpoint, auth_mode = smart_agent._resolve_agent_llm_credentials(
+        model="gpt-5.3-codex",
+        api_key=None,
+        endpoint=None,
+        auth_mode="saved_api_key",
+        auth_file=None,
+    )
+
+    assert model == "gpt-5.3-codex"
+    assert api_key == _make_oauth_token("acct_fallback")
+    assert endpoint == smart_agent.OPENAI_CODEX_BASE_URL
+    assert auth_mode == "openai_oauth"
+
+
+def test_resolve_agent_llm_credentials_errors_without_saved_login(monkeypatch):
+    class DummyManager:
+        def __init__(self, auth_path=None):
+            self.auth_path = auth_path
+
+        def ensure_access_token_with_codex_fallback(self, **kwargs):
+            return None
+
+    monkeypatch.setattr(smart_agent, "OpenAIOAuthManager", DummyManager)
+
+    with pytest.raises(ValueError, match="No saved OpenAI Codex login found"):
+        smart_agent._resolve_agent_llm_credentials(
+            model="gpt-5.3-codex",
+            api_key=None,
+            endpoint=None,
+            auth_mode="openai_oauth",
+            auth_file=None,
+        )

--- a/tests/utils/test_model_normalization.py
+++ b/tests/utils/test_model_normalization.py
@@ -20,3 +20,9 @@ def test_supported_models_ascii_fallback(monkeypatch):
     listing = model_config.ModelConfig.list_supported_models()
     assert "Usage:" in listing
     assert "💡" not in listing
+
+
+def test_codex_model_is_supported():
+    assert model_config.ModelConfig.is_model_supported("gpt-5.3-codex")
+    assert model_config.ModelConfig.normalize_model_id("openai/gpt-5.3-codex") == "gpt-5.3-codex"
+    assert model_config.ModelConfig.normalize_model_id("openai/gpt-5.3-codex-spark") == "gpt-5.3-codex-spark"


### PR DESCRIPTION
## Summary
- add OpenAI Codex OAuth resolution to `ov.Agent(...)` / `OmicVerseAgent(...)`, including fallback import from `~/.codex/auth.json`
- align Codex-capable model routing across `smart_agent`, `model_config`, Jarvis CLI, and setup wizard
- add regression coverage for Codex aliases and invalid non-OAuth API keys on the Codex backend

## Testing
- remote server `/slow/omicverse-codex-auth`: `pytest -q tests/utils/test_model_normalization.py tests/utils/test_agent_codex_auth.py`
- remote server `/slow/omicverse-codex-auth`: `pytest -q tests/utils/test_agent_initialization.py tests/utils/test_smart_agent.py tests/utils/test_harness_contracts.py tests/utils/test_harness_cli.py tests/utils/test_ovagent_run_store.py`