### PR TITLE
Codex/ovagent runtime upgrade 20260325

### DIFF
--- a/omicverse/utils/ovagent/__init__.py
+++ b/omicverse/utils/ovagent/__init__.py
@@ -24,7 +24,7 @@ from .context_budget import (
     TruncationPolicy,
     create_subagent_budget_manager,
 )
-from .subagent_controller import SubagentController
+from .subagent_controller import SubagentController, SubagentRuntime
 from .repair_loop import (
     DEFAULT_MAX_RETRIES,
     ExecutionRepairLoop,
@@ -33,6 +33,13 @@ from .repair_loop import (
     RepairResult,
     build_dataset_context,
     build_llm_repair_prompt,
+)
+from .permission_policy import (
+    PermissionDecision,
+    PermissionPolicy,
+    PermissionVerdict,
+    create_default_policy,
+    create_subagent_policy,
 )
 from .tool_scheduler import (
     ExecutionBatch,
@@ -81,6 +88,9 @@ __all__ = [
     "FailureEnvelope",
     "FollowUpGate",
     "OmicVerseRuntime",
+    "PermissionDecision",
+    "PermissionPolicy",
+    "PermissionVerdict",
     "ProactiveCodeTransformer",
     "PromptBuilder",
     "RepairAttempt",
@@ -89,6 +99,7 @@ __all__ = [
     "RunStore",
     "SessionService",
     "SubagentController",
+    "SubagentRuntime",
     "ScheduleResult",
     "ScheduledCall",
     "ToolMetadata",
@@ -106,7 +117,9 @@ __all__ = [
     "build_default_registry",
     "build_filesystem_context_instructions",
     "build_llm_repair_prompt",
+    "create_default_policy",
     "create_subagent_budget_manager",
+    "create_subagent_policy",
     "execute_batch",
     "collect_api_key_env",
     "create_llm_backend",

--- a/omicverse/utils/ovagent/__init__.py
+++ b/omicverse/utils/ovagent/__init__.py
@@ -7,6 +7,15 @@ from .protocol import AgentContext
 from .prompt_builder import PromptBuilder, CODE_QUALITY_RULES, build_filesystem_context_instructions
 from .analysis_executor import AnalysisExecutor, ProactiveCodeTransformer
 from .tool_runtime import ToolRuntime
+from .tool_registry import (
+    ApprovalClass,
+    IsolationMode,
+    OutputTier,
+    ParallelClass,
+    ToolMetadata,
+    ToolRegistry,
+    build_default_registry,
+)
 from .subagent_controller import SubagentController
 from .turn_controller import TurnController, FollowUpGate
 from .session_context import SessionService, ContextService
@@ -33,6 +42,7 @@ from .bootstrap import (
 
 __all__ = [
     "AgentContext",
+    "ApprovalClass",
     "AnalysisExecutor",
     "AnalysisRun",
     "CODE_QUALITY_RULES",
@@ -45,10 +55,16 @@ __all__ = [
     "RunStore",
     "SessionService",
     "SubagentController",
+    "ToolMetadata",
+    "ToolRegistry",
     "ToolRuntime",
     "TurnController",
     "WorkflowConfig",
     "WorkflowDocument",
+    "IsolationMode",
+    "OutputTier",
+    "ParallelClass",
+    "build_default_registry",
     "build_filesystem_context_instructions",
     "collect_api_key_env",
     "create_llm_backend",

--- a/omicverse/utils/ovagent/__init__.py
+++ b/omicverse/utils/ovagent/__init__.py
@@ -48,6 +48,7 @@ from .tool_scheduler import (
     ToolScheduler,
     execute_batch,
 )
+from .event_stream import RuntimeEventEmitter
 from .turn_controller import TurnController, FollowUpGate
 from .session_context import SessionService, ContextService
 from .registry_scanner import RegistryScanner
@@ -94,6 +95,7 @@ __all__ = [
     "ProactiveCodeTransformer",
     "PromptBuilder",
     "RepairAttempt",
+    "RuntimeEventEmitter",
     "RepairResult",
     "ResolvedBackend",
     "RunStore",

--- a/omicverse/utils/ovagent/__init__.py
+++ b/omicverse/utils/ovagent/__init__.py
@@ -5,6 +5,12 @@ from .runtime import OmicVerseRuntime
 from .workflow import WorkflowConfig, WorkflowDocument, load_workflow_document
 from .protocol import AgentContext
 from .prompt_builder import PromptBuilder, CODE_QUALITY_RULES, build_filesystem_context_instructions
+from .prompt_templates import (
+    PromptOverlay,
+    PromptTemplateEngine,
+    build_agentic_engine,
+    build_subagent_engine,
+)
 from .analysis_executor import AnalysisExecutor, ProactiveCodeTransformer
 from .tool_runtime import ToolRuntime
 from .tool_registry import (
@@ -94,6 +100,8 @@ __all__ = [
     "PermissionVerdict",
     "ProactiveCodeTransformer",
     "PromptBuilder",
+    "PromptOverlay",
+    "PromptTemplateEngine",
     "RepairAttempt",
     "RuntimeEventEmitter",
     "RepairResult",
@@ -116,9 +124,11 @@ __all__ = [
     "OutputTier",
     "ParallelClass",
     "build_dataset_context",
+    "build_agentic_engine",
     "build_default_registry",
     "build_filesystem_context_instructions",
     "build_llm_repair_prompt",
+    "build_subagent_engine",
     "create_default_policy",
     "create_subagent_budget_manager",
     "create_subagent_policy",

--- a/omicverse/utils/ovagent/__init__.py
+++ b/omicverse/utils/ovagent/__init__.py
@@ -25,6 +25,15 @@ from .context_budget import (
     create_subagent_budget_manager,
 )
 from .subagent_controller import SubagentController
+from .repair_loop import (
+    DEFAULT_MAX_RETRIES,
+    ExecutionRepairLoop,
+    FailureEnvelope,
+    RepairAttempt,
+    RepairResult,
+    build_dataset_context,
+    build_llm_repair_prompt,
+)
 from .tool_scheduler import (
     ExecutionBatch,
     ScheduleResult,
@@ -66,11 +75,16 @@ __all__ = [
     "CompactionCheckpoint",
     "ContextBudgetManager",
     "ContextService",
+    "DEFAULT_MAX_RETRIES",
     "ExecutionBatch",
+    "ExecutionRepairLoop",
+    "FailureEnvelope",
     "FollowUpGate",
     "OmicVerseRuntime",
     "ProactiveCodeTransformer",
     "PromptBuilder",
+    "RepairAttempt",
+    "RepairResult",
     "ResolvedBackend",
     "RunStore",
     "SessionService",
@@ -88,8 +102,10 @@ __all__ = [
     "IsolationMode",
     "OutputTier",
     "ParallelClass",
+    "build_dataset_context",
     "build_default_registry",
     "build_filesystem_context_instructions",
+    "build_llm_repair_prompt",
     "create_subagent_budget_manager",
     "execute_batch",
     "collect_api_key_env",

--- a/omicverse/utils/ovagent/__init__.py
+++ b/omicverse/utils/ovagent/__init__.py
@@ -16,6 +16,14 @@ from .tool_registry import (
     ToolRegistry,
     build_default_registry,
 )
+from .context_budget import (
+    BudgetSlice,
+    BudgetSliceType,
+    CompactionCheckpoint,
+    ContextBudgetManager,
+    TruncationPolicy,
+    create_subagent_budget_manager,
+)
 from .subagent_controller import SubagentController
 from .tool_scheduler import (
     ExecutionBatch,
@@ -52,7 +60,11 @@ __all__ = [
     "ApprovalClass",
     "AnalysisExecutor",
     "AnalysisRun",
+    "BudgetSlice",
+    "BudgetSliceType",
     "CODE_QUALITY_RULES",
+    "CompactionCheckpoint",
+    "ContextBudgetManager",
     "ContextService",
     "ExecutionBatch",
     "FollowUpGate",
@@ -69,6 +81,7 @@ __all__ = [
     "ToolRegistry",
     "ToolRuntime",
     "ToolScheduler",
+    "TruncationPolicy",
     "TurnController",
     "WorkflowConfig",
     "WorkflowDocument",
@@ -77,6 +90,7 @@ __all__ = [
     "ParallelClass",
     "build_default_registry",
     "build_filesystem_context_instructions",
+    "create_subagent_budget_manager",
     "execute_batch",
     "collect_api_key_env",
     "create_llm_backend",

--- a/omicverse/utils/ovagent/__init__.py
+++ b/omicverse/utils/ovagent/__init__.py
@@ -17,6 +17,13 @@ from .tool_registry import (
     build_default_registry,
 )
 from .subagent_controller import SubagentController
+from .tool_scheduler import (
+    ExecutionBatch,
+    ScheduleResult,
+    ScheduledCall,
+    ToolScheduler,
+    execute_batch,
+)
 from .turn_controller import TurnController, FollowUpGate
 from .session_context import SessionService, ContextService
 from .registry_scanner import RegistryScanner
@@ -47,6 +54,7 @@ __all__ = [
     "AnalysisRun",
     "CODE_QUALITY_RULES",
     "ContextService",
+    "ExecutionBatch",
     "FollowUpGate",
     "OmicVerseRuntime",
     "ProactiveCodeTransformer",
@@ -55,9 +63,12 @@ __all__ = [
     "RunStore",
     "SessionService",
     "SubagentController",
+    "ScheduleResult",
+    "ScheduledCall",
     "ToolMetadata",
     "ToolRegistry",
     "ToolRuntime",
+    "ToolScheduler",
     "TurnController",
     "WorkflowConfig",
     "WorkflowDocument",
@@ -66,6 +77,7 @@ __all__ = [
     "ParallelClass",
     "build_default_registry",
     "build_filesystem_context_instructions",
+    "execute_batch",
     "collect_api_key_env",
     "create_llm_backend",
     "display_backend_info",

--- a/omicverse/utils/ovagent/bootstrap.py
+++ b/omicverse/utils/ovagent/bootstrap.py
@@ -1,9 +1,17 @@
-"""Agent subsystem initialization.
+"""Agent subsystem initialization — CLI bootstrap banners.
 
 Extracted from ``OmicVerseAgent.__init__`` so that each bootstrap concern
 has its own focused, testable function.  Every function here is a pure
 factory — it creates and returns a subsystem value without storing it on
 an agent instance.
+
+CLI banner contract
+-------------------
+The ``print()`` calls in this module are **intentional, explicitly scoped
+CLI startup banners**.  They provide non-authoritative human feedback
+during agent initialization and are NOT part of the structured
+observability contract.  Machine consumers must read from the logger or
+harness event stream (see ``event_stream.py``), never from stdout.
 """
 
 from __future__ import annotations

--- a/omicverse/utils/ovagent/context_budget.py
+++ b/omicverse/utils/ovagent/context_budget.py
@@ -330,19 +330,26 @@ class ContextBudgetManager:
         # Convert token limit back to approximate char budget
         # Use 4 chars/token as inverse of our estimator
         char_budget = policy.max_tokens * 4
+        suffix_len = len(policy.suffix)
+
+        # Guard: if budget is too small to fit even the suffix, return the suffix.
+        if char_budget <= suffix_len:
+            return policy.suffix[:char_budget] if char_budget > 0 else ""
 
         if policy.strategy == "head":
             # Keep the tail
-            suffix_len = len(policy.suffix)
-            return policy.suffix + content[-(char_budget - suffix_len):]
+            tail_chars = char_budget - suffix_len
+            return policy.suffix + content[-tail_chars:]
 
         if policy.strategy == "middle":
             # Keep head + tail, drop middle
-            half = (char_budget - len(policy.suffix)) // 2
+            half = max((char_budget - suffix_len) // 2, 0)
+            if half == 0:
+                return policy.suffix
             return content[:half] + policy.suffix + content[-half:]
 
         # Default: "tail" strategy — keep head, truncate tail
-        keep = char_budget - len(policy.suffix)
+        keep = max(char_budget - suffix_len, 0)
         return content[:keep] + policy.suffix
 
     # -- compaction checkpoints ---------------------------------------------

--- a/omicverse/utils/ovagent/context_budget.py
+++ b/omicverse/utils/ovagent/context_budget.py
@@ -1,0 +1,509 @@
+"""Token-aware context budget manager for OVAgent.
+
+Replaces per-tool and per-turn character clipping with a budget layer
+that accounts for prompt segments, tool output tiers, conversation
+history, and subagent contexts.  Supports incremental sliding summaries
+instead of one-shot compaction only.
+
+Contract
+--------
+* Prompt and tool outputs consume **typed budget slices**.
+* Overflow policy is chosen by **content tier** (OutputTier from the
+  tool registry), not a single hard-coded constant.
+* Both the main-agent and subagent paths use the same budgeting model.
+* Compaction supports **incremental summaries / checkpoints** in
+  addition to the existing one-shot ``ContextCompactor``.
+"""
+
+from __future__ import annotations
+
+import re
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+from .tool_registry import OutputTier
+
+
+# ---------------------------------------------------------------------------
+# Token estimator (bounded, no external dependency)
+# ---------------------------------------------------------------------------
+
+# CJK regex for character-aware estimation
+_CJK_RE = re.compile(r"[\u4e00-\u9fff\u3040-\u309f\u30a0-\u30ff]")
+
+
+def estimate_tokens(text: str) -> int:
+    """Bounded token estimate without tiktoken.
+
+    Uses ~4 chars/token for ASCII, ~2 chars/token for CJK.
+    This is deliberately conservative to avoid under-counting.
+    """
+    if not text:
+        return 0
+    cjk = len(_CJK_RE.findall(text))
+    ascii_chars = len(text) - cjk
+    return max(1, cjk // 2 + ascii_chars // 4)
+
+
+# ---------------------------------------------------------------------------
+# Model context windows (canonical source)
+# ---------------------------------------------------------------------------
+
+MODEL_CONTEXT_WINDOWS: Dict[str, int] = {
+    "gpt-4o": 128_000,
+    "gpt-4o-mini": 128_000,
+    "gpt-5": 256_000,
+    "gpt-5-mini": 128_000,
+    "gemini/gemini-2.5-flash": 1_000_000,
+    "gemini/gemini-2.5-pro": 1_000_000,
+    "anthropic/claude-sonnet-4-20250514": 200_000,
+    "anthropic/claude-opus-4-20250514": 200_000,
+    "deepseek/deepseek-chat": 64_000,
+}
+
+_DEFAULT_CONTEXT_WINDOW = 32_000
+
+
+def get_context_window(model: str) -> int:
+    """Return context window size for *model*, falling back to default."""
+    return MODEL_CONTEXT_WINDOWS.get(model, _DEFAULT_CONTEXT_WINDOW)
+
+
+# ---------------------------------------------------------------------------
+# Budget slice types
+# ---------------------------------------------------------------------------
+
+
+class BudgetSliceType(str, Enum):
+    """Category of content consuming context budget."""
+
+    system_prompt = "system_prompt"
+    user_message = "user_message"
+    assistant_message = "assistant_message"
+    conversation_history = "conversation_history"
+    tool_output = "tool_output"
+    compaction_checkpoint = "compaction_checkpoint"
+
+
+# ---------------------------------------------------------------------------
+# Truncation policy per output tier
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class TruncationPolicy:
+    """Defines how overflow is handled for a given content tier.
+
+    Attributes
+    ----------
+    max_tokens : int
+        Maximum token budget for a single piece of content.
+    strategy : str
+        ``"tail"`` keeps the head and truncates the tail (default).
+        ``"head"`` keeps the tail.
+        ``"middle"`` keeps head + tail, drops middle.
+    suffix : str
+        Text appended when truncation occurs.
+    """
+
+    max_tokens: int
+    strategy: str = "tail"
+    suffix: str = "\n... (truncated)"
+
+
+# Default truncation policies keyed by OutputTier.
+# These replace the hard-coded 4000/6000/8000 char constants.
+_DEFAULT_TIER_POLICIES: Dict[OutputTier, TruncationPolicy] = {
+    OutputTier.minimal: TruncationPolicy(max_tokens=500),
+    OutputTier.standard: TruncationPolicy(max_tokens=2000),
+    OutputTier.verbose: TruncationPolicy(max_tokens=3000),
+}
+
+# Subagent tier policies are tighter to fit the smaller budget.
+_SUBAGENT_TIER_POLICIES: Dict[OutputTier, TruncationPolicy] = {
+    OutputTier.minimal: TruncationPolicy(max_tokens=300),
+    OutputTier.standard: TruncationPolicy(max_tokens=1200),
+    OutputTier.verbose: TruncationPolicy(max_tokens=1800),
+}
+
+
+# ---------------------------------------------------------------------------
+# Budget slice
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class BudgetSlice:
+    """A single allocation unit within the context budget.
+
+    Each slice records what type of content it holds, how many tokens
+    it consumes, and which output tier governs its overflow policy.
+    """
+
+    slice_type: BudgetSliceType
+    tokens: int
+    content_key: str = ""
+    tier: OutputTier = OutputTier.standard
+
+
+# ---------------------------------------------------------------------------
+# Compaction checkpoint (incremental summaries)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CompactionCheckpoint:
+    """Snapshot of conversation state for incremental compaction.
+
+    Instead of compacting the entire conversation in one shot,
+    checkpoints capture a rolling summary at a specific turn,
+    allowing the budget manager to drop old messages while
+    retaining their compressed essence.
+    """
+
+    turn_index: int
+    summary: str
+    tokens: int
+    timestamp: float = field(default_factory=time.time)
+    messages_covered: int = 0
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "turn_index": self.turn_index,
+            "summary_preview": self.summary[:200],
+            "tokens": self.tokens,
+            "timestamp": self.timestamp,
+            "messages_covered": self.messages_covered,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Context budget manager
+# ---------------------------------------------------------------------------
+
+
+class ContextBudgetManager:
+    """Token-aware context budget manager.
+
+    Tracks token consumption across typed budget slices, applies
+    tier-driven truncation policies for tool outputs, and maintains
+    incremental compaction checkpoints for sliding summaries.
+
+    Parameters
+    ----------
+    model : str
+        Model identifier (used to look up context window size).
+    context_window : int, optional
+        Override the model-derived context window.
+    tier_policies : dict, optional
+        Override the default per-tier truncation policies.
+    reserve_fraction : float
+        Fraction of the context window reserved for the model's
+        response generation (default 0.25 = 25%).
+    compaction_threshold : float
+        Fraction of the usable budget at which compaction triggers
+        (default 0.75 = 75%).
+    """
+
+    def __init__(
+        self,
+        model: str = "",
+        *,
+        context_window: int = 0,
+        tier_policies: Optional[Dict[OutputTier, TruncationPolicy]] = None,
+        reserve_fraction: float = 0.25,
+        compaction_threshold: float = 0.75,
+    ) -> None:
+        self._model = model
+        self._context_window = context_window or get_context_window(model)
+        self._tier_policies = dict(
+            tier_policies or _DEFAULT_TIER_POLICIES
+        )
+        self._reserve_fraction = reserve_fraction
+        self._compaction_threshold = compaction_threshold
+
+        # Usable budget = context window minus response reserve
+        self._usable_budget = int(
+            self._context_window * (1.0 - self._reserve_fraction)
+        )
+
+        # Tracking
+        self._slices: List[BudgetSlice] = []
+        self._checkpoints: List[CompactionCheckpoint] = []
+        self._total_consumed: int = 0
+
+    # -- properties ---------------------------------------------------------
+
+    @property
+    def context_window(self) -> int:
+        return self._context_window
+
+    @property
+    def usable_budget(self) -> int:
+        return self._usable_budget
+
+    @property
+    def total_consumed(self) -> int:
+        return self._total_consumed
+
+    @property
+    def remaining_budget(self) -> int:
+        return max(0, self._usable_budget - self._total_consumed)
+
+    @property
+    def utilization(self) -> float:
+        """Fraction of usable budget currently consumed (0.0–1.0+)."""
+        if self._usable_budget <= 0:
+            return 1.0
+        return self._total_consumed / self._usable_budget
+
+    @property
+    def checkpoints(self) -> Tuple[CompactionCheckpoint, ...]:
+        return tuple(self._checkpoints)
+
+    @property
+    def tier_policies(self) -> Dict[OutputTier, TruncationPolicy]:
+        return dict(self._tier_policies)
+
+    # -- budget tracking ----------------------------------------------------
+
+    def record(
+        self,
+        slice_type: BudgetSliceType,
+        content: str,
+        *,
+        content_key: str = "",
+        tier: OutputTier = OutputTier.standard,
+    ) -> BudgetSlice:
+        """Record a piece of content consuming budget.
+
+        Returns the ``BudgetSlice`` that was created.
+        """
+        tokens = estimate_tokens(content)
+        bs = BudgetSlice(
+            slice_type=slice_type,
+            tokens=tokens,
+            content_key=content_key,
+            tier=tier,
+        )
+        self._slices.append(bs)
+        self._total_consumed += tokens
+        return bs
+
+    def consumption_by_type(self) -> Dict[str, int]:
+        """Return total tokens consumed per slice type."""
+        totals: Dict[str, int] = {}
+        for s in self._slices:
+            key = s.slice_type.value
+            totals[key] = totals.get(key, 0) + s.tokens
+        return totals
+
+    # -- tier-driven truncation ---------------------------------------------
+
+    def get_truncation_policy(self, tier: OutputTier) -> TruncationPolicy:
+        """Return the truncation policy for *tier*."""
+        return self._tier_policies.get(
+            tier,
+            TruncationPolicy(max_tokens=2000),  # safe fallback
+        )
+
+    def truncate_output(
+        self,
+        content: str,
+        tier: OutputTier,
+    ) -> str:
+        """Apply tier-driven truncation to *content*.
+
+        Returns the (possibly truncated) content string.
+        """
+        if not content:
+            return content
+
+        policy = self.get_truncation_policy(tier)
+        content_tokens = estimate_tokens(content)
+
+        if content_tokens <= policy.max_tokens:
+            return content
+
+        # Convert token limit back to approximate char budget
+        # Use 4 chars/token as inverse of our estimator
+        char_budget = policy.max_tokens * 4
+
+        if policy.strategy == "head":
+            # Keep the tail
+            suffix_len = len(policy.suffix)
+            return policy.suffix + content[-(char_budget - suffix_len):]
+
+        if policy.strategy == "middle":
+            # Keep head + tail, drop middle
+            half = (char_budget - len(policy.suffix)) // 2
+            return content[:half] + policy.suffix + content[-half:]
+
+        # Default: "tail" strategy — keep head, truncate tail
+        keep = char_budget - len(policy.suffix)
+        return content[:keep] + policy.suffix
+
+    # -- compaction checkpoints ---------------------------------------------
+
+    def should_compact(self) -> bool:
+        """True when utilization exceeds the compaction threshold."""
+        return self.utilization >= self._compaction_threshold
+
+    def add_checkpoint(
+        self,
+        turn_index: int,
+        summary: str,
+        *,
+        messages_covered: int = 0,
+    ) -> CompactionCheckpoint:
+        """Record an incremental compaction checkpoint.
+
+        Checkpoints capture a rolling summary of conversation state
+        at a specific turn, enabling sliding-window compaction.
+        """
+        tokens = estimate_tokens(summary)
+        cp = CompactionCheckpoint(
+            turn_index=turn_index,
+            summary=summary,
+            tokens=tokens,
+            messages_covered=messages_covered,
+        )
+        self._checkpoints.append(cp)
+        return cp
+
+    def get_latest_checkpoint(self) -> Optional[CompactionCheckpoint]:
+        """Return the most recent checkpoint, or None."""
+        return self._checkpoints[-1] if self._checkpoints else None
+
+    def build_sliding_summary(self) -> str:
+        """Combine all checkpoints into a sliding summary string.
+
+        Returns an empty string if no checkpoints exist.
+        """
+        if not self._checkpoints:
+            return ""
+        parts = []
+        for cp in self._checkpoints:
+            parts.append(
+                f"[Turn {cp.turn_index}] {cp.summary}"
+            )
+        return "\n".join(parts)
+
+    def compact_history(
+        self,
+        messages: Sequence[Dict[str, Any]],
+        *,
+        keep_recent: int = 4,
+    ) -> Tuple[List[Dict[str, Any]], Optional[CompactionCheckpoint]]:
+        """Replace older messages with the latest checkpoint summary.
+
+        Keeps the system prompt (index 0) and the *keep_recent* most
+        recent messages.  Everything in between is replaced by the
+        sliding summary if checkpoints exist.
+
+        Returns (compacted_messages, checkpoint_used_or_None).
+        """
+        if len(messages) <= keep_recent + 1:
+            return list(messages), None
+
+        latest_cp = self.get_latest_checkpoint()
+        if latest_cp is None:
+            # No checkpoint available; return messages unchanged
+            return list(messages), None
+
+        # Keep system prompt + inject summary + keep recent messages
+        system_msg = messages[0] if messages else None
+        recent = list(messages[-keep_recent:])
+
+        compacted: List[Dict[str, Any]] = []
+        if system_msg is not None:
+            compacted.append(system_msg)
+
+        # Insert the sliding summary as a system-injected context message
+        summary_text = self.build_sliding_summary()
+        if summary_text:
+            compacted.append({
+                "role": "user",
+                "content": (
+                    "[Context summary from earlier turns]\n" + summary_text
+                ),
+            })
+
+        compacted.extend(recent)
+
+        # Track the compaction in budget
+        self.record(
+            BudgetSliceType.compaction_checkpoint,
+            summary_text,
+            content_key="sliding_summary",
+        )
+
+        return compacted, latest_cp
+
+    # -- summary / introspection --------------------------------------------
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialise budget state for debugging / tracing."""
+        return {
+            "model": self._model,
+            "context_window": self._context_window,
+            "usable_budget": self._usable_budget,
+            "total_consumed": self._total_consumed,
+            "remaining": self.remaining_budget,
+            "utilization": round(self.utilization, 4),
+            "should_compact": self.should_compact(),
+            "slice_count": len(self._slices),
+            "checkpoint_count": len(self._checkpoints),
+            "consumption_by_type": self.consumption_by_type(),
+            "tier_policies": {
+                tier.value: {
+                    "max_tokens": p.max_tokens,
+                    "strategy": p.strategy,
+                }
+                for tier, p in self._tier_policies.items()
+            },
+        }
+
+    def reset(self) -> None:
+        """Clear all tracked slices and checkpoints."""
+        self._slices.clear()
+        self._checkpoints.clear()
+        self._total_consumed = 0
+
+
+# ---------------------------------------------------------------------------
+# Factory for subagent budget managers
+# ---------------------------------------------------------------------------
+
+
+def create_subagent_budget_manager(
+    model: str = "",
+    *,
+    context_window: int = 0,
+) -> ContextBudgetManager:
+    """Create a budget manager with tighter policies for subagents.
+
+    Subagents operate with smaller context budgets and stricter
+    truncation limits, but share the same budgeting model.
+    """
+    return ContextBudgetManager(
+        model=model,
+        context_window=context_window,
+        tier_policies=_SUBAGENT_TIER_POLICIES,
+        reserve_fraction=0.25,
+        compaction_threshold=0.70,
+    )
+
+
+__all__ = [
+    "BudgetSlice",
+    "BudgetSliceType",
+    "CompactionCheckpoint",
+    "ContextBudgetManager",
+    "TruncationPolicy",
+    "create_subagent_budget_manager",
+    "estimate_tokens",
+    "get_context_window",
+]

--- a/omicverse/utils/ovagent/event_stream.py
+++ b/omicverse/utils/ovagent/event_stream.py
@@ -1,0 +1,360 @@
+"""RuntimeEventEmitter — unified observability surface for OVAgent runtime.
+
+Routes all runtime state through structured logger sinks and the harness
+event stream.  Print output is **not** part of this contract — it is
+non-authoritative and optional.
+
+Observability contract
+----------------------
+* Every dispatch, result, retry, and completion event is emitted through
+  **both** the Python logger and the harness event callback (when present).
+* Consumers of runtime state must read from the logger or event stream,
+  never from stdout.
+* CLI banners (bootstrap.py, auth.py) remain explicitly scoped as
+  non-authoritative human feedback and are NOT routed through this module.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any, Callable, Coroutine, Optional
+
+from ..harness import build_stream_event
+
+if TYPE_CHECKING:
+    from ..harness import RunTraceRecorder
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# RuntimeEventEmitter
+# ---------------------------------------------------------------------------
+
+
+class RuntimeEventEmitter:
+    """Emit structured runtime events through logger + harness event stream.
+
+    This is the single observability surface for the agentic turn loop,
+    tool dispatch, subagent execution, and completion feedback.
+
+    Parameters
+    ----------
+    recorder : RunTraceRecorder, optional
+        Harness trace recorder.  Events are appended to the trace when
+        provided.
+    event_callback : callable, optional
+        Async callback that receives harness stream events (dict).
+    source : str
+        Label identifying the emitting subsystem (``"turn_loop"``,
+        ``"subagent"``, ``"tool_runtime"``).
+    """
+
+    def __init__(
+        self,
+        *,
+        recorder: Optional["RunTraceRecorder"] = None,
+        event_callback: Optional[
+            Callable[..., Coroutine[Any, Any, None]]
+        ] = None,
+        source: str = "runtime",
+    ) -> None:
+        self._recorder = recorder
+        self._event_callback = event_callback
+        self._source = source
+
+    # ------------------------------------------------------------------
+    # Core emit
+    # ------------------------------------------------------------------
+
+    async def emit(
+        self,
+        event_type: str,
+        content: Any,
+        *,
+        turn_id: str = "",
+        trace_id: str = "",
+        session_id: str = "",
+        step_id: str = "",
+        category: str = "",
+        latency_ms: Optional[float] = None,
+        extra: Optional[dict[str, Any]] = None,
+    ) -> None:
+        """Emit a structured event through all sinks.
+
+        1. Always log via the module logger.
+        2. Append to trace recorder when available.
+        3. Forward to harness event callback when available.
+        """
+        event = build_stream_event(
+            event_type,
+            content,
+            turn_id=turn_id,
+            trace_id=trace_id,
+            session_id=session_id,
+            step_id=step_id,
+            category=category,
+            latency_ms=latency_ms,
+        )
+        if extra:
+            event.update(extra)
+
+        # 1. Structured log
+        logger.info(
+            "runtime_event source=%s type=%s category=%s content=%s",
+            self._source,
+            event_type,
+            category or "-",
+            _summarize(content),
+        )
+
+        # 2. Trace recorder
+        if self._recorder is not None:
+            self._recorder.add_event(event)
+
+        # 3. Harness event callback
+        if self._event_callback is not None:
+            await self._event_callback(event)
+
+    # ------------------------------------------------------------------
+    # Convenience methods — turn lifecycle
+    # ------------------------------------------------------------------
+
+    async def turn_started(
+        self,
+        turn: int,
+        max_turns: int,
+        tool_choice: str,
+        *,
+        turn_id: str = "",
+        trace_id: str = "",
+        session_id: str = "",
+    ) -> None:
+        """Emit a turn-started event."""
+        logger.info(
+            "turn_started turn=%d/%d tool_choice=%s",
+            turn + 1,
+            max_turns,
+            tool_choice,
+        )
+        await self.emit(
+            "status",
+            {
+                "turn": turn + 1,
+                "max_turns": max_turns,
+                "tool_choice": tool_choice,
+            },
+            turn_id=turn_id,
+            trace_id=trace_id,
+            session_id=session_id,
+            category="turn_lifecycle",
+        )
+
+    async def turn_cancelled(
+        self,
+        phase: str,
+        *,
+        turn_id: str = "",
+        trace_id: str = "",
+        session_id: str = "",
+    ) -> None:
+        """Emit a cancellation event."""
+        logger.info("turn_cancelled phase=%s", phase)
+        await self.emit(
+            "done",
+            f"Cancelled ({phase})",
+            turn_id=turn_id,
+            trace_id=trace_id,
+            session_id=session_id,
+            category="lifecycle",
+            extra={"cancelled": True},
+        )
+
+    async def max_turns_reached(
+        self,
+        max_turns: int,
+        *,
+        turn_id: str = "",
+        trace_id: str = "",
+        session_id: str = "",
+    ) -> None:
+        """Emit a max-turns-reached event."""
+        logger.warning("max_turns_reached max_turns=%d", max_turns)
+        await self.emit(
+            "done",
+            f"Reached max turns ({max_turns})",
+            turn_id=turn_id,
+            trace_id=trace_id,
+            session_id=session_id,
+            category="lifecycle",
+            extra={"max_turns": True},
+        )
+
+    # ------------------------------------------------------------------
+    # Convenience methods — tool dispatch
+    # ------------------------------------------------------------------
+
+    async def tool_dispatched(
+        self,
+        name: str,
+        arguments: dict[str, Any],
+        *,
+        batch_id: str = "",
+        parallel: bool = False,
+        step_id: str = "",
+        turn_id: str = "",
+        trace_id: str = "",
+        session_id: str = "",
+    ) -> None:
+        """Emit a tool-dispatch event."""
+        logger.info(
+            "tool_dispatched name=%s args=[%s] batch=%s parallel=%s",
+            name,
+            ", ".join(f"{k}=" for k in arguments),
+            batch_id,
+            parallel,
+        )
+
+    async def tool_completed(
+        self,
+        name: str,
+        *,
+        status: str = "success",
+        description: str = "",
+        step_id: str = "",
+        turn_id: str = "",
+        trace_id: str = "",
+        session_id: str = "",
+    ) -> None:
+        """Emit a tool-completion event."""
+        logger.info(
+            "tool_completed name=%s status=%s description=%s",
+            name,
+            status,
+            description[:120] if description else "-",
+        )
+
+    async def execution_completed(
+        self,
+        description: str,
+        *,
+        turn_id: str = "",
+        trace_id: str = "",
+        session_id: str = "",
+    ) -> None:
+        """Emit an execute_code completion event."""
+        logger.info("execution_completed description=%s", description[:120])
+
+    async def delegation_completed(
+        self,
+        agent_type: str,
+        task: str = "",
+        *,
+        turn_id: str = "",
+        trace_id: str = "",
+        session_id: str = "",
+    ) -> None:
+        """Emit a delegation-started/completed event."""
+        logger.info(
+            "delegation agent_type=%s task=%s",
+            agent_type,
+            task[:80] if task else "-",
+        )
+
+    async def task_finished(
+        self,
+        summary: str,
+        *,
+        turn_id: str = "",
+        trace_id: str = "",
+        session_id: str = "",
+    ) -> None:
+        """Emit a task-finished event."""
+        logger.info("task_finished summary=%s", summary[:120])
+
+    # ------------------------------------------------------------------
+    # Convenience methods — subagent lifecycle
+    # ------------------------------------------------------------------
+
+    async def subagent_turn(
+        self,
+        agent_type: str,
+        turn: int,
+        max_turns: int,
+    ) -> None:
+        """Log a subagent turn progression."""
+        logger.info(
+            "subagent_turn agent_type=%s turn=%d/%d",
+            agent_type,
+            turn + 1,
+            max_turns,
+        )
+
+    async def subagent_tool(
+        self,
+        agent_type: str,
+        tool_name: str,
+        arguments: dict[str, Any],
+    ) -> None:
+        """Log a subagent tool dispatch."""
+        logger.info(
+            "subagent_tool agent_type=%s tool=%s args=[%s]",
+            agent_type,
+            tool_name,
+            ", ".join(f"{k}=" for k in arguments),
+        )
+
+    async def subagent_finished(
+        self,
+        agent_type: str,
+        summary: str,
+    ) -> None:
+        """Log subagent completion."""
+        logger.info(
+            "subagent_finished agent_type=%s summary=%s",
+            agent_type,
+            summary[:120],
+        )
+
+    # ------------------------------------------------------------------
+    # Convenience — conversation log
+    # ------------------------------------------------------------------
+
+    def conversation_log_saved(self, path: str) -> None:
+        """Log that a conversation log was persisted (non-critical)."""
+        logger.info("conversation_log_saved path=%s", path)
+
+    # ------------------------------------------------------------------
+    # Convenience — agent response
+    # ------------------------------------------------------------------
+
+    async def agent_response(
+        self,
+        content: str,
+        *,
+        turn_id: str = "",
+        trace_id: str = "",
+        session_id: str = "",
+    ) -> None:
+        """Log an assistant text response (no tool calls)."""
+        logger.info(
+            "agent_response content=%s",
+            content[:200] if content else "-",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _summarize(content: Any, max_len: int = 120) -> str:
+    """Return a short string summary of *content* for log lines."""
+    if content is None:
+        return "-"
+    if isinstance(content, str):
+        return content[:max_len]
+    if isinstance(content, dict):
+        keys = ", ".join(content.keys())
+        return f"{{{keys}}}"[:max_len]
+    return str(content)[:max_len]

--- a/omicverse/utils/ovagent/event_stream.py
+++ b/omicverse/utils/ovagent/event_stream.py
@@ -214,6 +214,15 @@ class RuntimeEventEmitter:
             batch_id,
             parallel,
         )
+        await self.emit(
+            "tool_dispatched",
+            {"name": name, "batch_id": batch_id, "parallel": parallel},
+            step_id=step_id,
+            turn_id=turn_id,
+            trace_id=trace_id,
+            session_id=session_id,
+            category="tool_dispatch",
+        )
 
     async def tool_completed(
         self,
@@ -233,6 +242,15 @@ class RuntimeEventEmitter:
             status,
             description[:120] if description else "-",
         )
+        await self.emit(
+            "tool_completed",
+            {"name": name, "status": status},
+            step_id=step_id,
+            turn_id=turn_id,
+            trace_id=trace_id,
+            session_id=session_id,
+            category="tool_dispatch",
+        )
 
     async def execution_completed(
         self,
@@ -244,6 +262,14 @@ class RuntimeEventEmitter:
     ) -> None:
         """Emit an execute_code completion event."""
         logger.info("execution_completed description=%s", description[:120])
+        await self.emit(
+            "execution_completed",
+            description,
+            turn_id=turn_id,
+            trace_id=trace_id,
+            session_id=session_id,
+            category="tool_dispatch",
+        )
 
     async def delegation_completed(
         self,
@@ -260,6 +286,14 @@ class RuntimeEventEmitter:
             agent_type,
             task[:80] if task else "-",
         )
+        await self.emit(
+            "delegation_completed",
+            {"agent_type": agent_type, "task": task[:80] if task else ""},
+            turn_id=turn_id,
+            trace_id=trace_id,
+            session_id=session_id,
+            category="subagent_lifecycle",
+        )
 
     async def task_finished(
         self,
@@ -271,6 +305,14 @@ class RuntimeEventEmitter:
     ) -> None:
         """Emit a task-finished event."""
         logger.info("task_finished summary=%s", summary[:120])
+        await self.emit(
+            "done",
+            summary,
+            turn_id=turn_id,
+            trace_id=trace_id,
+            session_id=session_id,
+            category="lifecycle",
+        )
 
     # ------------------------------------------------------------------
     # Convenience methods — subagent lifecycle
@@ -282,12 +324,17 @@ class RuntimeEventEmitter:
         turn: int,
         max_turns: int,
     ) -> None:
-        """Log a subagent turn progression."""
+        """Emit a subagent turn progression event."""
         logger.info(
             "subagent_turn agent_type=%s turn=%d/%d",
             agent_type,
             turn + 1,
             max_turns,
+        )
+        await self.emit(
+            "status",
+            {"agent_type": agent_type, "turn": turn + 1, "max_turns": max_turns},
+            category="subagent_lifecycle",
         )
 
     async def subagent_tool(
@@ -296,12 +343,17 @@ class RuntimeEventEmitter:
         tool_name: str,
         arguments: dict[str, Any],
     ) -> None:
-        """Log a subagent tool dispatch."""
+        """Emit a subagent tool dispatch event."""
         logger.info(
             "subagent_tool agent_type=%s tool=%s args=[%s]",
             agent_type,
             tool_name,
             ", ".join(f"{k}=" for k in arguments),
+        )
+        await self.emit(
+            "tool_dispatched",
+            {"agent_type": agent_type, "name": tool_name},
+            category="subagent_lifecycle",
         )
 
     async def subagent_finished(
@@ -309,11 +361,16 @@ class RuntimeEventEmitter:
         agent_type: str,
         summary: str,
     ) -> None:
-        """Log subagent completion."""
+        """Emit a subagent completion event."""
         logger.info(
             "subagent_finished agent_type=%s summary=%s",
             agent_type,
             summary[:120],
+        )
+        await self.emit(
+            "done",
+            {"agent_type": agent_type, "summary": summary[:120]},
+            category="subagent_lifecycle",
         )
 
     # ------------------------------------------------------------------
@@ -336,10 +393,18 @@ class RuntimeEventEmitter:
         trace_id: str = "",
         session_id: str = "",
     ) -> None:
-        """Log an assistant text response (no tool calls)."""
+        """Emit an assistant text response event (no tool calls)."""
         logger.info(
             "agent_response content=%s",
             content[:200] if content else "-",
+        )
+        await self.emit(
+            "text",
+            content,
+            turn_id=turn_id,
+            trace_id=trace_id,
+            session_id=session_id,
+            category="turn_lifecycle",
         )
 
 

--- a/omicverse/utils/ovagent/permission_policy.py
+++ b/omicverse/utils/ovagent/permission_policy.py
@@ -1,0 +1,216 @@
+"""Per-tool permission policy for OVAgent tool dispatch.
+
+Maps tool names to allow/ask/deny permission verdicts based on registry
+metadata, explicit overrides, and allowlist/denylist constraints.  The
+policy layer sits between the turn loop / subagent controller and tool
+dispatch, enforcing per-tool and per-class permission decisions.
+
+Design for forward compatibility
+---------------------------------
+The ``PermissionPolicy`` *evaluates* verdicts; it does NOT *enforce*
+them (that is the caller's job).  This separation lets a future
+process-backed isolation layer inject its own enforcement without
+changing the evaluation contract.
+
+``create_subagent_policy`` produces a restricted policy that a
+``SubagentRuntime`` can carry to filter tool calls before dispatch.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Dict, FrozenSet, Optional
+
+from .tool_registry import ApprovalClass, IsolationMode, ToolRegistry
+
+
+# ---------------------------------------------------------------------------
+# Verdict types
+# ---------------------------------------------------------------------------
+
+
+class PermissionVerdict(str, Enum):
+    """Result of a permission evaluation."""
+
+    allow = "allow"
+    ask = "ask"
+    deny = "deny"
+
+
+@dataclass(frozen=True)
+class PermissionDecision:
+    """A resolved permission decision for a specific tool invocation."""
+
+    verdict: PermissionVerdict
+    tool_name: str
+    reason: str = ""
+    requires_isolation: IsolationMode = IsolationMode.none
+
+    @property
+    def is_allowed(self) -> bool:
+        return self.verdict == PermissionVerdict.allow
+
+    @property
+    def is_denied(self) -> bool:
+        return self.verdict == PermissionVerdict.deny
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "verdict": self.verdict.value,
+            "tool_name": self.tool_name,
+            "reason": self.reason,
+            "requires_isolation": self.requires_isolation.value,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Policy engine
+# ---------------------------------------------------------------------------
+
+
+class PermissionPolicy:
+    """Evaluate per-tool permission decisions from metadata and overrides.
+
+    Resolution order (highest to lowest priority):
+
+    1. Explicit deny list
+    2. Allowlist restriction (if set, only listed tools are reachable)
+    3. Per-tool overrides
+    4. Per-class overrides (keyed by ``ApprovalClass``)
+    5. Registry metadata defaults (``ToolMetadata.approval_class``)
+    6. Unknown-tool fallback (configurable, defaults to ``deny``)
+    """
+
+    def __init__(
+        self,
+        registry: ToolRegistry,
+        *,
+        tool_overrides: Optional[Dict[str, ApprovalClass]] = None,
+        class_overrides: Optional[Dict[ApprovalClass, PermissionVerdict]] = None,
+        denied_tools: Optional[FrozenSet[str]] = None,
+        allowed_tools: Optional[FrozenSet[str]] = None,
+        unknown_tool_default: PermissionVerdict = PermissionVerdict.deny,
+    ) -> None:
+        self._registry = registry
+        self._tool_overrides = dict(tool_overrides or {})
+        self._class_overrides = dict(class_overrides or {})
+        self._denied_tools = denied_tools or frozenset()
+        self._allowed_tools = allowed_tools
+        self._unknown_default = unknown_tool_default
+
+    @property
+    def registry(self) -> ToolRegistry:
+        """The underlying tool registry."""
+        return self._registry
+
+    def check(self, tool_name: str) -> PermissionDecision:
+        """Evaluate permission for a tool invocation.
+
+        Returns a ``PermissionDecision`` describing the verdict, the
+        reason for the decision, and any isolation requirement drawn
+        from the tool's registry metadata.
+        """
+        # 1. Explicit deny list — absolute priority
+        if tool_name in self._denied_tools:
+            return PermissionDecision(
+                verdict=PermissionVerdict.deny,
+                tool_name=tool_name,
+                reason="tool is in the explicit deny list",
+            )
+
+        # 2. Allowlist restriction
+        if self._allowed_tools is not None and tool_name not in self._allowed_tools:
+            canonical = self._registry.resolve_name(tool_name)
+            if not canonical or canonical not in self._allowed_tools:
+                return PermissionDecision(
+                    verdict=PermissionVerdict.deny,
+                    tool_name=tool_name,
+                    reason="tool is not in the allowed set",
+                )
+
+        # 3. Per-tool override
+        if tool_name in self._tool_overrides:
+            override = self._tool_overrides[tool_name]
+            return PermissionDecision(
+                verdict=PermissionVerdict(override.value),
+                tool_name=tool_name,
+                reason=f"per-tool override: {override.value}",
+                requires_isolation=self._get_isolation(tool_name),
+            )
+
+        # 4–5. Registry metadata lookup
+        meta = self._registry.get(tool_name)
+        if meta is None:
+            # 6. Unknown tool fallback
+            return PermissionDecision(
+                verdict=self._unknown_default,
+                tool_name=tool_name,
+                reason="unknown tool, applying default policy",
+            )
+
+        # 4. Class-level override
+        if meta.approval_class in self._class_overrides:
+            return PermissionDecision(
+                verdict=self._class_overrides[meta.approval_class],
+                tool_name=tool_name,
+                reason=f"class override for {meta.approval_class.value}",
+                requires_isolation=meta.isolation_mode,
+            )
+
+        # 5. Registry default
+        return PermissionDecision(
+            verdict=PermissionVerdict(meta.approval_class.value),
+            tool_name=tool_name,
+            reason="registry metadata default",
+            requires_isolation=meta.isolation_mode,
+        )
+
+    def _get_isolation(self, tool_name: str) -> IsolationMode:
+        meta = self._registry.get(tool_name)
+        return meta.isolation_mode if meta else IsolationMode.none
+
+    def summary(self) -> Dict[str, str]:
+        """Return ``{tool_name: verdict_description}`` for all registered tools."""
+        result: Dict[str, str] = {}
+        for entry in self._registry.all_entries():
+            decision = self.check(entry.canonical_name)
+            result[entry.canonical_name] = (
+                f"{decision.verdict.value} ({decision.reason})"
+            )
+        return result
+
+
+# ---------------------------------------------------------------------------
+# Factory helpers
+# ---------------------------------------------------------------------------
+
+
+def create_default_policy(registry: ToolRegistry) -> PermissionPolicy:
+    """Create the default permission policy from registry metadata alone."""
+    return PermissionPolicy(registry)
+
+
+def create_subagent_policy(
+    registry: ToolRegistry,
+    allowed_tools: FrozenSet[str],
+) -> PermissionPolicy:
+    """Create a restricted permission policy for subagent execution.
+
+    Subagents receive only the tools in their allowed set; everything
+    else is denied.  Unknown tools are denied by default.
+    """
+    return PermissionPolicy(
+        registry,
+        allowed_tools=allowed_tools,
+        unknown_tool_default=PermissionVerdict.deny,
+    )
+
+
+__all__ = [
+    "PermissionDecision",
+    "PermissionPolicy",
+    "PermissionVerdict",
+    "create_default_policy",
+    "create_subagent_policy",
+]

--- a/omicverse/utils/ovagent/permission_policy.py
+++ b/omicverse/utils/ovagent/permission_policy.py
@@ -119,10 +119,11 @@ class PermissionPolicy:
                 reason="tool is in the explicit deny list",
             )
 
-        # 2. Allowlist restriction
-        if self._allowed_tools is not None and tool_name not in self._allowed_tools:
-            canonical = self._registry.resolve_name(tool_name)
-            if not canonical or canonical not in self._allowed_tools:
+        # 2. Allowlist restriction — resolve aliases before checking so that an
+        # aliased name whose canonical is in the allowlist is not incorrectly denied.
+        canonical_name = self._registry.resolve_name(tool_name) or tool_name
+        if self._allowed_tools is not None:
+            if tool_name not in self._allowed_tools and canonical_name not in self._allowed_tools:
                 return PermissionDecision(
                     verdict=PermissionVerdict.deny,
                     tool_name=tool_name,

--- a/omicverse/utils/ovagent/prompt_builder.py
+++ b/omicverse/utils/ovagent/prompt_builder.py
@@ -16,7 +16,6 @@ from typing import TYPE_CHECKING, Any, List, Optional
 from .prompt_templates import (
     CODE_ONLY_MODE,
     PromptOverlay,
-    PromptTemplateEngine,
     build_agentic_engine,
     build_subagent_engine,
 )
@@ -110,9 +109,9 @@ class PromptBuilder:
         raise ValueError("Unknown subagent type: " + agent_type)
 
     def build_subagent_user_message(self, task: str, adata: Any) -> str:
-        msg = "Task: " + task + "\n\n"
+        msg = f"Task: {task}\n\n"
         if adata is not None and hasattr(adata, "shape"):
-            msg += "Dataset: " + str(adata.shape[0]) + " cells x " + str(adata.shape[1]) + " genes\n"
+            msg += f"Dataset: {adata.shape[0]} cells x {adata.shape[1]} genes\n"
         return msg
 
     # -- main agentic prompt ------------------------------------------------

--- a/omicverse/utils/ovagent/prompt_builder.py
+++ b/omicverse/utils/ovagent/prompt_builder.py
@@ -2,11 +2,24 @@
 
 Extracted from ``smart_agent.py`` to keep prompt assembly in one place.
 All methods are pure string construction with no side effects.
+
+Since task-034, the heavy lifting is delegated to the
+``PromptTemplateEngine`` in ``prompt_templates.py``; this module
+remains the public-facing composition API so existing callers are
+unaffected.
 """
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, List, Optional
+
+from .prompt_templates import (
+    CODE_ONLY_MODE,
+    PromptOverlay,
+    PromptTemplateEngine,
+    build_agentic_engine,
+    build_subagent_engine,
+)
 
 if TYPE_CHECKING:
     from .protocol import AgentContext
@@ -41,7 +54,12 @@ CODE_QUALITY_RULES = (
 # ---------------------------------------------------------------------------
 
 class PromptBuilder:
-    """Build system / user prompts for the agentic loop and subagents."""
+    """Build system / user prompts for the agentic loop and subagents.
+
+    Internally delegates to :class:`PromptTemplateEngine` for
+    deterministic overlay composition while keeping the public API
+    unchanged.
+    """
 
     def __init__(self, ctx: "AgentContext") -> None:
         self._ctx = ctx
@@ -49,68 +67,38 @@ class PromptBuilder:
     # -- subagent prompts ---------------------------------------------------
 
     def build_explore_prompt(self, context: str) -> str:
-        prompt = (
-            "You are a bioinformatics data inspector for OmicVerse. "
-            "Your job is to thoroughly characterize the dataset and report findings.\n\n"
-            "You CANNOT modify the data. Use inspect_data and run_snippet to explore.\n"
-            "Use search_functions to understand what OmicVerse functions are available.\n\n"
-            "Report:\n"
-            "1. Dataset dimensions (cells x genes)\n"
-            "2. Available metadata columns (obs, var) with example values\n"
-            "3. Existing embeddings (obsm) and layers\n"
-            "4. Data quality indicators (sparsity, mito%, batch columns, cell type annotations)\n"
-            "5. Potential issues or recommendations\n\n"
-            "Available packages: ov (omicverse), sc (scanpy), np (numpy), pd (pandas)\n\n"
-            "Call finish() with a comprehensive summary when done.\n"
-        )
+        engine = build_subagent_engine("explore")
         if context:
-            prompt += f"\nAdditional context from parent: {context}"
-        return prompt
+            engine.add_overlay(
+                PromptOverlay("parent_context", "Additional context from parent: " + context, priority=200)
+            )
+        return engine.render()
 
     def build_plan_prompt(self, context: str) -> str:
-        prompt = (
-            "You are a bioinformatics workflow architect for OmicVerse. "
-            "Design a step-by-step execution plan. Do NOT execute code — only plan.\n\n"
-            "Use search_functions to find OmicVerse functions and their prerequisites.\n"
-            "Use search_skills for domain-specific workflow guidance.\n"
-            "Use inspect_data and run_snippet to understand current data state.\n\n"
-            "Your plan should include:\n"
-            "1. Ordered steps with specific OmicVerse function calls and parameters\n"
-            "2. Quality check points between steps\n"
-            "3. Fallback strategies for known failure modes\n"
-            "4. Expected outputs at each step (obsm, obs columns, layers)\n\n"
+        engine = build_subagent_engine("plan")
+        engine.add_overlay(
+            PromptOverlay("finish_call", "Call finish() with the complete plan when done.", priority=60)
         )
-        prompt += CODE_QUALITY_RULES
-        prompt += "\nCall finish() with the complete plan when done.\n"
         if context:
-            prompt += f"\nAdditional context from parent: {context}"
+            engine.add_overlay(
+                PromptOverlay("parent_context", "Additional context from parent: " + context, priority=200)
+            )
+        # Skill listing overlay
         registry = self._ctx.skill_registry
         if registry is not None and getattr(registry, "skill_metadata", None):
-            prompt += "\nAvailable domain skills (use search_skills for details):\n"
+            lines = ["Available domain skills (use search_skills for details):"]
             for meta in sorted(registry.skill_metadata.values(), key=lambda s: s.slug):
-                prompt += f"  - {meta.slug}: {meta.description[:80]}\n"
-        return prompt
+                lines.append("  - " + meta.slug + ": " + meta.description[:80])
+            engine.add_overlay(PromptOverlay("skills", "\n".join(lines), priority=90))
+        return engine.render()
 
     def build_execute_prompt(self, context: str) -> str:
-        prompt = (
-            "You are a focused bioinformatics code executor for OmicVerse. "
-            "Complete the specific sub-task described. Execute code step by step.\n\n"
-            "Guidelines:\n"
-            "- Inspect data before writing code that depends on column names\n"
-            "- Execute in logical steps, not one giant block\n"
-            "- If code fails, diagnose and try a different approach\n"
-            "- Use run_snippet() for exploration, execute_code() for processing\n"
-            "- Call finish() when done with a summary of what was accomplished\n\n"
-        )
-        prompt += CODE_QUALITY_RULES
-        prompt += (
-            "\nAvailable packages: ov (omicverse), sc (scanpy), np (numpy), pd (pandas), "
-            "matplotlib, seaborn, scipy, sklearn\n"
-            "All OmicVerse functions are called via ov.* (e.g. ov.pp.preprocess, ov.pp.scale)\n"
-        )
+        engine = build_subagent_engine("execute")
         if context:
-            prompt += f"\nContext from parent: {context}"
-        return prompt
+            engine.add_overlay(
+                PromptOverlay("parent_context", "Context from parent: " + context, priority=200)
+            )
+        return engine.render()
 
     def build_subagent_system_prompt(self, agent_type: str, context: str = "") -> str:
         if agent_type == "explore":
@@ -119,96 +107,34 @@ class PromptBuilder:
             return self.build_plan_prompt(context)
         elif agent_type == "execute":
             return self.build_execute_prompt(context)
-        raise ValueError(f"Unknown subagent type: {agent_type}")
+        raise ValueError("Unknown subagent type: " + agent_type)
 
     def build_subagent_user_message(self, task: str, adata: Any) -> str:
-        msg = f"Task: {task}\n\n"
+        msg = "Task: " + task + "\n\n"
         if adata is not None and hasattr(adata, "shape"):
-            msg += f"Dataset: {adata.shape[0]} cells x {adata.shape[1]} genes\n"
+            msg += "Dataset: " + str(adata.shape[0]) + " cells x " + str(adata.shape[1]) + " genes\n"
         return msg
 
     # -- main agentic prompt ------------------------------------------------
 
     def build_agentic_system_prompt(self) -> str:
-        prompt = (
-            "You are OmicVerse Agent, an expert bioinformatics assistant that processes "
-            "single-cell, bulk RNA-seq, and spatial transcriptomics data.\n\n"
-            "You have OmicVerse data tools plus a Claude-style coding tool catalog.\n"
-            "Core Claude tools are ToolSearch, Bash, and Read. Deferred Claude tools "
-            "must be loaded through ToolSearch before use. High-risk tools require approval.\n\n"
-            "Use the legacy OmicVerse tools for dataset inspection and execution, and "
-            "use Claude-style tools for files, tasks, planning, worktrees, and questions.\n\n"
-            "Do not narrate future actions without taking them in the same turn. "
-            "If a tool is needed, call it now instead of saying that you will call it later.\n\n"
-            "CODING / FILESYSTEM:\n"
-            "- Use ToolSearch when you need deferred tools such as Edit, Write, Glob, Grep, NotebookEdit, Task*, or EnterWorktree\n"
-            "- Use Read for local files instead of shelling out to cat/head/sed when possible\n"
-            "- Use AskUserQuestion when a turn genuinely needs user clarification\n\n"
-            "WEB ACCESS:\n"
-            "- Use WebFetch(url) or web_fetch(url) to read any web page (GEO datasets, papers, docs)\n"
-            "- Use WebSearch(query) or web_search(query) to search the internet for information\n"
-            "- Use web_download(url) to download files (datasets, h5ad, csv, gz) to disk\n"
-            "- When the user provides a URL, ALWAYS fetch it first instead of asking them to paste content\n"
-            "- When you need background info (gene functions, diseases, methods), search the web\n"
-            "- To download GEO data, fetch the GEO page first to find download links, then use web_download\n\n"
-            "WORKFLOW:\n"
-            "1. If the user provides a URL, use web_fetch to read it\n"
-            "2. Use inspect_data to understand the dataset structure\n"
-            "3. Use search_functions to find relevant OmicVerse functions "
-            "(includes prerequisite chains and examples)\n"
-            "4. For complex multi-step workflows, use search_skills for domain guidance\n"
-            "5. Execute code step by step, checking results between steps\n"
-            "6. Call finish() when the task is complete\n\n"
-            "MANDATORY CODE QUALITY RULES:\n"
-            "- NEVER use f-strings in print() - use string concatenation: "
-            "print('Result: ' + str(value))\n"
-            "- NEVER assign result of in-place OmicVerse functions. Call them directly:\n"
-            "  ov.pp.pca(adata, n_pcs=50)   # CORRECT\n"
-            "  adata = ov.pp.pca(adata)      # WRONG - returns None!\n"
-            "  In-place functions: pca, scale, neighbors, leiden, umap, tsne, "
-            "sude, scrublet, mde, louvain, phate\n"
-            "- NEVER use .cat.categories - use .value_counts() instead\n"
-            "- ALWAYS wrap HVG selection in try/except with fallback:\n"
-            "  try:\n"
-            "      sc.pp.highly_variable_genes(adata, flavor='seurat_v3', n_top_genes=2000)\n"
-            "  except ValueError:\n"
-            "      sc.pp.highly_variable_genes(adata, flavor='seurat', n_top_genes=2000)\n"
-            "- ALWAYS validate batch column before batch operations "
-            "(check existence, fillna, astype('category'))\n\n"
-            "Guidelines:\n"
-            "- ALWAYS inspect data before writing code that depends on column names or structure\n"
-            "- Execute code in logical steps, not one giant block\n"
-            "- If code fails, read the error carefully, diagnose the issue, and try a different approach\n"
-            "- Use run_snippet() for exploration (won't modify data)\n"
-            "- Use execute_code() for actual processing (modifies data)\n"
-            "- Available packages: ov (omicverse), sc (scanpy), np (numpy), pd (pandas), "
-            "matplotlib, seaborn, scipy, sklearn\n"
-            "- All OmicVerse functions are called via ov.* (e.g. ov.pp.preprocess, ov.pp.scale)\n"
-            "- When saving files, use the output directory or current working directory\n\n"
-            "DELEGATION STRATEGY (use the delegate tool for complex tasks):\n"
-            "- Agent(subagent_type='explore', ...) or delegate('explore', ...) — read-only data characterization\n"
-            "- Agent(subagent_type='plan', ...) or delegate('plan', ...) — design workflow before execution\n"
-            "- Agent(subagent_type='execute', ...) or delegate('execute', ...) — focused execution step\n"
-            "- For simple single-step operations, execute directly without delegation\n"
-            "- Subagents have their own context window (prevents context overflow)\n"
-        )
+        engine = build_agentic_engine()
 
+        # Conditional: code-only mode overlay
         if getattr(self._ctx, "_code_only_mode", False):
-            prompt += (
-                "\nCLAW CODE-ONLY MODE:\n"
-                "- Reuse the normal OmicVerse Agent workflow, tools, search_functions, and search_skills logic.\n"
-                "- In this mode, execute_code captures the final Python code instead of running it.\n"
-                "- Use the same planning and tool-calling behavior you would use in Jarvis.\n"
-                "- When ready, call execute_code with the final OmicVerse Python snippet, then call finish.\n"
-                "- Do not stop at a prose-only plan when executable code is requested.\n"
-            )
+            engine.add_overlay(PromptOverlay("code_only_mode", CODE_ONLY_MODE, priority=80))
 
+        # Dynamic: skill listing overlay
         registry = self._ctx.skill_registry
         if registry is not None and getattr(registry, "skill_metadata", None):
-            prompt += "\nAvailable domain skills (use search_skills for detailed guidance):\n"
+            lines = ["Available domain skills (use search_skills for detailed guidance):"]
             for meta in sorted(registry.skill_metadata.values(), key=lambda s: s.slug):
-                prompt += f"  - {meta.slug}: {meta.description[:80]}\n"
+                lines.append("  - " + meta.slug + ": " + meta.description[:80])
+            engine.add_overlay(PromptOverlay("skills", "\n".join(lines), priority=90))
 
+        prompt = engine.render()
+
+        # Dynamic: provider/runtime overlay (OV runtime compose)
         if self._ctx._ov_runtime is not None:
             prompt = self._ctx._ov_runtime.compose_system_prompt(prompt)
 

--- a/omicverse/utils/ovagent/prompt_templates.py
+++ b/omicverse/utils/ovagent/prompt_templates.py
@@ -16,7 +16,7 @@ Prompt composition contract
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
 

--- a/omicverse/utils/ovagent/prompt_templates.py
+++ b/omicverse/utils/ovagent/prompt_templates.py
@@ -1,0 +1,346 @@
+"""Prompt template engine — composable prompt construction for OVAgent.
+
+Breaks monolithic prompt strings into reusable template blocks and
+deterministic overlay composition.  The engine guarantees that the same
+set of overlays always renders in the same order.
+
+Prompt composition contract
+---------------------------
+* A **base template** defines the agent identity and core behaviour.
+* **Overlays** add workflow, skill, provider, and runtime context.
+* Overlays are sorted by ``(priority, name)`` before concatenation,
+  so rendering is deterministic regardless of registration order.
+* ``PromptBuilder`` delegates to this engine internally; callers that
+  only need the builder API do not need to touch the engine directly.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+
+# ---------------------------------------------------------------------------
+# PromptOverlay — a named, prioritized text block
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PromptOverlay:
+    """A named text block composable into a rendered prompt.
+
+    Parameters
+    ----------
+    name : str
+        Unique key used for replacement and ordering.
+    content : str
+        The text content of this overlay.
+    priority : int
+        Lower values render earlier.  Default 100.
+    """
+
+    name: str
+    content: str
+    priority: int = 100
+
+
+# ---------------------------------------------------------------------------
+# PromptTemplateEngine — deterministic composition
+# ---------------------------------------------------------------------------
+
+
+class PromptTemplateEngine:
+    """Compose a prompt from a base template plus ordered overlays.
+
+    Rendering is deterministic: overlays are sorted by
+    ``(priority, name)`` and concatenated onto the base template
+    separated by blank lines.
+
+    Examples
+    --------
+    >>> engine = PromptTemplateEngine()
+    >>> engine.set_base("You are an assistant.")
+    >>> engine.add_overlay(PromptOverlay("tools", "Use tools.", priority=10))
+    >>> engine.add_overlay(PromptOverlay("skills", "Domain skills.", priority=20))
+    >>> print(engine.render())
+    You are an assistant.
+    <BLANKLINE>
+    Use tools.
+    <BLANKLINE>
+    Domain skills.
+    """
+
+    def __init__(self) -> None:
+        self._base: str = ""
+        self._overlays: Dict[str, PromptOverlay] = {}
+
+    # -- base ---------------------------------------------------------------
+
+    def set_base(self, template: str) -> None:
+        """Set the base system template."""
+        self._base = template
+
+    @property
+    def base(self) -> str:
+        """Return the current base template."""
+        return self._base
+
+    # -- overlay management -------------------------------------------------
+
+    def add_overlay(self, overlay: PromptOverlay) -> None:
+        """Register an overlay.  Replaces any existing with the same name."""
+        self._overlays[overlay.name] = overlay
+
+    def remove_overlay(self, name: str) -> None:
+        """Remove an overlay by name (no-op if absent)."""
+        self._overlays.pop(name, None)
+
+    def has_overlay(self, name: str) -> bool:
+        """Return whether an overlay with *name* is registered."""
+        return name in self._overlays
+
+    def get_overlay(self, name: str) -> Optional[PromptOverlay]:
+        """Return the overlay with *name*, or ``None``."""
+        return self._overlays.get(name)
+
+    @property
+    def overlay_names(self) -> List[str]:
+        """Return overlay names in render order."""
+        return [
+            o.name
+            for o in sorted(
+                self._overlays.values(), key=lambda o: (o.priority, o.name)
+            )
+        ]
+
+    # -- rendering ----------------------------------------------------------
+
+    def render(self) -> str:
+        """Render the complete prompt: base + sorted overlays.
+
+        Returns
+        -------
+        str
+            Concatenation of non-empty parts separated by ``\\n\\n``.
+        """
+        parts: List[str] = []
+        if self._base:
+            parts.append(self._base)
+        for overlay in sorted(
+            self._overlays.values(), key=lambda o: (o.priority, o.name)
+        ):
+            if overlay.content:
+                parts.append(overlay.content)
+        return "\n\n".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Predefined template blocks — extracted from PromptBuilder string literals
+# ---------------------------------------------------------------------------
+
+# Priority bands:
+#   10  identity / base
+#   20  tool catalog / coding instructions
+#   30  web access
+#   40  workflow steps
+#   50  code quality rules
+#   60  guidelines
+#   70  delegation strategy
+#   80  code-only mode (conditional)
+#   90  skill listing (dynamic)
+#  100  provider / runtime overlay (dynamic)
+
+BASE_IDENTITY = (
+    "You are OmicVerse Agent, an expert bioinformatics assistant that processes "
+    "single-cell, bulk RNA-seq, and spatial transcriptomics data.\n\n"
+    "You have OmicVerse data tools plus a Claude-style coding tool catalog.\n"
+    "Core Claude tools are ToolSearch, Bash, and Read. Deferred Claude tools "
+    "must be loaded through ToolSearch before use. High-risk tools require approval.\n\n"
+    "Use the legacy OmicVerse tools for dataset inspection and execution, and "
+    "use Claude-style tools for files, tasks, planning, worktrees, and questions.\n\n"
+    "Do not narrate future actions without taking them in the same turn. "
+    "If a tool is needed, call it now instead of saying that you will call it later."
+)
+
+TOOL_INSTRUCTIONS = (
+    "CODING / FILESYSTEM:\n"
+    "- Use ToolSearch when you need deferred tools such as Edit, Write, Glob, "
+    "Grep, NotebookEdit, Task*, or EnterWorktree\n"
+    "- Use Read for local files instead of shelling out to cat/head/sed when possible\n"
+    "- Use AskUserQuestion when a turn genuinely needs user clarification"
+)
+
+WEB_ACCESS = (
+    "WEB ACCESS:\n"
+    "- Use WebFetch(url) or web_fetch(url) to read any web page "
+    "(GEO datasets, papers, docs)\n"
+    "- Use WebSearch(query) or web_search(query) to search the internet "
+    "for information\n"
+    "- Use web_download(url) to download files (datasets, h5ad, csv, gz) to disk\n"
+    "- When the user provides a URL, ALWAYS fetch it first instead of "
+    "asking them to paste content\n"
+    "- When you need background info (gene functions, diseases, methods), "
+    "search the web\n"
+    "- To download GEO data, fetch the GEO page first to find download links, "
+    "then use web_download"
+)
+
+WORKFLOW_STEPS = (
+    "WORKFLOW:\n"
+    "1. If the user provides a URL, use web_fetch to read it\n"
+    "2. Use inspect_data to understand the dataset structure\n"
+    "3. Use search_functions to find relevant OmicVerse functions "
+    "(includes prerequisite chains and examples)\n"
+    "4. For complex multi-step workflows, use search_skills for domain guidance\n"
+    "5. Execute code step by step, checking results between steps\n"
+    "6. Call finish() when the task is complete"
+)
+
+GUIDELINES = (
+    "Guidelines:\n"
+    "- ALWAYS inspect data before writing code that depends on column names "
+    "or structure\n"
+    "- Execute code in logical steps, not one giant block\n"
+    "- If code fails, read the error carefully, diagnose the issue, and try "
+    "a different approach\n"
+    "- Use run_snippet() for exploration (won't modify data)\n"
+    "- Use execute_code() for actual processing (modifies data)\n"
+    "- Available packages: ov (omicverse), sc (scanpy), np (numpy), pd (pandas), "
+    "matplotlib, seaborn, scipy, sklearn\n"
+    "- All OmicVerse functions are called via ov.* (e.g. ov.pp.preprocess, "
+    "ov.pp.scale)\n"
+    "- When saving files, use the output directory or current working directory"
+)
+
+DELEGATION_STRATEGY = (
+    "DELEGATION STRATEGY (use the delegate tool for complex tasks):\n"
+    "- Agent(subagent_type='explore', ...) or delegate('explore', ...) "
+    "— read-only data characterization\n"
+    "- Agent(subagent_type='plan', ...) or delegate('plan', ...) "
+    "— design workflow before execution\n"
+    "- Agent(subagent_type='execute', ...) or delegate('execute', ...) "
+    "— focused execution step\n"
+    "- For simple single-step operations, execute directly without delegation\n"
+    "- Subagents have their own context window (prevents context overflow)"
+)
+
+CODE_ONLY_MODE = (
+    "CLAW CODE-ONLY MODE:\n"
+    "- Reuse the normal OmicVerse Agent workflow, tools, search_functions, "
+    "and search_skills logic.\n"
+    "- In this mode, execute_code captures the final Python code instead "
+    "of running it.\n"
+    "- Use the same planning and tool-calling behavior you would use in Jarvis.\n"
+    "- When ready, call execute_code with the final OmicVerse Python snippet, "
+    "then call finish.\n"
+    "- Do not stop at a prose-only plan when executable code is requested."
+)
+
+# Subagent base templates — keyed by agent type
+SUBAGENT_BASES: Dict[str, str] = {
+    "explore": (
+        "You are a bioinformatics data inspector for OmicVerse. "
+        "Your job is to thoroughly characterize the dataset and report findings.\n\n"
+        "You CANNOT modify the data. Use inspect_data and run_snippet to explore.\n"
+        "Use search_functions to understand what OmicVerse functions are available.\n\n"
+        "Report:\n"
+        "1. Dataset dimensions (cells x genes)\n"
+        "2. Available metadata columns (obs, var) with example values\n"
+        "3. Existing embeddings (obsm) and layers\n"
+        "4. Data quality indicators (sparsity, mito%, batch columns, "
+        "cell type annotations)\n"
+        "5. Potential issues or recommendations\n\n"
+        "Available packages: ov (omicverse), sc (scanpy), np (numpy), pd (pandas)\n\n"
+        "Call finish() with a comprehensive summary when done."
+    ),
+    "plan": (
+        "You are a bioinformatics workflow architect for OmicVerse. "
+        "Design a step-by-step execution plan. Do NOT execute code — only plan.\n\n"
+        "Use search_functions to find OmicVerse functions and their prerequisites.\n"
+        "Use search_skills for domain-specific workflow guidance.\n"
+        "Use inspect_data and run_snippet to understand current data state.\n\n"
+        "Your plan should include:\n"
+        "1. Ordered steps with specific OmicVerse function calls and parameters\n"
+        "2. Quality check points between steps\n"
+        "3. Fallback strategies for known failure modes\n"
+        "4. Expected outputs at each step (obsm, obs columns, layers)\n"
+    ),
+    "execute": (
+        "You are a focused bioinformatics code executor for OmicVerse. "
+        "Complete the specific sub-task described. Execute code step by step.\n\n"
+        "Guidelines:\n"
+        "- Inspect data before writing code that depends on column names\n"
+        "- Execute in logical steps, not one giant block\n"
+        "- If code fails, diagnose and try a different approach\n"
+        "- Use run_snippet() for exploration, execute_code() for processing\n"
+        "- Call finish() when done with a summary of what was accomplished\n"
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# Factory helpers — build engines for common prompt scenarios
+# ---------------------------------------------------------------------------
+
+
+def build_agentic_engine() -> PromptTemplateEngine:
+    """Return a ``PromptTemplateEngine`` pre-loaded with the standard
+    agentic-loop overlays (workflow, code quality, delegation, etc.).
+
+    Dynamic overlays (skills, code-only mode, provider/runtime) are
+    **not** included — callers add those based on runtime state.
+    """
+    engine = PromptTemplateEngine()
+    engine.set_base(BASE_IDENTITY)
+    engine.add_overlay(PromptOverlay("tool_instructions", TOOL_INSTRUCTIONS, priority=20))
+    engine.add_overlay(PromptOverlay("web_access", WEB_ACCESS, priority=30))
+    engine.add_overlay(PromptOverlay("workflow", WORKFLOW_STEPS, priority=40))
+    # Code quality rules are imported from prompt_builder to stay DRY
+    from .prompt_builder import CODE_QUALITY_RULES
+    engine.add_overlay(PromptOverlay("code_quality", CODE_QUALITY_RULES, priority=50))
+    engine.add_overlay(PromptOverlay("guidelines", GUIDELINES, priority=60))
+    engine.add_overlay(PromptOverlay("delegation", DELEGATION_STRATEGY, priority=70))
+    return engine
+
+
+def build_subagent_engine(agent_type: str) -> PromptTemplateEngine:
+    """Return a ``PromptTemplateEngine`` for a subagent prompt.
+
+    Parameters
+    ----------
+    agent_type : str
+        One of ``"explore"``, ``"plan"``, ``"execute"``.
+
+    Raises
+    ------
+    ValueError
+        If *agent_type* is not recognised.
+    """
+    if agent_type not in SUBAGENT_BASES:
+        raise ValueError(
+            f"Unknown subagent type: {agent_type!r}. "
+            f"Expected one of {sorted(SUBAGENT_BASES)}."
+        )
+    engine = PromptTemplateEngine()
+    engine.set_base(SUBAGENT_BASES[agent_type])
+    # Plan and execute subagents get code-quality rules
+    if agent_type in ("plan", "execute"):
+        from .prompt_builder import CODE_QUALITY_RULES
+        engine.add_overlay(
+            PromptOverlay("code_quality", CODE_QUALITY_RULES, priority=50)
+        )
+    # Execute subagent gets package list
+    if agent_type == "execute":
+        engine.add_overlay(
+            PromptOverlay(
+                "packages",
+                (
+                    "Available packages: ov (omicverse), sc (scanpy), "
+                    "np (numpy), pd (pandas), matplotlib, seaborn, scipy, sklearn\n"
+                    "All OmicVerse functions are called via ov.* "
+                    "(e.g. ov.pp.preprocess, ov.pp.scale)"
+                ),
+                priority=60,
+            )
+        )
+    return engine

--- a/omicverse/utils/ovagent/protocol.py
+++ b/omicverse/utils/ovagent/protocol.py
@@ -8,6 +8,22 @@ This breaks the circular import between ``smart_agent.py`` and the
 
 The protocol is ``@runtime_checkable`` so extracted modules and tests can
 validate duck-typed agent doubles at runtime when needed.
+
+Isolation boundary
+------------------
+``AgentContext`` describes the *parent* agent surface.  Subagents do NOT
+receive a full ``AgentContext``; instead they operate through a
+``SubagentRuntime`` (see ``subagent_controller.py``) that exposes only
+the scoped state a subagent is allowed to read or mutate:
+
+* ``SubagentRuntime.permission_policy`` — per-tool allow/ask/deny decisions.
+* ``SubagentRuntime.budget_manager``   — subagent-local token budget.
+* ``SubagentRuntime.tool_schemas``     — snapshotted (frozen) tool schemas.
+* ``SubagentRuntime.last_usage``       — subagent-local usage tracking.
+
+This separation ensures that subagent turns cannot implicitly mutate
+parent-agent state such as ``last_usage``, ``last_usage_breakdown``, or
+the parent's live tool registry.
 """
 
 from __future__ import annotations

--- a/omicverse/utils/ovagent/repair_loop.py
+++ b/omicverse/utils/ovagent/repair_loop.py
@@ -297,8 +297,9 @@ class ExecutionRepairLoop:
                 )
 
         if extract_code_fn is None:
-            ctx = self._executor._ctx
-            extract_code_fn = getattr(ctx, "_extract_python_code", None)
+            ctx = getattr(self._executor, "_ctx", None)
+            if ctx is not None:
+                extract_code_fn = getattr(ctx, "_extract_python_code", None)
 
         attempts: List[RepairAttempt] = []
         current_code = code

--- a/omicverse/utils/ovagent/repair_loop.py
+++ b/omicverse/utils/ovagent/repair_loop.py
@@ -303,6 +303,7 @@ class ExecutionRepairLoop:
 
         attempts: List[RepairAttempt] = []
         current_code = code
+        current_strategy = "passthrough"
         dataset_ctx = build_dataset_context(adata)
 
         for attempt_num in range(self._max_retries + 1):
@@ -311,7 +312,7 @@ class ExecutionRepairLoop:
                 result = exec_fn(current_code, adata)
                 attempts.append(RepairAttempt(
                     attempt=attempt_num,
-                    strategy="passthrough" if attempt_num == 0 else attempts[-1].strategy if attempts else "passthrough",
+                    strategy=current_strategy,
                     code=current_code,
                     success=True,
                 ))
@@ -370,6 +371,7 @@ class ExecutionRepairLoop:
                         envelope=envelope,
                     ))
                     current_code = guardrail_code
+                    current_strategy = "guardrail"
                     continue
 
                 # --- Stage 2: LLM-guided repair ---
@@ -388,6 +390,7 @@ class ExecutionRepairLoop:
                         envelope=envelope,
                     ))
                     current_code = llm_code
+                    current_strategy = "llm"
                     continue
 
                 # Neither guardrail nor LLM could produce new code — mark
@@ -433,8 +436,8 @@ class ExecutionRepairLoop:
             if diagnosed and extract_code_fn is not None:
                 try:
                     return extract_code_fn(diagnosed)
-                except Exception:
-                    # extract_code_fn may itself fail; fall back to raw diagnosed
+                except Exception as exc:
+                    logger.warning("extract_code_fn failed: %s", exc)
                     return diagnosed
             return diagnosed
         except Exception as exc:

--- a/omicverse/utils/ovagent/repair_loop.py
+++ b/omicverse/utils/ovagent/repair_loop.py
@@ -1,0 +1,441 @@
+"""ExecutionRepairLoop — structured self-healing for code execution failures.
+
+Replaces the former regex-first recovery path with a normalized failure
+envelope and bounded retry loop.  Domain-specific regex transforms
+(``ProactiveCodeTransformer``, ``apply_execution_error_fix``) are still
+applied as *optional early guardrails*, but they no longer own the primary
+repair path.  When guardrails cannot fix the code, the loop delegates to
+LLM-guided diagnosis with a consistent structured diagnostic payload.
+
+Failure envelope contract
+-------------------------
+Every execution failure is represented as a :class:`FailureEnvelope` that
+carries:
+
+* **phase** — which pipeline stage failed (``"execution"``, ``"transform"``,
+  ``"validation"``, …)
+* **exception** — the exception type name
+* **summary** — a concise human-readable error summary
+* **traceback_excerpt** — tail of the traceback (bounded length)
+* **retry_count** — how many repair attempts have been made so far
+* **repair_hints** — list of domain-specific hints (from guardrail matches)
+* **retry_safe** — whether an automatic retry is considered safe
+"""
+
+from __future__ import annotations
+
+import logging
+import traceback as _traceback_mod
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional
+
+if TYPE_CHECKING:
+    from .analysis_executor import AnalysisExecutor
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Failure envelope
+# ---------------------------------------------------------------------------
+
+_MAX_TRACEBACK_CHARS = 2000
+
+
+@dataclass
+class FailureEnvelope:
+    """Normalized diagnostic payload for a single execution failure.
+
+    Conforms to the interface contract:
+    phase + exception + summary + traceback excerpt + retry count +
+    repair hints + retry safety flag.
+    """
+
+    phase: str
+    exception: str
+    summary: str
+    traceback_excerpt: str
+    retry_count: int
+    repair_hints: List[str] = field(default_factory=list)
+    retry_safe: bool = True
+
+    # Optional rich context attached before LLM diagnosis
+    code: str = ""
+    dataset_context: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialise to a plain dict for logging / LLM prompt injection."""
+        return {
+            "phase": self.phase,
+            "exception": self.exception,
+            "summary": self.summary,
+            "traceback_excerpt": self.traceback_excerpt,
+            "retry_count": self.retry_count,
+            "repair_hints": list(self.repair_hints),
+            "retry_safe": self.retry_safe,
+            "code": self.code,
+            "dataset_context": self.dataset_context,
+        }
+
+    @classmethod
+    def from_exception(
+        cls,
+        exc: BaseException,
+        *,
+        phase: str = "execution",
+        retry_count: int = 0,
+        code: str = "",
+        dataset_context: str = "",
+        repair_hints: Optional[List[str]] = None,
+        retry_safe: bool = True,
+    ) -> "FailureEnvelope":
+        """Build an envelope from a caught exception."""
+        tb = _traceback_mod.format_exception(type(exc), exc, exc.__traceback__)
+        tb_text = "".join(tb)
+        return cls(
+            phase=phase,
+            exception=type(exc).__name__,
+            summary=str(exc)[:500],
+            traceback_excerpt=tb_text[-_MAX_TRACEBACK_CHARS:],
+            retry_count=retry_count,
+            repair_hints=list(repair_hints or []),
+            retry_safe=retry_safe,
+            code=code,
+            dataset_context=dataset_context,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Repair attempt result
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class RepairAttempt:
+    """Record of a single repair attempt within the loop."""
+
+    attempt: int
+    strategy: str  # "guardrail" | "llm" | "passthrough"
+    code: str
+    success: bool
+    envelope: Optional[FailureEnvelope] = None
+
+
+# ---------------------------------------------------------------------------
+# Repair result
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class RepairResult:
+    """Outcome of the full repair loop."""
+
+    success: bool
+    final_code: str
+    exec_result: Any = None
+    attempts: List[RepairAttempt] = field(default_factory=list)
+    final_envelope: Optional[FailureEnvelope] = None
+
+
+# ---------------------------------------------------------------------------
+# Dataset context builder
+# ---------------------------------------------------------------------------
+
+
+def build_dataset_context(adata: Any) -> str:
+    """Build a short dataset description for LLM diagnosis prompts."""
+    if adata is None:
+        return ""
+    parts: List[str] = []
+    if hasattr(adata, "shape"):
+        parts.append(f"Shape: {adata.shape[0]} obs x {adata.shape[1]} vars")
+    if hasattr(adata, "obs") and hasattr(adata.obs, "columns"):
+        cols = list(adata.obs.columns[:20])
+        parts.append(f"obs columns: {cols}")
+    if hasattr(adata, "var") and hasattr(adata.var, "columns"):
+        vcols = list(adata.var.columns[:10])
+        parts.append(f"var columns: {vcols}")
+    if hasattr(adata, "obsm") and hasattr(adata.obsm, "keys"):
+        try:
+            parts.append(f"obsm keys: {list(adata.obsm.keys())[:10]}")
+        except Exception:
+            pass
+    return "; ".join(parts) if parts else ""
+
+
+# ---------------------------------------------------------------------------
+# LLM repair prompt builder
+# ---------------------------------------------------------------------------
+
+
+def build_llm_repair_prompt(envelope: FailureEnvelope) -> str:
+    """Build a structured prompt for LLM-guided code repair.
+
+    The prompt provides code + error + traceback + dataset context in a
+    consistent format so the LLM can diagnose and fix the issue.
+    """
+    sections = [
+        "The following OmicVerse agent-generated Python code failed during execution.",
+        "",
+        f"--- PHASE ---\n{envelope.phase}",
+        "",
+        f"--- EXCEPTION ---\n{envelope.exception}: {envelope.summary}",
+        "",
+        f"--- TRACEBACK ---\n{envelope.traceback_excerpt}",
+        "",
+        f"--- CODE ---\n{envelope.code}",
+    ]
+
+    if envelope.dataset_context:
+        sections.extend(["", f"--- DATASET ---\n{envelope.dataset_context}"])
+
+    if envelope.repair_hints:
+        hints_text = "\n".join(f"  - {h}" for h in envelope.repair_hints)
+        sections.extend(["", f"--- REPAIR HINTS ---\n{hints_text}"])
+
+    sections.extend([
+        "",
+        f"--- RETRY COUNT ---\n{envelope.retry_count}",
+        "",
+        "Your task:",
+        "1. Diagnose the root cause of the error.",
+        "2. Generate a CORRECTED version of the full code that fixes the issue.",
+        "3. Wrap the corrected code in ```python ... ``` markers.",
+        "",
+        "Important rules:",
+        "- Fix ONLY the error. Do not change logic that already works.",
+        "- If a variable is undefined, define it or remove the reference.",
+        "- If a module is unavailable, use an alternative or add a try/except.",
+        "- Preserve all file output operations (savefig, to_csv, json.dump, etc.).",
+    ])
+
+    return "\n".join(sections)
+
+
+# ---------------------------------------------------------------------------
+# ExecutionRepairLoop
+# ---------------------------------------------------------------------------
+
+# Default maximum number of repair attempts before giving up.
+DEFAULT_MAX_RETRIES = 3
+
+
+class ExecutionRepairLoop:
+    """Bounded self-healing loop for code execution failures.
+
+    The loop runs up to *max_retries* repair attempts using this strategy
+    order:
+
+    1. **Guardrail pass** — ``AnalysisExecutor.apply_execution_error_fix``
+       applies fast regex-based transforms.  If the guardrail produces
+       different code, re-execute immediately.  This is an *optional* early
+       stage; if it does not match, the loop falls through.
+    2. **LLM diagnosis** — build a structured :class:`FailureEnvelope`,
+       call the LLM with a consistent diagnostic prompt, extract repaired
+       code, and re-execute.
+    3. If all attempts are exhausted, return the final
+       :class:`FailureEnvelope` to the caller.
+
+    Parameters
+    ----------
+    executor : AnalysisExecutor
+        Provides ``apply_execution_error_fix``, ``diagnose_error_with_llm``,
+        and ``execute_generated_code``.
+    max_retries : int
+        Upper bound on repair attempts (default 3).
+    """
+
+    def __init__(
+        self,
+        executor: "AnalysisExecutor",
+        *,
+        max_retries: int = DEFAULT_MAX_RETRIES,
+    ) -> None:
+        self._executor = executor
+        self._max_retries = max_retries
+
+    @property
+    def max_retries(self) -> int:
+        return self._max_retries
+
+    async def run(
+        self,
+        code: str,
+        adata: Any,
+        *,
+        exec_fn: Optional[Callable[..., Any]] = None,
+        extract_code_fn: Optional[Callable[[str], str]] = None,
+        phase: str = "execution",
+    ) -> RepairResult:
+        """Execute *code* and attempt bounded self-healing on failure.
+
+        Parameters
+        ----------
+        code : str
+            The code to execute.
+        adata : Any
+            The dataset object (typically AnnData).
+        exec_fn : callable, optional
+            ``(code, adata) -> result_dict``.  Defaults to
+            ``executor.execute_generated_code(code, adata, capture_stdout=True)``.
+        extract_code_fn : callable, optional
+            ``(llm_response) -> code_str``.  Used to extract Python from an
+            LLM repair response.  Defaults to
+            ``executor._ctx._extract_python_code``.
+        phase : str
+            Label for the pipeline phase (used in envelopes).
+
+        Returns
+        -------
+        RepairResult
+            Contains success flag, final code, exec result, list of
+            attempts, and (on failure) the final envelope.
+        """
+        if exec_fn is None:
+            def exec_fn(c, a):
+                return self._executor.execute_generated_code(
+                    c, a, capture_stdout=True
+                )
+
+        if extract_code_fn is None:
+            ctx = self._executor._ctx
+            extract_code_fn = getattr(ctx, "_extract_python_code", None)
+
+        attempts: List[RepairAttempt] = []
+        current_code = code
+        dataset_ctx = build_dataset_context(adata)
+
+        for attempt_num in range(self._max_retries + 1):
+            # --- Execute current code ---
+            try:
+                result = exec_fn(current_code, adata)
+                attempts.append(RepairAttempt(
+                    attempt=attempt_num,
+                    strategy="passthrough" if attempt_num == 0 else attempts[-1].strategy if attempts else "passthrough",
+                    code=current_code,
+                    success=True,
+                ))
+                return RepairResult(
+                    success=True,
+                    final_code=current_code,
+                    exec_result=result,
+                    attempts=attempts,
+                )
+            except Exception as exc:
+                envelope = FailureEnvelope.from_exception(
+                    exc,
+                    phase=phase,
+                    retry_count=attempt_num,
+                    code=current_code,
+                    dataset_context=dataset_ctx,
+                )
+
+                # Exhausted all retries?
+                if attempt_num >= self._max_retries:
+                    attempts.append(RepairAttempt(
+                        attempt=attempt_num,
+                        strategy="exhausted",
+                        code=current_code,
+                        success=False,
+                        envelope=envelope,
+                    ))
+                    return RepairResult(
+                        success=False,
+                        final_code=current_code,
+                        attempts=attempts,
+                        final_envelope=envelope,
+                    )
+
+                logger.info(
+                    "repair_loop attempt=%d/%d phase=%s exception=%s",
+                    attempt_num + 1,
+                    self._max_retries,
+                    phase,
+                    envelope.exception,
+                )
+
+                # --- Stage 1: Guardrail (regex) pass ---
+                guardrail_code = self._executor.apply_execution_error_fix(
+                    current_code, str(exc)
+                )
+                if guardrail_code and guardrail_code != current_code:
+                    envelope.repair_hints.append(
+                        "guardrail: regex transform produced different code"
+                    )
+                    attempts.append(RepairAttempt(
+                        attempt=attempt_num,
+                        strategy="guardrail",
+                        code=current_code,
+                        success=False,
+                        envelope=envelope,
+                    ))
+                    current_code = guardrail_code
+                    continue
+
+                # --- Stage 2: LLM-guided repair ---
+                llm_code = await self._try_llm_repair(
+                    envelope, extract_code_fn
+                )
+                if llm_code and llm_code.strip() and llm_code != current_code:
+                    envelope.repair_hints.append(
+                        "llm: diagnosis produced replacement code"
+                    )
+                    attempts.append(RepairAttempt(
+                        attempt=attempt_num,
+                        strategy="llm",
+                        code=current_code,
+                        success=False,
+                        envelope=envelope,
+                    ))
+                    current_code = llm_code
+                    continue
+
+                # Neither guardrail nor LLM could produce new code — mark
+                # envelope as not retry-safe and break early.
+                envelope.retry_safe = False
+                envelope.repair_hints.append(
+                    "no repair strategy produced new code"
+                )
+                attempts.append(RepairAttempt(
+                    attempt=attempt_num,
+                    strategy="none",
+                    code=current_code,
+                    success=False,
+                    envelope=envelope,
+                ))
+                return RepairResult(
+                    success=False,
+                    final_code=current_code,
+                    attempts=attempts,
+                    final_envelope=envelope,
+                )
+
+        # Should not be reached, but guard against it
+        return RepairResult(  # pragma: no cover
+            success=False,
+            final_code=current_code,
+            attempts=attempts,
+        )
+
+    async def _try_llm_repair(
+        self,
+        envelope: FailureEnvelope,
+        extract_code_fn: Optional[Callable[[str], str]],
+    ) -> Optional[str]:
+        """Attempt LLM-guided repair and return extracted code or None."""
+        try:
+            diagnosed = await self._executor.diagnose_error_with_llm(
+                envelope.code,
+                envelope.summary,
+                envelope.traceback_excerpt,
+                None,  # adata not passed to LLM diagnosis — context is in envelope
+            )
+            if diagnosed and extract_code_fn is not None:
+                try:
+                    return extract_code_fn(diagnosed)
+                except Exception:
+                    # extract_code_fn may itself fail; fall back to raw diagnosed
+                    return diagnosed
+            return diagnosed
+        except Exception as exc:
+            logger.debug("LLM repair failed: %s", exc)
+            return None

--- a/omicverse/utils/ovagent/subagent_controller.py
+++ b/omicverse/utils/ovagent/subagent_controller.py
@@ -31,7 +31,6 @@ from .context_budget import (
 from .permission_policy import (
     PermissionDecision,
     PermissionPolicy,
-    PermissionVerdict,
     create_subagent_policy,
 )
 from .tool_registry import OutputTier
@@ -240,7 +239,14 @@ class SubagentController:
 
             if response.raw_message:
                 if isinstance(response.raw_message, list):
-                    messages.extend(response.raw_message)
+                    for msg in response.raw_message:
+                        if isinstance(msg, dict):
+                            messages.append(msg)
+                        else:
+                            logger.warning(
+                                "subagent: skipping non-dict raw_message element type=%s",
+                                type(msg).__name__,
+                            )
                 else:
                     messages.append(response.raw_message)
             elif response.content:

--- a/omicverse/utils/ovagent/subagent_controller.py
+++ b/omicverse/utils/ovagent/subagent_controller.py
@@ -1,16 +1,35 @@
 """SubagentController — spawn and manage subagent conversations.
 
 Extracted from ``smart_agent.py``.  A subagent gets its own system prompt,
-restricted tool set, and independent message history.
+restricted tool set, independent message history, and — critically — an
+isolated ``SubagentRuntime`` that prevents mutable-state leakage between
+parent and child turns.
+
+Isolation contract
+------------------
+* Subagent **does not** write to the parent's ``ctx.last_usage``.
+* Subagent operates under a ``PermissionPolicy`` scoped to its allowed
+  tool set; tools outside the set are denied before dispatch.
+* Budget tracking uses a subagent-local ``ContextBudgetManager``.
+* Tool schemas are snapshotted at subagent creation time and not
+  re-read from the parent during the subagent's turn loop.
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, FrozenSet, List, Optional
 
 from .context_budget import (
     BudgetSliceType,
+    ContextBudgetManager,
     create_subagent_budget_manager,
+)
+from .permission_policy import (
+    PermissionDecision,
+    PermissionPolicy,
+    PermissionVerdict,
+    create_subagent_policy,
 )
 from .tool_registry import OutputTier
 
@@ -18,6 +37,59 @@ if TYPE_CHECKING:
     from .prompt_builder import PromptBuilder
     from .protocol import AgentContext
     from .tool_runtime import ToolRuntime
+
+
+# ---------------------------------------------------------------------------
+# Subagent runtime — isolated execution state for one subagent run
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SubagentRuntime:
+    """Scoped execution context for a single subagent run.
+
+    Captures everything the subagent needs and provides its own mutable
+    state space.  The parent agent's mutable context is **not** directly
+    accessible through this object.
+
+    Attributes
+    ----------
+    agent_type : str
+        The subagent kind (``"explore"``, ``"plan"``, ``"execute"``).
+    max_turns : int
+        Maximum number of LLM turns for this subagent run.
+    permission_policy : PermissionPolicy
+        Scoped permission evaluator — only allowed tools pass.
+    budget_manager : ContextBudgetManager
+        Subagent-local token budget tracker.
+    tool_schemas : list
+        Snapshotted tool schemas visible to this subagent.
+    last_usage : Any
+        LLM usage tracking — subagent-local, **not** shared with parent.
+    can_mutate_adata : bool
+        Whether this subagent type is allowed to mutate ``adata``.
+    """
+
+    agent_type: str
+    max_turns: int
+    permission_policy: PermissionPolicy
+    budget_manager: ContextBudgetManager
+    tool_schemas: List[Any] = field(default_factory=list)
+    last_usage: Any = None
+    can_mutate_adata: bool = False
+
+    def record_usage(self, usage: Any) -> None:
+        """Record LLM usage in the subagent's own state."""
+        self.last_usage = usage
+
+    def check_tool_permission(self, tool_name: str) -> PermissionDecision:
+        """Evaluate whether *tool_name* is permitted in this subagent."""
+        return self.permission_policy.check(tool_name)
+
+
+# ---------------------------------------------------------------------------
+# Controller
+# ---------------------------------------------------------------------------
 
 
 class SubagentController:
@@ -30,7 +102,8 @@ class SubagentController:
     prompt_builder : PromptBuilder
         Prompt construction helper.
     tool_runtime : ToolRuntime
-        Tool dispatch hub (shared with the parent loop).
+        Tool dispatch hub (used for dispatch only; mutable state is NOT
+        shared with the subagent).
     """
 
     def __init__(
@@ -43,6 +116,62 @@ class SubagentController:
         self._prompt_builder = prompt_builder
         self._tool_runtime = tool_runtime
 
+    # ------------------------------------------------------------------
+    # Subagent runtime factory
+    # ------------------------------------------------------------------
+
+    def _create_subagent_runtime(
+        self,
+        agent_type: str,
+        allowed_tools: FrozenSet[str],
+        max_turns: int,
+        can_mutate_adata: bool = False,
+    ) -> SubagentRuntime:
+        """Build an isolated ``SubagentRuntime`` for one subagent run.
+
+        This is the single factory point for subagent isolation.  It:
+
+        1. Creates a ``PermissionPolicy`` scoped to *allowed_tools*.
+        2. Snapshots the visible tool schemas (no live reference to parent).
+        3. Creates a subagent-local budget manager.
+        """
+        # Permission policy scoped to allowed tools
+        policy = create_subagent_policy(
+            self._tool_runtime.registry,
+            allowed_tools=allowed_tools,
+        )
+
+        # Budget manager — subagent-local
+        budget_model = (
+            getattr(
+                getattr(self._ctx._llm, "config", None), "model", None
+            )
+            or self._ctx.model
+            or ""
+        )
+        budget_manager = create_subagent_budget_manager(model=budget_model)
+
+        # Snapshot tool schemas — the subagent sees a frozen list, not a
+        # live reference into the parent's tool registry.
+        tool_schemas = list(
+            self._ctx._get_visible_agent_tools(
+                allowed_names=set(allowed_tools)
+            )
+        )
+
+        return SubagentRuntime(
+            agent_type=agent_type,
+            max_turns=max_turns,
+            permission_policy=policy,
+            budget_manager=budget_manager,
+            tool_schemas=tool_schemas,
+            can_mutate_adata=can_mutate_adata,
+        )
+
+    # ------------------------------------------------------------------
+    # Main entry point
+    # ------------------------------------------------------------------
+
     async def run_subagent(
         self,
         agent_type: str,
@@ -52,29 +181,25 @@ class SubagentController:
     ) -> dict:
         """Spawn a subagent with restricted tools and its own conversation.
 
+        The subagent runs inside a ``SubagentRuntime`` that isolates its
+        mutable state (usage tracking, budget, permission decisions) from
+        the parent agent.
+
         Returns
         -------
         dict
-            ``{"result": str, "adata": AnnData}``
+            ``{"result": str, "adata": AnnData, "last_usage": Any}``
         """
         from ..agent_config import SUBAGENT_CONFIGS
 
         config = SUBAGENT_CONFIGS[agent_type]
 
-        subagent_tools = self._ctx._get_visible_agent_tools(
-            allowed_names=set(config.allowed_tools)
-        )
-
-        # Subagent budget manager (tighter policies than main agent)
-        budget_model = (
-            getattr(
-                getattr(self._ctx._llm, "config", None), "model", None
-            )
-            or self._ctx.model
-            or ""
-        )
-        budget_manager = create_subagent_budget_manager(
-            model=budget_model
+        # Create isolated runtime
+        runtime = self._create_subagent_runtime(
+            agent_type=agent_type,
+            allowed_tools=frozenset(config.allowed_tools),
+            max_turns=config.max_turns,
+            can_mutate_adata=config.can_mutate_adata,
         )
 
         messages = [
@@ -94,18 +219,19 @@ class SubagentController:
 
         working_adata = adata
 
-        for turn in range(config.max_turns):
+        for turn in range(runtime.max_turns):
             print(
                 f"      \U0001f504 [{agent_type}] "
-                f"Turn {turn + 1}/{config.max_turns}"
+                f"Turn {turn + 1}/{runtime.max_turns}"
             )
 
             response = await self._ctx._llm.chat(
-                messages, tools=subagent_tools, tool_choice="auto"
+                messages, tools=runtime.tool_schemas, tool_choice="auto"
             )
 
+            # Record usage in subagent runtime — NOT on parent ctx
             if response.usage:
-                self._ctx.last_usage = response.usage
+                runtime.record_usage(response.usage)
 
             if response.raw_message:
                 if isinstance(response.raw_message, list):
@@ -121,6 +247,7 @@ class SubagentController:
                 return {
                     "result": response.content or "",
                     "adata": working_adata,
+                    "last_usage": runtime.last_usage,
                 }
 
             for tc in response.tool_calls:
@@ -129,8 +256,22 @@ class SubagentController:
                     f"{tc.name}({', '.join(f'{k}=' for k in tc.arguments)})"
                 )
 
+                # Permission check before dispatch
+                decision = runtime.check_tool_permission(tc.name)
+                if decision.is_denied:
+                    tool_output = (
+                        f"Permission denied for tool '{tc.name}': "
+                        f"{decision.reason}"
+                    )
+                    tool_msg = self._ctx._llm.format_tool_result_message(
+                        tc.id, tc.name, tool_output
+                    )
+                    messages.append(tool_msg)
+                    continue
+
                 result = await self._tool_runtime.dispatch_tool(
-                    tc, working_adata, task
+                    tc, working_adata, task,
+                    permission_policy=runtime.permission_policy,
                 )
 
                 if (
@@ -138,7 +279,8 @@ class SubagentController:
                     and isinstance(result, dict)
                     and "adata" in result
                 ):
-                    working_adata = result["adata"]
+                    if runtime.can_mutate_adata:
+                        working_adata = result["adata"]
                     tool_output = result.get("output", "Code executed.")
                 elif tc.name == "finish":
                     summary = tc.arguments.get("summary", "")
@@ -146,23 +288,27 @@ class SubagentController:
                         f"      \u2705 [{agent_type}] "
                         f"Finished: {summary[:120]}"
                     )
-                    return {"result": summary, "adata": working_adata}
+                    return {
+                        "result": summary,
+                        "adata": working_adata,
+                        "last_usage": runtime.last_usage,
+                    }
                 elif isinstance(result, str):
                     tool_output = result
                 else:
                     tool_output = str(result)
 
-                # Tier-driven truncation via shared budget model
+                # Tier-driven truncation via subagent-local budget manager
                 meta = self._tool_runtime.registry.get(tc.name)
                 output_tier = (
                     meta.output_tier
                     if meta is not None
                     else OutputTier.standard
                 )
-                tool_output = budget_manager.truncate_output(
+                tool_output = runtime.budget_manager.truncate_output(
                     tool_output, output_tier
                 )
-                budget_manager.record(
+                runtime.budget_manager.record(
                     BudgetSliceType.tool_output,
                     tool_output,
                     content_key=tc.name,
@@ -177,7 +323,8 @@ class SubagentController:
         return {
             "result": (
                 f"Subagent ({agent_type}) reached max turns "
-                f"({config.max_turns})"
+                f"({runtime.max_turns})"
             ),
             "adata": working_adata,
+            "last_usage": runtime.last_usage,
         }

--- a/omicverse/utils/ovagent/subagent_controller.py
+++ b/omicverse/utils/ovagent/subagent_controller.py
@@ -17,8 +17,11 @@ Isolation contract
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, FrozenSet, List, Optional
+
+logger = logging.getLogger(__name__)
 
 from .context_budget import (
     BudgetSliceType,
@@ -220,9 +223,11 @@ class SubagentController:
         working_adata = adata
 
         for turn in range(runtime.max_turns):
-            print(
-                f"      \U0001f504 [{agent_type}] "
-                f"Turn {turn + 1}/{runtime.max_turns}"
+            logger.info(
+                "subagent_turn agent_type=%s turn=%d/%d",
+                agent_type,
+                turn + 1,
+                runtime.max_turns,
             )
 
             response = await self._ctx._llm.chat(
@@ -251,9 +256,11 @@ class SubagentController:
                 }
 
             for tc in response.tool_calls:
-                print(
-                    f"      \U0001f527 [{agent_type}] "
-                    f"{tc.name}({', '.join(f'{k}=' for k in tc.arguments)})"
+                logger.info(
+                    "subagent_tool agent_type=%s tool=%s args=[%s]",
+                    agent_type,
+                    tc.name,
+                    ", ".join(f"{k}=" for k in tc.arguments),
                 )
 
                 # Permission check before dispatch
@@ -284,9 +291,10 @@ class SubagentController:
                     tool_output = result.get("output", "Code executed.")
                 elif tc.name == "finish":
                     summary = tc.arguments.get("summary", "")
-                    print(
-                        f"      \u2705 [{agent_type}] "
-                        f"Finished: {summary[:120]}"
+                    logger.info(
+                        "subagent_finished agent_type=%s summary=%s",
+                        agent_type,
+                        summary[:120],
                     )
                     return {
                         "result": summary,

--- a/omicverse/utils/ovagent/subagent_controller.py
+++ b/omicverse/utils/ovagent/subagent_controller.py
@@ -8,6 +8,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from .context_budget import (
+    BudgetSliceType,
+    create_subagent_budget_manager,
+)
+from .tool_registry import OutputTier
+
 if TYPE_CHECKING:
     from .prompt_builder import PromptBuilder
     from .protocol import AgentContext
@@ -57,6 +63,18 @@ class SubagentController:
 
         subagent_tools = self._ctx._get_visible_agent_tools(
             allowed_names=set(config.allowed_tools)
+        )
+
+        # Subagent budget manager (tighter policies than main agent)
+        budget_model = (
+            getattr(
+                getattr(self._ctx._llm, "config", None), "model", None
+            )
+            or self._ctx.model
+            or ""
+        )
+        budget_manager = create_subagent_budget_manager(
+            model=budget_model
         )
 
         messages = [
@@ -134,8 +152,22 @@ class SubagentController:
                 else:
                     tool_output = str(result)
 
-                if len(tool_output) > 6000:
-                    tool_output = tool_output[:5500] + "\n... (truncated)"
+                # Tier-driven truncation via shared budget model
+                meta = self._tool_runtime.registry.get(tc.name)
+                output_tier = (
+                    meta.output_tier
+                    if meta is not None
+                    else OutputTier.standard
+                )
+                tool_output = budget_manager.truncate_output(
+                    tool_output, output_tier
+                )
+                budget_manager.record(
+                    BudgetSliceType.tool_output,
+                    tool_output,
+                    content_key=tc.name,
+                    tier=output_tier,
+                )
 
                 tool_msg = self._ctx._llm.format_tool_result_message(
                     tc.id, tc.name, tool_output

--- a/omicverse/utils/ovagent/tool_registry.py
+++ b/omicverse/utils/ovagent/tool_registry.py
@@ -1,0 +1,377 @@
+"""Tool metadata contract and registry seam for OVAgent dispatch.
+
+Defines the execution-facing tool metadata model (ToolMetadata) and the
+registry (ToolRegistry) that maps canonical tool names to metadata and
+handler callables.  The model reuses ToolDefinition from tool_catalog
+where available and adds policy attributes (approval, parallelism,
+output tier, isolation) that drive dispatch, scheduling, and permission
+decisions.
+
+This module is the stable contract for follow-on dispatch and scheduler
+tasks.  The registry is a *seam*: metadata is registered declaratively,
+and handler callables are bound at runtime.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Callable, Dict, Optional, Tuple
+
+from ..harness.tool_catalog import (
+    ToolCatalog,
+    ToolDefinition,
+    get_default_tool_catalog,
+)
+from .tool_runtime import LEGACY_AGENT_TOOLS
+
+
+# ---------------------------------------------------------------------------
+# Policy enums
+# ---------------------------------------------------------------------------
+
+
+class ApprovalClass(str, Enum):
+    """Per-tool approval policy tier."""
+
+    allow = "allow"
+    ask = "ask"
+    deny = "deny"
+
+
+class ParallelClass(str, Enum):
+    """Per-tool parallel-safety classification."""
+
+    readonly = "readonly"
+    stateful = "stateful"
+    exclusive = "exclusive"
+
+
+class OutputTier(str, Enum):
+    """Expected output volume tier for context-budget decisions."""
+
+    minimal = "minimal"
+    standard = "standard"
+    verbose = "verbose"
+
+
+class IsolationMode(str, Enum):
+    """Execution isolation requirement."""
+
+    none = "none"
+    sandbox = "sandbox"
+    worktree = "worktree"
+
+
+# ---------------------------------------------------------------------------
+# Tool metadata model
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ToolMetadata:
+    """Execution-facing contract for a single tool.
+
+    Carries everything that dispatch, scheduling, approval routing, and
+    context budgeting need for one tool.  When a ``ToolDefinition`` from
+    the catalog exists, it is referenced via *definition*; legacy tools
+    that only have a raw dict schema use *legacy_schema* instead.
+    """
+
+    canonical_name: str
+    handler_key: str
+    approval_class: ApprovalClass
+    parallel_class: ParallelClass
+    output_tier: OutputTier
+    isolation_mode: IsolationMode
+    is_async: bool = False
+    definition: Optional[ToolDefinition] = None
+    legacy_schema: Optional[Dict[str, Any]] = field(default=None, hash=False)
+    pre_exec_hook: Optional[str] = None
+    post_exec_hook: Optional[str] = None
+    normalize_result_hook: Optional[str] = None
+    migration_notes: str = ""
+
+    @property
+    def schema(self) -> Dict[str, Any]:
+        """Return the JSON-schema payload for this tool."""
+        if self.definition is not None:
+            return self.definition.to_tool_schema()
+        if self.legacy_schema is not None:
+            return dict(self.legacy_schema)
+        return {
+            "name": self.canonical_name,
+            "description": "",
+            "parameters": {"type": "object", "properties": {}, "required": []},
+        }
+
+    @property
+    def aliases(self) -> Tuple[str, ...]:
+        """All known aliases (including the canonical name)."""
+        if self.definition is not None:
+            return self.definition.all_aliases
+        return (self.canonical_name,)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialise to a plain dict for inspection and debugging."""
+        return {
+            "canonical_name": self.canonical_name,
+            "handler_key": self.handler_key,
+            "approval_class": self.approval_class.value,
+            "parallel_class": self.parallel_class.value,
+            "output_tier": self.output_tier.value,
+            "isolation_mode": self.isolation_mode.value,
+            "is_async": self.is_async,
+            "has_definition": self.definition is not None,
+            "has_legacy_schema": self.legacy_schema is not None,
+            "pre_exec_hook": self.pre_exec_hook,
+            "post_exec_hook": self.post_exec_hook,
+            "normalize_result_hook": self.normalize_result_hook,
+            "migration_notes": self.migration_notes,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+class ToolRegistry:
+    """Registry seam: maps canonical names to metadata and handler callables.
+
+    Alias resolution delegates to the underlying ``ToolCatalog`` for
+    catalog tools, so all existing normalization rules (snake_case,
+    kebab-case, legacy aliases) continue to work unchanged.
+    """
+
+    def __init__(self, catalog: Optional[ToolCatalog] = None) -> None:
+        self._catalog = catalog or get_default_tool_catalog()
+        self._entries: Dict[str, ToolMetadata] = {}
+        self._handlers: Dict[str, Callable[..., Any]] = {}
+
+    # -- registration -------------------------------------------------------
+
+    def register(self, metadata: ToolMetadata) -> None:
+        """Register a tool's metadata.  Raises on duplicate canonical names."""
+        name = metadata.canonical_name
+        if name in self._entries:
+            raise ValueError(f"Duplicate registration for canonical name: {name}")
+        self._entries[name] = metadata
+
+    def register_handler(self, handler_key: str, handler: Callable[..., Any]) -> None:
+        """Bind a callable to a handler key at runtime."""
+        self._handlers[handler_key] = handler
+
+    # -- lookup -------------------------------------------------------------
+
+    def resolve_name(self, name_or_alias: str) -> str:
+        """Resolve a name or alias to a canonical tool name, or ``""``."""
+        if not name_or_alias:
+            return ""
+        if name_or_alias in self._entries:
+            return name_or_alias
+        # Delegate to catalog for alias / normalization resolution.
+        catalog_name = self._catalog.resolve_name(name_or_alias)
+        if catalog_name and catalog_name in self._entries:
+            return catalog_name
+        return ""
+
+    def get(self, name_or_alias: str) -> Optional[ToolMetadata]:
+        """Look up metadata by canonical name or any known alias."""
+        canonical = self.resolve_name(name_or_alias)
+        return self._entries.get(canonical) if canonical else None
+
+    def get_handler(self, name_or_alias: str) -> Optional[Callable[..., Any]]:
+        """Look up the runtime handler for a tool."""
+        metadata = self.get(name_or_alias)
+        if metadata is None:
+            return None
+        return self._handlers.get(metadata.handler_key)
+
+    # -- introspection ------------------------------------------------------
+
+    def all_entries(self) -> Tuple[ToolMetadata, ...]:
+        """Return all registered metadata entries."""
+        return tuple(self._entries.values())
+
+    def handler_keys(self) -> frozenset[str]:
+        """Return all distinct handler keys referenced by registered entries."""
+        return frozenset(m.handler_key for m in self._entries.values())
+
+    def validate_handlers(self) -> list[str]:
+        """Return handler keys that have no bound callable (unresolved seam)."""
+        return sorted(key for key in self.handler_keys() if key not in self._handlers)
+
+    def policy_summary(self) -> Dict[str, Dict[str, str]]:
+        """Return a {name: {policy_field: value}} dict for all entries."""
+        return {
+            name: {
+                "approval_class": meta.approval_class.value,
+                "parallel_class": meta.parallel_class.value,
+                "output_tier": meta.output_tier.value,
+                "isolation_mode": meta.isolation_mode.value,
+            }
+            for name, meta in sorted(self._entries.items())
+        }
+
+
+# ---------------------------------------------------------------------------
+# Default registry construction
+# ---------------------------------------------------------------------------
+
+# Policy tuples: (handler_key, approval, parallel, output, isolation, is_async)
+_CatalogPolicy = Tuple[str, ApprovalClass, ParallelClass, OutputTier, IsolationMode, bool]
+
+_CATALOG_TOOL_POLICIES: Dict[str, _CatalogPolicy] = {
+    "ToolSearch":          ("tool_search",          ApprovalClass.allow, ParallelClass.readonly,  OutputTier.minimal,  IsolationMode.none,     False),
+    "Bash":                ("bash",                 ApprovalClass.ask,   ParallelClass.stateful,  OutputTier.verbose,  IsolationMode.sandbox,  False),
+    "Read":                ("read",                 ApprovalClass.allow, ParallelClass.readonly,  OutputTier.standard, IsolationMode.none,     False),
+    "Edit":                ("edit",                 ApprovalClass.ask,   ParallelClass.stateful,  OutputTier.standard, IsolationMode.none,     False),
+    "Write":               ("write",                ApprovalClass.ask,   ParallelClass.stateful,  OutputTier.standard, IsolationMode.none,     False),
+    "Glob":                ("glob",                 ApprovalClass.allow, ParallelClass.readonly,  OutputTier.standard, IsolationMode.none,     False),
+    "Grep":                ("grep",                 ApprovalClass.allow, ParallelClass.readonly,  OutputTier.standard, IsolationMode.none,     False),
+    "NotebookEdit":        ("notebook_edit",        ApprovalClass.ask,   ParallelClass.stateful,  OutputTier.standard, IsolationMode.none,     False),
+    "Agent":               ("agent",                ApprovalClass.ask,   ParallelClass.stateful,  OutputTier.verbose,  IsolationMode.none,     True),
+    "AskUserQuestion":     ("ask_user_question",    ApprovalClass.allow, ParallelClass.exclusive, OutputTier.minimal,  IsolationMode.none,     False),
+    "TaskCreate":          ("task_create",          ApprovalClass.allow, ParallelClass.stateful,  OutputTier.minimal,  IsolationMode.none,     False),
+    "TaskGet":             ("task_get",             ApprovalClass.allow, ParallelClass.readonly,  OutputTier.minimal,  IsolationMode.none,     False),
+    "TaskList":            ("task_list",            ApprovalClass.allow, ParallelClass.readonly,  OutputTier.minimal,  IsolationMode.none,     False),
+    "TaskOutput":          ("task_output",          ApprovalClass.allow, ParallelClass.readonly,  OutputTier.standard, IsolationMode.none,     False),
+    "TaskStop":            ("task_stop",            ApprovalClass.ask,   ParallelClass.stateful,  OutputTier.minimal,  IsolationMode.none,     False),
+    "TaskUpdate":          ("task_update",          ApprovalClass.allow, ParallelClass.stateful,  OutputTier.minimal,  IsolationMode.none,     False),
+    "EnterPlanMode":       ("enter_plan_mode",      ApprovalClass.allow, ParallelClass.exclusive, OutputTier.minimal,  IsolationMode.none,     False),
+    "ExitPlanMode":        ("exit_plan_mode",       ApprovalClass.allow, ParallelClass.exclusive, OutputTier.minimal,  IsolationMode.none,     False),
+    "EnterWorktree":       ("enter_worktree",       ApprovalClass.ask,   ParallelClass.exclusive, OutputTier.minimal,  IsolationMode.worktree, False),
+    "Skill":               ("skill",                ApprovalClass.allow, ParallelClass.readonly,  OutputTier.standard, IsolationMode.none,     False),
+    "WebFetch":            ("web_fetch",            ApprovalClass.allow, ParallelClass.readonly,  OutputTier.standard, IsolationMode.none,     False),
+    "WebSearch":           ("web_search",           ApprovalClass.allow, ParallelClass.readonly,  OutputTier.standard, IsolationMode.none,     False),
+    "ListMcpResourcesTool":("list_mcp_resources",   ApprovalClass.allow, ParallelClass.readonly,  OutputTier.minimal,  IsolationMode.none,     False),
+    "ReadMcpResourceTool": ("read_mcp_resource",    ApprovalClass.allow, ParallelClass.readonly,  OutputTier.standard, IsolationMode.none,     False),
+}
+
+_CATALOG_MIGRATION_NOTES: Dict[str, str] = {
+    "Agent": (
+        "Requires late-bound subagent_controller; dispatch must check "
+        "initialisation before calling handler."
+    ),
+    "Skill": (
+        "Legacy schema 'search_skills' in LEGACY_AGENT_TOOLS normalises "
+        "to this entry via catalog alias resolution."
+    ),
+    "WebFetch": (
+        "Legacy schema 'web_fetch' in LEGACY_AGENT_TOOLS normalises to "
+        "this entry via catalog alias resolution."
+    ),
+    "WebSearch": (
+        "Legacy schema 'web_search' in LEGACY_AGENT_TOOLS normalises to "
+        "this entry via catalog alias resolution."
+    ),
+}
+
+# Legacy tool names that are aliases of catalog tools (handled by catalog
+# normalization, NOT separate registry entries).
+_LEGACY_CATALOG_ALIASES: frozenset[str] = frozenset({
+    "delegate",       # → Agent
+    "web_fetch",      # → WebFetch
+    "web_search",     # → WebSearch
+    "search_skills",  # → Skill
+})
+
+# Legacy-only tools: no catalog ToolDefinition, own registry entries.
+# Tuple: (handler_key, approval, parallel, output, isolation, is_async, migration_notes)
+_LegacyPolicy = Tuple[str, ApprovalClass, ParallelClass, OutputTier, IsolationMode, bool, str]
+
+_LEGACY_TOOL_POLICIES: Dict[str, _LegacyPolicy] = {
+    "inspect_data": (
+        "inspect_data", ApprovalClass.allow, ParallelClass.readonly,
+        OutputTier.standard, IsolationMode.none, False,
+        "Requires adata parameter; handler is read-only.",
+    ),
+    "execute_code": (
+        "execute_code", ApprovalClass.ask, ParallelClass.stateful,
+        OutputTier.verbose, IsolationMode.sandbox, False,
+        "Requires adata parameter; handler includes proactive-transform and retry logic.",
+    ),
+    "run_snippet": (
+        "run_snippet", ApprovalClass.allow, ParallelClass.readonly,
+        OutputTier.verbose, IsolationMode.sandbox, False,
+        "Requires adata parameter; executes on a shallow copy (read-only).",
+    ),
+    "search_functions": (
+        "search_functions", ApprovalClass.allow, ParallelClass.readonly,
+        OutputTier.standard, IsolationMode.none, False,
+        "",
+    ),
+    "web_download": (
+        "web_download", ApprovalClass.ask, ParallelClass.stateful,
+        OutputTier.standard, IsolationMode.none, False,
+        "",
+    ),
+    "finish": (
+        "finish", ApprovalClass.allow, ParallelClass.exclusive,
+        OutputTier.minimal, IsolationMode.none, False,
+        "Terminal tool; handler returns a fixed dict inline in dispatch_tool.",
+    ),
+}
+
+
+def build_default_registry() -> ToolRegistry:
+    """Construct the default registry from the live tool catalog and legacy tools.
+
+    Every tool that ``dispatch_tool`` can route to gets a ``ToolMetadata``
+    entry.  Legacy names that are aliases for catalog tools (delegate,
+    web_fetch, web_search, search_skills) resolve through the catalog's
+    alias normalization and do NOT get separate entries.
+    """
+    catalog = get_default_tool_catalog()
+    registry = ToolRegistry(catalog)
+
+    # ---- catalog tools ----------------------------------------------------
+    for tool_def in catalog.all_tools():
+        name = tool_def.name
+        policy = _CATALOG_TOOL_POLICIES.get(name)
+        if policy is None:
+            continue
+        handler_key, approval, parallel, output, isolation, is_async = policy
+        registry.register(ToolMetadata(
+            canonical_name=name,
+            handler_key=handler_key,
+            approval_class=approval,
+            parallel_class=parallel,
+            output_tier=output,
+            isolation_mode=isolation,
+            is_async=is_async,
+            definition=tool_def,
+            migration_notes=_CATALOG_MIGRATION_NOTES.get(name, ""),
+        ))
+
+    # ---- legacy-only tools ------------------------------------------------
+    legacy_by_name: Dict[str, Dict[str, Any]] = {
+        t["name"]: t for t in LEGACY_AGENT_TOOLS
+    }
+    for name, policy in _LEGACY_TOOL_POLICIES.items():
+        handler_key, approval, parallel, output, isolation, is_async, migration = policy
+        registry.register(ToolMetadata(
+            canonical_name=name,
+            handler_key=handler_key,
+            approval_class=approval,
+            parallel_class=parallel,
+            output_tier=output,
+            isolation_mode=isolation,
+            is_async=is_async,
+            legacy_schema=legacy_by_name.get(name),
+            migration_notes=migration,
+        ))
+
+    return registry
+
+
+__all__ = [
+    "ApprovalClass",
+    "IsolationMode",
+    "OutputTier",
+    "ParallelClass",
+    "ToolMetadata",
+    "ToolRegistry",
+    "build_default_registry",
+]

--- a/omicverse/utils/ovagent/tool_registry.py
+++ b/omicverse/utils/ovagent/tool_registry.py
@@ -86,7 +86,7 @@ class ToolMetadata:
     isolation_mode: IsolationMode
     is_async: bool = False
     definition: Optional[ToolDefinition] = None
-    legacy_schema: Optional[Dict[str, Any]] = field(default=None, hash=False)
+    legacy_schema: Optional[Dict[str, Any]] = field(default=None, hash=False, compare=False)
     pre_exec_hook: Optional[str] = None
     post_exec_hook: Optional[str] = None
     normalize_result_hook: Optional[str] = None

--- a/omicverse/utils/ovagent/tool_runtime.py
+++ b/omicverse/utils/ovagent/tool_runtime.py
@@ -573,6 +573,7 @@ class ToolRuntime:
 
         # --- Structured self-healing loop ---
         repair_loop = ExecutionRepairLoop(self._executor, max_retries=3)
+        extract_code_fn = getattr(self._ctx, "_extract_python_code", None)
 
         import asyncio as _asyncio
 
@@ -586,11 +587,13 @@ class ToolRuntime:
             with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
                 repair_result = pool.submit(
                     _asyncio.run,
-                    repair_loop.run(code, adata, phase="execution"),
+                    repair_loop.run(code, adata, phase="execution",
+                                   extract_code_fn=extract_code_fn),
                 ).result()
         else:
             repair_result = _asyncio.run(
-                repair_loop.run(code, adata, phase="execution")
+                repair_loop.run(code, adata, phase="execution",
+                               extract_code_fn=extract_code_fn)
             )
 
         if repair_result.success:

--- a/omicverse/utils/ovagent/tool_runtime.py
+++ b/omicverse/utils/ovagent/tool_runtime.py
@@ -518,6 +518,7 @@ class ToolRuntime:
         self, code: str, description: str, adata: Any
     ) -> dict:
         from .analysis_executor import ProactiveCodeTransformer
+        from .repair_loop import ExecutionRepairLoop
 
         code = ProactiveCodeTransformer().transform(code)
         if getattr(self._ctx, "_code_only_mode", False):
@@ -535,20 +536,58 @@ class ToolRuntime:
         prereq_warnings = self._executor.check_code_prerequisites(code, adata)
 
         self._executor._notebook_fallback_error = None
+
+        # --- Structured self-healing loop ---
+        repair_loop = ExecutionRepairLoop(self._executor, max_retries=3)
+
+        import asyncio as _asyncio
+
         try:
-            result = self._executor.execute_generated_code(
-                code, adata, capture_stdout=True
+            loop = _asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
+
+        if loop and loop.is_running():
+            import concurrent.futures
+            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+                repair_result = pool.submit(
+                    _asyncio.run,
+                    repair_loop.run(code, adata, phase="execution"),
+                ).result()
+        else:
+            repair_result = _asyncio.run(
+                repair_loop.run(code, adata, phase="execution")
             )
+
+        if repair_result.success:
+            result = repair_result.exec_result
             stdout = result.get("stdout", "") if isinstance(result, dict) else ""
-            result_adata = result.get("adata", adata) if isinstance(result, dict) else (result if result is not None else adata)
+            result_adata = (
+                result.get("adata", adata)
+                if isinstance(result, dict)
+                else (result if result is not None else adata)
+            )
 
             output_parts: List[str] = []
-            notebook_err = getattr(self._executor, "_notebook_fallback_error", None)
+            notebook_err = getattr(
+                self._executor, "_notebook_fallback_error", None
+            )
             if notebook_err:
                 output_parts.append(
                     f"WARNING: notebook session execution failed with error:\n{notebook_err}\n"
                     f"Fell back to in-process execution. Please fix the code to avoid this error."
                 )
+
+            # Annotate recovered attempts
+            if len(repair_result.attempts) > 1:
+                strategies = [
+                    a.strategy for a in repair_result.attempts if not a.success
+                ]
+                output_parts.append(
+                    f"RECOVERED after {len(repair_result.attempts)} attempt(s) "
+                    f"(strategies: {', '.join(strategies)})"
+                )
+
             if prereq_warnings:
                 output_parts.append(
                     f"PREREQUISITE WARNINGS: {prereq_warnings}"
@@ -573,52 +612,31 @@ class ToolRuntime:
                     else "Code executed successfully (no output)."
                 ),
             }
-        except Exception as e:
-            original_error = str(e)
-            tb_str = traceback.format_exc()
 
-            fixed_code = self._executor.apply_execution_error_fix(
-                code, original_error
-            )
-            if fixed_code:
-                try:
-                    result = self._executor.execute_generated_code(
-                        fixed_code, adata, capture_stdout=True
-                    )
-                    stdout = result.get("stdout", "")
-                    result_adata = result.get("adata", adata)
-                    output_parts = [
-                        f"RECOVERED (pattern fix): {original_error}"
-                    ]
-                    if stdout.strip():
-                        output_parts.append(f"stdout:\n{stdout[:3000]}")
-                    try:
-                        output_parts.append(
-                            f"Result adata shape: "
-                            f"{result_adata.shape[0]} cells x "
-                            f"{result_adata.shape[1]} features"
-                        )
-                    except Exception:
-                        output_parts.append(
-                            f"Result type: {type(result_adata).__name__}"
-                        )
-                    return {
-                        "adata": result_adata,
-                        "output": "\n".join(output_parts),
-                    }
-                except Exception:
-                    pass
-
+        # All repair attempts failed — return structured diagnostic
+        envelope = repair_result.final_envelope
+        if envelope is not None:
             error_output = (
-                f"ERROR: {e}\n\nTraceback (last 2000 chars):\n"
-                f"{tb_str[-2000:]}"
+                f"ERROR: {envelope.exception}: {envelope.summary}\n\n"
+                f"Phase: {envelope.phase}\n"
+                f"Attempts: {envelope.retry_count + 1}/{repair_loop.max_retries + 1}\n"
+                f"Traceback (last {len(envelope.traceback_excerpt)} chars):\n"
+                f"{envelope.traceback_excerpt}"
             )
-            if prereq_warnings:
-                error_output = (
-                    f"PREREQUISITE WARNINGS: {prereq_warnings}\n\n"
-                    f"{error_output}"
+            if envelope.repair_hints:
+                error_output += (
+                    "\nRepair hints:\n"
+                    + "\n".join(f"  - {h}" for h in envelope.repair_hints)
                 )
-            return {"adata": adata, "output": error_output}
+        else:
+            error_output = "ERROR: execution failed with no diagnostic envelope"
+
+        if prereq_warnings:
+            error_output = (
+                f"PREREQUISITE WARNINGS: {prereq_warnings}\n\n"
+                f"{error_output}"
+            )
+        return {"adata": adata, "output": error_output}
 
     def _tool_run_snippet(self, code: str, adata: Any) -> str:
         """Read-only snippet — no adata copy, no serialisation round-trip."""

--- a/omicverse/utils/ovagent/tool_runtime.py
+++ b/omicverse/utils/ovagent/tool_runtime.py
@@ -6,6 +6,7 @@ All tool handler methods follow the pattern ``_tool_<name>(self, ...)``.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import mimetypes
@@ -29,6 +30,7 @@ from ..._registry import _global_registry
 if TYPE_CHECKING:
     from .analysis_executor import AnalysisExecutor
     from .protocol import AgentContext
+    from .tool_registry import ToolRegistry
 
 logger = logging.getLogger(__name__)
 
@@ -168,9 +170,13 @@ class ToolRuntime:
     """
 
     def __init__(self, ctx: "AgentContext", executor: "AnalysisExecutor") -> None:
+        from .tool_registry import build_default_registry
+
         self._ctx = ctx
         self._executor = executor
         self._subagent_controller: Any = None  # late-bound
+        self._registry: "ToolRegistry" = build_default_registry()
+        self._bind_handlers()
 
     def set_subagent_controller(self, controller: Any) -> None:
         """Late-bind the subagent controller to avoid circular deps."""
@@ -183,6 +189,11 @@ class ToolRuntime:
                 "Subagent controller is not initialized; Agent delegation is unavailable."
             )
         return self._subagent_controller
+
+    @property
+    def registry(self) -> "ToolRegistry":
+        """The tool registry backing this runtime's dispatch."""
+        return self._registry
 
     # ------------------------------------------------------------------
     # Tool facade — visibility, plan-mode gating, loaded-tool tracking
@@ -231,203 +242,193 @@ class ToolRuntime:
         return tool_name in {"execute_code", "web_download"}
 
     # ------------------------------------------------------------------
+    # Registry-driven handler bindings
+    # ------------------------------------------------------------------
+
+    def _bind_handlers(self) -> None:
+        """Bind handler callables to the registry for all registered tools.
+
+        Each handler has the uniform signature
+        ``(args: dict, adata: Any, request: str) -> Any``.
+        """
+        r = self._registry
+        # fmt: off
+        r.register_handler("tool_search", lambda a, d, _: self._tool_tool_search(
+            a.get("query", ""), max_results=a.get("max_results", 5)))
+        r.register_handler("bash", lambda a, d, _: self._tool_bash(
+            a.get("command", ""), description=a.get("description", ""),
+            timeout=a.get("timeout", 120000),
+            run_in_background=bool(a.get("run_in_background", False)),
+            dangerouslyDisableSandbox=bool(a.get("dangerouslyDisableSandbox", False))))
+        r.register_handler("read", lambda a, d, _: self._tool_read(
+            a.get("file_path", ""), offset=a.get("offset", 0),
+            limit=a.get("limit", 2000), pages=a.get("pages", "")))
+        r.register_handler("edit", lambda a, d, _: self._tool_edit(
+            a.get("file_path", ""), a.get("old_string", ""),
+            a.get("new_string", ""), replace_all=bool(a.get("replace_all", False))))
+        r.register_handler("write", lambda a, d, _: self._tool_write(
+            a.get("file_path", ""), a.get("content", "")))
+        r.register_handler("glob", lambda a, d, _: self._tool_glob(
+            a.get("pattern", ""), root=a.get("root", ""),
+            max_results=a.get("max_results", 200)))
+        r.register_handler("grep", lambda a, d, _: self._tool_grep(
+            a.get("pattern", ""), root=a.get("root", ""),
+            glob=a.get("glob", ""), max_results=a.get("max_results", 200)))
+        r.register_handler("notebook_edit", lambda a, d, _: self._tool_notebook_edit(
+            a.get("file_path", ""), cell_index=a.get("cell_index", 0),
+            source=a.get("source", ""), cell_type=a.get("cell_type", "")))
+        r.register_handler("inspect_data", lambda a, d, _: self._tool_inspect_data(
+            d, a.get("aspect", "full")))
+        r.register_handler("execute_code", self._dispatch_execute_code)
+        r.register_handler("run_snippet", self._dispatch_run_snippet)
+        r.register_handler("search_functions", lambda a, d, _: self._tool_search_functions(
+            a.get("query", "")))
+        r.register_handler("agent", self._dispatch_agent)
+        r.register_handler("ask_user_question", self._dispatch_ask_user_question)
+        r.register_handler("task_create", lambda a, d, _: self._tool_create_task(
+            a.get("title", ""), description=a.get("description", ""),
+            status=a.get("status", "pending")))
+        r.register_handler("task_get", lambda a, d, _: self._tool_get_task(
+            a.get("task_id", "")))
+        r.register_handler("task_list", lambda a, d, _: self._tool_list_tasks(
+            status=a.get("status", "")))
+        r.register_handler("task_output", lambda a, d, _: self._tool_task_output(
+            a.get("task_id", ""), offset=a.get("offset", 0),
+            limit=a.get("limit", 200)))
+        r.register_handler("task_stop", lambda a, d, _: self._tool_task_stop(
+            a.get("task_id", "")))
+        r.register_handler("task_update", lambda a, d, _: self._tool_task_update(
+            a.get("task_id", ""), a.get("status", ""),
+            summary=a.get("summary", "")))
+        r.register_handler("enter_plan_mode", lambda a, d, _: self._tool_enter_plan_mode(
+            reason=a.get("reason", "")))
+        r.register_handler("exit_plan_mode", lambda a, d, _: self._tool_exit_plan_mode(
+            summary=a.get("summary", "")))
+        r.register_handler("enter_worktree", lambda a, d, _: self._tool_enter_worktree(
+            branch_name=a.get("branch_name", ""),
+            path=a.get("path", ""), base_ref=a.get("base_ref", "HEAD")))
+        r.register_handler("skill", lambda a, d, _: self._tool_skill(
+            a.get("query", ""), mode=a.get("mode", "search")))
+        r.register_handler("web_fetch", lambda a, d, _: self._tool_web_fetch(
+            a.get("url", ""), prompt=a.get("prompt")))
+        r.register_handler("web_search", lambda a, d, _: self._tool_web_search(
+            a.get("query", ""), num_results=a.get("num_results", 5)))
+        r.register_handler("list_mcp_resources", lambda a, d, _: self._tool_list_mcp_resources(
+            server=a.get("server", "")))
+        r.register_handler("read_mcp_resource", lambda a, d, _: self._tool_read_mcp_resource(
+            a.get("server", ""), a.get("uri", "")))
+        r.register_handler("web_download", lambda a, d, _: self._tool_web_download(
+            a.get("url", ""), filename=a.get("filename"),
+            directory=a.get("directory")))
+        r.register_handler("finish", lambda a, d, _: self._tool_finish(
+            a.get("summary", "")))
+        # fmt: on
+
+    # ------------------------------------------------------------------
+    # Dispatch helpers (validation / async wrappers)
+    # ------------------------------------------------------------------
+
+    def _dispatch_execute_code(
+        self, args: dict, adata: Any, request: str
+    ) -> Any:
+        code = args.get("code", "")
+        if not code or not code.strip():
+            return json.dumps(
+                {"error": "execute_code requires a non-empty 'code' argument."},
+                ensure_ascii=False,
+            )
+        return self._tool_execute_code(code, args.get("description", ""), adata)
+
+    def _dispatch_run_snippet(
+        self, args: dict, adata: Any, request: str
+    ) -> Any:
+        snippet = args.get("code", "")
+        if not snippet or not snippet.strip():
+            return json.dumps(
+                {"error": "run_snippet requires a non-empty 'code' argument."},
+                ensure_ascii=False,
+            )
+        return self._tool_run_snippet(snippet, adata)
+
+    async def _dispatch_agent(
+        self, args: dict, adata: Any, request: str
+    ) -> Any:
+        agent_type = args.get(
+            "subagent_type", args.get("agent_type", "explore")
+        )
+        task = args.get("task", "")
+        context = args.get("context", "")
+        print(
+            f"   -> Delegating to {agent_type} subagent: {task[:80]}..."
+        )
+        subagent_controller = self._require_subagent_controller()
+        sub_result = await subagent_controller.run_subagent(
+            agent_type=agent_type,
+            task=task,
+            adata=adata,
+            context=context,
+        )
+        if agent_type == "execute":
+            return {
+                "adata": sub_result["adata"],
+                "output": sub_result["result"],
+            }
+        return sub_result["result"]
+
+    def _dispatch_ask_user_question(
+        self, args: dict, adata: Any, request: str
+    ) -> Any:
+        question = args.get("question", "") or args.get("prompt", "")
+        if not question:
+            return json.dumps(
+                {"error": "AskUserQuestion requires a non-empty 'question' argument."},
+                ensure_ascii=False,
+            )
+        return self._tool_ask_user_question(
+            question,
+            header=args.get("header", ""),
+            options=args.get("options", []),
+        )
+
+    # ------------------------------------------------------------------
     # Dispatch
     # ------------------------------------------------------------------
 
     async def dispatch_tool(
         self, tool_call: Any, current_adata: Any, request: str
     ) -> Any:
-        """Dispatch a tool call and return the result."""
-        name = normalize_tool_name(tool_call.name)
+        """Dispatch a tool call through the registry and return the result.
+
+        Resolution flow:
+        1. Resolve the tool name via the registry (handles canonical names,
+           catalog aliases, legacy aliases, and case normalization).
+        2. Check plan-mode blocking for the resolved canonical name.
+        3. Look up the bound handler callable.
+        4. Call the handler with ``(args, adata, request)`` and await if async.
+        """
+        raw_name = tool_call.name
         args = tool_call.arguments
 
-        if self.tool_blocked_in_plan_mode(name):
-            return f"{name} is blocked because the session is currently in plan mode."
+        # Registry-driven name resolution (delegates to catalog for aliases)
+        canonical = self._registry.resolve_name(raw_name)
+        if not canonical:
+            # Fallback through catalog normalization for edge cases
+            canonical = normalize_tool_name(raw_name)
 
-        if name == "ToolSearch":
-            return self._tool_tool_search(
-                args.get("query", ""),
-                max_results=args.get("max_results", 5),
+        if self.tool_blocked_in_plan_mode(canonical):
+            return (
+                f"{canonical} is blocked because the session is "
+                "currently in plan mode."
             )
-        elif name == "Bash":
-            return self._tool_bash(
-                args.get("command", ""),
-                description=args.get("description", ""),
-                timeout=args.get("timeout", 120000),
-                run_in_background=bool(args.get("run_in_background", False)),
-                dangerouslyDisableSandbox=bool(
-                    args.get("dangerouslyDisableSandbox", False)
-                ),
-            )
-        elif name == "Read":
-            return self._tool_read(
-                args.get("file_path", ""),
-                offset=args.get("offset", 0),
-                limit=args.get("limit", 2000),
-                pages=args.get("pages", ""),
-            )
-        elif name == "Edit":
-            return self._tool_edit(
-                args.get("file_path", ""),
-                args.get("old_string", ""),
-                args.get("new_string", ""),
-                replace_all=bool(args.get("replace_all", False)),
-            )
-        elif name == "Write":
-            return self._tool_write(
-                args.get("file_path", ""),
-                args.get("content", ""),
-            )
-        elif name == "Glob":
-            return self._tool_glob(
-                args.get("pattern", ""),
-                root=args.get("root", ""),
-                max_results=args.get("max_results", 200),
-            )
-        elif name == "Grep":
-            return self._tool_grep(
-                args.get("pattern", ""),
-                root=args.get("root", ""),
-                glob=args.get("glob", ""),
-                max_results=args.get("max_results", 200),
-            )
-        elif name == "NotebookEdit":
-            return self._tool_notebook_edit(
-                args.get("file_path", ""),
-                cell_index=args.get("cell_index", 0),
-                source=args.get("source", ""),
-                cell_type=args.get("cell_type", ""),
-            )
-        elif name == "inspect_data":
-            return self._tool_inspect_data(
-                current_adata, args.get("aspect", "full")
-            )
-        elif name == "execute_code":
-            code = args.get("code", "")
-            if not code or not code.strip():
-                return json.dumps(
-                    {"error": "execute_code requires a non-empty 'code' argument."},
-                    ensure_ascii=False,
-                )
-            return self._tool_execute_code(
-                code,
-                args.get("description", ""),
-                current_adata,
-            )
-        elif name == "run_snippet":
-            snippet = args.get("code", "")
-            if not snippet or not snippet.strip():
-                return json.dumps(
-                    {"error": "run_snippet requires a non-empty 'code' argument."},
-                    ensure_ascii=False,
-                )
-            return self._tool_run_snippet(snippet, current_adata)
-        elif name == "search_functions":
-            return self._tool_search_functions(args.get("query", ""))
-        elif name == "search_skills":
-            return self._tool_search_skills(args.get("query", ""))
-        elif name == "Agent":
-            agent_type = args.get(
-                "subagent_type", args.get("agent_type", "explore")
-            )
-            task = args.get("task", "")
-            context = args.get("context", "")
-            print(
-                f"   -> Delegating to {agent_type} subagent: {task[:80]}..."
-            )
-            subagent_controller = self._require_subagent_controller()
-            sub_result = await subagent_controller.run_subagent(
-                agent_type=agent_type,
-                task=task,
-                adata=current_adata,
-                context=context,
-            )
-            if agent_type == "execute":
-                return {
-                    "adata": sub_result["adata"],
-                    "output": sub_result["result"],
-                }
-            return sub_result["result"]
-        elif name == "AskUserQuestion":
-            question = args.get("question", "") or args.get("prompt", "")
-            if not question:
-                return json.dumps(
-                    {"error": "AskUserQuestion requires a non-empty 'question' argument."},
-                    ensure_ascii=False,
-                )
-            return self._tool_ask_user_question(
-                question,
-                header=args.get("header", ""),
-                options=args.get("options", []),
-            )
-        elif name == "TaskCreate":
-            return self._tool_create_task(
-                args.get("title", ""),
-                description=args.get("description", ""),
-                status=args.get("status", "pending"),
-            )
-        elif name == "TaskGet":
-            return self._tool_get_task(args.get("task_id", ""))
-        elif name == "TaskList":
-            return self._tool_list_tasks(status=args.get("status", ""))
-        elif name == "TaskOutput":
-            return self._tool_task_output(
-                args.get("task_id", ""),
-                offset=args.get("offset", 0),
-                limit=args.get("limit", 200),
-            )
-        elif name == "TaskStop":
-            return self._tool_task_stop(args.get("task_id", ""))
-        elif name == "TaskUpdate":
-            return self._tool_task_update(
-                args.get("task_id", ""),
-                args.get("status", ""),
-                summary=args.get("summary", ""),
-            )
-        elif name == "EnterPlanMode":
-            return self._tool_enter_plan_mode(reason=args.get("reason", ""))
-        elif name == "ExitPlanMode":
-            return self._tool_exit_plan_mode(summary=args.get("summary", ""))
-        elif name == "EnterWorktree":
-            return self._tool_enter_worktree(
-                branch_name=args.get("branch_name", ""),
-                path=args.get("path", ""),
-                base_ref=args.get("base_ref", "HEAD"),
-            )
-        elif name == "Skill":
-            return self._tool_skill(
-                args.get("query", ""),
-                mode=args.get("mode", "search"),
-            )
-        elif name == "WebFetch":
-            return self._tool_web_fetch(
-                args.get("url", ""),
-                prompt=args.get("prompt"),
-            )
-        elif name == "WebSearch":
-            return self._tool_web_search(
-                args.get("query", ""),
-                num_results=args.get("num_results", 5),
-            )
-        elif name == "ListMcpResourcesTool":
-            return self._tool_list_mcp_resources(
-                server=args.get("server", "")
-            )
-        elif name == "ReadMcpResourceTool":
-            return self._tool_read_mcp_resource(
-                args.get("server", ""),
-                args.get("uri", ""),
-            )
-        elif name == "web_download":
-            return self._tool_web_download(
-                args.get("url", ""),
-                filename=args.get("filename"),
-                directory=args.get("directory"),
-            )
-        elif name == "finish":
-            return {"finished": True, "summary": args.get("summary", "")}
-        else:
-            return f"Unknown tool: {name}"
+
+        handler = self._registry.get_handler(canonical)
+        if handler is None:
+            return f"Unknown tool: {raw_name}"
+
+        result = handler(args, current_adata, request)
+        if asyncio.iscoroutine(result):
+            result = await result
+        return result
 
     # ------------------------------------------------------------------
     # OmicVerse data tools
@@ -1697,3 +1698,11 @@ class ToolRuntime:
             ensure_ascii=False,
             indent=2,
         )
+
+    # ------------------------------------------------------------------
+    # Terminal tools
+    # ------------------------------------------------------------------
+
+    def _tool_finish(self, summary: str) -> dict:
+        """Return the terminal finish payload."""
+        return {"finished": True, "summary": summary}

--- a/omicverse/utils/ovagent/tool_runtime.py
+++ b/omicverse/utils/ovagent/tool_runtime.py
@@ -359,8 +359,10 @@ class ToolRuntime:
         )
         task = args.get("task", "")
         context = args.get("context", "")
-        print(
-            f"   -> Delegating to {agent_type} subagent: {task[:80]}..."
+        logger.info(
+            "delegation_started agent_type=%s task=%s",
+            agent_type,
+            task[:80],
         )
         subagent_controller = self._require_subagent_controller()
         sub_result = await subagent_controller.run_subagent(

--- a/omicverse/utils/ovagent/tool_runtime.py
+++ b/omicverse/utils/ovagent/tool_runtime.py
@@ -29,6 +29,7 @@ from ..._registry import _global_registry
 
 if TYPE_CHECKING:
     from .analysis_executor import AnalysisExecutor
+    from .permission_policy import PermissionPolicy
     from .protocol import AgentContext
     from .tool_registry import ToolRegistry
 
@@ -395,16 +396,30 @@ class ToolRuntime:
     # ------------------------------------------------------------------
 
     async def dispatch_tool(
-        self, tool_call: Any, current_adata: Any, request: str
+        self,
+        tool_call: Any,
+        current_adata: Any,
+        request: str,
+        *,
+        permission_policy: Optional["PermissionPolicy"] = None,
     ) -> Any:
         """Dispatch a tool call through the registry and return the result.
 
         Resolution flow:
         1. Resolve the tool name via the registry (handles canonical names,
            catalog aliases, legacy aliases, and case normalization).
-        2. Check plan-mode blocking for the resolved canonical name.
-        3. Look up the bound handler callable.
-        4. Call the handler with ``(args, adata, request)`` and await if async.
+        2. Check the optional *permission_policy* (deny → immediate return).
+        3. Check plan-mode blocking for the resolved canonical name.
+        4. Look up the bound handler callable.
+        5. Call the handler with ``(args, adata, request)`` and await if async.
+
+        Parameters
+        ----------
+        permission_policy : PermissionPolicy, optional
+            When provided, the tool is checked against the policy before
+            dispatch.  Denied tools return an error message immediately
+            without executing.  This is used by subagent isolation to
+            enforce scoped tool restrictions.
         """
         raw_name = tool_call.name
         args = tool_call.arguments
@@ -414,6 +429,14 @@ class ToolRuntime:
         if not canonical:
             # Fallback through catalog normalization for edge cases
             canonical = normalize_tool_name(raw_name)
+
+        # Permission policy check (when provided by caller)
+        if permission_policy is not None:
+            decision = permission_policy.check(canonical)
+            if decision.is_denied:
+                return (
+                    f"Permission denied for {canonical}: {decision.reason}"
+                )
 
         if self.tool_blocked_in_plan_mode(canonical):
             return (

--- a/omicverse/utils/ovagent/tool_scheduler.py
+++ b/omicverse/utils/ovagent/tool_scheduler.py
@@ -1,0 +1,262 @@
+"""Dependency-safe tool scheduler for OVAgent turn execution.
+
+Partitions an ordered sequence of tool calls into execution batches
+based on ``ParallelClass`` policy metadata from the ``ToolRegistry``.
+Read-only tool calls that appear consecutively may execute concurrently
+within a single batch, while stateful, approval-gated, and
+isolation-sensitive tools are serialized into their own batches.
+
+Contract
+--------
+* **Input**: ordered list of tool calls (as received from the LLM).
+* **Output**: ordered list of ``ExecutionBatch`` objects.
+* **Deterministic ordering**: results are always returned in the
+  original call order regardless of which calls ran in parallel.
+* **Trace coherence**: each tool call retains its position index so
+  that the caller can emit step/event traces in the correct sequence.
+
+This module is the stable scheduling seam between the turn loop
+(``TurnController``) and tool dispatch (``ToolRuntime``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Callable, Coroutine, List, Optional, Sequence, Tuple
+
+from .tool_registry import ParallelClass, ToolRegistry
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+
+def _make_batch_id() -> str:
+    return "batch_" + uuid.uuid4().hex[:12]
+
+
+@dataclass
+class ScheduledCall:
+    """A single tool call annotated with its original position and policy."""
+
+    index: int
+    tool_call: Any  # provider-specific tool-call object (has .name, .id, .arguments)
+    canonical_name: str
+    parallel_class: ParallelClass
+    batch_id: str = ""
+
+
+@dataclass
+class ExecutionBatch:
+    """A group of tool calls that share an execution strategy.
+
+    * ``parallel=True`` means all calls in the batch MAY run concurrently.
+    * ``parallel=False`` means they MUST run sequentially (in list order).
+    """
+
+    batch_id: str
+    calls: List[ScheduledCall]
+    parallel: bool
+
+    @property
+    def size(self) -> int:
+        return len(self.calls)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "batch_id": self.batch_id,
+            "parallel": self.parallel,
+            "size": self.size,
+            "calls": [
+                {
+                    "index": c.index,
+                    "canonical_name": c.canonical_name,
+                    "parallel_class": c.parallel_class.value,
+                }
+                for c in self.calls
+            ],
+        }
+
+
+@dataclass
+class ScheduleResult:
+    """Complete schedule for one turn's tool calls."""
+
+    batches: List[ExecutionBatch]
+    total_calls: int
+
+    @property
+    def total_batches(self) -> int:
+        return len(self.batches)
+
+    @property
+    def has_parallel(self) -> bool:
+        return any(b.parallel and b.size > 1 for b in self.batches)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "total_calls": self.total_calls,
+            "total_batches": self.total_batches,
+            "has_parallel": self.has_parallel,
+            "batches": [b.to_dict() for b in self.batches],
+        }
+
+
+# ---------------------------------------------------------------------------
+# Scheduler
+# ---------------------------------------------------------------------------
+
+
+class ToolScheduler:
+    """Partition tool calls into dependency-safe execution batches.
+
+    The scheduler walks the ordered list of tool calls and groups
+    consecutive ``ParallelClass.readonly`` calls into a single parallel
+    batch.  Any ``stateful`` or ``exclusive`` call forces a batch
+    boundary:
+
+    * ``exclusive`` tools always run alone in their own batch.
+    * ``stateful`` tools are placed in a serial (non-parallel) batch.
+    * Unknown tools (not in the registry) default to ``stateful``
+      to guarantee safety.
+    """
+
+    def __init__(self, registry: ToolRegistry) -> None:
+        self._registry = registry
+
+    def _classify(self, tool_call: Any) -> Tuple[str, ParallelClass]:
+        """Resolve name and parallel class for a tool call."""
+        raw_name = tool_call.name
+        canonical = self._registry.resolve_name(raw_name)
+        if not canonical:
+            # Fall back: treat as canonical if no alias found
+            canonical = raw_name
+
+        meta = self._registry.get(canonical)
+        if meta is not None:
+            return canonical, meta.parallel_class
+
+        # Unknown tool → conservative default
+        return canonical, ParallelClass.stateful
+
+    def schedule(self, tool_calls: Sequence[Any]) -> ScheduleResult:
+        """Partition *tool_calls* into execution batches.
+
+        Returns a ``ScheduleResult`` whose batches preserve the original
+        call ordering.  The caller should iterate batches in order and,
+        within each parallel batch, may dispatch all calls concurrently
+        while still collecting results in index order.
+        """
+        if not tool_calls:
+            return ScheduleResult(batches=[], total_calls=0)
+
+        batches: List[ExecutionBatch] = []
+        pending_readonly: List[ScheduledCall] = []
+
+        def _flush_readonly() -> None:
+            if not pending_readonly:
+                return
+            bid = _make_batch_id()
+            for sc in pending_readonly:
+                sc.batch_id = bid
+            batches.append(ExecutionBatch(
+                batch_id=bid,
+                calls=list(pending_readonly),
+                parallel=True,
+            ))
+            pending_readonly.clear()
+
+        for idx, tc in enumerate(tool_calls):
+            canonical, par_class = self._classify(tc)
+            sc = ScheduledCall(
+                index=idx,
+                tool_call=tc,
+                canonical_name=canonical,
+                parallel_class=par_class,
+            )
+
+            if par_class == ParallelClass.readonly:
+                pending_readonly.append(sc)
+
+            elif par_class == ParallelClass.exclusive:
+                # Flush any pending readonly, then isolate this call
+                _flush_readonly()
+                bid = _make_batch_id()
+                sc.batch_id = bid
+                batches.append(ExecutionBatch(
+                    batch_id=bid,
+                    calls=[sc],
+                    parallel=False,
+                ))
+
+            else:
+                # stateful (or anything else): flush readonly, serial batch
+                _flush_readonly()
+                bid = _make_batch_id()
+                sc.batch_id = bid
+                batches.append(ExecutionBatch(
+                    batch_id=bid,
+                    calls=[sc],
+                    parallel=False,
+                ))
+
+        # Flush trailing readonly calls
+        _flush_readonly()
+
+        return ScheduleResult(batches=batches, total_calls=len(tool_calls))
+
+
+# ---------------------------------------------------------------------------
+# Batch executor helper
+# ---------------------------------------------------------------------------
+
+
+async def execute_batch(
+    batch: ExecutionBatch,
+    dispatch_fn: Callable[..., Coroutine],
+) -> List[Tuple[int, Any]]:
+    """Execute a batch of tool calls and return results in index order.
+
+    Parameters
+    ----------
+    batch : ExecutionBatch
+        The batch to execute.
+    dispatch_fn : async callable
+        ``async def dispatch_fn(scheduled_call: ScheduledCall) -> Any``
+        — the per-call dispatch function.
+
+    Returns
+    -------
+    list of (index, result) tuples, sorted by the original call index.
+    """
+    if not batch.calls:
+        return []
+
+    if batch.parallel and len(batch.calls) > 1:
+        # Concurrent execution with deterministic result ordering
+        async def _run(sc: ScheduledCall) -> Tuple[int, Any]:
+            result = await dispatch_fn(sc)
+            return (sc.index, result)
+
+        pairs = await asyncio.gather(*[_run(sc) for sc in batch.calls])
+        # Sort by original index to guarantee deterministic ordering
+        return sorted(pairs, key=lambda p: p[0])
+
+    # Serial execution (single call, or non-parallel batch)
+    results: List[Tuple[int, Any]] = []
+    for sc in batch.calls:
+        result = await dispatch_fn(sc)
+        results.append((sc.index, result))
+    return results
+
+
+__all__ = [
+    "ExecutionBatch",
+    "ScheduleResult",
+    "ScheduledCall",
+    "ToolScheduler",
+    "execute_batch",
+]

--- a/omicverse/utils/ovagent/tool_scheduler.py
+++ b/omicverse/utils/ovagent/tool_scheduler.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 import asyncio
 import uuid
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any, Callable, Coroutine, List, Optional, Sequence, Tuple
 
 from .tool_registry import ParallelClass, ToolRegistry
@@ -236,12 +236,21 @@ async def execute_batch(
         return []
 
     if batch.parallel and len(batch.calls) > 1:
-        # Concurrent execution with deterministic result ordering
+        # Concurrent execution with deterministic result ordering.
+        # return_exceptions=True ensures all tasks run to completion even if
+        # one fails, rather than cancelling remaining tasks on first exception.
         async def _run(sc: ScheduledCall) -> Tuple[int, Any]:
             result = await dispatch_fn(sc)
             return (sc.index, result)
 
-        pairs = await asyncio.gather(*[_run(sc) for sc in batch.calls])
+        raw = await asyncio.gather(
+            *[_run(sc) for sc in batch.calls], return_exceptions=True
+        )
+        pairs: List[Tuple[int, Any]] = []
+        for item in raw:
+            if isinstance(item, BaseException):
+                raise item
+            pairs.append(item)  # type: ignore[arg-type]
         # Sort by original index to guarantee deterministic ordering
         return sorted(pairs, key=lambda p: p[0])
 

--- a/omicverse/utils/ovagent/turn_controller.py
+++ b/omicverse/utils/ovagent/turn_controller.py
@@ -28,6 +28,7 @@ from .context_budget import (
     BudgetSliceType,
     ContextBudgetManager,
 )
+from .event_stream import RuntimeEventEmitter
 from .tool_registry import OutputTier
 from .tool_scheduler import ToolScheduler, execute_batch, ScheduledCall
 
@@ -498,7 +499,7 @@ class TurnController:
             out_file.write_text(
                 json.dumps(_safe(messages), indent=2, ensure_ascii=False)
             )
-            print(f"   \U0001f4dd Conversation log saved: {out_file}")
+            logger.info("conversation_log_saved path=%s", out_file)
         except Exception as exc:
             logger.debug("Failed to save conversation log: %s", exc)
 
@@ -625,6 +626,12 @@ class TurnController:
             ]
 
         _sync_runtime_trace()
+
+        emitter = RuntimeEventEmitter(
+            recorder=recorder,
+            event_callback=event_callback,
+            source="turn_loop",
+        )
 
         async def emit(event):
             recorder.add_event(event)
@@ -768,7 +775,6 @@ class TurnController:
             for turn in range(max_turns):
                 # --- Cancel checkpoint: before LLM call ---
                 if _is_cancelled():
-                    print("   \u26d4 Cancelled before LLM call")
                     recorder.add_step(
                         "status", summary="cancelled_before_llm"
                     )
@@ -782,21 +788,15 @@ class TurnController:
                     )
                     if ctx._trace_store is not None:
                         recorder.save(ctx._trace_store)
-                    await emit(
-                        build_stream_event(
-                            "done",
-                            "Cancelled",
-                            turn_id=recorder.trace.turn_id,
-                            trace_id=recorder.trace.trace_id,
-                            session_id=recorder.trace.session_id,
-                            category="lifecycle",
-                        )
-                        | {"cancelled": True}
+                    await emitter.turn_cancelled(
+                        "before_llm_call",
+                        turn_id=recorder.trace.turn_id,
+                        trace_id=recorder.trace.trace_id,
+                        session_id=recorder.trace.session_id,
                     )
                     self._save_conversation_log(messages)
                     return current_adata
 
-                print(f"   \U0001f504 Turn {turn + 1}/{max_turns}")
                 tool_choice = FollowUpGate.select_tool_choice(
                     request=request,
                     adata=current_adata,
@@ -812,14 +812,13 @@ class TurnController:
                         turn + 1,
                     )
 
-                logger.info(
-                    "agentic_llm_call_start turn=%d/%d tool_choice=%s "
-                    "messages=%d post_tool=%s",
-                    turn + 1,
+                await emitter.turn_started(
+                    turn,
                     max_turns,
                     tool_choice,
-                    len(messages),
-                    "yes" if meaningful_tool_call_seen else "no",
+                    turn_id=recorder.trace.turn_id,
+                    trace_id=recorder.trace.trace_id,
+                    session_id=recorder.trace.session_id,
                 )
                 t_llm_start = time.time()
                 stall_retries = 0
@@ -927,9 +926,11 @@ class TurnController:
                             "llm_chunk",
                             summary=final_summary[:200],
                         )
-                        print(
-                            "   \U0001f4ac Agent response: "
-                            f"{final_summary[:200]}"
+                        await emitter.agent_response(
+                            final_summary,
+                            turn_id=recorder.trace.turn_id,
+                            trace_id=recorder.trace.trace_id,
+                            session_id=recorder.trace.session_id,
                         )
                         await emit(
                             build_stream_event(
@@ -1064,9 +1065,6 @@ class TurnController:
 
                 for batch in schedule.batches:
                     if _is_cancelled():
-                        print(
-                            "   \u26d4 Cancelled before tool dispatch"
-                        )
                         recorder.add_step(
                             "status",
                             summary="cancelled_before_tool_dispatch",
@@ -1084,16 +1082,11 @@ class TurnController:
                         )
                         if ctx._trace_store is not None:
                             recorder.save(ctx._trace_store)
-                        await emit(
-                            build_stream_event(
-                                "done",
-                                "Cancelled",
-                                turn_id=recorder.trace.turn_id,
-                                trace_id=recorder.trace.trace_id,
-                                session_id=recorder.trace.session_id,
-                                category="lifecycle",
-                            )
-                            | {"cancelled": True}
+                        await emitter.turn_cancelled(
+                            "before_tool_dispatch",
+                            turn_id=recorder.trace.turn_id,
+                            trace_id=recorder.trace.trace_id,
+                            session_id=recorder.trace.session_id,
                         )
                         self._save_conversation_log(messages)
                         return current_adata
@@ -1113,9 +1106,15 @@ class TurnController:
                             },
                         )
                         _step_ids[sc.index] = tool_step_id
-                        print(
-                            f"   \U0001f527 Tool: {canonical or tc.name}"
-                            f"({', '.join(f'{k}=' for k in tc.arguments)})"
+                        await emitter.tool_dispatched(
+                            canonical or tc.name,
+                            tc.arguments,
+                            batch_id=batch.batch_id,
+                            parallel=batch.parallel,
+                            step_id=tool_step_id,
+                            turn_id=recorder.trace.turn_id,
+                            trace_id=recorder.trace.trace_id,
+                            session_id=recorder.trace.session_id,
                         )
                         await emit(
                             build_stream_event(
@@ -1201,11 +1200,13 @@ class TurnController:
                                         "description", "execute_code"
                                     ),
                                 )
-                                print(
-                                    "      \u2705 "
-                                    + tc.arguments.get(
+                                await emitter.execution_completed(
+                                    tc.arguments.get(
                                         "description", "Code executed"
-                                    )
+                                    ),
+                                    turn_id=recorder.trace.turn_id,
+                                    trace_id=recorder.trace.trace_id,
+                                    session_id=recorder.trace.session_id,
                                 )
                                 await emit(
                                     build_stream_event(
@@ -1218,10 +1219,11 @@ class TurnController:
                                     )
                                 )
                             else:
-                                print(
-                                    "      \u2705 delegate("
-                                    + tc.arguments.get("agent_type", "")
-                                    + ") completed"
+                                await emitter.delegation_completed(
+                                    tc.arguments.get("agent_type", ""),
+                                    turn_id=recorder.trace.turn_id,
+                                    trace_id=recorder.trace.trace_id,
+                                    session_id=recorder.trace.session_id,
                                 )
 
                             shape = (
@@ -1257,7 +1259,12 @@ class TurnController:
                             recorder.add_step(
                                 "done", name=canonical, summary=summary
                             )
-                            print(f"   \u2705 Finished: {summary}")
+                            await emitter.task_finished(
+                                summary,
+                                turn_id=recorder.trace.turn_id,
+                                trace_id=recorder.trace.trace_id,
+                                session_id=recorder.trace.session_id,
+                            )
                             tool_output = f"Task finished: {summary}"
                             finished = True
                         elif isinstance(result, str):
@@ -1512,16 +1519,6 @@ class TurnController:
                     )
                 )
             else:
-                logger.warning(
-                    "agentic_loop_max_turns max_turns=%d "
-                    "meaningful_tool=%s",
-                    max_turns,
-                    meaningful_tool_call_seen,
-                )
-                print(
-                    f"   \u26a0\ufe0f  Max turns ({max_turns}) reached, "
-                    "returning current result"
-                )
                 final_summary = final_summary or (
                     f"Reached max turns ({max_turns})"
                 )
@@ -1533,16 +1530,11 @@ class TurnController:
                 _finalize_analysis_run("max_turns", final_summary)
                 if ctx._trace_store is not None:
                     recorder.save(ctx._trace_store)
-                await emit(
-                    build_stream_event(
-                        "done",
-                        final_summary,
-                        turn_id=recorder.trace.turn_id,
-                        trace_id=recorder.trace.trace_id,
-                        session_id=recorder.trace.session_id,
-                        category="lifecycle",
-                    )
-                    | {"max_turns": True}
+                await emitter.max_turns_reached(
+                    max_turns,
+                    turn_id=recorder.trace.turn_id,
+                    trace_id=recorder.trace.trace_id,
+                    session_id=recorder.trace.session_id,
                 )
             if ctx.last_usage:
                 await emit(

--- a/omicverse/utils/ovagent/turn_controller.py
+++ b/omicverse/utils/ovagent/turn_controller.py
@@ -24,6 +24,11 @@ from ..harness.runtime_state import runtime_state
 from ..harness.tool_catalog import normalize_tool_name
 from ..session_history import HistoryEntry
 
+from .context_budget import (
+    BudgetSliceType,
+    ContextBudgetManager,
+)
+from .tool_registry import OutputTier
 from .tool_scheduler import ToolScheduler, execute_batch, ScheduledCall
 
 if TYPE_CHECKING:
@@ -725,6 +730,19 @@ class TurnController:
             },
         )
 
+        # --- Token-aware context budget manager ---
+        budget_model = (
+            getattr(getattr(ctx._llm, "config", None), "model", None)
+            or ctx.model
+            or ""
+        )
+        budget_manager = ContextBudgetManager(model=budget_model)
+        budget_manager.record(
+            BudgetSliceType.system_prompt,
+            system_prompt,
+            content_key="system_prompt",
+        )
+
         current_adata = adata
         completed_without_tool_calls = False
         meaningful_tool_call_seen = False
@@ -1247,18 +1265,24 @@ class TurnController:
                         else:
                             tool_output = str(result)
 
-                        # Truncate
-                        max_tool_output_chars = 8000
-                        if canonical in {
-                            "WebFetch", "WebSearch",
-                            "web_fetch", "web_search",
-                        }:
-                            max_tool_output_chars = 4000
-                        if len(tool_output) > max_tool_output_chars:
-                            tool_output = (
-                                tool_output[: max_tool_output_chars - 500]
-                                + "\n... (truncated)"
-                            )
+                        # Tier-driven truncation via budget manager
+                        meta = self._tool_runtime.registry.get(
+                            canonical
+                        )
+                        output_tier = (
+                            meta.output_tier
+                            if meta is not None
+                            else OutputTier.standard
+                        )
+                        tool_output = budget_manager.truncate_output(
+                            tool_output, output_tier
+                        )
+                        budget_manager.record(
+                            BudgetSliceType.tool_output,
+                            tool_output,
+                            content_key=canonical or tc.name,
+                            tier=output_tier,
+                        )
 
                         try:
                             parsed_tool_output = json.loads(tool_output)
@@ -1392,6 +1416,40 @@ class TurnController:
                                 ._consecutive_readonly
                             ),
                         },
+                    )
+
+                # --- Incremental compaction checkpoint ---
+                if (
+                    not finished
+                    and budget_manager.should_compact()
+                    and len(messages) > 6
+                ):
+                    # Build a short summary of tool results from
+                    # this turn for the checkpoint
+                    turn_tool_names = [
+                        tc.name for tc in response.tool_calls
+                    ]
+                    cp_summary = (
+                        f"Tools called: {', '.join(turn_tool_names)}. "
+                        f"Budget utilization: "
+                        f"{budget_manager.utilization:.0%}."
+                    )
+                    budget_manager.add_checkpoint(
+                        turn_index=turn,
+                        summary=cp_summary,
+                        messages_covered=len(messages),
+                    )
+                    logger.info(
+                        "budget_checkpoint turn=%d "
+                        "utilization=%.2f messages=%d",
+                        turn + 1,
+                        budget_manager.utilization,
+                        len(messages),
+                    )
+                    recorder.add_step(
+                        "status",
+                        summary="budget_compaction_checkpoint",
+                        data=budget_manager.to_dict(),
                     )
 
                 if finished:

--- a/omicverse/utils/ovagent/turn_controller.py
+++ b/omicverse/utils/ovagent/turn_controller.py
@@ -24,6 +24,8 @@ from ..harness.runtime_state import runtime_state
 from ..harness.tool_catalog import normalize_tool_name
 from ..session_history import HistoryEntry
 
+from .tool_scheduler import ToolScheduler, execute_batch, ScheduledCall
+
 if TYPE_CHECKING:
     from .prompt_builder import PromptBuilder
     from .protocol import AgentContext
@@ -1021,8 +1023,28 @@ class TurnController:
                 finished = False
                 no_tool_retry_count = 0
 
-                for tc in response.tool_calls:
-                    canonical = normalize_tool_name(tc.name)
+                # --- Schedule tool calls into batches ---
+                scheduler = ToolScheduler(
+                    self._tool_runtime.registry
+                )
+                schedule = scheduler.schedule(response.tool_calls)
+                logger.info(
+                    "tool_schedule turn=%d batches=%d parallel=%s "
+                    "total_calls=%d",
+                    turn + 1,
+                    schedule.total_batches,
+                    schedule.has_parallel,
+                    schedule.total_calls,
+                )
+
+                # Pre-allocate result slots indexed by original position
+                _ordered_results: List[Optional[tuple]] = [
+                    None
+                ] * schedule.total_calls
+                # Map from call index → step_id for trace coherence
+                _step_ids: Dict[int, str] = {}
+
+                for batch in schedule.batches:
                     if _is_cancelled():
                         print(
                             "   \u26d4 Cancelled before tool dispatch"
@@ -1058,249 +1080,283 @@ class TurnController:
                         self._save_conversation_log(messages)
                         return current_adata
 
-                    tool_step_id = recorder.add_step(
-                        "tool_call",
-                        name=canonical or tc.name,
-                        summary=f"{canonical or tc.name} dispatched",
-                        data={"arguments": tc.arguments},
-                    )
-                    print(
-                        f"   \U0001f527 Tool: {canonical or tc.name}"
-                        f"({', '.join(f'{k}=' for k in tc.arguments)})"
-                    )
-
-                    await emit(
-                        build_stream_event(
-                            "item_started",
-                            {
-                                "item_type": "tool_call",
-                                "name": canonical or tc.name,
-                            },
-                            turn_id=recorder.trace.turn_id,
-                            trace_id=recorder.trace.trace_id,
-                            step_id=tool_step_id,
-                            session_id=recorder.trace.session_id,
-                            category="item",
-                        )
-                    )
-                    await emit(
-                        build_stream_event(
+                    # Emit item_started for each call in the batch
+                    for sc in batch.calls:
+                        tc = sc.tool_call
+                        canonical = sc.canonical_name
+                        tool_step_id = recorder.add_step(
                             "tool_call",
-                            {
-                                "name": canonical or tc.name,
+                            name=canonical or tc.name,
+                            summary=f"{canonical or tc.name} dispatched",
+                            data={
                                 "arguments": tc.arguments,
+                                "batch_id": batch.batch_id,
+                                "parallel": batch.parallel,
                             },
-                            turn_id=recorder.trace.turn_id,
-                            trace_id=recorder.trace.trace_id,
-                            step_id=tool_step_id,
-                            session_id=recorder.trace.session_id,
-                            category="tool",
                         )
+                        _step_ids[sc.index] = tool_step_id
+                        print(
+                            f"   \U0001f527 Tool: {canonical or tc.name}"
+                            f"({', '.join(f'{k}=' for k in tc.arguments)})"
+                        )
+                        await emit(
+                            build_stream_event(
+                                "item_started",
+                                {
+                                    "item_type": "tool_call",
+                                    "name": canonical or tc.name,
+                                    "batch_id": batch.batch_id,
+                                    "parallel": batch.parallel,
+                                },
+                                turn_id=recorder.trace.turn_id,
+                                trace_id=recorder.trace.trace_id,
+                                step_id=tool_step_id,
+                                session_id=recorder.trace.session_id,
+                                category="item",
+                            )
+                        )
+                        await emit(
+                            build_stream_event(
+                                "tool_call",
+                                {
+                                    "name": canonical or tc.name,
+                                    "arguments": tc.arguments,
+                                },
+                                turn_id=recorder.trace.turn_id,
+                                trace_id=recorder.trace.trace_id,
+                                step_id=tool_step_id,
+                                session_id=recorder.trace.session_id,
+                                category="tool",
+                            )
+                        )
+
+                    # Dispatch the batch
+                    async def _dispatch_scheduled(
+                        sc: ScheduledCall,
+                    ) -> Any:
+                        return await self._tool_runtime.dispatch_tool(
+                            sc.tool_call, current_adata, request
+                        )
+
+                    batch_results = await execute_batch(
+                        batch, _dispatch_scheduled
                     )
 
-                    result = await self._tool_runtime.dispatch_tool(
-                        tc, current_adata, request
-                    )
-                    if canonical not in {
-                        "finish", "TaskGet", "TaskList",
-                        "TaskOutput", "ToolSearch",
-                    }:
-                        meaningful_tool_call_seen = True
+                    # Process results in original index order
+                    for call_idx, result in batch_results:
+                        sc = batch.calls[
+                            call_idx - batch.calls[0].index
+                        ]
+                        tc = sc.tool_call
+                        canonical = sc.canonical_name
+                        tool_step_id = _step_ids[call_idx]
 
-                    if (
-                        canonical
-                        in ("execute_code", "Agent", "delegate")
-                        and isinstance(result, dict)
-                        and "adata" in result
-                    ):
-                        current_adata = result["adata"]
-                        tool_output = result.get(
-                            "output", "Code executed."
-                        )
-                        if canonical == "execute_code":
-                            code = tc.arguments.get("code", "")
-                            recorder.add_step(
-                                "code",
-                                name=canonical,
-                                summary=tc.arguments.get(
-                                    "description", "Code executed"
-                                ),
-                                data={"code": code},
+                        if canonical not in {
+                            "finish", "TaskGet", "TaskList",
+                            "TaskOutput", "ToolSearch",
+                        }:
+                            meaningful_tool_call_seen = True
+
+                        if (
+                            canonical
+                            in ("execute_code", "Agent", "delegate")
+                            and isinstance(result, dict)
+                            and "adata" in result
+                        ):
+                            current_adata = result["adata"]
+                            tool_output = result.get(
+                                "output", "Code executed."
                             )
-                            recorder.add_artifact(
-                                "code",
-                                label=tc.arguments.get(
-                                    "description", "execute_code"
-                                ),
-                            )
-                            print(
-                                "      \u2705 "
-                                + tc.arguments.get(
-                                    "description", "Code executed"
+                            if canonical == "execute_code":
+                                code = tc.arguments.get("code", "")
+                                recorder.add_step(
+                                    "code",
+                                    name=canonical,
+                                    summary=tc.arguments.get(
+                                        "description", "Code executed"
+                                    ),
+                                    data={"code": code},
                                 )
+                                recorder.add_artifact(
+                                    "code",
+                                    label=tc.arguments.get(
+                                        "description", "execute_code"
+                                    ),
+                                )
+                                print(
+                                    "      \u2705 "
+                                    + tc.arguments.get(
+                                        "description", "Code executed"
+                                    )
+                                )
+                                await emit(
+                                    build_stream_event(
+                                        "code",
+                                        code,
+                                        turn_id=recorder.trace.turn_id,
+                                        trace_id=recorder.trace.trace_id,
+                                        session_id=recorder.trace.session_id,
+                                        category="execution",
+                                    )
+                                )
+                            else:
+                                print(
+                                    "      \u2705 delegate("
+                                    + tc.arguments.get("agent_type", "")
+                                    + ") completed"
+                                )
+
+                            shape = (
+                                (
+                                    current_adata.shape[0],
+                                    current_adata.shape[1],
+                                )
+                                if hasattr(current_adata, "shape")
+                                else None
+                            )
+                            recorder.add_step(
+                                "result",
+                                name=canonical or tc.name,
+                                summary="adata updated",
+                                data={"shape": shape},
                             )
                             await emit(
                                 build_stream_event(
-                                    "code",
-                                    code,
+                                    "result",
+                                    current_adata,
                                     turn_id=recorder.trace.turn_id,
                                     trace_id=recorder.trace.trace_id,
                                     session_id=recorder.trace.session_id,
                                     category="execution",
                                 )
+                                | {"shape": shape}
                             )
+                        elif canonical == "finish":
+                            summary = tc.arguments.get(
+                                "summary", "Task completed"
+                            )
+                            final_summary = summary
+                            recorder.add_step(
+                                "done", name=canonical, summary=summary
+                            )
+                            print(f"   \u2705 Finished: {summary}")
+                            tool_output = f"Task finished: {summary}"
+                            finished = True
+                        elif isinstance(result, str):
+                            tool_output = result
                         else:
-                            print(
-                                "      \u2705 delegate("
-                                + tc.arguments.get("agent_type", "")
-                                + ") completed"
+                            tool_output = str(result)
+
+                        # Truncate
+                        max_tool_output_chars = 8000
+                        if canonical in {
+                            "WebFetch", "WebSearch",
+                            "web_fetch", "web_search",
+                        }:
+                            max_tool_output_chars = 4000
+                        if len(tool_output) > max_tool_output_chars:
+                            tool_output = (
+                                tool_output[: max_tool_output_chars - 500]
+                                + "\n... (truncated)"
                             )
 
-                        shape = (
-                            (
-                                current_adata.shape[0],
-                                current_adata.shape[1],
-                            )
-                            if hasattr(current_adata, "shape")
-                            else None
+                        try:
+                            parsed_tool_output = json.loads(tool_output)
+                        except Exception as e:
+                            logger.debug("turn_controller: failed to parse tool output as JSON (%s)", e)
+                            parsed_tool_output = None
+
+                        if isinstance(parsed_tool_output, dict):
+                            if canonical == "ToolSearch":
+                                await emit(
+                                    build_stream_event(
+                                        "status",
+                                        {
+                                            "loaded_tools": (
+                                                parsed_tool_output.get(
+                                                    "loaded_tools", []
+                                                )
+                                            ),
+                                            "newly_loaded": (
+                                                parsed_tool_output.get(
+                                                    "newly_loaded", []
+                                                )
+                                            ),
+                                        },
+                                        turn_id=recorder.trace.turn_id,
+                                        trace_id=recorder.trace.trace_id,
+                                        step_id=tool_step_id,
+                                        session_id=recorder.trace.session_id,
+                                        category="runtime",
+                                    )
+                                )
+                            elif canonical in {
+                                "EnterPlanMode", "ExitPlanMode",
+                            }:
+                                await emit(
+                                    build_stream_event(
+                                        "status",
+                                        {"plan_mode": parsed_tool_output},
+                                        turn_id=recorder.trace.turn_id,
+                                        trace_id=recorder.trace.trace_id,
+                                        step_id=tool_step_id,
+                                        session_id=recorder.trace.session_id,
+                                        category="runtime",
+                                    )
+                                )
+                            elif canonical == "EnterWorktree":
+                                await emit(
+                                    build_stream_event(
+                                        "status",
+                                        {"worktree": parsed_tool_output},
+                                        turn_id=recorder.trace.turn_id,
+                                        trace_id=recorder.trace.trace_id,
+                                        step_id=tool_step_id,
+                                        session_id=recorder.trace.session_id,
+                                        category="runtime",
+                                    )
+                                )
+                            elif canonical in {
+                                "TaskCreate", "TaskUpdate",
+                                "TaskStop", "Bash",
+                            }:
+                                await emit(
+                                    build_stream_event(
+                                        "task_update",
+                                        parsed_tool_output,
+                                        turn_id=recorder.trace.turn_id,
+                                        trace_id=recorder.trace.trace_id,
+                                        step_id=tool_step_id,
+                                        session_id=recorder.trace.session_id,
+                                        category="task",
+                                    )
+                                )
+
+                        _ordered_results[call_idx] = (
+                            tc.id, tc.name, tool_output
                         )
-                        recorder.add_step(
-                            "result",
-                            name=canonical or tc.name,
-                            summary="adata updated",
-                            data={"shape": shape},
-                        )
+                        _sync_runtime_trace()
                         await emit(
                             build_stream_event(
-                                "result",
-                                current_adata,
+                                "item_completed",
+                                {
+                                    "item_type": "tool_call",
+                                    "name": canonical or tc.name,
+                                    "status": "success",
+                                    "batch_id": batch.batch_id,
+                                },
                                 turn_id=recorder.trace.turn_id,
                                 trace_id=recorder.trace.trace_id,
+                                step_id=tool_step_id,
                                 session_id=recorder.trace.session_id,
-                                category="execution",
+                                category="item",
                             )
-                            | {"shape": shape}
-                        )
-                    elif canonical == "finish":
-                        summary = tc.arguments.get(
-                            "summary", "Task completed"
-                        )
-                        final_summary = summary
-                        recorder.add_step(
-                            "done", name=canonical, summary=summary
-                        )
-                        print(f"   \u2705 Finished: {summary}")
-                        tool_output = f"Task finished: {summary}"
-                        finished = True
-                    elif isinstance(result, str):
-                        tool_output = result
-                    else:
-                        tool_output = str(result)
-
-                    # Truncate
-                    max_tool_output_chars = 8000
-                    if canonical in {
-                        "WebFetch", "WebSearch",
-                        "web_fetch", "web_search",
-                    }:
-                        max_tool_output_chars = 4000
-                    if len(tool_output) > max_tool_output_chars:
-                        tool_output = (
-                            tool_output[: max_tool_output_chars - 500]
-                            + "\n... (truncated)"
                         )
 
-                    try:
-                        parsed_tool_output = json.loads(tool_output)
-                    except Exception as e:
-                        logger.debug("turn_controller: failed to parse tool output as JSON (%s)", e)
-                        parsed_tool_output = None
-
-                    if isinstance(parsed_tool_output, dict):
-                        if canonical == "ToolSearch":
-                            await emit(
-                                build_stream_event(
-                                    "status",
-                                    {
-                                        "loaded_tools": (
-                                            parsed_tool_output.get(
-                                                "loaded_tools", []
-                                            )
-                                        ),
-                                        "newly_loaded": (
-                                            parsed_tool_output.get(
-                                                "newly_loaded", []
-                                            )
-                                        ),
-                                    },
-                                    turn_id=recorder.trace.turn_id,
-                                    trace_id=recorder.trace.trace_id,
-                                    step_id=tool_step_id,
-                                    session_id=recorder.trace.session_id,
-                                    category="runtime",
-                                )
-                            )
-                        elif canonical in {
-                            "EnterPlanMode", "ExitPlanMode",
-                        }:
-                            await emit(
-                                build_stream_event(
-                                    "status",
-                                    {"plan_mode": parsed_tool_output},
-                                    turn_id=recorder.trace.turn_id,
-                                    trace_id=recorder.trace.trace_id,
-                                    step_id=tool_step_id,
-                                    session_id=recorder.trace.session_id,
-                                    category="runtime",
-                                )
-                            )
-                        elif canonical == "EnterWorktree":
-                            await emit(
-                                build_stream_event(
-                                    "status",
-                                    {"worktree": parsed_tool_output},
-                                    turn_id=recorder.trace.turn_id,
-                                    trace_id=recorder.trace.trace_id,
-                                    step_id=tool_step_id,
-                                    session_id=recorder.trace.session_id,
-                                    category="runtime",
-                                )
-                            )
-                        elif canonical in {
-                            "TaskCreate", "TaskUpdate",
-                            "TaskStop", "Bash",
-                        }:
-                            await emit(
-                                build_stream_event(
-                                    "task_update",
-                                    parsed_tool_output,
-                                    turn_id=recorder.trace.turn_id,
-                                    trace_id=recorder.trace.trace_id,
-                                    step_id=tool_step_id,
-                                    session_id=recorder.trace.session_id,
-                                    category="task",
-                                )
-                            )
-
-                    tool_results.append(
-                        (tc.id, tc.name, tool_output)
-                    )
-                    _sync_runtime_trace()
-                    await emit(
-                        build_stream_event(
-                            "item_completed",
-                            {
-                                "item_type": "tool_call",
-                                "name": canonical or tc.name,
-                                "status": "success",
-                            },
-                            turn_id=recorder.trace.turn_id,
-                            trace_id=recorder.trace.trace_id,
-                            step_id=tool_step_id,
-                            session_id=recorder.trace.session_id,
-                            category="item",
-                        )
-                    )
+                # Collect results preserving original order
+                tool_results = [
+                    r for r in _ordered_results if r is not None
+                ]
 
                 self._append_tool_results(messages, tool_results)
 

--- a/tests/utils/test_context_budget.py
+++ b/tests/utils/test_context_budget.py
@@ -1,0 +1,624 @@
+"""Tests for the token-aware context budget manager.
+
+Validates that:
+- Token estimation is bounded and consistent (no external dependency).
+- Budget slices track typed consumption by category.
+- Truncation is policy-driven by OutputTier, not hard-coded constants.
+- Compaction supports incremental checkpoints and sliding summaries.
+- Main-agent and subagent paths share a consistent budgeting model.
+- Budget utilization and compaction thresholds work correctly.
+- History compaction replaces old messages with checkpoint summaries.
+- The manager integrates with the existing ToolRegistry OutputTier enum.
+
+These tests run under ``OV_AGENT_RUN_HARNESS_TESTS=1``.
+"""
+
+import importlib
+import importlib.machinery
+import os
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Guard
+# ---------------------------------------------------------------------------
+
+_RUN_HARNESS = os.environ.get("OV_AGENT_RUN_HARNESS_TESTS", "").lower() in {
+    "1", "true", "yes", "on",
+}
+pytestmark = pytest.mark.skipif(
+    not _RUN_HARNESS,
+    reason="Context budget tests require OV_AGENT_RUN_HARNESS_TESTS=1.",
+)
+
+# ---------------------------------------------------------------------------
+# Bootstrap: lightweight package stubs (matches test_runtime_contracts.py)
+# ---------------------------------------------------------------------------
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+PACKAGE_ROOT = PROJECT_ROOT / "omicverse"
+
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+_SAVED = {
+    name: sys.modules.get(name)
+    for name in ["omicverse", "omicverse.utils"]
+}
+for name in ["omicverse", "omicverse.utils"]:
+    sys.modules.pop(name, None)
+
+_ov_pkg = types.ModuleType("omicverse")
+_ov_pkg.__path__ = [str(PACKAGE_ROOT)]
+_ov_pkg.__spec__ = importlib.machinery.ModuleSpec(
+    "omicverse", loader=None, is_package=True
+)
+sys.modules["omicverse"] = _ov_pkg
+
+_utils_pkg = types.ModuleType("omicverse.utils")
+_utils_pkg.__path__ = [str(PACKAGE_ROOT / "utils")]
+_utils_pkg.__spec__ = importlib.machinery.ModuleSpec(
+    "omicverse.utils", loader=None, is_package=True
+)
+sys.modules["omicverse.utils"] = _utils_pkg
+_ov_pkg.utils = _utils_pkg
+
+from omicverse.utils.ovagent.context_budget import (
+    BudgetSlice,
+    BudgetSliceType,
+    CompactionCheckpoint,
+    ContextBudgetManager,
+    TruncationPolicy,
+    create_subagent_budget_manager,
+    estimate_tokens,
+    get_context_window,
+)
+from omicverse.utils.ovagent.tool_registry import OutputTier
+
+for name, mod in _SAVED.items():
+    if mod is None:
+        sys.modules.pop(name, None)
+    else:
+        sys.modules[name] = mod
+
+
+# ===================================================================
+# 1. Token estimator
+# ===================================================================
+
+
+class TestEstimateTokens:
+    """Token estimator uses a bounded heuristic, not raw char count."""
+
+    def test_empty_string(self):
+        assert estimate_tokens("") == 0
+
+    def test_ascii_text(self):
+        # ~4 chars per token for ASCII
+        text = "Hello world this is a test"
+        tokens = estimate_tokens(text)
+        assert tokens > 0
+        assert tokens == len(text) // 4
+
+    def test_cjk_text(self):
+        # ~2 chars per token for CJK
+        text = "\u4f60\u597d\u4e16\u754c"  # 4 CJK chars
+        tokens = estimate_tokens(text)
+        assert tokens == 2  # 4 // 2
+
+    def test_mixed_text(self):
+        text = "Hello \u4f60\u597d"  # 6 ASCII + 2 CJK
+        tokens = estimate_tokens(text)
+        # 6 ASCII // 4 = 1, 2 CJK // 2 = 1 → 2
+        assert tokens == 2
+
+    def test_minimum_one_token(self):
+        assert estimate_tokens("a") >= 1
+
+    def test_returns_int(self):
+        assert isinstance(estimate_tokens("test content"), int)
+
+
+# ===================================================================
+# 2. Context window lookup
+# ===================================================================
+
+
+class TestGetContextWindow:
+    def test_known_model(self):
+        assert get_context_window("gpt-4o") == 128_000
+
+    def test_unknown_model_fallback(self):
+        assert get_context_window("unknown-model-xyz") == 32_000
+
+    def test_anthropic_model(self):
+        assert get_context_window("anthropic/claude-opus-4-20250514") == 200_000
+
+
+# ===================================================================
+# 3. Budget slice tracking
+# ===================================================================
+
+
+class TestBudgetSliceTracking:
+    """Budget manager tracks typed slices of consumed context."""
+
+    def test_record_returns_slice(self):
+        mgr = ContextBudgetManager(context_window=10_000)
+        bs = mgr.record(
+            BudgetSliceType.system_prompt,
+            "You are a test agent.",
+            content_key="sys",
+        )
+        assert isinstance(bs, BudgetSlice)
+        assert bs.slice_type == BudgetSliceType.system_prompt
+        assert bs.tokens > 0
+
+    def test_total_consumed_updates(self):
+        mgr = ContextBudgetManager(context_window=10_000)
+        assert mgr.total_consumed == 0
+        mgr.record(BudgetSliceType.system_prompt, "prompt text")
+        assert mgr.total_consumed > 0
+
+    def test_remaining_budget_decreases(self):
+        mgr = ContextBudgetManager(context_window=10_000)
+        initial = mgr.remaining_budget
+        mgr.record(BudgetSliceType.user_message, "user request")
+        assert mgr.remaining_budget < initial
+
+    def test_consumption_by_type(self):
+        mgr = ContextBudgetManager(context_window=10_000)
+        mgr.record(BudgetSliceType.system_prompt, "prompt")
+        mgr.record(BudgetSliceType.tool_output, "output1")
+        mgr.record(BudgetSliceType.tool_output, "output2")
+        by_type = mgr.consumption_by_type()
+        assert "system_prompt" in by_type
+        assert "tool_output" in by_type
+        assert by_type["tool_output"] > 0
+
+    def test_reset_clears_state(self):
+        mgr = ContextBudgetManager(context_window=10_000)
+        mgr.record(BudgetSliceType.system_prompt, "prompt")
+        mgr.add_checkpoint(0, "summary")
+        mgr.reset()
+        assert mgr.total_consumed == 0
+        assert len(mgr.checkpoints) == 0
+
+
+# ===================================================================
+# 4. Tier-driven truncation (acceptance criterion)
+# ===================================================================
+
+
+class TestTierDrivenTruncation:
+    """Tool-output truncation is policy-driven by output tier,
+    not a single hard-coded constant."""
+
+    def test_minimal_tier_has_tight_limit(self):
+        mgr = ContextBudgetManager(context_window=100_000)
+        policy = mgr.get_truncation_policy(OutputTier.minimal)
+        assert policy.max_tokens == 500
+
+    def test_standard_tier_moderate_limit(self):
+        mgr = ContextBudgetManager(context_window=100_000)
+        policy = mgr.get_truncation_policy(OutputTier.standard)
+        assert policy.max_tokens == 2000
+
+    def test_verbose_tier_larger_limit(self):
+        mgr = ContextBudgetManager(context_window=100_000)
+        policy = mgr.get_truncation_policy(OutputTier.verbose)
+        assert policy.max_tokens == 3000
+
+    def test_different_tiers_different_limits(self):
+        """Each tier has a distinct truncation policy."""
+        mgr = ContextBudgetManager(context_window=100_000)
+        limits = set()
+        for tier in OutputTier:
+            p = mgr.get_truncation_policy(tier)
+            limits.add(p.max_tokens)
+        # All three tiers should have different limits
+        assert len(limits) == 3
+
+    def test_short_content_not_truncated(self):
+        mgr = ContextBudgetManager(context_window=100_000)
+        short = "This is short."
+        result = mgr.truncate_output(short, OutputTier.minimal)
+        assert result == short
+
+    def test_long_content_truncated_with_suffix(self):
+        mgr = ContextBudgetManager(context_window=100_000)
+        # Create content much larger than the minimal tier limit
+        long_content = "x" * 10_000
+        result = mgr.truncate_output(long_content, OutputTier.minimal)
+        assert len(result) < len(long_content)
+        assert result.endswith("... (truncated)")
+
+    def test_verbose_tier_allows_more_than_minimal(self):
+        mgr = ContextBudgetManager(context_window=100_000)
+        # Content that exceeds minimal but not verbose
+        content = "x" * 5000  # ~1250 tokens
+        result_minimal = mgr.truncate_output(content, OutputTier.minimal)
+        result_verbose = mgr.truncate_output(content, OutputTier.verbose)
+        assert len(result_minimal) < len(result_verbose)
+
+    def test_empty_content_returns_empty(self):
+        mgr = ContextBudgetManager(context_window=100_000)
+        assert mgr.truncate_output("", OutputTier.standard) == ""
+
+    def test_custom_tier_policies(self):
+        """Custom policies override defaults."""
+        custom = {
+            OutputTier.minimal: TruncationPolicy(max_tokens=100),
+            OutputTier.standard: TruncationPolicy(max_tokens=200),
+            OutputTier.verbose: TruncationPolicy(max_tokens=400),
+        }
+        mgr = ContextBudgetManager(
+            context_window=10_000, tier_policies=custom
+        )
+        assert mgr.get_truncation_policy(OutputTier.minimal).max_tokens == 100
+
+    def test_truncation_strategy_tail(self):
+        """Default 'tail' strategy keeps the head."""
+        mgr = ContextBudgetManager(context_window=100_000)
+        content = "HEADER_" + "x" * 10_000
+        result = mgr.truncate_output(content, OutputTier.minimal)
+        assert result.startswith("HEADER_")
+
+    def test_truncation_strategy_head(self):
+        """'head' strategy keeps the tail."""
+        custom = {
+            OutputTier.standard: TruncationPolicy(
+                max_tokens=100, strategy="head"
+            ),
+        }
+        mgr = ContextBudgetManager(
+            context_window=100_000, tier_policies=custom
+        )
+        content = "x" * 10_000 + "_TAIL"
+        result = mgr.truncate_output(content, OutputTier.standard)
+        assert result.endswith("_TAIL")
+
+    def test_truncation_strategy_middle(self):
+        """'middle' strategy keeps head + tail, drops middle."""
+        custom = {
+            OutputTier.standard: TruncationPolicy(
+                max_tokens=100, strategy="middle"
+            ),
+        }
+        mgr = ContextBudgetManager(
+            context_window=100_000, tier_policies=custom
+        )
+        content = "HEAD" + "x" * 10_000 + "TAIL"
+        result = mgr.truncate_output(content, OutputTier.standard)
+        assert "HEAD" in result
+        assert "TAIL" in result
+        assert "... (truncated)" in result
+
+
+# ===================================================================
+# 5. Incremental compaction checkpoints (acceptance criterion)
+# ===================================================================
+
+
+class TestCompactionCheckpoints:
+    """Compaction supports incremental summaries, not just one-shot."""
+
+    def test_add_checkpoint(self):
+        mgr = ContextBudgetManager(context_window=10_000)
+        cp = mgr.add_checkpoint(
+            turn_index=3,
+            summary="Called Read and Grep on dataset files.",
+            messages_covered=8,
+        )
+        assert isinstance(cp, CompactionCheckpoint)
+        assert cp.turn_index == 3
+        assert cp.messages_covered == 8
+        assert cp.tokens > 0
+
+    def test_multiple_checkpoints(self):
+        mgr = ContextBudgetManager(context_window=10_000)
+        mgr.add_checkpoint(0, "first summary")
+        mgr.add_checkpoint(3, "second summary")
+        mgr.add_checkpoint(6, "third summary")
+        assert len(mgr.checkpoints) == 3
+
+    def test_latest_checkpoint(self):
+        mgr = ContextBudgetManager(context_window=10_000)
+        assert mgr.get_latest_checkpoint() is None
+        mgr.add_checkpoint(0, "first")
+        mgr.add_checkpoint(5, "latest")
+        latest = mgr.get_latest_checkpoint()
+        assert latest is not None
+        assert latest.turn_index == 5
+        assert latest.summary == "latest"
+
+    def test_build_sliding_summary(self):
+        mgr = ContextBudgetManager(context_window=10_000)
+        mgr.add_checkpoint(0, "Explored dataset structure")
+        mgr.add_checkpoint(3, "Ran QC filtering")
+        summary = mgr.build_sliding_summary()
+        assert "[Turn 0]" in summary
+        assert "[Turn 3]" in summary
+        assert "Explored dataset" in summary
+        assert "QC filtering" in summary
+
+    def test_empty_sliding_summary(self):
+        mgr = ContextBudgetManager(context_window=10_000)
+        assert mgr.build_sliding_summary() == ""
+
+    def test_checkpoint_to_dict(self):
+        mgr = ContextBudgetManager(context_window=10_000)
+        cp = mgr.add_checkpoint(2, "summary text", messages_covered=5)
+        d = cp.to_dict()
+        assert d["turn_index"] == 2
+        assert d["messages_covered"] == 5
+        assert "summary_preview" in d
+        assert d["tokens"] > 0
+
+
+# ===================================================================
+# 6. Compaction threshold and should_compact
+# ===================================================================
+
+
+class TestCompactionThreshold:
+    def test_initially_no_compaction_needed(self):
+        mgr = ContextBudgetManager(context_window=100_000)
+        assert not mgr.should_compact()
+
+    def test_compaction_triggers_at_threshold(self):
+        mgr = ContextBudgetManager(
+            context_window=1000,
+            compaction_threshold=0.5,
+            reserve_fraction=0.0,
+        )
+        # Fill over half the budget
+        mgr.record(BudgetSliceType.system_prompt, "x" * 2200)
+        assert mgr.should_compact()
+
+    def test_utilization_property(self):
+        mgr = ContextBudgetManager(
+            context_window=1000, reserve_fraction=0.0
+        )
+        assert mgr.utilization == 0.0
+        mgr.record(BudgetSliceType.system_prompt, "x" * 2000)
+        assert mgr.utilization > 0.0
+
+
+# ===================================================================
+# 7. History compaction with checkpoints
+# ===================================================================
+
+
+class TestHistoryCompaction:
+    """compact_history replaces old messages with checkpoint summaries."""
+
+    def test_short_history_unchanged(self):
+        mgr = ContextBudgetManager(context_window=10_000)
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi"},
+        ]
+        result, cp = mgr.compact_history(messages, keep_recent=4)
+        assert len(result) == 3
+        assert cp is None
+
+    def test_long_history_compacted(self):
+        mgr = ContextBudgetManager(context_window=10_000)
+        mgr.add_checkpoint(2, "Explored data and ran QC")
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "msg1"},
+            {"role": "assistant", "content": "resp1"},
+            {"role": "user", "content": "msg2"},
+            {"role": "assistant", "content": "resp2"},
+            {"role": "user", "content": "msg3"},
+            {"role": "assistant", "content": "resp3"},
+            {"role": "user", "content": "msg4"},
+            {"role": "assistant", "content": "resp4"},
+        ]
+        result, cp = mgr.compact_history(messages, keep_recent=2)
+        assert cp is not None
+        # Should have: system + summary + 2 recent
+        assert result[0]["role"] == "system"
+        assert "[Context summary" in result[1]["content"]
+        assert len(result) == 4  # system + summary + 2 recent
+
+    def test_no_checkpoint_no_compaction(self):
+        mgr = ContextBudgetManager(context_window=10_000)
+        messages = [{"role": "system", "content": "sys"}] + [
+            {"role": "user", "content": f"msg{i}"} for i in range(10)
+        ]
+        result, cp = mgr.compact_history(messages, keep_recent=2)
+        assert cp is None
+        assert len(result) == 11  # unchanged
+
+
+# ===================================================================
+# 8. Subagent budget manager (shared model, tighter policies)
+# ===================================================================
+
+
+class TestSubagentBudgetManager:
+    """Main-agent and subagent share the same budgeting model
+    but with different tier policies."""
+
+    def test_subagent_uses_same_class(self):
+        mgr = create_subagent_budget_manager()
+        assert isinstance(mgr, ContextBudgetManager)
+
+    def test_subagent_tighter_standard_limit(self):
+        main = ContextBudgetManager()
+        sub = create_subagent_budget_manager()
+        main_std = main.get_truncation_policy(OutputTier.standard)
+        sub_std = sub.get_truncation_policy(OutputTier.standard)
+        assert sub_std.max_tokens < main_std.max_tokens
+
+    def test_subagent_tighter_verbose_limit(self):
+        main = ContextBudgetManager()
+        sub = create_subagent_budget_manager()
+        main_v = main.get_truncation_policy(OutputTier.verbose)
+        sub_v = sub.get_truncation_policy(OutputTier.verbose)
+        assert sub_v.max_tokens < main_v.max_tokens
+
+    def test_subagent_consistent_api(self):
+        """Subagent manager has all the same methods."""
+        sub = create_subagent_budget_manager()
+        assert hasattr(sub, "truncate_output")
+        assert hasattr(sub, "record")
+        assert hasattr(sub, "should_compact")
+        assert hasattr(sub, "add_checkpoint")
+        assert hasattr(sub, "compact_history")
+
+    def test_subagent_lower_compaction_threshold(self):
+        """Subagent compacts earlier than main agent."""
+        main = ContextBudgetManager()
+        sub = create_subagent_budget_manager()
+        # Subagent threshold is 0.70, main is 0.75
+        assert sub._compaction_threshold <= main._compaction_threshold
+
+
+# ===================================================================
+# 9. Manager introspection / to_dict
+# ===================================================================
+
+
+class TestManagerIntrospection:
+    def test_to_dict_structure(self):
+        mgr = ContextBudgetManager(model="gpt-4o")
+        mgr.record(BudgetSliceType.system_prompt, "sys prompt")
+        mgr.add_checkpoint(0, "cp1")
+        d = mgr.to_dict()
+        assert d["model"] == "gpt-4o"
+        assert d["context_window"] == 128_000
+        assert d["slice_count"] == 1
+        assert d["checkpoint_count"] == 1
+        assert "consumption_by_type" in d
+        assert "tier_policies" in d
+        assert "should_compact" in d
+
+    def test_usable_budget_less_than_window(self):
+        mgr = ContextBudgetManager(context_window=100_000)
+        assert mgr.usable_budget < mgr.context_window
+        assert mgr.usable_budget == int(100_000 * 0.75)
+
+
+# ===================================================================
+# 10. Acceptance criterion: token-aware, not raw char limits
+# ===================================================================
+
+
+class TestAcceptanceCriterion:
+    """Validates the full acceptance criterion:
+
+    Context budgeting is token-aware or uses a bounded estimator
+    rather than raw char limits; tool-output truncation is
+    policy-driven by output tier; compaction supports incremental
+    summaries or checkpoints; main-agent and subagent paths share
+    a consistent budgeting model.
+    """
+
+    def test_token_aware_not_char_based(self):
+        """Budget tracking uses token estimates, not raw char counts."""
+        mgr = ContextBudgetManager(context_window=10_000)
+        content = "x" * 100  # 100 chars → ~25 tokens
+        bs = mgr.record(BudgetSliceType.tool_output, content)
+        assert bs.tokens == 25  # token estimate, not 100
+
+    def test_truncation_is_tier_driven(self):
+        """Different OutputTiers produce different truncation limits."""
+        mgr = ContextBudgetManager(context_window=100_000)
+        long_content = "data " * 5000  # ~25000 chars
+
+        results = {}
+        for tier in OutputTier:
+            results[tier] = mgr.truncate_output(long_content, tier)
+
+        # Minimal should be shortest, verbose longest
+        assert len(results[OutputTier.minimal]) < len(results[OutputTier.standard])
+        assert len(results[OutputTier.standard]) < len(results[OutputTier.verbose])
+
+    def test_compaction_supports_incremental_checkpoints(self):
+        """Multiple checkpoints build a sliding summary."""
+        mgr = ContextBudgetManager(context_window=10_000)
+        mgr.add_checkpoint(0, "Loaded dataset")
+        mgr.add_checkpoint(3, "Ran preprocessing")
+        mgr.add_checkpoint(6, "Completed clustering")
+
+        summary = mgr.build_sliding_summary()
+        assert "Loaded dataset" in summary
+        assert "Ran preprocessing" in summary
+        assert "Completed clustering" in summary
+        assert len(mgr.checkpoints) == 3
+
+    def test_main_and_subagent_share_model(self):
+        """Both paths use ContextBudgetManager with same API."""
+        main = ContextBudgetManager(model="gpt-4o")
+        sub = create_subagent_budget_manager(model="gpt-4o")
+
+        assert type(main) is type(sub)
+        assert main.context_window == sub.context_window
+
+        # Both can truncate, record, checkpoint
+        for mgr in (main, sub):
+            mgr.record(BudgetSliceType.system_prompt, "prompt")
+            result = mgr.truncate_output("x" * 50000, OutputTier.standard)
+            assert "truncated" in result
+            mgr.add_checkpoint(0, "test")
+            assert len(mgr.checkpoints) == 1
+
+    def test_overflow_policy_chosen_by_tier(self):
+        """Overflow policy is chosen by content tier, not a single
+        hard-coded constant — the core interface contract."""
+        mgr = ContextBudgetManager(context_window=100_000)
+
+        # Each tier has its own distinct policy
+        policies = {
+            tier: mgr.get_truncation_policy(tier) for tier in OutputTier
+        }
+        max_tokens_set = {p.max_tokens for p in policies.values()}
+        assert len(max_tokens_set) == len(OutputTier), (
+            "Each tier should have a distinct max_tokens limit"
+        )
+
+    def test_budget_records_tool_output_with_tier(self):
+        """Record method accepts tier parameter for tool outputs."""
+        mgr = ContextBudgetManager(context_window=100_000)
+        bs = mgr.record(
+            BudgetSliceType.tool_output,
+            "tool result data",
+            content_key="Read",
+            tier=OutputTier.standard,
+        )
+        assert bs.tier == OutputTier.standard
+        assert bs.slice_type == BudgetSliceType.tool_output
+
+
+# ===================================================================
+# 11. Export contract
+# ===================================================================
+
+
+class TestExportContract:
+    """Context budget types are exported from ovagent.__init__."""
+
+    def test_exports_available(self):
+        import omicverse.utils.ovagent as ovagent_pkg
+        for name in [
+            "BudgetSlice",
+            "BudgetSliceType",
+            "CompactionCheckpoint",
+            "ContextBudgetManager",
+            "TruncationPolicy",
+            "create_subagent_budget_manager",
+        ]:
+            assert name in ovagent_pkg.__all__, (
+                f"{name} missing from ovagent.__all__"
+            )
+            assert getattr(ovagent_pkg, name, None) is not None, (
+                f"{name} not importable from ovagent"
+            )

--- a/tests/utils/test_event_stream.py
+++ b/tests/utils/test_event_stream.py
@@ -1,0 +1,396 @@
+"""Tests for ovagent.event_stream — runtime observability contract.
+
+Verifies:
+  - RuntimeEventEmitter routes events through logger + harness sinks
+  - No print() calls remain in core runtime modules (turn_controller,
+    tool_runtime, subagent_controller)
+  - Bootstrap CLI banners are preserved and explicitly scoped
+  - Structured events cover dispatch, results, retries, and completion
+"""
+
+import ast
+import asyncio
+import importlib
+import importlib.machinery
+import importlib.util
+import inspect
+import logging
+import os
+import sys
+import types
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Guard: these tests require the harness env-var
+# ---------------------------------------------------------------------------
+
+_RUN_HARNESS = os.environ.get("OV_AGENT_RUN_HARNESS_TESTS", "").lower() in {
+    "1", "true", "yes", "on",
+}
+pytestmark = pytest.mark.skipif(
+    not _RUN_HARNESS,
+    reason="Observability contract tests require OV_AGENT_RUN_HARNESS_TESTS=1.",
+)
+
+# ---------------------------------------------------------------------------
+# Bootstrap: lightweight package stubs to avoid heavy omicverse.__init__
+# ---------------------------------------------------------------------------
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+PACKAGE_ROOT = PROJECT_ROOT / "omicverse"
+
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+_SAVED = {
+    name: sys.modules.get(name)
+    for name in ["omicverse", "omicverse.utils"]
+}
+for name in ["omicverse", "omicverse.utils"]:
+    sys.modules.pop(name, None)
+
+_ov_pkg = types.ModuleType("omicverse")
+_ov_pkg.__path__ = [str(PACKAGE_ROOT)]
+_ov_pkg.__spec__ = importlib.machinery.ModuleSpec(
+    "omicverse", loader=None, is_package=True
+)
+sys.modules["omicverse"] = _ov_pkg
+
+_utils_pkg = types.ModuleType("omicverse.utils")
+_utils_pkg.__path__ = [str(PACKAGE_ROOT / "utils")]
+_utils_pkg.__spec__ = importlib.machinery.ModuleSpec(
+    "omicverse.utils", loader=None, is_package=True
+)
+sys.modules["omicverse.utils"] = _utils_pkg
+_ov_pkg.utils = _utils_pkg
+
+# Now import the modules under test
+from omicverse.utils.ovagent.event_stream import (
+    RuntimeEventEmitter,
+    _summarize,
+)
+
+for name, mod in _SAVED.items():
+    if mod is None:
+        sys.modules.pop(name, None)
+    else:
+        sys.modules[name] = mod
+
+
+# ---------------------------------------------------------------------------
+# Paths to source modules for AST-level print detection
+# ---------------------------------------------------------------------------
+
+OVAGENT_DIR = PACKAGE_ROOT / "utils" / "ovagent"
+
+# Core runtime modules that MUST NOT contain print() calls
+RUNTIME_MODULES = [
+    OVAGENT_DIR / "turn_controller.py",
+    OVAGENT_DIR / "tool_runtime.py",
+    OVAGENT_DIR / "subagent_controller.py",
+]
+
+# CLI banner modules where print() is explicitly allowed
+CLI_BANNER_MODULES = [
+    OVAGENT_DIR / "bootstrap.py",
+    OVAGENT_DIR / "auth.py",
+]
+
+
+# ===========================================================================
+# 1. No print() in core runtime modules
+# ===========================================================================
+
+
+def _find_print_calls(filepath: Path) -> list[int]:
+    """Return line numbers of print() calls in *filepath* using AST."""
+    source = filepath.read_text()
+    tree = ast.parse(source, filename=str(filepath))
+    lines = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            func = node.func
+            # Direct call: print(...)
+            if isinstance(func, ast.Name) and func.id == "print":
+                lines.append(node.lineno)
+            # builtins.print(...)
+            if (
+                isinstance(func, ast.Attribute)
+                and func.attr == "print"
+                and isinstance(func.value, ast.Name)
+                and func.value.id == "builtins"
+            ):
+                lines.append(node.lineno)
+    return lines
+
+
+class TestNoPrintInRuntimeModules:
+    """Core runtime modules must not use print() for state reporting."""
+
+    @pytest.mark.parametrize(
+        "module_path",
+        RUNTIME_MODULES,
+        ids=[p.stem for p in RUNTIME_MODULES],
+    )
+    def test_no_print_calls(self, module_path: Path):
+        lines = _find_print_calls(module_path)
+        assert lines == [], (
+            f"{module_path.name} contains print() calls on lines {lines}. "
+            f"Runtime state must go through logger/event_stream, not stdout."
+        )
+
+
+class TestCLIBannersPreserved:
+    """Bootstrap and auth modules retain their CLI banner print() calls."""
+
+    @pytest.mark.parametrize(
+        "module_path",
+        CLI_BANNER_MODULES,
+        ids=[p.stem for p in CLI_BANNER_MODULES],
+    )
+    def test_cli_banners_exist(self, module_path: Path):
+        lines = _find_print_calls(module_path)
+        assert len(lines) > 0, (
+            f"{module_path.name} should retain CLI banner print() calls "
+            f"as non-authoritative human feedback."
+        )
+
+    def test_bootstrap_docstring_declares_cli_contract(self):
+        source = (OVAGENT_DIR / "bootstrap.py").read_text()
+        assert "CLI banner contract" in source, (
+            "bootstrap.py must explicitly declare its CLI banner contract "
+            "in the module docstring."
+        )
+
+
+# ===========================================================================
+# 2. RuntimeEventEmitter unit tests
+# ===========================================================================
+
+
+class TestRuntimeEventEmitter:
+    """Test the unified observability surface."""
+
+    def _run(self, coro):
+        return asyncio.run(coro)
+
+    def test_emit_logs_to_logger(self, caplog):
+        emitter = RuntimeEventEmitter(source="test")
+        with caplog.at_level(logging.INFO, logger="omicverse.utils.ovagent.event_stream"):
+            self._run(emitter.emit("status", {"key": "value"}, category="test_cat"))
+        assert any("runtime_event" in rec.message for rec in caplog.records)
+        assert any("source=test" in rec.message for rec in caplog.records)
+
+    def test_emit_records_to_trace(self):
+        recorder = MagicMock()
+        recorder.add_event = MagicMock()
+        emitter = RuntimeEventEmitter(recorder=recorder, source="test")
+        self._run(emitter.emit("status", "hello"))
+        recorder.add_event.assert_called_once()
+        event = recorder.add_event.call_args[0][0]
+        assert event["type"] == "status"
+
+    def test_emit_calls_event_callback(self):
+        captured = []
+
+        async def callback(event):
+            captured.append(event)
+
+        emitter = RuntimeEventEmitter(event_callback=callback, source="test")
+        self._run(emitter.emit("tool_call", {"name": "bash"}))
+        assert len(captured) == 1
+        assert captured[0]["type"] == "tool_call"
+
+    def test_emit_without_callback_or_recorder(self, caplog):
+        """Emitter works with no recorder or callback — logger only."""
+        emitter = RuntimeEventEmitter(source="bare")
+        with caplog.at_level(logging.INFO, logger="omicverse.utils.ovagent.event_stream"):
+            self._run(emitter.emit("status", "test"))
+        assert any("runtime_event" in rec.message for rec in caplog.records)
+
+    def test_emit_extra_merged(self):
+        captured = []
+
+        async def callback(event):
+            captured.append(event)
+
+        emitter = RuntimeEventEmitter(event_callback=callback, source="test")
+        self._run(
+            emitter.emit(
+                "done", "ok", extra={"cancelled": True}
+            )
+        )
+        assert captured[0]["cancelled"] is True
+
+    def test_turn_started(self, caplog):
+        emitter = RuntimeEventEmitter(source="test")
+        with caplog.at_level(logging.INFO, logger="omicverse.utils.ovagent.event_stream"):
+            self._run(emitter.turn_started(0, 15, "auto"))
+        assert any("turn_started" in rec.message for rec in caplog.records)
+        assert any("turn=1/15" in rec.message for rec in caplog.records)
+
+    def test_turn_cancelled(self):
+        captured = []
+
+        async def callback(event):
+            captured.append(event)
+
+        emitter = RuntimeEventEmitter(event_callback=callback, source="test")
+        self._run(emitter.turn_cancelled("before_llm_call"))
+        assert len(captured) == 1
+        assert captured[0]["type"] == "done"
+        assert captured[0].get("cancelled") is True
+
+    def test_max_turns_reached(self, caplog):
+        emitter = RuntimeEventEmitter(source="test")
+        with caplog.at_level(logging.WARNING, logger="omicverse.utils.ovagent.event_stream"):
+            self._run(emitter.max_turns_reached(15))
+        assert any("max_turns_reached" in rec.message for rec in caplog.records)
+
+    def test_tool_dispatched(self, caplog):
+        emitter = RuntimeEventEmitter(source="test")
+        with caplog.at_level(logging.INFO, logger="omicverse.utils.ovagent.event_stream"):
+            self._run(emitter.tool_dispatched("bash", {"command": "ls"}))
+        assert any("tool_dispatched" in rec.message for rec in caplog.records)
+        assert any("name=bash" in rec.message for rec in caplog.records)
+
+    def test_tool_completed(self, caplog):
+        emitter = RuntimeEventEmitter(source="test")
+        with caplog.at_level(logging.INFO, logger="omicverse.utils.ovagent.event_stream"):
+            self._run(emitter.tool_completed("bash", status="success"))
+        assert any("tool_completed" in rec.message for rec in caplog.records)
+
+    def test_execution_completed(self, caplog):
+        emitter = RuntimeEventEmitter(source="test")
+        with caplog.at_level(logging.INFO, logger="omicverse.utils.ovagent.event_stream"):
+            self._run(emitter.execution_completed("Run analysis"))
+        assert any("execution_completed" in rec.message for rec in caplog.records)
+
+    def test_delegation_completed(self, caplog):
+        emitter = RuntimeEventEmitter(source="test")
+        with caplog.at_level(logging.INFO, logger="omicverse.utils.ovagent.event_stream"):
+            self._run(emitter.delegation_completed("explore", task="find data"))
+        assert any("delegation" in rec.message for rec in caplog.records)
+
+    def test_task_finished(self, caplog):
+        emitter = RuntimeEventEmitter(source="test")
+        with caplog.at_level(logging.INFO, logger="omicverse.utils.ovagent.event_stream"):
+            self._run(emitter.task_finished("Analysis complete"))
+        assert any("task_finished" in rec.message for rec in caplog.records)
+
+    def test_subagent_turn(self, caplog):
+        emitter = RuntimeEventEmitter(source="test")
+        with caplog.at_level(logging.INFO, logger="omicverse.utils.ovagent.event_stream"):
+            self._run(emitter.subagent_turn("explore", 0, 5))
+        assert any("subagent_turn" in rec.message for rec in caplog.records)
+
+    def test_subagent_tool(self, caplog):
+        emitter = RuntimeEventEmitter(source="test")
+        with caplog.at_level(logging.INFO, logger="omicverse.utils.ovagent.event_stream"):
+            self._run(emitter.subagent_tool("explore", "bash", {"command": "ls"}))
+        assert any("subagent_tool" in rec.message for rec in caplog.records)
+
+    def test_subagent_finished(self, caplog):
+        emitter = RuntimeEventEmitter(source="test")
+        with caplog.at_level(logging.INFO, logger="omicverse.utils.ovagent.event_stream"):
+            self._run(emitter.subagent_finished("explore", "Found 3 files"))
+        assert any("subagent_finished" in rec.message for rec in caplog.records)
+
+    def test_conversation_log_saved(self, caplog):
+        emitter = RuntimeEventEmitter(source="test")
+        with caplog.at_level(logging.INFO, logger="omicverse.utils.ovagent.event_stream"):
+            emitter.conversation_log_saved("/tmp/test.json")
+        assert any("conversation_log_saved" in rec.message for rec in caplog.records)
+
+    def test_agent_response(self, caplog):
+        emitter = RuntimeEventEmitter(source="test")
+        with caplog.at_level(logging.INFO, logger="omicverse.utils.ovagent.event_stream"):
+            self._run(emitter.agent_response("Here is the result"))
+        assert any("agent_response" in rec.message for rec in caplog.records)
+
+
+# ===========================================================================
+# 3. _summarize helper
+# ===========================================================================
+
+
+class TestSummarize:
+    def test_none(self):
+        assert _summarize(None) == "-"
+
+    def test_string(self):
+        assert _summarize("hello") == "hello"
+
+    def test_long_string_truncated(self):
+        long = "x" * 200
+        assert len(_summarize(long)) <= 120
+
+    def test_dict_shows_keys(self):
+        result = _summarize({"name": "bash", "args": {}})
+        assert "name" in result
+        assert "args" in result
+
+    def test_other_type(self):
+        assert _summarize(42) == "42"
+
+
+# ===========================================================================
+# 4. Export contract — RuntimeEventEmitter in __init__.py
+# ===========================================================================
+
+
+class TestExportContract:
+    def test_event_emitter_exported(self):
+        import omicverse.utils.ovagent as pkg
+        assert hasattr(pkg, "RuntimeEventEmitter")
+        assert pkg.RuntimeEventEmitter is RuntimeEventEmitter
+
+    def test_event_emitter_in_all(self):
+        import omicverse.utils.ovagent as pkg
+        assert "RuntimeEventEmitter" in pkg.__all__
+
+
+# ===========================================================================
+# 5. Observability coherence — structured events cover all lifecycle phases
+# ===========================================================================
+
+
+class TestObservabilityCoherence:
+    """Verify that the emitter covers all required lifecycle phases."""
+
+    REQUIRED_METHODS = [
+        "turn_started",
+        "turn_cancelled",
+        "max_turns_reached",
+        "tool_dispatched",
+        "tool_completed",
+        "execution_completed",
+        "delegation_completed",
+        "task_finished",
+        "subagent_turn",
+        "subagent_tool",
+        "subagent_finished",
+        "agent_response",
+        "conversation_log_saved",
+    ]
+
+    def test_emitter_has_all_lifecycle_methods(self):
+        for method_name in self.REQUIRED_METHODS:
+            assert hasattr(RuntimeEventEmitter, method_name), (
+                f"RuntimeEventEmitter missing required method: {method_name}"
+            )
+            method = getattr(RuntimeEventEmitter, method_name)
+            assert callable(method), (
+                f"RuntimeEventEmitter.{method_name} is not callable"
+            )
+
+    def test_emitter_methods_are_documented(self):
+        for method_name in self.REQUIRED_METHODS:
+            method = getattr(RuntimeEventEmitter, method_name)
+            assert method.__doc__, (
+                f"RuntimeEventEmitter.{method_name} lacks a docstring"
+            )

--- a/tests/utils/test_ovagent_tool_runtime.py
+++ b/tests/utils/test_ovagent_tool_runtime.py
@@ -391,3 +391,178 @@ class TestSmartAgentDelegation:
             assert not hasattr(OmicVerseAgent, name), (
                 f"OmicVerseAgent still has {name} — should be removed"
             )
+
+
+# -----------------------------------------------------------------------
+# Task-025: Registry-driven dispatch tests
+# -----------------------------------------------------------------------
+
+
+class TestRegistryDrivenDispatch:
+    """Registry-driven dispatch preserves canonical names, aliases, and behavior."""
+
+    def _make_rt(self):
+        ctx = _DummyCtx()
+        return ToolRuntime(ctx, _DummyExecutor())
+
+    def test_registry_is_initialized(self):
+        rt = self._make_rt()
+        assert rt.registry is not None
+        entries = rt.registry.all_entries()
+        assert len(entries) > 0
+
+    def test_all_handler_keys_are_bound(self):
+        rt = self._make_rt()
+        unresolved = rt.registry.validate_handlers()
+        assert unresolved == [], f"Unresolved handler keys: {unresolved}"
+
+    def test_canonical_catalog_tools_resolve(self):
+        rt = self._make_rt()
+        for name in [
+            "ToolSearch", "Bash", "Read", "Edit", "Write", "Glob", "Grep",
+            "NotebookEdit", "Agent", "AskUserQuestion", "EnterPlanMode",
+            "ExitPlanMode", "EnterWorktree", "Skill", "WebFetch",
+            "WebSearch", "ListMcpResourcesTool", "ReadMcpResourceTool",
+        ]:
+            canonical = rt.registry.resolve_name(name)
+            assert canonical == name, f"{name} did not resolve to itself"
+            handler = rt.registry.get_handler(name)
+            assert handler is not None, f"No handler for {name}"
+
+    def test_legacy_tools_resolve(self):
+        rt = self._make_rt()
+        for name in [
+            "inspect_data", "execute_code", "run_snippet",
+            "search_functions", "web_download", "finish",
+        ]:
+            canonical = rt.registry.resolve_name(name)
+            assert canonical == name, f"Legacy tool {name} did not resolve"
+            handler = rt.registry.get_handler(name)
+            assert handler is not None, f"No handler for legacy tool {name}"
+
+    def test_legacy_aliases_resolve_to_catalog_tools(self):
+        rt = self._make_rt()
+        assert rt.registry.resolve_name("delegate") == "Agent"
+        assert rt.registry.resolve_name("web_fetch") == "WebFetch"
+        assert rt.registry.resolve_name("web_search") == "WebSearch"
+        assert rt.registry.resolve_name("search_skills") == "Skill"
+
+    def test_case_insensitive_resolution(self):
+        rt = self._make_rt()
+        assert rt.registry.resolve_name("bash") == "Bash"
+        assert rt.registry.resolve_name("read") == "Read"
+
+    def test_dispatch_tool_search_via_registry(self):
+        rt = self._make_rt()
+        tc = SimpleNamespace(name="ToolSearch", arguments={"query": "select:Edit"})
+        result = asyncio.run(rt.dispatch_tool(tc, None, "test"))
+        parsed = json.loads(result)
+        assert "Edit" in parsed.get("selected_tools", [])
+
+    def test_dispatch_finish_via_registry(self):
+        rt = self._make_rt()
+        tc = SimpleNamespace(name="finish", arguments={"summary": "all done"})
+        result = asyncio.run(rt.dispatch_tool(tc, None, "test"))
+        assert result == {"finished": True, "summary": "all done"}
+
+    def test_dispatch_unknown_tool_via_registry(self):
+        rt = self._make_rt()
+        tc = SimpleNamespace(name="nonexistent_tool_xyz", arguments={})
+        result = asyncio.run(rt.dispatch_tool(tc, None, "test"))
+        assert "Unknown tool" in result
+
+    def test_dispatch_inspect_data_passes_adata(self):
+        rt = self._make_rt()
+        tc = SimpleNamespace(name="inspect_data", arguments={"aspect": "shape"})
+        result = asyncio.run(rt.dispatch_tool(tc, None, "test"))
+        assert "No dataset" in result
+
+    def test_dispatch_execute_code_empty_validation(self):
+        rt = self._make_rt()
+        tc = SimpleNamespace(
+            name="execute_code", arguments={"code": "", "description": ""}
+        )
+        result = asyncio.run(rt.dispatch_tool(tc, None, "test"))
+        parsed = json.loads(result)
+        assert "error" in parsed
+
+    def test_dispatch_run_snippet_empty_validation(self):
+        rt = self._make_rt()
+        tc = SimpleNamespace(name="run_snippet", arguments={"code": "  "})
+        result = asyncio.run(rt.dispatch_tool(tc, None, "test"))
+        parsed = json.loads(result)
+        assert "error" in parsed
+
+    def test_dispatch_ask_user_question_empty_validation(self):
+        rt = self._make_rt()
+        tc = SimpleNamespace(name="AskUserQuestion", arguments={})
+        result = asyncio.run(rt.dispatch_tool(tc, None, "test"))
+        parsed = json.loads(result)
+        assert "error" in parsed
+
+    def test_plan_mode_blocking_via_registry_dispatch(self):
+        ctx = _DummyCtx()
+        rt = ToolRuntime(ctx, _DummyExecutor())
+        sid = ctx._session_id
+        runtime_state.enter_plan_mode(sid, reason="test")
+        try:
+            tc = SimpleNamespace(name="Bash", arguments={"command": "ls"})
+            result = asyncio.run(rt.dispatch_tool(tc, None, "test"))
+            assert "plan mode" in result.lower()
+        finally:
+            runtime_state.exit_plan_mode(sid, reason="cleanup")
+
+    def test_plan_mode_blocking_legacy_tools_via_registry(self):
+        ctx = _DummyCtx()
+        rt = ToolRuntime(ctx, _DummyExecutor())
+        sid = ctx._session_id
+        runtime_state.enter_plan_mode(sid, reason="test")
+        try:
+            tc = SimpleNamespace(
+                name="execute_code",
+                arguments={"code": "x=1", "description": "test"},
+            )
+            result = asyncio.run(rt.dispatch_tool(tc, None, "test"))
+            assert "plan mode" in result.lower()
+        finally:
+            runtime_state.exit_plan_mode(sid, reason="cleanup")
+
+    def test_agent_dispatch_via_registry_without_controller_raises(self):
+        rt = self._make_rt()
+        tc = SimpleNamespace(
+            name="Agent",
+            arguments={"agent_type": "explore", "task": "inspect this"},
+        )
+        with pytest.raises(RuntimeError, match="Subagent controller"):
+            asyncio.run(rt.dispatch_tool(tc, None, "test"))
+
+    def test_dispatch_search_functions_via_registry(self, monkeypatch):
+        rt = self._make_rt()
+        fake_registry = SimpleNamespace(find=lambda query: [])
+        monkeypatch.setattr(tool_runtime_module, "_global_registry", fake_registry)
+        tc = SimpleNamespace(
+            name="search_functions", arguments={"query": "dynamo"}
+        )
+        result = asyncio.run(rt.dispatch_tool(tc, None, "test"))
+        assert "dynamo" in result.lower()
+
+    def test_dispatch_via_legacy_alias_delegate(self):
+        """Dispatching 'delegate' resolves through the registry to Agent."""
+        rt = self._make_rt()
+        tc = SimpleNamespace(
+            name="delegate",
+            arguments={"agent_type": "explore", "task": "test"},
+        )
+        # Should resolve to Agent and fail without controller
+        with pytest.raises(RuntimeError, match="Subagent controller"):
+            asyncio.run(rt.dispatch_tool(tc, None, "test"))
+
+    def test_handler_count_matches_registered_entries(self):
+        rt = self._make_rt()
+        entries = rt.registry.all_entries()
+        bound_keys = set()
+        for meta in entries:
+            handler = rt.registry.get_handler(meta.canonical_name)
+            if handler is not None:
+                bound_keys.add(meta.handler_key)
+        assert bound_keys == rt.registry.handler_keys()

--- a/tests/utils/test_permission_policy.py
+++ b/tests/utils/test_permission_policy.py
@@ -1,0 +1,790 @@
+"""Tests for subagent isolation and per-tool permission policy (task-029).
+
+Covers:
+  - PermissionPolicy verdict resolution (allow/ask/deny)
+  - Per-tool and per-class overrides
+  - Allowlist and denylist enforcement
+  - Unknown tool fallback
+  - Subagent policy factory (create_subagent_policy)
+  - SubagentRuntime isolation properties
+  - dispatch_tool permission_policy integration
+  - Isolation: subagent does NOT mutate parent state
+  - High-risk tools and isolation modes are explicit in metadata
+"""
+
+import asyncio
+import importlib
+import importlib.machinery
+import importlib.util
+import os
+import sys
+import types
+from contextlib import contextmanager
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Guard: require harness env-var
+# ---------------------------------------------------------------------------
+
+_RUN_HARNESS = os.environ.get("OV_AGENT_RUN_HARNESS_TESTS", "").lower() in {
+    "1", "true", "yes", "on",
+}
+pytestmark = pytest.mark.skipif(
+    not _RUN_HARNESS,
+    reason="Permission policy tests require OV_AGENT_RUN_HARNESS_TESTS=1.",
+)
+
+# ---------------------------------------------------------------------------
+# Bootstrap: lightweight package stubs
+# ---------------------------------------------------------------------------
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+PACKAGE_ROOT = PROJECT_ROOT / "omicverse"
+
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+_SAVED = {
+    name: sys.modules.get(name)
+    for name in ["omicverse", "omicverse.utils"]
+}
+for name in ["omicverse", "omicverse.utils"]:
+    sys.modules.pop(name, None)
+
+_ov_pkg = types.ModuleType("omicverse")
+_ov_pkg.__path__ = [str(PACKAGE_ROOT)]
+_ov_pkg.__spec__ = importlib.machinery.ModuleSpec(
+    "omicverse", loader=None, is_package=True
+)
+sys.modules["omicverse"] = _ov_pkg
+
+_utils_pkg = types.ModuleType("omicverse.utils")
+_utils_pkg.__path__ = [str(PACKAGE_ROOT / "utils")]
+_utils_pkg.__spec__ = importlib.machinery.ModuleSpec(
+    "omicverse.utils", loader=None, is_package=True
+)
+sys.modules["omicverse.utils"] = _utils_pkg
+_ov_pkg.utils = _utils_pkg
+
+from omicverse.utils.ovagent import (
+    PermissionDecision,
+    PermissionPolicy,
+    PermissionVerdict,
+    SubagentController,
+    SubagentRuntime,
+    ToolRuntime,
+    create_default_policy,
+    create_subagent_policy,
+)
+from omicverse.utils.ovagent.permission_policy import (
+    PermissionDecision as _PD,
+    PermissionPolicy as _PP,
+    PermissionVerdict as _PV,
+)
+from omicverse.utils.ovagent.tool_registry import (
+    ApprovalClass,
+    IsolationMode,
+    OutputTier,
+    ParallelClass,
+    ToolMetadata,
+    ToolRegistry,
+    build_default_registry,
+)
+from omicverse.utils.ovagent.tool_runtime import LEGACY_AGENT_TOOLS
+from omicverse.utils.ovagent.context_budget import create_subagent_budget_manager
+
+for name, mod in _SAVED.items():
+    if mod is None:
+        sys.modules.pop(name, None)
+    else:
+        sys.modules[name] = mod
+
+
+# ---------------------------------------------------------------------------
+# Minimal test doubles
+# ---------------------------------------------------------------------------
+
+class _DummyCtx:
+    """Minimal AgentContext stub."""
+
+    LEGACY_AGENT_TOOLS = LEGACY_AGENT_TOOLS
+
+    def __init__(self, session_id="test-perm-session"):
+        self.model = "test-model"
+        self.provider = "openai"
+        self.endpoint = "https://api.example.com"
+        self.api_key = None
+        self._llm = None
+        self._config = SimpleNamespace()
+        self._security_config = SimpleNamespace()
+        self._security_scanner = SimpleNamespace()
+        self._filesystem_context = None
+        self.skill_registry = None
+        self._notebook_executor = None
+        self._ov_runtime = None
+        self._trace_store = None
+        self._session_history = None
+        self._context_compactor = None
+        self._approval_handler = None
+        self._reporter = MagicMock()
+        self.last_usage = None
+        self.last_usage_breakdown = {}
+        self._last_run_trace = None
+        self._active_run_id = ""
+        self._web_session_id = session_id
+        self._managed_api_env = {}
+        self._code_only_mode = False
+        self._code_only_captured_code = ""
+        self._code_only_captured_history = []
+        self.use_notebook_execution = False
+        self.enable_filesystem_context = False
+
+    def _get_runtime_session_id(self):
+        return self._web_session_id
+
+    def _emit(self, level, message, category=""):
+        pass
+
+    def _get_harness_session_id(self):
+        return self._web_session_id
+
+    def _get_visible_agent_tools(self, *, allowed_names=None):
+        return []
+
+    def _get_loaded_tool_names(self):
+        return []
+
+    def _refresh_runtime_working_directory(self):
+        return "."
+
+    def _tool_blocked_in_plan_mode(self, tool_name):
+        return False
+
+    def _detect_repo_root(self, cwd=None):
+        return None
+
+    def _resolve_local_path(self, file_path, *, allow_relative=False):
+        raise NotImplementedError
+
+    def _ensure_server_tool_mode(self, tool_name):
+        pass
+
+    def _request_interaction(self, payload):
+        raise NotImplementedError
+
+    def _request_tool_approval(self, tool_name, *, reason, payload):
+        raise NotImplementedError
+
+    def _load_skill_guidance(self, slug):
+        return ""
+
+    def _extract_python_code(self, text):
+        return text
+
+    def _normalize_registry_entry_for_codegen(self, entry):
+        return entry
+
+    def _build_agentic_system_prompt(self):
+        return "test"
+
+    async def _run_agentic_loop(self, request, adata, **kwargs):
+        return adata
+
+    @contextmanager
+    def _temporary_api_keys(self):
+        yield
+
+
+class _DummyExecutor:
+    pass
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def registry():
+    return build_default_registry()
+
+
+@pytest.fixture
+def default_policy(registry):
+    return create_default_policy(registry)
+
+
+# ===================================================================
+# 1. PermissionVerdict enum
+# ===================================================================
+
+class TestPermissionVerdict:
+
+    def test_verdict_values(self):
+        assert PermissionVerdict.allow == "allow"
+        assert PermissionVerdict.ask == "ask"
+        assert PermissionVerdict.deny == "deny"
+
+    def test_verdict_is_string_enum(self):
+        assert isinstance(PermissionVerdict.allow, str)
+
+
+# ===================================================================
+# 2. PermissionDecision
+# ===================================================================
+
+class TestPermissionDecision:
+
+    def test_is_allowed(self):
+        d = PermissionDecision(
+            verdict=PermissionVerdict.allow, tool_name="Read"
+        )
+        assert d.is_allowed is True
+        assert d.is_denied is False
+
+    def test_is_denied(self):
+        d = PermissionDecision(
+            verdict=PermissionVerdict.deny, tool_name="Bash"
+        )
+        assert d.is_denied is True
+        assert d.is_allowed is False
+
+    def test_ask_is_neither_allowed_nor_denied(self):
+        d = PermissionDecision(
+            verdict=PermissionVerdict.ask, tool_name="Edit"
+        )
+        assert d.is_allowed is False
+        assert d.is_denied is False
+
+    def test_to_dict(self):
+        d = PermissionDecision(
+            verdict=PermissionVerdict.deny,
+            tool_name="Bash",
+            reason="test reason",
+            requires_isolation=IsolationMode.sandbox,
+        )
+        as_dict = d.to_dict()
+        assert as_dict["verdict"] == "deny"
+        assert as_dict["tool_name"] == "Bash"
+        assert as_dict["reason"] == "test reason"
+        assert as_dict["requires_isolation"] == "sandbox"
+
+    def test_frozen(self):
+        d = PermissionDecision(
+            verdict=PermissionVerdict.allow, tool_name="Read"
+        )
+        with pytest.raises(AttributeError):
+            d.verdict = PermissionVerdict.deny  # type: ignore[misc]
+
+
+# ===================================================================
+# 3. PermissionPolicy — registry defaults
+# ===================================================================
+
+class TestPermissionPolicyRegistryDefaults:
+
+    def test_readonly_tools_are_allowed(self, default_policy):
+        for name in ["Read", "Glob", "Grep", "ToolSearch"]:
+            decision = default_policy.check(name)
+            assert decision.verdict == PermissionVerdict.allow, (
+                f"Expected {name} to be allowed"
+            )
+
+    def test_high_risk_tools_are_ask(self, default_policy):
+        for name in ["Bash", "Edit", "Write"]:
+            decision = default_policy.check(name)
+            assert decision.verdict == PermissionVerdict.ask, (
+                f"Expected {name} to be ask"
+            )
+
+    def test_execute_code_requires_sandbox(self, default_policy):
+        decision = default_policy.check("execute_code")
+        assert decision.verdict == PermissionVerdict.ask
+        assert decision.requires_isolation == IsolationMode.sandbox
+
+    def test_unknown_tool_is_denied(self, default_policy):
+        decision = default_policy.check("nonexistent_tool_xyz")
+        assert decision.is_denied
+        assert "unknown tool" in decision.reason
+
+    def test_registry_property(self, default_policy, registry):
+        assert default_policy.registry is registry
+
+    def test_reason_populated(self, default_policy):
+        decision = default_policy.check("Read")
+        assert decision.reason != ""
+
+
+# ===================================================================
+# 4. PermissionPolicy — deny list
+# ===================================================================
+
+class TestPermissionPolicyDenyList:
+
+    def test_denied_tool_overrides_registry(self, registry):
+        policy = PermissionPolicy(
+            registry,
+            denied_tools=frozenset({"Read"}),
+        )
+        decision = policy.check("Read")
+        assert decision.is_denied
+        assert "deny list" in decision.reason
+
+    def test_denied_tool_overrides_allowlist(self, registry):
+        policy = PermissionPolicy(
+            registry,
+            denied_tools=frozenset({"Read"}),
+            allowed_tools=frozenset({"Read", "Glob"}),
+        )
+        decision = policy.check("Read")
+        assert decision.is_denied
+
+
+# ===================================================================
+# 5. PermissionPolicy — allowlist
+# ===================================================================
+
+class TestPermissionPolicyAllowlist:
+
+    def test_tool_not_in_allowlist_is_denied(self, registry):
+        policy = PermissionPolicy(
+            registry,
+            allowed_tools=frozenset({"Read", "Glob"}),
+        )
+        decision = policy.check("Bash")
+        assert decision.is_denied
+        assert "not in the allowed set" in decision.reason
+
+    def test_tool_in_allowlist_passes_through(self, registry):
+        policy = PermissionPolicy(
+            registry,
+            allowed_tools=frozenset({"Read", "Glob"}),
+        )
+        decision = policy.check("Read")
+        assert decision.is_allowed
+
+    def test_none_allowlist_means_all_allowed(self, registry):
+        policy = PermissionPolicy(registry, allowed_tools=None)
+        decision = policy.check("Read")
+        assert decision.is_allowed
+
+
+# ===================================================================
+# 6. PermissionPolicy — per-tool overrides
+# ===================================================================
+
+class TestPermissionPolicyToolOverrides:
+
+    def test_per_tool_override_changes_verdict(self, registry):
+        policy = PermissionPolicy(
+            registry,
+            tool_overrides={"Read": ApprovalClass.deny},
+        )
+        decision = policy.check("Read")
+        assert decision.is_denied
+        assert "per-tool override" in decision.reason
+
+    def test_per_tool_override_to_allow(self, registry):
+        policy = PermissionPolicy(
+            registry,
+            tool_overrides={"Bash": ApprovalClass.allow},
+        )
+        decision = policy.check("Bash")
+        assert decision.is_allowed
+
+
+# ===================================================================
+# 7. PermissionPolicy — per-class overrides
+# ===================================================================
+
+class TestPermissionPolicyClassOverrides:
+
+    def test_class_override_affects_all_tools_in_class(self, registry):
+        policy = PermissionPolicy(
+            registry,
+            class_overrides={ApprovalClass.ask: PermissionVerdict.deny},
+        )
+        # Bash has ApprovalClass.ask in registry
+        decision = policy.check("Bash")
+        assert decision.is_denied
+        assert "class override" in decision.reason
+
+    def test_class_override_does_not_affect_other_classes(self, registry):
+        policy = PermissionPolicy(
+            registry,
+            class_overrides={ApprovalClass.ask: PermissionVerdict.deny},
+        )
+        # Read has ApprovalClass.allow — unaffected
+        decision = policy.check("Read")
+        assert decision.is_allowed
+
+
+# ===================================================================
+# 8. PermissionPolicy — unknown tool default
+# ===================================================================
+
+class TestPermissionPolicyUnknownDefault:
+
+    def test_unknown_default_deny(self, registry):
+        policy = PermissionPolicy(
+            registry,
+            unknown_tool_default=PermissionVerdict.deny,
+        )
+        decision = policy.check("imaginary_tool")
+        assert decision.is_denied
+
+    def test_unknown_default_ask(self, registry):
+        policy = PermissionPolicy(
+            registry,
+            unknown_tool_default=PermissionVerdict.ask,
+        )
+        decision = policy.check("imaginary_tool")
+        assert decision.verdict == PermissionVerdict.ask
+
+
+# ===================================================================
+# 9. Policy summary
+# ===================================================================
+
+class TestPermissionPolicySummary:
+
+    def test_summary_includes_all_registered_tools(self, default_policy, registry):
+        summary = default_policy.summary()
+        for entry in registry.all_entries():
+            assert entry.canonical_name in summary
+
+    def test_summary_values_are_strings(self, default_policy):
+        summary = default_policy.summary()
+        for v in summary.values():
+            assert isinstance(v, str)
+
+
+# ===================================================================
+# 10. create_subagent_policy factory
+# ===================================================================
+
+class TestCreateSubagentPolicy:
+
+    def test_only_allowed_tools_pass(self, registry):
+        policy = create_subagent_policy(
+            registry,
+            allowed_tools=frozenset({"inspect_data", "finish"}),
+        )
+        assert policy.check("inspect_data").is_allowed
+        assert policy.check("finish").is_allowed
+        assert policy.check("Bash").is_denied
+        assert policy.check("execute_code").is_denied
+
+    def test_unknown_tools_denied(self, registry):
+        policy = create_subagent_policy(
+            registry,
+            allowed_tools=frozenset({"Read"}),
+        )
+        assert policy.check("nonexistent").is_denied
+
+    def test_explore_subagent_tool_set(self, registry):
+        explore_tools = frozenset({
+            "inspect_data", "run_snippet", "search_functions",
+            "web_fetch", "web_search", "finish",
+        })
+        policy = create_subagent_policy(registry, allowed_tools=explore_tools)
+        for tool in explore_tools:
+            decision = policy.check(tool)
+            assert not decision.is_denied, f"{tool} should not be denied"
+        # execute_code NOT in explore set
+        assert policy.check("execute_code").is_denied
+        assert policy.check("Bash").is_denied
+
+
+# ===================================================================
+# 11. create_default_policy factory
+# ===================================================================
+
+class TestCreateDefaultPolicy:
+
+    def test_returns_permission_policy(self, registry):
+        policy = create_default_policy(registry)
+        assert isinstance(policy, PermissionPolicy)
+
+    def test_default_policy_matches_registry_metadata(self, registry):
+        policy = create_default_policy(registry)
+        for entry in registry.all_entries():
+            decision = policy.check(entry.canonical_name)
+            expected = PermissionVerdict(entry.approval_class.value)
+            assert decision.verdict == expected, (
+                f"{entry.canonical_name}: expected {expected}, got {decision.verdict}"
+            )
+
+
+# ===================================================================
+# 12. SubagentRuntime isolation
+# ===================================================================
+
+class TestSubagentRuntime:
+
+    def _make_runtime(self, registry, allowed=None):
+        allowed = allowed or frozenset({"inspect_data", "finish"})
+        policy = create_subagent_policy(registry, allowed_tools=allowed)
+        budget = create_subagent_budget_manager(model="test")
+        return SubagentRuntime(
+            agent_type="explore",
+            max_turns=5,
+            permission_policy=policy,
+            budget_manager=budget,
+            tool_schemas=[{"name": "inspect_data"}, {"name": "finish"}],
+        )
+
+    def test_construction(self, registry):
+        rt = self._make_runtime(registry)
+        assert rt.agent_type == "explore"
+        assert rt.max_turns == 5
+        assert rt.last_usage is None
+
+    def test_record_usage_is_local(self, registry):
+        rt = self._make_runtime(registry)
+        rt.record_usage({"prompt_tokens": 100, "completion_tokens": 50})
+        assert rt.last_usage == {"prompt_tokens": 100, "completion_tokens": 50}
+
+    def test_check_tool_permission_allowed(self, registry):
+        rt = self._make_runtime(registry)
+        decision = rt.check_tool_permission("inspect_data")
+        assert not decision.is_denied
+
+    def test_check_tool_permission_denied(self, registry):
+        rt = self._make_runtime(registry)
+        decision = rt.check_tool_permission("Bash")
+        assert decision.is_denied
+
+    def test_can_mutate_adata_default_false(self, registry):
+        rt = self._make_runtime(registry)
+        assert rt.can_mutate_adata is False
+
+    def test_tool_schemas_are_snapshot(self, registry):
+        rt = self._make_runtime(registry)
+        original_len = len(rt.tool_schemas)
+        rt.tool_schemas.append({"name": "injected"})
+        assert len(rt.tool_schemas) == original_len + 1
+        # A new runtime gets a fresh list
+        rt2 = self._make_runtime(registry)
+        assert len(rt2.tool_schemas) == original_len
+
+
+# ===================================================================
+# 13. dispatch_tool with permission_policy
+# ===================================================================
+
+class TestDispatchToolPermission:
+
+    def _make_runtime(self):
+        ctx = _DummyCtx()
+        rt = ToolRuntime(ctx, _DummyExecutor())
+        return rt
+
+    def test_dispatch_without_policy_works(self):
+        rt = self._make_runtime()
+        tc = SimpleNamespace(name="finish", id="tc-1", arguments={"summary": "done"})
+        result = asyncio.run(rt.dispatch_tool(tc, None, "test"))
+        # finish handler returns a dict
+        assert isinstance(result, (str, dict))
+
+    def test_dispatch_with_allow_policy_works(self):
+        rt = self._make_runtime()
+        policy = create_default_policy(rt.registry)
+        tc = SimpleNamespace(name="finish", id="tc-1", arguments={"summary": "done"})
+        result = asyncio.run(
+            rt.dispatch_tool(tc, None, "test", permission_policy=policy)
+        )
+        assert isinstance(result, (str, dict))
+
+    def test_dispatch_with_deny_policy_blocks(self):
+        rt = self._make_runtime()
+        policy = PermissionPolicy(
+            rt.registry,
+            denied_tools=frozenset({"finish"}),
+        )
+        tc = SimpleNamespace(name="finish", id="tc-1", arguments={"summary": "done"})
+        result = asyncio.run(
+            rt.dispatch_tool(tc, None, "test", permission_policy=policy)
+        )
+        assert isinstance(result, str)
+        assert "Permission denied" in result
+
+    def test_dispatch_subagent_policy_restricts_tools(self):
+        rt = self._make_runtime()
+        policy = create_subagent_policy(
+            rt.registry,
+            allowed_tools=frozenset({"inspect_data"}),
+        )
+        # finish not in allowed set → denied
+        tc = SimpleNamespace(name="finish", id="tc-1", arguments={"summary": "done"})
+        result = asyncio.run(
+            rt.dispatch_tool(tc, None, "test", permission_policy=policy)
+        )
+        assert "Permission denied" in result
+
+
+# ===================================================================
+# 14. Subagent does NOT mutate parent state
+# ===================================================================
+
+class TestSubagentIsolationFromParent:
+
+    def test_subagent_runtime_does_not_share_parent_usage(self, registry):
+        ctx = _DummyCtx()
+        ctx.last_usage = {"prompt_tokens": 999}
+
+        rt = SubagentRuntime(
+            agent_type="explore",
+            max_turns=3,
+            permission_policy=create_subagent_policy(
+                registry, frozenset({"finish"})
+            ),
+            budget_manager=create_subagent_budget_manager(model="test"),
+        )
+        rt.record_usage({"prompt_tokens": 42})
+
+        # Parent unchanged
+        assert ctx.last_usage == {"prompt_tokens": 999}
+        # Subagent has its own
+        assert rt.last_usage == {"prompt_tokens": 42}
+
+    def test_subagent_controller_creates_isolated_runtime(self, registry):
+        ctx = _DummyCtx()
+        from omicverse.utils.ovagent.prompt_builder import PromptBuilder
+
+        pb = PromptBuilder(ctx)
+        rt = ToolRuntime(ctx, _DummyExecutor())
+        sc = SubagentController(ctx, pb, rt)
+
+        subagent_rt = sc._create_subagent_runtime(
+            agent_type="explore",
+            allowed_tools=frozenset({"inspect_data", "finish"}),
+            max_turns=5,
+        )
+        assert isinstance(subagent_rt, SubagentRuntime)
+        assert subagent_rt.agent_type == "explore"
+        assert subagent_rt.max_turns == 5
+        assert subagent_rt.can_mutate_adata is False
+        assert subagent_rt.last_usage is None
+
+
+# ===================================================================
+# 15. High-risk tools and isolation modes are explicit in metadata
+# ===================================================================
+
+class TestHighRiskToolMetadata:
+
+    def test_execute_code_is_ask_and_sandbox(self, registry):
+        meta = registry.get("execute_code")
+        assert meta is not None
+        assert meta.approval_class == ApprovalClass.ask
+        assert meta.isolation_mode == IsolationMode.sandbox
+
+    def test_bash_is_ask_and_sandbox(self, registry):
+        meta = registry.get("Bash")
+        assert meta is not None
+        assert meta.approval_class == ApprovalClass.ask
+        assert meta.isolation_mode == IsolationMode.sandbox
+
+    def test_enter_worktree_is_ask_and_worktree(self, registry):
+        meta = registry.get("EnterWorktree")
+        assert meta is not None
+        assert meta.approval_class == ApprovalClass.ask
+        assert meta.isolation_mode == IsolationMode.worktree
+
+    def test_read_only_tools_have_no_isolation(self, registry):
+        for name in ["Read", "Glob", "Grep", "ToolSearch"]:
+            meta = registry.get(name)
+            assert meta is not None
+            assert meta.isolation_mode == IsolationMode.none, (
+                f"{name} should have no isolation requirement"
+            )
+
+    def test_all_registered_tools_have_explicit_isolation(self, registry):
+        for entry in registry.all_entries():
+            assert isinstance(entry.isolation_mode, IsolationMode), (
+                f"{entry.canonical_name} missing IsolationMode"
+            )
+            assert isinstance(entry.approval_class, ApprovalClass), (
+                f"{entry.canonical_name} missing ApprovalClass"
+            )
+
+
+# ===================================================================
+# 16. Exports contract
+# ===================================================================
+
+class TestExportsContract:
+
+    def test_permission_types_in_ovagent_all(self):
+        import omicverse.utils.ovagent as pkg
+        all_names = set(pkg.__all__)
+        expected = {
+            "PermissionDecision", "PermissionPolicy", "PermissionVerdict",
+            "SubagentRuntime",
+            "create_default_policy", "create_subagent_policy",
+        }
+        missing = expected - all_names
+        assert not missing, f"Missing from __all__: {missing}"
+
+    def test_permission_types_importable(self):
+        from omicverse.utils.ovagent import (
+            PermissionDecision,
+            PermissionPolicy,
+            PermissionVerdict,
+            SubagentRuntime,
+            create_default_policy,
+            create_subagent_policy,
+        )
+        assert PermissionDecision is not None
+        assert PermissionPolicy is not None
+        assert PermissionVerdict is not None
+        assert SubagentRuntime is not None
+        assert create_default_policy is not None
+        assert create_subagent_policy is not None
+
+
+# ===================================================================
+# 17. Priority ordering: deny > allowlist > override > class > default
+# ===================================================================
+
+class TestPriorityOrdering:
+
+    def test_deny_beats_everything(self, registry):
+        policy = PermissionPolicy(
+            registry,
+            denied_tools=frozenset({"Read"}),
+            allowed_tools=frozenset({"Read"}),
+            tool_overrides={"Read": ApprovalClass.allow},
+        )
+        assert policy.check("Read").is_denied
+
+    def test_allowlist_beats_override(self, registry):
+        policy = PermissionPolicy(
+            registry,
+            allowed_tools=frozenset({"Glob"}),
+            tool_overrides={"Bash": ApprovalClass.allow},
+        )
+        # Bash not in allowlist → denied despite per-tool allow override
+        assert policy.check("Bash").is_denied
+
+    def test_tool_override_beats_class_override(self, registry):
+        policy = PermissionPolicy(
+            registry,
+            tool_overrides={"Bash": ApprovalClass.allow},
+            class_overrides={ApprovalClass.ask: PermissionVerdict.deny},
+        )
+        decision = policy.check("Bash")
+        assert decision.is_allowed
+
+    def test_class_override_beats_registry_default(self, registry):
+        policy = PermissionPolicy(
+            registry,
+            class_overrides={ApprovalClass.allow: PermissionVerdict.ask},
+        )
+        decision = policy.check("Read")
+        assert decision.verdict == PermissionVerdict.ask

--- a/tests/utils/test_prompt_templates.py
+++ b/tests/utils/test_prompt_templates.py
@@ -1,0 +1,516 @@
+"""Tests for ovagent.prompt_templates — prompt composition contract.
+
+Verifies:
+  - PromptTemplateEngine renders deterministically (sorted by priority, name)
+  - PromptOverlay is immutable (frozen dataclass)
+  - Predefined template constants contain expected content
+  - build_agentic_engine and build_subagent_engine produce valid engines
+  - PromptBuilder delegates to the template engine correctly
+  - Workflow/skill/provider overlay behaviour
+  - Export contract in __init__.py
+"""
+
+import importlib
+import importlib.machinery
+import importlib.util
+import os
+import sys
+import types
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Guard: these tests require the harness env-var
+# ---------------------------------------------------------------------------
+
+_RUN_HARNESS = os.environ.get("OV_AGENT_RUN_HARNESS_TESTS", "").lower() in {
+    "1", "true", "yes", "on",
+}
+pytestmark = pytest.mark.skipif(
+    not _RUN_HARNESS,
+    reason="Prompt template contract tests require OV_AGENT_RUN_HARNESS_TESTS=1.",
+)
+
+# ---------------------------------------------------------------------------
+# Bootstrap: lightweight package stubs to avoid heavy omicverse.__init__
+# ---------------------------------------------------------------------------
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+PACKAGE_ROOT = PROJECT_ROOT / "omicverse"
+
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+_SAVED = {
+    name: sys.modules.get(name)
+    for name in ["omicverse", "omicverse.utils"]
+}
+for name in ["omicverse", "omicverse.utils"]:
+    sys.modules.pop(name, None)
+
+_ov_pkg = types.ModuleType("omicverse")
+_ov_pkg.__path__ = [str(PACKAGE_ROOT)]
+_ov_pkg.__spec__ = importlib.machinery.ModuleSpec(
+    "omicverse", loader=None, is_package=True
+)
+sys.modules["omicverse"] = _ov_pkg
+
+_utils_pkg = types.ModuleType("omicverse.utils")
+_utils_pkg.__path__ = [str(PACKAGE_ROOT / "utils")]
+_utils_pkg.__spec__ = importlib.machinery.ModuleSpec(
+    "omicverse.utils", loader=None, is_package=True
+)
+sys.modules["omicverse.utils"] = _utils_pkg
+_ov_pkg.utils = _utils_pkg
+
+# Now import the modules under test
+from omicverse.utils.ovagent.prompt_templates import (
+    BASE_IDENTITY,
+    CODE_ONLY_MODE,
+    DELEGATION_STRATEGY,
+    GUIDELINES,
+    SUBAGENT_BASES,
+    TOOL_INSTRUCTIONS,
+    WEB_ACCESS,
+    WORKFLOW_STEPS,
+    PromptOverlay,
+    PromptTemplateEngine,
+    build_agentic_engine,
+    build_subagent_engine,
+)
+from omicverse.utils.ovagent.prompt_builder import (
+    CODE_QUALITY_RULES,
+    PromptBuilder,
+)
+
+for name, mod in _SAVED.items():
+    if mod is None:
+        sys.modules.pop(name, None)
+    else:
+        sys.modules[name] = mod
+
+
+# ---------------------------------------------------------------------------
+# Helpers — minimal AgentContext stub
+# ---------------------------------------------------------------------------
+
+
+def _make_ctx(
+    *,
+    code_only: bool = False,
+    skills: dict | None = None,
+    ov_runtime: Any = None,
+) -> MagicMock:
+    """Return a minimal mock satisfying the AgentContext protocol."""
+    ctx = MagicMock()
+    ctx._code_only_mode = code_only
+    ctx._ov_runtime = ov_runtime
+    if skills is not None:
+        reg = MagicMock()
+        reg.skill_metadata = skills
+        ctx.skill_registry = reg
+    else:
+        ctx.skill_registry = None
+    return ctx
+
+
+class _FakeSkillMeta:
+    def __init__(self, slug: str, description: str) -> None:
+        self.slug = slug
+        self.description = description
+
+
+# ===========================================================================
+# 1. PromptOverlay unit tests
+# ===========================================================================
+
+
+class TestPromptOverlay:
+    def test_fields(self):
+        o = PromptOverlay("name", "content", priority=42)
+        assert o.name == "name"
+        assert o.content == "content"
+        assert o.priority == 42
+
+    def test_default_priority(self):
+        o = PromptOverlay("x", "y")
+        assert o.priority == 100
+
+    def test_frozen(self):
+        o = PromptOverlay("x", "y")
+        with pytest.raises(AttributeError):
+            o.name = "z"  # type: ignore[misc]
+
+
+# ===========================================================================
+# 2. PromptTemplateEngine unit tests
+# ===========================================================================
+
+
+class TestPromptTemplateEngine:
+    def test_empty_engine(self):
+        engine = PromptTemplateEngine()
+        assert engine.render() == ""
+
+    def test_base_only(self):
+        engine = PromptTemplateEngine()
+        engine.set_base("Hello")
+        assert engine.render() == "Hello"
+
+    def test_overlays_sorted_by_priority(self):
+        engine = PromptTemplateEngine()
+        engine.set_base("base")
+        engine.add_overlay(PromptOverlay("c", "third", priority=30))
+        engine.add_overlay(PromptOverlay("a", "first", priority=10))
+        engine.add_overlay(PromptOverlay("b", "second", priority=20))
+        assert engine.render() == "base\n\nfirst\n\nsecond\n\nthird"
+
+    def test_overlays_sorted_by_name_on_tie(self):
+        engine = PromptTemplateEngine()
+        engine.set_base("base")
+        engine.add_overlay(PromptOverlay("beta", "B", priority=10))
+        engine.add_overlay(PromptOverlay("alpha", "A", priority=10))
+        assert engine.render() == "base\n\nA\n\nB"
+
+    def test_deterministic_render(self):
+        """Same overlays always produce the same output."""
+        engine = PromptTemplateEngine()
+        engine.set_base("base")
+        engine.add_overlay(PromptOverlay("x", "X", priority=50))
+        engine.add_overlay(PromptOverlay("y", "Y", priority=10))
+        first = engine.render()
+        second = engine.render()
+        assert first == second
+
+    def test_replace_overlay(self):
+        engine = PromptTemplateEngine()
+        engine.add_overlay(PromptOverlay("x", "old"))
+        engine.add_overlay(PromptOverlay("x", "new"))
+        assert "new" in engine.render()
+        assert "old" not in engine.render()
+
+    def test_remove_overlay(self):
+        engine = PromptTemplateEngine()
+        engine.add_overlay(PromptOverlay("x", "content"))
+        engine.remove_overlay("x")
+        assert engine.render() == ""
+
+    def test_remove_nonexistent_is_noop(self):
+        engine = PromptTemplateEngine()
+        engine.remove_overlay("missing")  # should not raise
+
+    def test_has_overlay(self):
+        engine = PromptTemplateEngine()
+        assert not engine.has_overlay("x")
+        engine.add_overlay(PromptOverlay("x", "y"))
+        assert engine.has_overlay("x")
+
+    def test_get_overlay(self):
+        engine = PromptTemplateEngine()
+        assert engine.get_overlay("x") is None
+        o = PromptOverlay("x", "y", priority=5)
+        engine.add_overlay(o)
+        assert engine.get_overlay("x") == o
+
+    def test_overlay_names_in_order(self):
+        engine = PromptTemplateEngine()
+        engine.add_overlay(PromptOverlay("c", "C", priority=30))
+        engine.add_overlay(PromptOverlay("a", "A", priority=10))
+        engine.add_overlay(PromptOverlay("b", "B", priority=20))
+        assert engine.overlay_names == ["a", "b", "c"]
+
+    def test_empty_content_skipped(self):
+        engine = PromptTemplateEngine()
+        engine.set_base("base")
+        engine.add_overlay(PromptOverlay("empty", "", priority=10))
+        engine.add_overlay(PromptOverlay("real", "content", priority=20))
+        assert engine.render() == "base\n\ncontent"
+
+    def test_base_property(self):
+        engine = PromptTemplateEngine()
+        assert engine.base == ""
+        engine.set_base("hello")
+        assert engine.base == "hello"
+
+
+# ===========================================================================
+# 3. Predefined template constants
+# ===========================================================================
+
+
+class TestPredefinedTemplates:
+    def test_base_identity_mentions_omicverse(self):
+        assert "OmicVerse Agent" in BASE_IDENTITY
+
+    def test_tool_instructions_mentions_toolsearch(self):
+        assert "ToolSearch" in TOOL_INSTRUCTIONS
+
+    def test_web_access_mentions_webfetch(self):
+        assert "WebFetch" in WEB_ACCESS
+
+    def test_workflow_steps_has_numbered_steps(self):
+        assert "1." in WORKFLOW_STEPS
+        assert "6." in WORKFLOW_STEPS
+
+    def test_guidelines_mentions_inspect(self):
+        assert "inspect data" in GUIDELINES
+
+    def test_delegation_mentions_explore(self):
+        assert "explore" in DELEGATION_STRATEGY
+
+    def test_code_only_mode_mentions_claw(self):
+        assert "CLAW" in CODE_ONLY_MODE
+
+    def test_subagent_bases_has_all_types(self):
+        assert set(SUBAGENT_BASES.keys()) == {"explore", "plan", "execute"}
+
+
+# ===========================================================================
+# 4. Factory helpers
+# ===========================================================================
+
+
+class TestBuildAgenticEngine:
+    def test_returns_engine(self):
+        engine = build_agentic_engine()
+        assert isinstance(engine, PromptTemplateEngine)
+
+    def test_base_is_identity(self):
+        engine = build_agentic_engine()
+        assert engine.base == BASE_IDENTITY
+
+    def test_has_workflow_overlays(self):
+        engine = build_agentic_engine()
+        expected = {"tool_instructions", "web_access", "workflow", "code_quality",
+                    "guidelines", "delegation"}
+        assert expected.issubset(set(engine.overlay_names))
+
+    def test_render_contains_key_sections(self):
+        rendered = build_agentic_engine().render()
+        assert "OmicVerse Agent" in rendered
+        assert "CODING / FILESYSTEM" in rendered
+        assert "WEB ACCESS" in rendered
+        assert "WORKFLOW" in rendered
+        assert "MANDATORY CODE QUALITY" in rendered
+        assert "DELEGATION STRATEGY" in rendered
+
+    def test_overlay_order_is_deterministic(self):
+        names_a = build_agentic_engine().overlay_names
+        names_b = build_agentic_engine().overlay_names
+        assert names_a == names_b
+
+    def test_no_code_only_by_default(self):
+        engine = build_agentic_engine()
+        assert not engine.has_overlay("code_only_mode")
+
+
+class TestBuildSubagentEngine:
+    @pytest.mark.parametrize("agent_type", ["explore", "plan", "execute"])
+    def test_returns_engine(self, agent_type):
+        engine = build_subagent_engine(agent_type)
+        assert isinstance(engine, PromptTemplateEngine)
+
+    def test_explore_has_no_code_quality(self):
+        engine = build_subagent_engine("explore")
+        assert not engine.has_overlay("code_quality")
+
+    def test_plan_has_code_quality(self):
+        engine = build_subagent_engine("plan")
+        assert engine.has_overlay("code_quality")
+
+    def test_execute_has_code_quality_and_packages(self):
+        engine = build_subagent_engine("execute")
+        assert engine.has_overlay("code_quality")
+        assert engine.has_overlay("packages")
+
+    def test_unknown_type_raises(self):
+        with pytest.raises(ValueError, match="Unknown subagent type"):
+            build_subagent_engine("invalid")
+
+
+# ===========================================================================
+# 5. PromptBuilder integration — engine-backed composition
+# ===========================================================================
+
+
+class TestPromptBuilderAgenticEngine:
+    def test_basic_prompt_contains_identity(self):
+        ctx = _make_ctx()
+        builder = PromptBuilder(ctx)
+        prompt = builder.build_agentic_system_prompt()
+        assert "OmicVerse Agent" in prompt
+
+    def test_code_only_mode_overlay(self):
+        ctx = _make_ctx(code_only=True)
+        builder = PromptBuilder(ctx)
+        prompt = builder.build_agentic_system_prompt()
+        assert "CLAW CODE-ONLY MODE" in prompt
+
+    def test_skill_overlay_added(self):
+        skills = {
+            "clustering": _FakeSkillMeta("clustering", "Run Leiden clustering"),
+            "deg": _FakeSkillMeta("deg", "Differential expression analysis"),
+        }
+        ctx = _make_ctx(skills=skills)
+        builder = PromptBuilder(ctx)
+        prompt = builder.build_agentic_system_prompt()
+        assert "clustering" in prompt
+        assert "deg" in prompt
+
+    def test_runtime_compose_called(self):
+        runtime = MagicMock()
+        runtime.compose_system_prompt.return_value = "COMPOSED"
+        ctx = _make_ctx(ov_runtime=runtime)
+        builder = PromptBuilder(ctx)
+        result = builder.build_agentic_system_prompt()
+        runtime.compose_system_prompt.assert_called_once()
+        assert result == "COMPOSED"
+
+    def test_no_runtime_no_compose(self):
+        ctx = _make_ctx(ov_runtime=None)
+        builder = PromptBuilder(ctx)
+        prompt = builder.build_agentic_system_prompt()
+        assert "OmicVerse Agent" in prompt
+
+
+class TestPromptBuilderSubagentEngine:
+    @pytest.mark.parametrize("agent_type", ["explore", "plan", "execute"])
+    def test_builds_without_error(self, agent_type):
+        ctx = _make_ctx()
+        builder = PromptBuilder(ctx)
+        prompt = builder.build_subagent_system_prompt(agent_type)
+        assert len(prompt) > 0
+
+    def test_explore_contains_inspector_identity(self):
+        ctx = _make_ctx()
+        prompt = PromptBuilder(ctx).build_explore_prompt("")
+        assert "data inspector" in prompt
+
+    def test_plan_contains_architect_identity(self):
+        ctx = _make_ctx()
+        prompt = PromptBuilder(ctx).build_plan_prompt("")
+        assert "workflow architect" in prompt
+
+    def test_execute_contains_executor_identity(self):
+        ctx = _make_ctx()
+        prompt = PromptBuilder(ctx).build_execute_prompt("")
+        assert "code executor" in prompt
+
+    def test_context_appended_explore(self):
+        ctx = _make_ctx()
+        prompt = PromptBuilder(ctx).build_explore_prompt("extra info")
+        assert "extra info" in prompt
+
+    def test_context_appended_plan(self):
+        ctx = _make_ctx()
+        prompt = PromptBuilder(ctx).build_plan_prompt("extra info")
+        assert "extra info" in prompt
+
+    def test_context_appended_execute(self):
+        ctx = _make_ctx()
+        prompt = PromptBuilder(ctx).build_execute_prompt("extra info")
+        assert "extra info" in prompt
+
+    def test_plan_skill_overlay(self):
+        skills = {
+            "spatial": _FakeSkillMeta("spatial", "Spatial transcriptomics"),
+        }
+        ctx = _make_ctx(skills=skills)
+        prompt = PromptBuilder(ctx).build_plan_prompt("")
+        assert "spatial" in prompt
+
+    def test_unknown_type_raises(self):
+        ctx = _make_ctx()
+        with pytest.raises(ValueError, match="Unknown subagent type"):
+            PromptBuilder(ctx).build_subagent_system_prompt("unknown")
+
+    def test_user_message_basic(self):
+        ctx = _make_ctx()
+        msg = PromptBuilder(ctx).build_subagent_user_message("do analysis", None)
+        assert "do analysis" in msg
+
+    def test_user_message_with_adata(self):
+        ctx = _make_ctx()
+        adata = MagicMock()
+        adata.shape = (1000, 2000)
+        msg = PromptBuilder(ctx).build_subagent_user_message("do analysis", adata)
+        assert "1000" in msg
+        assert "2000" in msg
+
+
+# ===========================================================================
+# 6. Composition determinism — the core contract
+# ===========================================================================
+
+
+class TestCompositionDeterminism:
+    """Verify the prompt composition contract: base + workflow + skill +
+    runtime/provider overlays render deterministically."""
+
+    def test_agentic_prompt_deterministic(self):
+        skills = {
+            "z_last": _FakeSkillMeta("z_last", "Last skill"),
+            "a_first": _FakeSkillMeta("a_first", "First skill"),
+        }
+        ctx = _make_ctx(code_only=True, skills=skills)
+        builder = PromptBuilder(ctx)
+        p1 = builder.build_agentic_system_prompt()
+        p2 = builder.build_agentic_system_prompt()
+        assert p1 == p2
+
+    def test_subagent_prompt_deterministic(self):
+        ctx = _make_ctx()
+        builder = PromptBuilder(ctx)
+        for agent_type in ("explore", "plan", "execute"):
+            p1 = builder.build_subagent_system_prompt(agent_type, "ctx")
+            p2 = builder.build_subagent_system_prompt(agent_type, "ctx")
+            assert p1 == p2, "Subagent prompt for " + agent_type + " not deterministic"
+
+    def test_overlay_order_preserved_across_engines(self):
+        """Two independently constructed engines with the same overlays
+        must render identically."""
+        def _build():
+            engine = PromptTemplateEngine()
+            engine.set_base("base")
+            engine.add_overlay(PromptOverlay("z", "Z", priority=10))
+            engine.add_overlay(PromptOverlay("a", "A", priority=10))
+            engine.add_overlay(PromptOverlay("m", "M", priority=5))
+            return engine.render()
+
+        assert _build() == _build()
+
+
+# ===========================================================================
+# 7. Export contract — prompt_templates symbols in __init__.py
+# ===========================================================================
+
+
+class TestExportContract:
+    def test_prompt_overlay_exported(self):
+        import omicverse.utils.ovagent as pkg
+        assert hasattr(pkg, "PromptOverlay")
+        assert pkg.PromptOverlay is PromptOverlay
+
+    def test_prompt_template_engine_exported(self):
+        import omicverse.utils.ovagent as pkg
+        assert hasattr(pkg, "PromptTemplateEngine")
+        assert pkg.PromptTemplateEngine is PromptTemplateEngine
+
+    def test_build_agentic_engine_exported(self):
+        import omicverse.utils.ovagent as pkg
+        assert hasattr(pkg, "build_agentic_engine")
+        assert pkg.build_agentic_engine is build_agentic_engine
+
+    def test_build_subagent_engine_exported(self):
+        import omicverse.utils.ovagent as pkg
+        assert hasattr(pkg, "build_subagent_engine")
+        assert pkg.build_subagent_engine is build_subagent_engine
+
+    def test_all_contains_new_symbols(self):
+        import omicverse.utils.ovagent as pkg
+        for name in ("PromptOverlay", "PromptTemplateEngine",
+                     "build_agentic_engine", "build_subagent_engine"):
+            assert name in pkg.__all__, name + " missing from __all__"

--- a/tests/utils/test_repair_loop.py
+++ b/tests/utils/test_repair_loop.py
@@ -1,0 +1,594 @@
+"""Tests for the ExecutionRepairLoop and FailureEnvelope subsystem.
+
+Acceptance criteria verified:
+  - Execution failures produce structured diagnostic payloads (FailureEnvelope).
+  - Recovery supports multiple bounded attempts.
+  - LLM-guided repair receives code + error + traceback + dataset context in a
+    consistent format.
+  - Regex transforms remain optional guardrails instead of owning the full
+    repair path.
+"""
+
+import asyncio
+import importlib
+import importlib.machinery
+import importlib.util
+import os
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Dict, List, Optional
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Guard: these tests require the harness env-var
+# ---------------------------------------------------------------------------
+
+_RUN_HARNESS = os.environ.get("OV_AGENT_RUN_HARNESS_TESTS", "").lower() in {
+    "1", "true", "yes", "on",
+}
+pytestmark = pytest.mark.skipif(
+    not _RUN_HARNESS,
+    reason="Repair-loop tests require OV_AGENT_RUN_HARNESS_TESTS=1.",
+)
+
+# ---------------------------------------------------------------------------
+# Bootstrap: lightweight package stubs
+# ---------------------------------------------------------------------------
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+PACKAGE_ROOT = PROJECT_ROOT / "omicverse"
+
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+_SAVED = {
+    name: sys.modules.get(name)
+    for name in ["omicverse", "omicverse.utils"]
+}
+for name in ["omicverse", "omicverse.utils"]:
+    sys.modules.pop(name, None)
+
+_ov_pkg = types.ModuleType("omicverse")
+_ov_pkg.__path__ = [str(PACKAGE_ROOT)]
+_ov_pkg.__spec__ = importlib.machinery.ModuleSpec(
+    "omicverse", loader=None, is_package=True
+)
+sys.modules["omicverse"] = _ov_pkg
+
+_utils_pkg = types.ModuleType("omicverse.utils")
+_utils_pkg.__path__ = [str(PACKAGE_ROOT / "utils")]
+_utils_pkg.__spec__ = importlib.machinery.ModuleSpec(
+    "omicverse.utils", loader=None, is_package=True
+)
+sys.modules["omicverse.utils"] = _utils_pkg
+_ov_pkg.utils = _utils_pkg
+
+from omicverse.utils.ovagent.repair_loop import (
+    DEFAULT_MAX_RETRIES,
+    ExecutionRepairLoop,
+    FailureEnvelope,
+    RepairAttempt,
+    RepairResult,
+    build_dataset_context,
+    build_llm_repair_prompt,
+)
+
+for name, mod in _SAVED.items():
+    if mod is None:
+        sys.modules.pop(name, None)
+    else:
+        sys.modules[name] = mod
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _FakeAdata:
+    """Minimal AnnData stand-in for dataset context tests."""
+
+    def __init__(self, n_obs=100, n_vars=200):
+        self.shape = (n_obs, n_vars)
+        self.obs = SimpleNamespace(columns=["batch", "cell_type", "n_genes"])
+        self.var = SimpleNamespace(columns=["gene_name", "highly_variable"])
+        self.obsm = SimpleNamespace(keys=lambda: ["X_pca", "X_umap"])
+
+
+class _FakeExecutor:
+    """Minimal AnalysisExecutor double for repair loop tests."""
+
+    def __init__(
+        self,
+        exec_side_effects=None,
+        guardrail_return=None,
+        llm_return=None,
+    ):
+        self._exec_call_count = 0
+        self._exec_side_effects = exec_side_effects or []
+        self._guardrail_return = guardrail_return
+        self._llm_return = llm_return
+        self._ctx = SimpleNamespace(
+            _llm=None,
+            _extract_python_code=lambda text: text,
+        )
+
+    def execute_generated_code(self, code, adata, capture_stdout=True):
+        idx = self._exec_call_count
+        self._exec_call_count += 1
+        if idx < len(self._exec_side_effects):
+            effect = self._exec_side_effects[idx]
+            if isinstance(effect, Exception):
+                raise effect
+            return effect
+        return {"stdout": "", "adata": adata}
+
+    def apply_execution_error_fix(self, code, error_msg):
+        return self._guardrail_return
+
+    async def diagnose_error_with_llm(self, code, error_msg, traceback_str, adata):
+        return self._llm_return
+
+
+def _run(coro):
+    """Run an async coroutine synchronously."""
+    return asyncio.run(coro)
+
+
+# ===================================================================
+# 1. FailureEnvelope — structured diagnostic payload
+# ===================================================================
+
+
+class TestFailureEnvelope:
+    """Execution failures produce structured diagnostic payloads."""
+
+    def test_from_exception_basic(self):
+        try:
+            raise ValueError("bad column 'batch'")
+        except ValueError as exc:
+            env = FailureEnvelope.from_exception(
+                exc, phase="execution", retry_count=0, code="print(1)"
+            )
+
+        assert env.phase == "execution"
+        assert env.exception == "ValueError"
+        assert "bad column" in env.summary
+        assert env.retry_count == 0
+        assert env.code == "print(1)"
+        assert env.retry_safe is True
+        assert isinstance(env.repair_hints, list)
+
+    def test_from_exception_preserves_traceback(self):
+        try:
+            raise RuntimeError("segfault simulation")
+        except RuntimeError as exc:
+            env = FailureEnvelope.from_exception(exc, phase="transform")
+
+        assert "RuntimeError" in env.traceback_excerpt
+        assert "segfault simulation" in env.traceback_excerpt
+
+    def test_to_dict_roundtrip(self):
+        env = FailureEnvelope(
+            phase="validation",
+            exception="AssertionError",
+            summary="expected 3 got 5",
+            traceback_excerpt="Traceback...",
+            retry_count=2,
+            repair_hints=["check shape"],
+            retry_safe=False,
+            code="assert x == 3",
+            dataset_context="100 obs x 200 vars",
+        )
+        d = env.to_dict()
+        assert d["phase"] == "validation"
+        assert d["exception"] == "AssertionError"
+        assert d["summary"] == "expected 3 got 5"
+        assert d["retry_count"] == 2
+        assert d["repair_hints"] == ["check shape"]
+        assert d["retry_safe"] is False
+        assert d["code"] == "assert x == 3"
+        assert d["dataset_context"] == "100 obs x 200 vars"
+
+    def test_envelope_contract_fields(self):
+        """All fields from the interface contract are present."""
+        env = FailureEnvelope(
+            phase="execution",
+            exception="TypeError",
+            summary="test",
+            traceback_excerpt="tb",
+            retry_count=0,
+        )
+        required_fields = {
+            "phase", "exception", "summary", "traceback_excerpt",
+            "retry_count", "repair_hints", "retry_safe",
+        }
+        actual = set(env.to_dict().keys())
+        assert required_fields.issubset(actual), (
+            f"Missing contract fields: {required_fields - actual}"
+        )
+
+    def test_traceback_bounded_length(self):
+        """Traceback excerpt is bounded to prevent unbounded payloads."""
+        try:
+            # Generate a long traceback chain
+            exec("1/0")
+        except Exception as exc:
+            env = FailureEnvelope.from_exception(exc)
+
+        assert len(env.traceback_excerpt) <= 2000
+
+    def test_summary_bounded_length(self):
+        """Summary is bounded even for very long exception messages."""
+        try:
+            raise ValueError("x" * 1000)
+        except ValueError as exc:
+            env = FailureEnvelope.from_exception(exc)
+
+        assert len(env.summary) <= 500
+
+
+# ===================================================================
+# 2. build_dataset_context
+# ===================================================================
+
+
+class TestBuildDatasetContext:
+    def test_with_adata(self):
+        adata = _FakeAdata()
+        ctx = build_dataset_context(adata)
+        assert "100 obs x 200 vars" in ctx
+        assert "batch" in ctx
+
+    def test_with_none(self):
+        assert build_dataset_context(None) == ""
+
+
+# ===================================================================
+# 3. build_llm_repair_prompt — consistent format
+# ===================================================================
+
+
+class TestBuildLLMRepairPrompt:
+    """LLM-guided repair receives code + error + traceback + dataset context."""
+
+    def test_prompt_contains_all_sections(self):
+        env = FailureEnvelope(
+            phase="execution",
+            exception="TypeError",
+            summary="unsupported operand",
+            traceback_excerpt="File test.py line 5\nTypeError: ...",
+            retry_count=1,
+            code="x = 1 + 'a'",
+            dataset_context="100 obs x 200 vars",
+            repair_hints=["check types"],
+        )
+        prompt = build_llm_repair_prompt(env)
+
+        assert "--- PHASE ---" in prompt
+        assert "execution" in prompt
+        assert "--- EXCEPTION ---" in prompt
+        assert "TypeError" in prompt
+        assert "--- TRACEBACK ---" in prompt
+        assert "--- CODE ---" in prompt
+        assert "x = 1 + 'a'" in prompt
+        assert "--- DATASET ---" in prompt
+        assert "100 obs x 200 vars" in prompt
+        assert "--- REPAIR HINTS ---" in prompt
+        assert "check types" in prompt
+        assert "--- RETRY COUNT ---" in prompt
+        assert "1" in prompt
+
+    def test_prompt_without_dataset(self):
+        env = FailureEnvelope(
+            phase="execution",
+            exception="NameError",
+            summary="name 'x' is not defined",
+            traceback_excerpt="tb...",
+            retry_count=0,
+            code="print(x)",
+        )
+        prompt = build_llm_repair_prompt(env)
+        assert "--- DATASET ---" not in prompt
+        assert "--- CODE ---" in prompt
+
+    def test_prompt_without_hints(self):
+        env = FailureEnvelope(
+            phase="execution",
+            exception="NameError",
+            summary="name 'x' is not defined",
+            traceback_excerpt="tb...",
+            retry_count=0,
+            code="print(x)",
+            repair_hints=[],
+        )
+        prompt = build_llm_repair_prompt(env)
+        assert "--- REPAIR HINTS ---" not in prompt
+
+
+# ===================================================================
+# 4. ExecutionRepairLoop — bounded retries
+# ===================================================================
+
+
+class TestExecutionRepairLoopBounded:
+    """Recovery supports multiple bounded attempts."""
+
+    def test_success_on_first_try(self):
+        executor = _FakeExecutor(
+            exec_side_effects=[{"stdout": "ok", "adata": None}]
+        )
+        loop = ExecutionRepairLoop(executor, max_retries=3)
+        result = _run(loop.run("print(1)", None))
+
+        assert result.success is True
+        assert len(result.attempts) == 1
+        assert result.final_envelope is None
+
+    def test_guardrail_recovery(self):
+        """Guardrail produces a fix and the second attempt succeeds."""
+        executor = _FakeExecutor(
+            exec_side_effects=[
+                ValueError("dtype error"),
+                {"stdout": "fixed", "adata": None},
+            ],
+            guardrail_return="fixed_code",
+        )
+        loop = ExecutionRepairLoop(executor, max_retries=3)
+        result = _run(loop.run("broken_code", None))
+
+        assert result.success is True
+        assert len(result.attempts) == 2
+        assert result.attempts[0].strategy == "guardrail"
+        assert result.attempts[0].success is False
+        assert result.attempts[1].success is True
+
+    def test_llm_recovery(self):
+        """LLM diagnosis produces a fix after guardrail returns None."""
+        executor = _FakeExecutor(
+            exec_side_effects=[
+                ValueError("unknown error"),
+                {"stdout": "llm fixed", "adata": None},
+            ],
+            guardrail_return=None,
+            llm_return="llm_fixed_code",
+        )
+        loop = ExecutionRepairLoop(executor, max_retries=3)
+        result = _run(loop.run("broken_code", None))
+
+        assert result.success is True
+        assert len(result.attempts) == 2
+        assert result.attempts[0].strategy == "llm"
+
+    def test_max_retries_respected(self):
+        """Loop stops after max_retries even if failures continue."""
+        executor = _FakeExecutor(
+            exec_side_effects=[
+                ValueError("err1"),
+                ValueError("err2"),
+                ValueError("err3"),
+                ValueError("err4"),
+            ],
+            guardrail_return="always_different_code",
+        )
+        # Need the guardrail to actually produce different code each time
+        call_count = [0]
+        original_fix = executor.apply_execution_error_fix
+
+        def varying_fix(code, error_msg):
+            call_count[0] += 1
+            return f"fixed_v{call_count[0]}"
+
+        executor.apply_execution_error_fix = varying_fix
+        loop = ExecutionRepairLoop(executor, max_retries=2)
+        result = _run(loop.run("code", None))
+
+        assert result.success is False
+        assert result.final_envelope is not None
+        # 1 initial + max_retries = 3 total exec attempts
+        assert len(result.attempts) <= 3
+
+    def test_no_repair_strategy_exits_early(self):
+        """When neither guardrail nor LLM produce new code, loop exits."""
+        executor = _FakeExecutor(
+            exec_side_effects=[ValueError("unfixable")],
+            guardrail_return=None,
+            llm_return=None,
+        )
+        loop = ExecutionRepairLoop(executor, max_retries=3)
+        result = _run(loop.run("code", None))
+
+        assert result.success is False
+        assert result.final_envelope is not None
+        assert result.final_envelope.retry_safe is False
+        assert "no repair strategy" in result.final_envelope.repair_hints[0]
+
+    def test_default_max_retries(self):
+        assert DEFAULT_MAX_RETRIES == 3
+
+
+# ===================================================================
+# 5. Regex transforms are optional guardrails
+# ===================================================================
+
+
+class TestGuardrailsOptional:
+    """Regex transforms remain optional guardrails, not the primary path."""
+
+    def test_guardrail_skipped_when_no_match(self):
+        """When guardrail returns None, loop falls through to LLM."""
+        executor = _FakeExecutor(
+            exec_side_effects=[
+                ValueError("obscure error"),
+                {"stdout": "ok", "adata": None},
+            ],
+            guardrail_return=None,
+            llm_return="llm_fixed_code",
+        )
+        loop = ExecutionRepairLoop(executor, max_retries=3)
+        result = _run(loop.run("code", None))
+
+        assert result.success is True
+        assert result.attempts[0].strategy == "llm"
+
+    def test_guardrail_returns_same_code_falls_through(self):
+        """When guardrail returns same code, it's not treated as a fix."""
+        executor = _FakeExecutor(
+            exec_side_effects=[
+                ValueError("error"),
+                {"stdout": "ok", "adata": None},
+            ],
+            guardrail_return=None,  # will be overridden
+            llm_return="llm_fixed_code",
+        )
+        # Make guardrail return the same code
+        executor.apply_execution_error_fix = lambda code, err: code
+        loop = ExecutionRepairLoop(executor, max_retries=3)
+        result = _run(loop.run("code", None))
+
+        assert result.success is True
+        # Should have used LLM, not guardrail
+        assert result.attempts[0].strategy == "llm"
+
+    def test_guardrail_used_as_first_attempt_when_available(self):
+        """When guardrail matches, it's tried before LLM (as a guardrail)."""
+        executor = _FakeExecutor(
+            exec_side_effects=[
+                ValueError("dtype error"),
+                {"stdout": "ok", "adata": None},
+            ],
+            guardrail_return="guardrail_fixed",
+        )
+        loop = ExecutionRepairLoop(executor, max_retries=3)
+        result = _run(loop.run("original_code", None))
+
+        assert result.success is True
+        assert result.attempts[0].strategy == "guardrail"
+
+
+# ===================================================================
+# 6. Structured diagnostic in repair result
+# ===================================================================
+
+
+class TestRepairResultDiagnostics:
+    """RepairResult carries structured diagnostics on failure."""
+
+    def test_failure_result_has_envelope(self):
+        executor = _FakeExecutor(
+            exec_side_effects=[TypeError("bad type")],
+            guardrail_return=None,
+            llm_return=None,
+        )
+        loop = ExecutionRepairLoop(executor, max_retries=3)
+        result = _run(loop.run("code", _FakeAdata()))
+
+        assert result.success is False
+        env = result.final_envelope
+        assert env is not None
+        assert env.phase == "execution"
+        assert env.exception == "TypeError"
+        assert "bad type" in env.summary
+        assert env.code == "code"
+        assert "100 obs x 200 vars" in env.dataset_context
+
+    def test_success_result_has_no_envelope(self):
+        executor = _FakeExecutor(
+            exec_side_effects=[{"stdout": "", "adata": None}]
+        )
+        loop = ExecutionRepairLoop(executor, max_retries=3)
+        result = _run(loop.run("code", None))
+
+        assert result.success is True
+        assert result.final_envelope is None
+
+    def test_attempts_list_tracks_history(self):
+        call_count = [0]
+
+        def varying_fix(code, error_msg):
+            call_count[0] += 1
+            return f"v{call_count[0]}"
+
+        executor = _FakeExecutor(
+            exec_side_effects=[
+                ValueError("err1"),
+                ValueError("err2"),
+                {"stdout": "ok", "adata": None},
+            ],
+        )
+        executor.apply_execution_error_fix = varying_fix
+        loop = ExecutionRepairLoop(executor, max_retries=3)
+        result = _run(loop.run("code", None))
+
+        assert result.success is True
+        assert len(result.attempts) == 3
+        assert result.attempts[0].success is False
+        assert result.attempts[1].success is False
+        assert result.attempts[2].success is True
+
+
+# ===================================================================
+# 7. Integration: __init__.py exports include repair_loop types
+# ===================================================================
+
+
+class TestRepairLoopExports:
+    """New repair_loop types are exported from ovagent package."""
+
+    def test_exports_present(self):
+        import omicverse.utils.ovagent as ovagent_pkg
+
+        expected = {
+            "FailureEnvelope",
+            "ExecutionRepairLoop",
+            "RepairAttempt",
+            "RepairResult",
+            "DEFAULT_MAX_RETRIES",
+            "build_dataset_context",
+            "build_llm_repair_prompt",
+        }
+        actual = set(ovagent_pkg.__all__)
+        missing = expected - actual
+        assert not missing, f"Missing repair_loop exports: {missing}"
+
+    def test_exports_resolve(self):
+        import omicverse.utils.ovagent as ovagent_pkg
+
+        for name in [
+            "FailureEnvelope",
+            "ExecutionRepairLoop",
+            "RepairAttempt",
+            "RepairResult",
+        ]:
+            obj = getattr(ovagent_pkg, name, None)
+            assert obj is not None, f"Export '{name}' is None"
+
+
+# ===================================================================
+# 8. Custom exec_fn support
+# ===================================================================
+
+
+class TestCustomExecFn:
+    """Repair loop supports custom execution functions."""
+
+    def test_custom_exec_fn(self):
+        executor = _FakeExecutor()
+        loop = ExecutionRepairLoop(executor, max_retries=1)
+
+        call_log = []
+
+        def custom_exec(code, adata):
+            call_log.append(code)
+            return {"stdout": "custom", "adata": adata}
+
+        result = _run(loop.run(
+            "code", None, exec_fn=custom_exec, phase="custom"
+        ))
+
+        assert result.success is True
+        assert call_log == ["code"]

--- a/tests/utils/test_runtime_contracts.py
+++ b/tests/utils/test_runtime_contracts.py
@@ -1,0 +1,632 @@
+"""Runtime contract tests for the OVAgent subsystem surface.
+
+Verifies that the live checked-out OVAgent modules satisfy the
+runtime contracts that the review baseline depends on:
+
+  - ``ovagent/__init__.py`` exports resolve to real objects
+  - ``AgentContext`` protocol is runtime-checkable and lists expected members
+  - Module composition seams (ToolRuntime, TurnController, PromptBuilder,
+    SessionService, ContextService, SubagentController, RegistryScanner)
+    can be instantiated against a duck-typed context double
+  - ``OmicVerseRuntime`` workflow composition contract
+  - ``FollowUpGate`` classification heuristics
+  - ``WorkflowDocument`` / ``WorkflowConfig`` round-trip
+  - ``AnalysisRun`` / ``RunStore`` lifecycle
+  - ``ProactiveCodeTransformer`` is importable and callable
+
+These tests are intentionally lightweight: no real LLM calls, no heavy
+optional dependencies.  They run under ``OV_AGENT_RUN_HARNESS_TESTS=1``.
+"""
+
+import importlib
+import importlib.machinery
+import importlib.util
+import inspect
+import os
+import sys
+import types
+from contextlib import contextmanager
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Dict, List, Optional
+from unittest.mock import MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Guard: these tests require the harness env-var
+# ---------------------------------------------------------------------------
+
+_RUN_HARNESS = os.environ.get("OV_AGENT_RUN_HARNESS_TESTS", "").lower() in {
+    "1", "true", "yes", "on",
+}
+pytestmark = pytest.mark.skipif(
+    not _RUN_HARNESS,
+    reason="Runtime contract tests require OV_AGENT_RUN_HARNESS_TESTS=1.",
+)
+
+# ---------------------------------------------------------------------------
+# Bootstrap: lightweight package stubs to avoid heavy omicverse.__init__
+# ---------------------------------------------------------------------------
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+PACKAGE_ROOT = PROJECT_ROOT / "omicverse"
+
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+_SAVED = {
+    name: sys.modules.get(name)
+    for name in ["omicverse", "omicverse.utils"]
+}
+for name in ["omicverse", "omicverse.utils"]:
+    sys.modules.pop(name, None)
+
+_ov_pkg = types.ModuleType("omicverse")
+_ov_pkg.__path__ = [str(PACKAGE_ROOT)]
+_ov_pkg.__spec__ = importlib.machinery.ModuleSpec(
+    "omicverse", loader=None, is_package=True
+)
+sys.modules["omicverse"] = _ov_pkg
+
+_utils_pkg = types.ModuleType("omicverse.utils")
+_utils_pkg.__path__ = [str(PACKAGE_ROOT / "utils")]
+_utils_pkg.__spec__ = importlib.machinery.ModuleSpec(
+    "omicverse.utils", loader=None, is_package=True
+)
+sys.modules["omicverse.utils"] = _utils_pkg
+_ov_pkg.utils = _utils_pkg
+
+# Now import the ovagent package
+import omicverse.utils.ovagent as ovagent_pkg
+from omicverse.utils.ovagent import (
+    AgentContext,
+    AnalysisExecutor,
+    AnalysisRun,
+    CODE_QUALITY_RULES,
+    ContextService,
+    FollowUpGate,
+    OmicVerseRuntime,
+    ProactiveCodeTransformer,
+    PromptBuilder,
+    RegistryScanner,
+    ResolvedBackend,
+    RunStore,
+    SessionService,
+    SubagentController,
+    ToolRuntime,
+    TurnController,
+    WorkflowConfig,
+    WorkflowDocument,
+    build_filesystem_context_instructions,
+    collect_api_key_env,
+    create_llm_backend,
+    display_backend_info,
+    display_reflection_config,
+    format_skill_overview,
+    initialize_filesystem_context,
+    initialize_notebook_executor,
+    initialize_ov_runtime,
+    initialize_security,
+    initialize_session_history,
+    initialize_skill_registry,
+    initialize_tracing,
+    load_workflow_document,
+    resolve_model_and_provider,
+    temporary_api_keys,
+)
+from omicverse.utils.ovagent.protocol import AgentContext as AgentContextProtocol
+from omicverse.utils.ovagent.tool_runtime import LEGACY_AGENT_TOOLS
+from omicverse.utils.harness.runtime_state import runtime_state
+
+for name, mod in _SAVED.items():
+    if mod is None:
+        sys.modules.pop(name, None)
+    else:
+        sys.modules[name] = mod
+
+
+# ---------------------------------------------------------------------------
+# Minimal duck-typed context double (matches AgentContext protocol)
+# ---------------------------------------------------------------------------
+
+class _MinimalCtx:
+    """Lightweight AgentContext double for composition tests."""
+
+    LEGACY_AGENT_TOOLS = LEGACY_AGENT_TOOLS
+
+    def __init__(self, session_id: str = "test-contract-session"):
+        self.model = "test-model"
+        self.provider = "openai"
+        self.endpoint = "https://api.example.com"
+        self.api_key = None
+        self._llm = None
+        self._config = SimpleNamespace()
+        self._security_config = SimpleNamespace()
+        self._security_scanner = SimpleNamespace()
+        self._filesystem_context = None
+        self.skill_registry = None
+        self._notebook_executor = None
+        self._ov_runtime = None
+        self._trace_store = None
+        self._session_history = None
+        self._context_compactor = None
+        self._approval_handler = None
+        self._reporter = MagicMock()
+        self.last_usage = None
+        self.last_usage_breakdown = {}
+        self._last_run_trace = None
+        self._active_run_id = ""
+        self._web_session_id = session_id
+        self._managed_api_env = {}
+        self._code_only_mode = False
+        self._code_only_captured_code = ""
+        self._code_only_captured_history = []
+        self.use_notebook_execution = False
+        self.enable_filesystem_context = False
+
+    def _emit(self, level, message, category=""):
+        pass
+
+    def _get_harness_session_id(self):
+        return self._web_session_id
+
+    def _get_runtime_session_id(self):
+        return self._web_session_id or "default"
+
+    def _get_visible_agent_tools(self, *, allowed_names=None):
+        return []
+
+    def _get_loaded_tool_names(self):
+        return []
+
+    def _refresh_runtime_working_directory(self):
+        return "."
+
+    def _tool_blocked_in_plan_mode(self, tool_name):
+        return False
+
+    def _detect_repo_root(self, cwd=None):
+        return None
+
+    def _resolve_local_path(self, file_path, *, allow_relative=False):
+        raise NotImplementedError
+
+    def _ensure_server_tool_mode(self, tool_name):
+        pass
+
+    def _request_interaction(self, payload):
+        raise NotImplementedError
+
+    def _request_tool_approval(self, tool_name, *, reason, payload):
+        raise NotImplementedError
+
+    def _load_skill_guidance(self, slug):
+        return ""
+
+    def _extract_python_code(self, text):
+        return text
+
+    def _extract_python_code_strict(self, text):
+        return text
+
+    def _gather_code_candidates(self, text):
+        return [text]
+
+    def _normalize_code_candidate(self, code):
+        return code
+
+    def _collect_static_registry_entries(self, query, max_entries=20):
+        return []
+
+    def _collect_runtime_registry_entries(self, query, max_entries=20):
+        return []
+
+    def _review_generated_code_lightweight(self, request, code, entries):
+        return code
+
+    def _contains_forbidden_scanpy_usage(self, code):
+        return False
+
+    def _rewrite_scanpy_calls_with_registry(self, code, entries):
+        return code
+
+    def _normalize_registry_entry_for_codegen(self, entry):
+        return entry
+
+    def _build_agentic_system_prompt(self):
+        return "You are a test agent."
+
+    async def _run_agentic_loop(self, request, adata, event_callback=None,
+                                cancel_event=None, history=None,
+                                approval_handler=None, request_content=None):
+        return adata
+
+    @contextmanager
+    def _temporary_api_keys(self):
+        yield
+
+
+class _DummyExecutor:
+    pass
+
+
+# ===================================================================
+# 1. __init__.py export contract
+# ===================================================================
+
+class TestOvagentExports:
+    """Every name in ovagent.__all__ resolves to a real object."""
+
+    def test_all_exports_are_importable(self):
+        all_names = ovagent_pkg.__all__
+        assert len(all_names) > 0
+        for name in all_names:
+            obj = getattr(ovagent_pkg, name, None)
+            assert obj is not None, f"ovagent.__all__ lists '{name}' but it is None"
+
+    def test_key_classes_in_all(self):
+        expected = {
+            "AgentContext", "ToolRuntime", "TurnController", "FollowUpGate",
+            "PromptBuilder", "SessionService", "ContextService",
+            "SubagentController", "RegistryScanner", "OmicVerseRuntime",
+            "AnalysisExecutor", "ProactiveCodeTransformer",
+            "WorkflowConfig", "WorkflowDocument", "AnalysisRun", "RunStore",
+        }
+        actual = set(ovagent_pkg.__all__)
+        missing = expected - actual
+        assert not missing, f"Expected exports missing from __all__: {missing}"
+
+    def test_key_functions_in_all(self):
+        expected = {
+            "load_workflow_document", "build_filesystem_context_instructions",
+            "resolve_model_and_provider", "collect_api_key_env",
+            "temporary_api_keys", "create_llm_backend",
+        }
+        actual = set(ovagent_pkg.__all__)
+        missing = expected - actual
+        assert not missing, f"Expected function exports missing: {missing}"
+
+
+# ===================================================================
+# 2. AgentContext protocol contract
+# ===================================================================
+
+class TestAgentContextProtocol:
+    """AgentContext is runtime-checkable and defines the expected surface."""
+
+    def test_protocol_is_runtime_checkable(self):
+        assert hasattr(AgentContextProtocol, "__protocol_attrs__") or hasattr(
+            AgentContextProtocol, "__abstractmethods__"
+        ) or isinstance(AgentContextProtocol, type)
+
+    def test_minimal_ctx_satisfies_protocol(self):
+        ctx = _MinimalCtx()
+        assert isinstance(ctx, AgentContextProtocol)
+
+    def test_protocol_requires_core_attributes(self):
+        """Protocol must declare model, provider, endpoint at minimum."""
+        hints = {}
+        for cls in AgentContextProtocol.__mro__:
+            hints.update(getattr(cls, "__annotations__", {}))
+        assert "model" in hints
+        assert "provider" in hints
+        assert "endpoint" in hints
+
+    def test_protocol_requires_subsystem_refs(self):
+        hints = {}
+        for cls in AgentContextProtocol.__mro__:
+            hints.update(getattr(cls, "__annotations__", {}))
+        for attr in ["_llm", "_config", "_reporter", "_notebook_executor",
+                      "_trace_store", "_session_history"]:
+            assert attr in hints, f"Protocol missing subsystem ref '{attr}'"
+
+
+# ===================================================================
+# 3. Module composition seams
+# ===================================================================
+
+class TestModuleComposition:
+    """Key OVAgent modules can be instantiated with a duck-typed context."""
+
+    def test_tool_runtime_construction(self):
+        ctx = _MinimalCtx()
+        rt = ToolRuntime(ctx, _DummyExecutor())
+        assert rt is not None
+
+    def test_tool_runtime_has_dispatch_tool(self):
+        ctx = _MinimalCtx()
+        rt = ToolRuntime(ctx, _DummyExecutor())
+        assert hasattr(rt, "dispatch_tool")
+        assert callable(rt.dispatch_tool)
+
+    def test_tool_runtime_get_visible_agent_tools(self):
+        ctx = _MinimalCtx()
+        rt = ToolRuntime(ctx, _DummyExecutor())
+        tools = rt.get_visible_agent_tools()
+        assert isinstance(tools, list)
+        names = {t["name"] for t in tools}
+        # Must include both catalog and legacy tools
+        assert "inspect_data" in names
+        assert "execute_code" in names
+
+    def test_prompt_builder_construction(self):
+        ctx = _MinimalCtx()
+        pb = PromptBuilder(ctx)
+        assert pb is not None
+
+    def test_prompt_builder_has_explore_prompt(self):
+        ctx = _MinimalCtx()
+        pb = PromptBuilder(ctx)
+        result = pb.build_explore_prompt("test context")
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+    def test_session_service_construction(self):
+        ctx = _MinimalCtx()
+        svc = SessionService(ctx)
+        assert svc is not None
+
+    def test_session_service_session_id(self):
+        ctx = _MinimalCtx(session_id="contract-test-id")
+        svc = SessionService(ctx)
+        sid = svc.get_harness_session_id()
+        assert sid == "contract-test-id"
+
+    def test_context_service_construction(self):
+        ctx = _MinimalCtx()
+        svc = ContextService(ctx)
+        assert svc is not None
+
+    def test_registry_scanner_construction(self):
+        scanner = RegistryScanner()
+        assert scanner is not None
+        assert scanner._static_registry_entries_cache is None
+
+    def test_subagent_controller_construction(self):
+        ctx = _MinimalCtx()
+        pb = PromptBuilder(ctx)
+        rt = ToolRuntime(ctx, _DummyExecutor())
+        sc = SubagentController(ctx, pb, rt)
+        assert sc is not None
+
+
+# ===================================================================
+# 4. FollowUpGate heuristics
+# ===================================================================
+
+class TestFollowUpGateContract:
+    """FollowUpGate classification patterns are stable."""
+
+    def test_url_request_requires_tool_action(self):
+        assert FollowUpGate.request_requires_tool_action(
+            "fetch https://example.com/data.csv", None
+        ) is True
+
+    def test_adata_present_requires_tool_action(self):
+        assert FollowUpGate.request_requires_tool_action(
+            "analyze this", object()
+        ) is True
+
+    def test_empty_request_no_tool_action(self):
+        assert FollowUpGate.request_requires_tool_action("", None) is False
+
+    def test_action_verb_requires_tool_action(self):
+        for verb in ["analyze", "download", "inspect", "load", "execute"]:
+            result = FollowUpGate.request_requires_tool_action(
+                f"{verb} the dataset", None
+            )
+            assert result is True, f"Expected True for action verb '{verb}'"
+
+    def test_gate_has_expected_patterns(self):
+        """FollowUpGate exposes the documented regex patterns."""
+        assert hasattr(FollowUpGate, "URL_PATTERN")
+        assert hasattr(FollowUpGate, "ACTION_REQUEST_PATTERN")
+        assert hasattr(FollowUpGate, "PROMISSORY_PATTERN")
+        assert hasattr(FollowUpGate, "BLOCKER_PATTERN")
+        assert hasattr(FollowUpGate, "RESULT_PATTERN")
+
+
+# ===================================================================
+# 5. OmicVerseRuntime workflow composition
+# ===================================================================
+
+class TestOmicVerseRuntimeContract:
+    """OmicVerseRuntime composes workflow documents into prompts."""
+
+    def test_runtime_construction_without_workflow(self, tmp_path):
+        rt = OmicVerseRuntime(repo_root=tmp_path)
+        assert rt.repo_root == tmp_path
+        assert rt.workflow is not None
+
+    def test_compose_system_prompt_noop_without_workflow(self, tmp_path):
+        rt = OmicVerseRuntime(repo_root=tmp_path)
+        base = "Base system prompt."
+        result = rt.compose_system_prompt(base)
+        assert result == base
+
+    def test_compose_system_prompt_injects_workflow(self, tmp_path):
+        wf = tmp_path / "WORKFLOW.md"
+        wf.write_text(
+            "---\n"
+            "domain: bioinformatics\n"
+            "default_tools:\n"
+            "  - inspect_data\n"
+            "---\n"
+            "\n"
+            "Run QC first.\n",
+            encoding="utf-8",
+        )
+        rt = OmicVerseRuntime(repo_root=tmp_path, workflow_path=wf)
+        result = rt.compose_system_prompt("Base prompt.")
+        assert "REPOSITORY WORKFLOW POLICY" in result
+        assert "bioinformatics" in result
+        assert "Run QC first." in result
+
+    def test_reload_workflow_returns_document(self, tmp_path):
+        rt = OmicVerseRuntime(repo_root=tmp_path)
+        doc = rt.reload_workflow()
+        assert isinstance(doc, WorkflowDocument)
+
+
+# ===================================================================
+# 6. WorkflowDocument / WorkflowConfig
+# ===================================================================
+
+class TestWorkflowContractTypes:
+
+    def test_workflow_config_has_expected_fields(self):
+        cfg = WorkflowConfig()
+        assert hasattr(cfg, "domain")
+        assert hasattr(cfg, "default_tools")
+
+    def test_load_workflow_document_returns_document(self, tmp_path):
+        doc = load_workflow_document(tmp_path)
+        assert isinstance(doc, WorkflowDocument)
+
+    def test_workflow_document_has_config_and_body(self, tmp_path):
+        doc = load_workflow_document(tmp_path)
+        assert hasattr(doc, "config")
+        assert hasattr(doc, "body")
+        assert isinstance(doc.config, WorkflowConfig)
+
+
+# ===================================================================
+# 7. RunStore / AnalysisRun lifecycle
+# ===================================================================
+
+class TestRunStoreContract:
+
+    def test_run_store_construction(self, tmp_path):
+        store = RunStore(root=tmp_path / "runs")
+        assert store is not None
+
+    def test_analysis_run_has_expected_fields(self):
+        run = AnalysisRun(
+            run_id="test-run-001",
+            request="run qc",
+            model="test-model",
+            provider="openai",
+        )
+        assert run.run_id == "test-run-001"
+        assert run.status == "started"
+        assert isinstance(run.trace_ids, list)
+        assert isinstance(run.artifacts, list)
+
+    def test_start_and_finish_run(self, tmp_path):
+        store = RunStore(root=tmp_path / "runs")
+        doc = load_workflow_document(tmp_path)
+        run = store.start_run(
+            request="test analysis",
+            model="test-model",
+            provider="openai",
+            session_id="sess-001",
+            workflow=doc,
+        )
+        assert run.status == "started"
+        finished = store.finish_run(run.run_id, status="success", summary="done")
+        assert finished.status == "success"
+
+
+# ===================================================================
+# 8. ProactiveCodeTransformer
+# ===================================================================
+
+class TestProactiveCodeTransformerContract:
+
+    def test_transformer_is_importable(self):
+        assert ProactiveCodeTransformer is not None
+
+    def test_transformer_has_inplace_functions(self):
+        assert hasattr(ProactiveCodeTransformer, "INPLACE_FUNCTIONS")
+        funcs = ProactiveCodeTransformer.INPLACE_FUNCTIONS
+        assert isinstance(funcs, set)
+        assert "pca" in funcs
+        assert "scale" in funcs
+
+    def test_transformer_instantiation(self):
+        t = ProactiveCodeTransformer()
+        assert t is not None
+
+
+# ===================================================================
+# 9. LEGACY_AGENT_TOOLS contract
+# ===================================================================
+
+class TestLegacyToolsContract:
+
+    def test_legacy_tools_is_list(self):
+        assert isinstance(LEGACY_AGENT_TOOLS, list)
+        assert len(LEGACY_AGENT_TOOLS) > 0
+
+    def test_legacy_tools_have_required_fields(self):
+        for tool in LEGACY_AGENT_TOOLS:
+            assert "name" in tool, f"Tool missing 'name': {tool}"
+            assert "description" in tool, f"Tool missing 'description': {tool}"
+            assert "parameters" in tool, f"Tool missing 'parameters': {tool}"
+            assert tool["parameters"]["type"] == "object"
+
+    def test_expected_legacy_tool_names(self):
+        names = {t["name"] for t in LEGACY_AGENT_TOOLS}
+        expected = {
+            "inspect_data", "execute_code", "run_snippet",
+            "search_functions", "search_skills", "delegate",
+            "web_fetch", "web_search", "web_download", "finish",
+        }
+        assert expected == names
+
+
+# ===================================================================
+# 10. CODE_QUALITY_RULES constant
+# ===================================================================
+
+class TestCodeQualityRulesContract:
+
+    def test_code_quality_rules_is_string(self):
+        assert isinstance(CODE_QUALITY_RULES, str)
+        assert len(CODE_QUALITY_RULES) > 0
+
+    def test_code_quality_rules_mentions_mandatory(self):
+        assert "MANDATORY" in CODE_QUALITY_RULES
+
+
+# ===================================================================
+# 11. Auth module surface
+# ===================================================================
+
+class TestAuthSurfaceContract:
+
+    def test_resolve_model_and_provider_callable(self):
+        assert callable(resolve_model_and_provider)
+
+    def test_collect_api_key_env_callable(self):
+        assert callable(collect_api_key_env)
+
+    def test_temporary_api_keys_callable(self):
+        assert callable(temporary_api_keys)
+
+    def test_resolved_backend_is_type(self):
+        assert isinstance(ResolvedBackend, type)
+
+
+# ===================================================================
+# 12. Bootstrap function surface
+# ===================================================================
+
+class TestBootstrapSurfaceContract:
+
+    def test_bootstrap_functions_are_callable(self):
+        funcs = [
+            format_skill_overview,
+            initialize_skill_registry,
+            initialize_notebook_executor,
+            initialize_filesystem_context,
+            initialize_session_history,
+            initialize_tracing,
+            initialize_security,
+            initialize_ov_runtime,
+            create_llm_backend,
+            display_reflection_config,
+        ]
+        for fn in funcs:
+            assert callable(fn), f"{fn} is not callable"

--- a/tests/utils/test_runtime_upgrade_audit.py
+++ b/tests/utils/test_runtime_upgrade_audit.py
@@ -27,8 +27,20 @@ import pytest
 # Guard
 # ---------------------------------------------------------------------------
 
+def _is_truthy_env(var_name: str) -> bool:
+    """Return True only if the env var is set to a common truthy value.
+
+    Accepts: "1", "true", "yes", "on" (case-insensitive, with optional
+    surrounding whitespace).  Avoids false positives from "0" or "false".
+    """
+    value = os.environ.get(var_name)
+    if value is None:
+        return False
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
 pytestmark = pytest.mark.skipif(
-    not os.environ.get("OV_AGENT_RUN_HARNESS_TESTS"),
+    not _is_truthy_env("OV_AGENT_RUN_HARNESS_TESTS"),
     reason="harness tests disabled",
 )
 

--- a/tests/utils/test_runtime_upgrade_audit.py
+++ b/tests/utils/test_runtime_upgrade_audit.py
@@ -1,0 +1,605 @@
+"""Cross-module integration audit for the OVAgent runtime-upgrade wave.
+
+Verifies that the seven new runtime subsystems (tasks 024-030, 034)
+work together correctly on the real codebase:
+
+  - tool_registry, tool_scheduler, context_budget, repair_loop,
+    permission_policy, event_stream, prompt_templates
+
+These tests are intentionally lightweight: no real LLM calls, no heavy
+optional dependencies.  They run under ``OV_AGENT_RUN_HARNESS_TESTS=1``.
+"""
+
+import ast
+import asyncio
+import importlib
+import importlib.machinery
+import os
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Guard
+# ---------------------------------------------------------------------------
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("OV_AGENT_RUN_HARNESS_TESTS"),
+    reason="harness tests disabled",
+)
+
+# ---------------------------------------------------------------------------
+# Bootstrap: lightweight package stubs to avoid heavy omicverse.__init__
+# ---------------------------------------------------------------------------
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+PACKAGE_ROOT = PROJECT_ROOT / "omicverse"
+
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+_SAVED = {n: sys.modules.get(n) for n in ["omicverse", "omicverse.utils"]}
+for n in ["omicverse", "omicverse.utils"]:
+    sys.modules.pop(n, None)
+
+_ov_pkg = types.ModuleType("omicverse")
+_ov_pkg.__path__ = [str(PACKAGE_ROOT)]
+_ov_pkg.__spec__ = importlib.machinery.ModuleSpec("omicverse", loader=None, is_package=True)
+sys.modules["omicverse"] = _ov_pkg
+
+_utils_pkg = types.ModuleType("omicverse.utils")
+_utils_pkg.__path__ = [str(PACKAGE_ROOT / "utils")]
+_utils_pkg.__spec__ = importlib.machinery.ModuleSpec("omicverse.utils", loader=None, is_package=True)
+sys.modules["omicverse.utils"] = _utils_pkg
+_ov_pkg.utils = _utils_pkg
+
+import omicverse.utils.ovagent as ovagent_pkg  # noqa: E402
+from omicverse.utils.ovagent import (  # noqa: E402
+    ApprovalClass, BudgetSlice, BudgetSliceType, CompactionCheckpoint,
+    ContextBudgetManager, ExecutionBatch, FailureEnvelope, IsolationMode,
+    OutputTier, ParallelClass, PermissionDecision, PermissionPolicy,
+    PermissionVerdict, PromptBuilder, PromptOverlay, PromptTemplateEngine,
+    RuntimeEventEmitter, ScheduleResult, ScheduledCall, SubagentController,
+    SubagentRuntime, ToolMetadata, ToolRegistry, ToolRuntime, ToolScheduler,
+    TruncationPolicy, TurnController, build_agentic_engine,
+    build_dataset_context, build_default_registry, build_llm_repair_prompt,
+    build_subagent_engine, create_default_policy,
+    create_subagent_budget_manager, create_subagent_policy, execute_batch,
+)
+from omicverse.utils.ovagent.tool_runtime import LEGACY_AGENT_TOOLS  # noqa: E402
+
+for n, mod in _SAVED.items():
+    if mod is None:
+        sys.modules.pop(n, None)
+    else:
+        sys.modules[n] = mod
+
+# ---------------------------------------------------------------------------
+# Minimal context double (matches AgentContext protocol)
+# ---------------------------------------------------------------------------
+
+_STUB_METHODS = [
+    "_emit", "_get_harness_session_id", "_get_runtime_session_id",
+    "_get_visible_agent_tools", "_get_loaded_tool_names",
+    "_refresh_runtime_working_directory", "_tool_blocked_in_plan_mode",
+    "_detect_repo_root", "_resolve_local_path", "_ensure_server_tool_mode",
+    "_request_interaction", "_request_tool_approval", "_load_skill_guidance",
+    "_extract_python_code", "_extract_python_code_strict",
+    "_gather_code_candidates", "_normalize_code_candidate",
+    "_collect_static_registry_entries", "_collect_runtime_registry_entries",
+    "_review_generated_code_lightweight", "_contains_forbidden_scanpy_usage",
+    "_rewrite_scanpy_calls_with_registry",
+    "_normalize_registry_entry_for_codegen", "_build_agentic_system_prompt",
+]
+
+
+class _MinimalCtx:
+    """Lightweight AgentContext double for integration tests."""
+    LEGACY_AGENT_TOOLS = LEGACY_AGENT_TOOLS
+
+    def __init__(self):
+        self.model = "test-model"
+        self.provider = "openai"
+        self.endpoint = "https://api.example.com"
+        self.api_key = None
+        self._llm = None
+        self._config = SimpleNamespace()
+        self._security_config = SimpleNamespace()
+        self._security_scanner = SimpleNamespace()
+        self._filesystem_context = None
+        self.skill_registry = None
+        self._notebook_executor = None
+        self._ov_runtime = None
+        self._trace_store = None
+        self._session_history = None
+        self._context_compactor = None
+        self._approval_handler = None
+        self._reporter = MagicMock()
+        self.last_usage = None
+        self.last_usage_breakdown = {}
+        self._last_run_trace = None
+        self._active_run_id = ""
+        self._web_session_id = "test-audit-session"
+        self._managed_api_env = {}
+        self._code_only_mode = False
+        self._code_only_captured_code = ""
+        self._code_only_captured_history = []
+        self.use_notebook_execution = False
+        self.enable_filesystem_context = False
+        # Attach stub methods that return neutral defaults
+        for name in _STUB_METHODS:
+            if not hasattr(self, name):
+                setattr(self, name, lambda *a, _n=name, **kw: (
+                    [] if "collect" in _n or "gather" in _n or "visible" in _n or "loaded" in _n
+                    else "" if "build" in _n or "extract" in _n or "load" in _n or "rewrite" in _n
+                    else None
+                ))
+
+    def _get_harness_session_id(self):
+        return self._web_session_id
+
+    def _get_runtime_session_id(self):
+        return self._web_session_id or "default"
+
+    def _get_visible_agent_tools(self, *, allowed_names=None):
+        return []
+
+    def _get_loaded_tool_names(self):
+        return []
+
+    async def _run_agentic_loop(self, request, adata, event_callback=None,
+                                cancel_event=None, history=None,
+                                approval_handler=None, request_content=None):
+        return adata
+
+
+class _DummyExecutor:
+    pass
+
+
+class _FakeToolCall:
+    """Simple stand-in for a provider tool-call object."""
+    def __init__(self, name, call_id="tc_1", arguments=None):
+        self.name = name
+        self.id = call_id
+        self.arguments = arguments or {}
+
+
+# ===================================================================
+# 1. TestExportCompleteness
+# ===================================================================
+
+class TestExportCompleteness:
+    """Every new public symbol is reachable and listed in __all__."""
+
+    NEW_SYMBOLS = {
+        "ToolMetadata", "ToolRegistry", "build_default_registry",
+        "ApprovalClass", "ParallelClass", "OutputTier", "IsolationMode",
+        "ToolScheduler", "ExecutionBatch", "ScheduledCall", "ScheduleResult",
+        "execute_batch", "ContextBudgetManager", "BudgetSlice",
+        "BudgetSliceType", "CompactionCheckpoint", "TruncationPolicy",
+        "create_subagent_budget_manager", "ExecutionRepairLoop",
+        "FailureEnvelope", "RepairAttempt", "RepairResult",
+        "build_dataset_context", "build_llm_repair_prompt",
+        "PermissionPolicy", "PermissionDecision", "PermissionVerdict",
+        "create_default_policy", "create_subagent_policy",
+        "RuntimeEventEmitter", "PromptTemplateEngine", "PromptOverlay",
+        "build_agentic_engine", "build_subagent_engine",
+    }
+
+    def test_all_new_symbols_in_all(self):
+        missing = self.NEW_SYMBOLS - set(ovagent_pkg.__all__)
+        assert not missing, f"Missing from __all__: {missing}"
+
+    def test_all_new_symbols_resolve(self):
+        for name in self.NEW_SYMBOLS:
+            assert getattr(ovagent_pkg, name, None) is not None, f"'{name}' is None"
+
+    def test_no_stale_symbols_in_all(self):
+        for name in ovagent_pkg.__all__:
+            assert getattr(ovagent_pkg, name, None) is not None, f"Stale: '{name}'"
+
+
+# ===================================================================
+# 2. TestCrossModuleTypeCoherence
+# ===================================================================
+
+class TestCrossModuleTypeCoherence:
+    """Types from different modules compose correctly."""
+
+    def test_scheduler_accepts_registry_produces_parallel_class(self):
+        registry = build_default_registry()
+        result = ToolScheduler(registry).schedule([_FakeToolCall("Read")])
+        assert isinstance(result, ScheduleResult)
+        assert isinstance(result.batches[0].calls[0].parallel_class, ParallelClass)
+
+    def test_permission_policy_uses_same_approval_class(self):
+        registry = build_default_registry()
+        decision = PermissionPolicy(registry).check("Bash")
+        meta = registry.get("Bash")
+        assert decision.verdict.value == meta.approval_class.value
+
+    def test_budget_manager_truncate_uses_output_tier(self):
+        mgr = ContextBudgetManager(model="test")
+        assert (mgr.get_truncation_policy(OutputTier.verbose).max_tokens
+                > mgr.get_truncation_policy(OutputTier.minimal).max_tokens)
+
+    def test_prompt_engine_feeds_prompt_builder(self):
+        prompt = PromptBuilder(_MinimalCtx()).build_agentic_system_prompt()
+        assert isinstance(prompt, str) and "OmicVerse" in prompt
+
+    def test_create_subagent_policy_returns_permission_decision(self):
+        registry = build_default_registry()
+        dec = create_subagent_policy(registry, frozenset({"Read"})).check("Read")
+        assert isinstance(dec, PermissionDecision)
+
+
+# ===================================================================
+# 3. TestRegistryToSchedulerPipeline
+# ===================================================================
+
+class TestRegistryToSchedulerPipeline:
+    """Registry -> Scheduler -> Batch execution pipeline."""
+
+    def test_schedule_produces_batches(self):
+        result = ToolScheduler(build_default_registry()).schedule(
+            [_FakeToolCall("Read"), _FakeToolCall("Glob"), _FakeToolCall("Grep")]
+        )
+        assert result.total_calls == 3 and result.total_batches >= 1
+
+    def test_readonly_tools_batched_together(self):
+        result = ToolScheduler(build_default_registry()).schedule(
+            [_FakeToolCall("Read"), _FakeToolCall("Glob"), _FakeToolCall("Grep")]
+        )
+        assert result.total_batches == 1
+        assert result.batches[0].parallel is True and result.batches[0].size == 3
+
+    def test_stateful_tool_forces_serial_batch(self):
+        result = ToolScheduler(build_default_registry()).schedule(
+            [_FakeToolCall("Read"), _FakeToolCall("Bash"), _FakeToolCall("Read", "tc_3")]
+        )
+        assert result.total_batches == 3
+        assert result.batches[1].parallel is False
+
+    def test_execute_batch_returns_results_in_index_order(self):
+        batch = ToolScheduler(build_default_registry()).schedule(
+            [_FakeToolCall("Read"), _FakeToolCall("Glob", "tc_2")]
+        ).batches[0]
+
+        async def dispatch(sc):
+            return f"r_{sc.index}"
+
+        results = asyncio.run(execute_batch(batch, dispatch))
+        assert [i for i, _ in results] == sorted(i for i, _ in results)
+        assert results[0] == (0, "r_0") and results[1] == (1, "r_1")
+
+
+# ===================================================================
+# 4. TestRegistryToPermissionPipeline
+# ===================================================================
+
+class TestRegistryToPermissionPipeline:
+    """Registry -> PermissionPolicy -> check verdicts."""
+
+    def test_known_tool_verdicts(self):
+        policy = create_default_policy(build_default_registry())
+        assert policy.check("Read").verdict == PermissionVerdict.allow
+        assert policy.check("Bash").verdict == PermissionVerdict.ask
+
+    def test_unknown_tool_denied(self):
+        assert create_default_policy(build_default_registry()).check(
+            "nonexistent_xyz"
+        ).verdict == PermissionVerdict.deny
+
+    def test_subagent_policy_restricts_tools(self):
+        registry = build_default_registry()
+        policy = create_subagent_policy(registry, frozenset({"Read", "Glob", "inspect_data"}))
+        assert not policy.check("Read").is_denied
+        assert not policy.check("inspect_data").is_denied
+        assert policy.check("Bash").is_denied
+        assert policy.check("Edit").is_denied
+
+
+# ===================================================================
+# 5. TestBudgetManagerIntegration
+# ===================================================================
+
+class TestBudgetManagerIntegration:
+    """ContextBudgetManager cross-module integration."""
+
+    def test_record_slices_and_consumption_by_type(self):
+        mgr = ContextBudgetManager(model="gpt-4o")
+        mgr.record(BudgetSliceType.system_prompt, "System prompt text here")
+        mgr.record(BudgetSliceType.tool_output, "Tool output", content_key="bash",
+                    tier=OutputTier.verbose)
+        totals = mgr.consumption_by_type()
+        assert "system_prompt" in totals and "tool_output" in totals
+        assert mgr.total_consumed > 0
+
+    def test_truncate_verbose_vs_minimal(self):
+        mgr = ContextBudgetManager(model="test")
+        long_text = "x" * 50000
+        v = mgr.truncate_output(long_text, OutputTier.verbose)
+        m = mgr.truncate_output(long_text, OutputTier.minimal)
+        assert len(v) > len(m) and len(v) < len(long_text)
+
+    def test_compact_history_with_checkpoint(self):
+        mgr = ContextBudgetManager(model="test")
+        mgr.add_checkpoint(0, "Summary of turns 0-3", messages_covered=4)
+        messages = [{"role": "system", "content": "Agent."}] + [
+            {"role": r, "content": f"msg {i}"}
+            for i in range(6) for r in ["user", "assistant"]
+        ]
+        compacted, cp = mgr.compact_history(messages, keep_recent=2)
+        assert cp is not None and isinstance(cp, CompactionCheckpoint)
+        assert len(compacted) <= len(messages)
+
+    def test_subagent_budget_tighter_policies(self):
+        default_v = ContextBudgetManager(model="test").get_truncation_policy(OutputTier.verbose)
+        sub_v = create_subagent_budget_manager(model="test").get_truncation_policy(OutputTier.verbose)
+        assert sub_v.max_tokens < default_v.max_tokens
+
+
+# ===================================================================
+# 6. TestRepairLoopIntegration
+# ===================================================================
+
+class TestRepairLoopIntegration:
+    """FailureEnvelope, repair prompt, and dataset context."""
+
+    def test_envelope_from_exception_roundtrip(self):
+        try:
+            raise ValueError("missing column 'batch'")
+        except ValueError as exc:
+            env = FailureEnvelope.from_exception(exc, phase="execution", retry_count=1,
+                                                  code="print('hello')")
+        assert env.exception == "ValueError" and "missing column" in env.summary
+        d = env.to_dict()
+        assert d["phase"] == "execution" and isinstance(d["repair_hints"], list)
+
+    def test_build_llm_repair_prompt_non_empty(self):
+        env = FailureEnvelope(phase="execution", exception="KeyError",
+                              summary="'batch' not found",
+                              traceback_excerpt="KeyError: 'batch'",
+                              retry_count=0, code="adata.obs['batch']",
+                              dataset_context="Shape: 1000 obs x 500 vars",
+                              repair_hints=["check column names"])
+        prompt = build_llm_repair_prompt(env)
+        assert len(prompt) > 50 and "KeyError" in prompt and "DATASET" in prompt
+
+    def test_build_dataset_context_handles_none_and_missing(self):
+        assert build_dataset_context(None) == ""
+        assert build_dataset_context(SimpleNamespace()) == ""
+
+    def test_build_dataset_context_with_shape(self):
+        result = build_dataset_context(SimpleNamespace(shape=(500, 200)))
+        assert "500" in result and "200" in result
+
+
+# ===================================================================
+# 7. TestEventStreamIntegration
+# ===================================================================
+
+class TestEventStreamIntegration:
+    """RuntimeEventEmitter integration with callbacks and AST checks."""
+
+    def test_callback_receives_structured_payloads(self):
+        captured = []
+        async def cb(event): captured.append(event)
+        emitter = RuntimeEventEmitter(event_callback=cb, source="audit")
+        asyncio.run(emitter.emit("status", {"key": "val"}, category="test"))
+        assert len(captured) == 1 and captured[0]["type"] == "status"
+
+    def test_event_types_coverage(self):
+        for m in ["turn_started", "tool_dispatched", "tool_completed", "task_finished"]:
+            assert hasattr(RuntimeEventEmitter, m) and callable(getattr(RuntimeEventEmitter, m))
+
+    def test_no_bare_print_in_runtime_modules(self):
+        ovagent_dir = PACKAGE_ROOT / "utils" / "ovagent"
+        for mod_path in [
+            ovagent_dir / f for f in [
+                "turn_controller.py", "tool_runtime.py", "subagent_controller.py",
+                "event_stream.py", "tool_scheduler.py", "context_budget.py",
+                "permission_policy.py",
+            ]
+        ]:
+            if not mod_path.exists():
+                continue
+            tree = ast.parse(mod_path.read_text(), filename=str(mod_path))
+            lines = [n.lineno for n in ast.walk(tree)
+                     if isinstance(n, ast.Call) and isinstance(n.func, ast.Name)
+                     and n.func.id == "print"]
+            assert lines == [], f"{mod_path.name} has print() on lines {lines}"
+
+
+# ===================================================================
+# 8. TestPromptCompositionPipeline
+# ===================================================================
+
+class TestPromptCompositionPipeline:
+    """PromptTemplateEngine -> PromptBuilder composition."""
+
+    def test_agentic_engine_has_expected_overlays(self):
+        engine = build_agentic_engine()
+        assert isinstance(engine, PromptTemplateEngine)
+        assert engine.has_overlay("tool_instructions") and engine.has_overlay("workflow")
+
+    def test_subagent_engine_explore(self):
+        rendered = build_subagent_engine("explore").render()
+        assert "bioinformatics" in rendered.lower() or "data" in rendered.lower()
+
+    def test_builder_produces_prompt_with_engine_content(self):
+        prompt = PromptBuilder(_MinimalCtx()).build_agentic_system_prompt()
+        assert "OmicVerse" in prompt and "ToolSearch" in prompt
+
+    def test_overlay_priority_deterministic(self):
+        def make():
+            e = PromptTemplateEngine()
+            e.set_base("base")
+            e.add_overlay(PromptOverlay("z_last", "Z", priority=200))
+            e.add_overlay(PromptOverlay("a_first", "A", priority=10))
+            e.add_overlay(PromptOverlay("m_mid", "M", priority=100))
+            return e.overlay_names
+        assert make() == ["a_first", "m_mid", "z_last"]
+        assert make() == make()  # deterministic across calls
+
+
+# ===================================================================
+# 9. TestSubagentIsolationContract
+# ===================================================================
+
+class TestSubagentIsolationContract:
+    """SubagentRuntime scoped isolation guarantees."""
+
+    def _make_rt(self, allowed):
+        registry = build_default_registry()
+        return SubagentRuntime(
+            agent_type="explore", max_turns=5,
+            permission_policy=create_subagent_policy(registry, frozenset(allowed)),
+            budget_manager=create_subagent_budget_manager(model="test"),
+            tool_schemas=[{"name": "Read"}, {"name": "Glob"}],
+        )
+
+    def test_permission_denies_outside_allowed_set(self):
+        rt = self._make_rt({"Read", "Glob"})
+        assert not rt.check_tool_permission("Read").is_denied
+        assert rt.check_tool_permission("Bash").is_denied
+
+    def test_budget_manager_independence(self):
+        parent = ContextBudgetManager(model="test")
+        child = create_subagent_budget_manager(model="test")
+        child.record(BudgetSliceType.tool_output, "output", tier=OutputTier.standard)
+        assert child.total_consumed > 0 and parent.total_consumed == 0
+
+    def test_tool_schemas_are_snapshot(self):
+        original = [{"name": "Read"}, {"name": "Glob"}]
+        rt = self._make_rt({"Read"})
+        rt.tool_schemas = list(original)
+        rt.tool_schemas.append({"name": "Bash"})
+        assert len(original) == 2  # original unaffected
+
+
+# ===================================================================
+# 10. TestEndToEndDispatchPath
+# ===================================================================
+
+class TestEndToEndDispatchPath:
+    """Registry -> Scheduler -> Permission -> Budget end-to-end."""
+
+    def test_full_pipeline_consistency(self):
+        registry = build_default_registry()
+        scheduler = ToolScheduler(registry)
+        policy = create_default_policy(registry)
+        budget = ContextBudgetManager(model="test")
+
+        calls = [_FakeToolCall("Read"), _FakeToolCall("Bash", "tc_2"),
+                 _FakeToolCall("Glob", "tc_3")]
+        schedule = scheduler.schedule(calls)
+        assert schedule.total_calls == 3
+
+        all_sc = [sc for b in schedule.batches for sc in b.calls]
+        for sc in all_sc:
+            meta = registry.get(sc.canonical_name)
+            assert meta is not None
+            assert sc.parallel_class == meta.parallel_class
+            # Permission is consistent with registry
+            assert policy.check(sc.canonical_name).verdict == PermissionVerdict(
+                meta.approval_class.value
+            )
+            # Budget can record with correct tier
+            budget.record(BudgetSliceType.tool_output,
+                          f"output from {sc.canonical_name}",
+                          content_key=sc.canonical_name, tier=meta.output_tier)
+
+        assert budget.total_consumed > 0
+        assert "tool_output" in budget.consumption_by_type()
+
+
+# ===================================================================
+# 11. TestNoNewDependencies
+# ===================================================================
+
+class TestNoNewDependencies:
+    """Runtime-upgrade modules don't add new project dependencies."""
+
+    KNOWN_DEPS = {
+        "numpy", "scanpy", "pandas", "matplotlib", "scikit-learn", "scipy",
+        "networkx", "multiprocess", "seaborn", "datetime", "statsmodels",
+        "ipywidgets", "pygam", "igraph", "tqdm", "adjusttext", "scikit-misc",
+        "scikit-image", "plotly", "numba", "requests", "transformers",
+        "marsilea", "openai", "omicverse-skills", "omicverse-notebook",
+        "zarr", "anndata", "setuptools", "wheel", "cython",
+    }
+
+    def test_no_new_core_dependencies(self):
+        import re as _re
+        text = (PROJECT_ROOT / "pyproject.toml").read_text()
+        in_deps, deps = False, []
+        for line in text.splitlines():
+            s = line.strip()
+            if s.startswith("dependencies"):
+                in_deps = True; continue
+            if in_deps and s == "]":
+                break
+            if in_deps:
+                c = s.strip("',\" ")
+                if c and not c.startswith("#"):
+                    deps.append(c)
+        actual = {_re.match(r"^([A-Za-z0-9_-]+)", d).group(1).lower()
+                  for d in deps if _re.match(r"^([A-Za-z0-9_-]+)", d)}
+        new = actual - self.KNOWN_DEPS
+        assert not new, f"New dependencies: {new}"
+
+    def test_runtime_modules_import_only_stdlib_and_project(self):
+        ovagent_dir = PACKAGE_ROOT / "utils" / "ovagent"
+        stdlib = set(sys.stdlib_module_names) if hasattr(sys, "stdlib_module_names") else set()
+        for mod_path in [ovagent_dir / f for f in [
+            "tool_registry.py", "tool_scheduler.py", "context_budget.py",
+            "repair_loop.py", "permission_policy.py", "event_stream.py",
+            "prompt_templates.py",
+        ]]:
+            if not mod_path.exists():
+                continue
+            tree = ast.parse(mod_path.read_text(), filename=str(mod_path))
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Import):
+                    for alias in node.names:
+                        top = alias.name.split(".")[0]
+                        assert top in stdlib or alias.name.startswith(("omicverse", ".")), (
+                            f"{mod_path.name} imports external: {alias.name}"
+                        )
+
+
+# ===================================================================
+# 12. TestInterfaceStability
+# ===================================================================
+
+class TestInterfaceStability:
+    """Public APIs from existing modules remain stable."""
+
+    def test_omicverse_agent_methods(self):
+        source = (PACKAGE_ROOT / "utils" / "smart_agent.py").read_text()
+        for m in ["_run_agentic_loop", "run_async", "stream_async", "generate_code_async"]:
+            assert f"def {m}" in source, f"OmicVerseAgent missing: {m}"
+
+    def test_tool_runtime_methods(self):
+        ctx = _MinimalCtx()
+        rt = ToolRuntime(ctx, _DummyExecutor())
+        for m in ["dispatch_tool", "get_visible_agent_tools", "get_loaded_tool_names"]:
+            assert hasattr(rt, m) and callable(getattr(rt, m))
+
+    def test_turn_controller_3arg(self):
+        ctx = _MinimalCtx()
+        assert TurnController(ctx, PromptBuilder(ctx), ToolRuntime(ctx, _DummyExecutor())) is not None
+
+    def test_subagent_controller_3arg(self):
+        ctx = _MinimalCtx()
+        assert SubagentController(ctx, PromptBuilder(ctx), ToolRuntime(ctx, _DummyExecutor())) is not None
+
+    def test_prompt_builder_ctx(self):
+        pb = PromptBuilder(_MinimalCtx())
+        assert hasattr(pb, "build_agentic_system_prompt") and hasattr(pb, "build_explore_prompt")

--- a/tests/utils/test_tool_registry.py
+++ b/tests/utils/test_tool_registry.py
@@ -1,0 +1,639 @@
+"""Contract tests for the tool metadata model and registry seam.
+
+Validates that ToolMetadata, ToolRegistry, and build_default_registry()
+satisfy the acceptance criteria for task-024:
+
+- A concrete tool metadata model exists for the live codebase
+- The model reuses existing tool_catalog definitions where possible
+- Handler registration, alias normalization, policy attributes, and
+  migration constraints are explicit
+- Follow-on dispatch and scheduler tasks have a stable contract
+"""
+
+import pytest
+
+from omicverse.utils.ovagent.tool_registry import (
+    ApprovalClass,
+    IsolationMode,
+    OutputTier,
+    ParallelClass,
+    ToolMetadata,
+    ToolRegistry,
+    build_default_registry,
+    _CATALOG_TOOL_POLICIES,
+    _LEGACY_TOOL_POLICIES,
+    _LEGACY_CATALOG_ALIASES,
+)
+from omicverse.utils.harness.tool_catalog import (
+    CLAUDE_CODE_TOOLS,
+    ToolCatalog,
+    ToolDefinition,
+    get_default_tool_catalog,
+    normalize_tool_name,
+)
+from omicverse.utils.ovagent.tool_runtime import LEGACY_AGENT_TOOLS
+
+
+# ===================================================================
+# 1. ToolMetadata model
+# ===================================================================
+
+
+class TestToolMetadataModel:
+    """ToolMetadata is a concrete, frozen data model with all required fields."""
+
+    def test_construction_with_catalog_definition(self):
+        catalog = get_default_tool_catalog()
+        read_def = catalog.get("Read")
+        assert read_def is not None
+
+        meta = ToolMetadata(
+            canonical_name="Read",
+            handler_key="read",
+            approval_class=ApprovalClass.allow,
+            parallel_class=ParallelClass.readonly,
+            output_tier=OutputTier.standard,
+            isolation_mode=IsolationMode.none,
+            definition=read_def,
+        )
+        assert meta.canonical_name == "Read"
+        assert meta.handler_key == "read"
+        assert meta.definition is read_def
+
+    def test_construction_with_legacy_schema(self):
+        schema = {"name": "inspect_data", "description": "Inspect", "parameters": {}}
+        meta = ToolMetadata(
+            canonical_name="inspect_data",
+            handler_key="inspect_data",
+            approval_class=ApprovalClass.allow,
+            parallel_class=ParallelClass.readonly,
+            output_tier=OutputTier.standard,
+            isolation_mode=IsolationMode.none,
+            legacy_schema=schema,
+        )
+        assert meta.legacy_schema is not None
+        assert meta.definition is None
+
+    def test_frozen_immutability(self):
+        meta = ToolMetadata(
+            canonical_name="test",
+            handler_key="test",
+            approval_class=ApprovalClass.allow,
+            parallel_class=ParallelClass.readonly,
+            output_tier=OutputTier.minimal,
+            isolation_mode=IsolationMode.none,
+        )
+        with pytest.raises(AttributeError):
+            meta.canonical_name = "changed"  # type: ignore[misc]
+
+    def test_schema_property_catalog_tool(self):
+        catalog = get_default_tool_catalog()
+        bash_def = catalog.get("Bash")
+        meta = ToolMetadata(
+            canonical_name="Bash",
+            handler_key="bash",
+            approval_class=ApprovalClass.ask,
+            parallel_class=ParallelClass.stateful,
+            output_tier=OutputTier.verbose,
+            isolation_mode=IsolationMode.sandbox,
+            definition=bash_def,
+        )
+        schema = meta.schema
+        assert schema["name"] == "Bash"
+        assert "parameters" in schema
+
+    def test_schema_property_legacy_tool(self):
+        legacy = {"name": "finish", "description": "Done", "parameters": {"type": "object"}}
+        meta = ToolMetadata(
+            canonical_name="finish",
+            handler_key="finish",
+            approval_class=ApprovalClass.allow,
+            parallel_class=ParallelClass.exclusive,
+            output_tier=OutputTier.minimal,
+            isolation_mode=IsolationMode.none,
+            legacy_schema=legacy,
+        )
+        schema = meta.schema
+        assert schema["name"] == "finish"
+
+    def test_schema_property_fallback(self):
+        meta = ToolMetadata(
+            canonical_name="synthetic",
+            handler_key="synthetic",
+            approval_class=ApprovalClass.deny,
+            parallel_class=ParallelClass.exclusive,
+            output_tier=OutputTier.minimal,
+            isolation_mode=IsolationMode.none,
+        )
+        schema = meta.schema
+        assert schema["name"] == "synthetic"
+
+    def test_aliases_catalog_tool(self):
+        catalog = get_default_tool_catalog()
+        agent_def = catalog.get("Agent")
+        meta = ToolMetadata(
+            canonical_name="Agent",
+            handler_key="agent",
+            approval_class=ApprovalClass.ask,
+            parallel_class=ParallelClass.stateful,
+            output_tier=OutputTier.verbose,
+            isolation_mode=IsolationMode.none,
+            definition=agent_def,
+        )
+        aliases = meta.aliases
+        assert "Agent" in aliases
+        assert "delegate" in aliases  # legacy alias
+
+    def test_aliases_legacy_tool(self):
+        meta = ToolMetadata(
+            canonical_name="inspect_data",
+            handler_key="inspect_data",
+            approval_class=ApprovalClass.allow,
+            parallel_class=ParallelClass.readonly,
+            output_tier=OutputTier.standard,
+            isolation_mode=IsolationMode.none,
+        )
+        assert meta.aliases == ("inspect_data",)
+
+    def test_to_dict_roundtrip(self):
+        meta = ToolMetadata(
+            canonical_name="Read",
+            handler_key="read",
+            approval_class=ApprovalClass.allow,
+            parallel_class=ParallelClass.readonly,
+            output_tier=OutputTier.standard,
+            isolation_mode=IsolationMode.none,
+            migration_notes="test note",
+        )
+        d = meta.to_dict()
+        assert d["canonical_name"] == "Read"
+        assert d["approval_class"] == "allow"
+        assert d["migration_notes"] == "test note"
+
+    def test_all_required_fields_present(self):
+        """ToolMetadata has every field that dispatch and scheduler need."""
+        required_fields = {
+            "canonical_name", "handler_key",
+            "approval_class", "parallel_class",
+            "output_tier", "isolation_mode",
+            "is_async",
+        }
+        meta = ToolMetadata(
+            canonical_name="t", handler_key="t",
+            approval_class=ApprovalClass.allow,
+            parallel_class=ParallelClass.readonly,
+            output_tier=OutputTier.minimal,
+            isolation_mode=IsolationMode.none,
+        )
+        for field_name in required_fields:
+            assert hasattr(meta, field_name), f"Missing field: {field_name}"
+
+    def test_hook_fields_present(self):
+        """Optional lifecycle hooks are part of the contract."""
+        meta = ToolMetadata(
+            canonical_name="t", handler_key="t",
+            approval_class=ApprovalClass.allow,
+            parallel_class=ParallelClass.readonly,
+            output_tier=OutputTier.minimal,
+            isolation_mode=IsolationMode.none,
+            pre_exec_hook="validate_input",
+            post_exec_hook="log_result",
+            normalize_result_hook="truncate",
+        )
+        assert meta.pre_exec_hook == "validate_input"
+        assert meta.post_exec_hook == "log_result"
+        assert meta.normalize_result_hook == "truncate"
+
+
+# ===================================================================
+# 2. Policy enums
+# ===================================================================
+
+
+class TestPolicyEnums:
+    """Policy enums are string-valued and exhaustive for their domain."""
+
+    def test_approval_class_values(self):
+        assert set(ApprovalClass) == {
+            ApprovalClass.allow, ApprovalClass.ask, ApprovalClass.deny,
+        }
+        assert ApprovalClass.allow.value == "allow"
+
+    def test_parallel_class_values(self):
+        assert set(ParallelClass) == {
+            ParallelClass.readonly, ParallelClass.stateful, ParallelClass.exclusive,
+        }
+
+    def test_output_tier_values(self):
+        assert set(OutputTier) == {
+            OutputTier.minimal, OutputTier.standard, OutputTier.verbose,
+        }
+
+    def test_isolation_mode_values(self):
+        assert set(IsolationMode) == {
+            IsolationMode.none, IsolationMode.sandbox, IsolationMode.worktree,
+        }
+
+    def test_enums_are_string_subclass(self):
+        assert isinstance(ApprovalClass.allow, str)
+        assert isinstance(ParallelClass.readonly, str)
+
+
+# ===================================================================
+# 3. ToolRegistry
+# ===================================================================
+
+
+class TestToolRegistry:
+
+    def test_register_and_get(self):
+        registry = ToolRegistry()
+        meta = ToolMetadata(
+            canonical_name="TestTool",
+            handler_key="test_tool",
+            approval_class=ApprovalClass.allow,
+            parallel_class=ParallelClass.readonly,
+            output_tier=OutputTier.minimal,
+            isolation_mode=IsolationMode.none,
+        )
+        registry.register(meta)
+        assert registry.get("TestTool") is meta
+
+    def test_duplicate_registration_raises(self):
+        registry = ToolRegistry()
+        meta = ToolMetadata(
+            canonical_name="Dup",
+            handler_key="dup",
+            approval_class=ApprovalClass.allow,
+            parallel_class=ParallelClass.readonly,
+            output_tier=OutputTier.minimal,
+            isolation_mode=IsolationMode.none,
+        )
+        registry.register(meta)
+        with pytest.raises(ValueError, match="Duplicate"):
+            registry.register(meta)
+
+    def test_resolve_name_direct(self):
+        registry = ToolRegistry()
+        meta = ToolMetadata(
+            canonical_name="Read",
+            handler_key="read",
+            approval_class=ApprovalClass.allow,
+            parallel_class=ParallelClass.readonly,
+            output_tier=OutputTier.standard,
+            isolation_mode=IsolationMode.none,
+            definition=get_default_tool_catalog().get("Read"),
+        )
+        registry.register(meta)
+        assert registry.resolve_name("Read") == "Read"
+
+    def test_resolve_name_via_catalog_alias(self):
+        """Alias normalization delegates to the catalog."""
+        registry = build_default_registry()
+        # "delegate" is a legacy alias for "Agent" in the catalog
+        assert registry.resolve_name("delegate") == "Agent"
+        # "web_fetch" normalises to "WebFetch"
+        assert registry.resolve_name("web_fetch") == "WebFetch"
+        # snake_case normalization
+        assert registry.resolve_name("tool_search") == "ToolSearch"
+
+    def test_resolve_name_empty(self):
+        registry = ToolRegistry()
+        assert registry.resolve_name("") == ""
+        assert registry.resolve_name("nonexistent") == ""
+
+    def test_get_returns_none_for_unknown(self):
+        registry = ToolRegistry()
+        assert registry.get("unknown") is None
+
+    def test_handler_registration_and_lookup(self):
+        registry = ToolRegistry()
+        meta = ToolMetadata(
+            canonical_name="Tool",
+            handler_key="my_handler",
+            approval_class=ApprovalClass.allow,
+            parallel_class=ParallelClass.readonly,
+            output_tier=OutputTier.minimal,
+            isolation_mode=IsolationMode.none,
+        )
+        registry.register(meta)
+
+        handler = lambda: "result"
+        registry.register_handler("my_handler", handler)
+        assert registry.get_handler("Tool") is handler
+
+    def test_get_handler_unbound_returns_none(self):
+        registry = ToolRegistry()
+        meta = ToolMetadata(
+            canonical_name="Tool",
+            handler_key="unbound",
+            approval_class=ApprovalClass.allow,
+            parallel_class=ParallelClass.readonly,
+            output_tier=OutputTier.minimal,
+            isolation_mode=IsolationMode.none,
+        )
+        registry.register(meta)
+        assert registry.get_handler("Tool") is None
+
+    def test_validate_handlers(self):
+        registry = ToolRegistry()
+        meta_a = ToolMetadata(
+            canonical_name="A", handler_key="ha",
+            approval_class=ApprovalClass.allow,
+            parallel_class=ParallelClass.readonly,
+            output_tier=OutputTier.minimal,
+            isolation_mode=IsolationMode.none,
+        )
+        meta_b = ToolMetadata(
+            canonical_name="B", handler_key="hb",
+            approval_class=ApprovalClass.allow,
+            parallel_class=ParallelClass.readonly,
+            output_tier=OutputTier.minimal,
+            isolation_mode=IsolationMode.none,
+        )
+        registry.register(meta_a)
+        registry.register(meta_b)
+        registry.register_handler("ha", lambda: None)
+        # "hb" is still unbound
+        unbound = registry.validate_handlers()
+        assert unbound == ["hb"]
+
+    def test_all_entries(self):
+        registry = ToolRegistry()
+        meta = ToolMetadata(
+            canonical_name="X", handler_key="x",
+            approval_class=ApprovalClass.allow,
+            parallel_class=ParallelClass.readonly,
+            output_tier=OutputTier.minimal,
+            isolation_mode=IsolationMode.none,
+        )
+        registry.register(meta)
+        entries = registry.all_entries()
+        assert len(entries) == 1
+        assert entries[0] is meta
+
+    def test_handler_keys(self):
+        registry = build_default_registry()
+        keys = registry.handler_keys()
+        assert "bash" in keys
+        assert "read" in keys
+        assert "inspect_data" in keys
+
+    def test_policy_summary(self):
+        registry = build_default_registry()
+        summary = registry.policy_summary()
+        assert "Bash" in summary
+        assert summary["Bash"]["approval_class"] == "ask"
+        assert summary["Read"]["parallel_class"] == "readonly"
+
+
+# ===================================================================
+# 4. Default registry — coverage and correctness
+# ===================================================================
+
+
+class TestBuildDefaultRegistry:
+    """build_default_registry() must cover every dispatched tool."""
+
+    @pytest.fixture()
+    def registry(self):
+        return build_default_registry()
+
+    def test_every_catalog_tool_has_metadata(self, registry):
+        """All catalog ToolDefinitions have a registry entry."""
+        catalog = get_default_tool_catalog()
+        for tool_def in catalog.all_tools():
+            meta = registry.get(tool_def.name)
+            assert meta is not None, f"Missing registry entry for catalog tool: {tool_def.name}"
+
+    def test_every_non_alias_legacy_tool_has_metadata(self, registry):
+        """Legacy-only tools (not catalog aliases) have registry entries."""
+        for tool_schema in LEGACY_AGENT_TOOLS:
+            name = tool_schema["name"]
+            if name in _LEGACY_CATALOG_ALIASES:
+                continue
+            meta = registry.get(name)
+            assert meta is not None, f"Missing registry entry for legacy tool: {name}"
+
+    def test_legacy_catalog_aliases_resolve_to_catalog_entry(self, registry):
+        """Legacy names that are catalog aliases resolve correctly."""
+        expected = {
+            "delegate": "Agent",
+            "web_fetch": "WebFetch",
+            "web_search": "WebSearch",
+            "search_skills": "Skill",
+        }
+        for alias, canonical in expected.items():
+            meta = registry.get(alias)
+            assert meta is not None, f"Alias {alias!r} should resolve"
+            assert meta.canonical_name == canonical
+
+    def test_catalog_tools_reuse_tool_definition(self, registry):
+        """Catalog-sourced entries carry their ToolDefinition."""
+        catalog = get_default_tool_catalog()
+        for tool_def in catalog.all_tools():
+            meta = registry.get(tool_def.name)
+            assert meta is not None
+            assert meta.definition is tool_def, (
+                f"{tool_def.name}: definition should be the exact catalog ToolDefinition"
+            )
+
+    def test_legacy_tools_carry_legacy_schema(self, registry):
+        """Legacy-only entries carry their raw dict schema."""
+        legacy_names = set(_LEGACY_TOOL_POLICIES.keys())
+        legacy_by_name = {t["name"]: t for t in LEGACY_AGENT_TOOLS}
+        for name in legacy_names:
+            meta = registry.get(name)
+            assert meta is not None
+            if name in legacy_by_name:
+                assert meta.legacy_schema is not None
+                assert meta.legacy_schema["name"] == name
+
+    def test_no_duplicate_handler_keys(self, registry):
+        """Each entry has a unique handler key."""
+        seen: dict[str, str] = {}
+        for meta in registry.all_entries():
+            if meta.handler_key in seen:
+                assert False, (
+                    f"Duplicate handler_key {meta.handler_key!r}: "
+                    f"{seen[meta.handler_key]} and {meta.canonical_name}"
+                )
+            seen[meta.handler_key] = meta.canonical_name
+
+    def test_all_handlers_initially_unbound(self, registry):
+        """Default registry is a seam — no handlers bound yet."""
+        unbound = registry.validate_handlers()
+        assert len(unbound) > 0, "Default registry should have unbound handler keys"
+        assert len(unbound) == len(registry.handler_keys())
+
+    def test_total_entry_count(self, registry):
+        """Registry covers exactly all catalog + legacy-only tools."""
+        expected = len(CLAUDE_CODE_TOOLS) + len(_LEGACY_TOOL_POLICIES)
+        assert len(registry.all_entries()) == expected
+
+
+# ===================================================================
+# 5. Policy attribute correctness
+# ===================================================================
+
+
+class TestPolicyAttributes:
+    """Policy classifications are consistent with existing tool properties."""
+
+    @pytest.fixture()
+    def registry(self):
+        return build_default_registry()
+
+    def test_high_risk_catalog_tools_require_approval(self, registry):
+        """Catalog tools with high_risk=True must have approval_class=ask."""
+        catalog = get_default_tool_catalog()
+        for tool_def in catalog.all_tools():
+            if tool_def.high_risk:
+                meta = registry.get(tool_def.name)
+                assert meta is not None
+                assert meta.approval_class == ApprovalClass.ask, (
+                    f"{tool_def.name}: high_risk=True but approval_class={meta.approval_class}"
+                )
+
+    def test_only_agent_is_async(self, registry):
+        """Only Agent requires an async handler."""
+        for meta in registry.all_entries():
+            if meta.canonical_name == "Agent":
+                assert meta.is_async is True
+            else:
+                assert meta.is_async is False, (
+                    f"{meta.canonical_name}: unexpected is_async=True"
+                )
+
+    def test_enter_worktree_has_worktree_isolation(self, registry):
+        meta = registry.get("EnterWorktree")
+        assert meta is not None
+        assert meta.isolation_mode == IsolationMode.worktree
+
+    def test_code_execution_tools_have_sandbox_isolation(self, registry):
+        for name in ("Bash", "execute_code", "run_snippet"):
+            meta = registry.get(name)
+            assert meta is not None
+            assert meta.isolation_mode == IsolationMode.sandbox, (
+                f"{name}: expected sandbox isolation"
+            )
+
+    def test_finish_is_exclusive(self, registry):
+        meta = registry.get("finish")
+        assert meta is not None
+        assert meta.parallel_class == ParallelClass.exclusive
+
+    def test_read_only_tools_are_readonly_parallel(self, registry):
+        readonly_tools = ["Read", "Glob", "Grep", "ToolSearch", "inspect_data", "search_functions"]
+        for name in readonly_tools:
+            meta = registry.get(name)
+            assert meta is not None
+            assert meta.parallel_class == ParallelClass.readonly, (
+                f"{name}: expected readonly parallel class"
+            )
+
+    def test_mode_changing_tools_are_exclusive(self, registry):
+        for name in ("EnterPlanMode", "ExitPlanMode", "AskUserQuestion"):
+            meta = registry.get(name)
+            assert meta is not None
+            assert meta.parallel_class == ParallelClass.exclusive, (
+                f"{name}: expected exclusive parallel class"
+            )
+
+
+# ===================================================================
+# 6. Migration constraints
+# ===================================================================
+
+
+class TestMigrationConstraints:
+
+    @pytest.fixture()
+    def registry(self):
+        return build_default_registry()
+
+    def test_agent_has_migration_notes(self, registry):
+        meta = registry.get("Agent")
+        assert meta is not None
+        assert "subagent_controller" in meta.migration_notes
+
+    def test_adata_tools_have_migration_notes(self, registry):
+        for name in ("inspect_data", "execute_code", "run_snippet"):
+            meta = registry.get(name)
+            assert meta is not None
+            assert "adata" in meta.migration_notes.lower(), (
+                f"{name}: migration notes should mention adata dependency"
+            )
+
+    def test_finish_has_migration_notes(self, registry):
+        meta = registry.get("finish")
+        assert meta is not None
+        assert "terminal" in meta.migration_notes.lower()
+
+    def test_aliased_tools_have_migration_notes(self, registry):
+        """Catalog tools that absorb legacy aliases document the relationship."""
+        for name in ("Skill", "WebFetch", "WebSearch"):
+            meta = registry.get(name)
+            assert meta is not None
+            assert "legacy" in meta.migration_notes.lower(), (
+                f"{name}: should document legacy alias migration"
+            )
+
+
+# ===================================================================
+# 7. Stable contract for follow-on tasks
+# ===================================================================
+
+
+class TestSchedulerDispatchContract:
+    """The registry contract is sufficient for dispatch and scheduling."""
+
+    @pytest.fixture()
+    def registry(self):
+        return build_default_registry()
+
+    def test_every_entry_has_handler_key(self, registry):
+        for meta in registry.all_entries():
+            assert meta.handler_key, f"{meta.canonical_name}: empty handler_key"
+
+    def test_every_entry_has_valid_approval_class(self, registry):
+        for meta in registry.all_entries():
+            assert isinstance(meta.approval_class, ApprovalClass)
+
+    def test_every_entry_has_valid_parallel_class(self, registry):
+        for meta in registry.all_entries():
+            assert isinstance(meta.parallel_class, ParallelClass)
+
+    def test_every_entry_has_valid_output_tier(self, registry):
+        for meta in registry.all_entries():
+            assert isinstance(meta.output_tier, OutputTier)
+
+    def test_every_entry_has_valid_isolation_mode(self, registry):
+        for meta in registry.all_entries():
+            assert isinstance(meta.isolation_mode, IsolationMode)
+
+    def test_every_entry_has_schema(self, registry):
+        """Scheduler needs the JSON schema to validate tool call arguments."""
+        for meta in registry.all_entries():
+            schema = meta.schema
+            assert isinstance(schema, dict)
+            assert "name" in schema
+
+    def test_policy_summary_complete(self, registry):
+        """policy_summary returns one row per entry with all policy fields."""
+        summary = registry.policy_summary()
+        assert len(summary) == len(registry.all_entries())
+        for name, policies in summary.items():
+            assert "approval_class" in policies
+            assert "parallel_class" in policies
+            assert "output_tier" in policies
+            assert "isolation_mode" in policies
+
+    def test_catalog_policy_table_covers_all_catalog_tools(self):
+        """The policy table has an entry for every tool in CLAUDE_CODE_TOOLS."""
+        catalog_names = {t.name for t in CLAUDE_CODE_TOOLS}
+        policy_names = set(_CATALOG_TOOL_POLICIES.keys())
+        assert catalog_names == policy_names, (
+            f"Missing from policy table: {catalog_names - policy_names}; "
+            f"Extra in policy table: {policy_names - catalog_names}"
+        )

--- a/tests/utils/test_tool_scheduler.py
+++ b/tests/utils/test_tool_scheduler.py
@@ -1,0 +1,597 @@
+"""Tests for the dependency-safe tool scheduler.
+
+Validates that:
+- Consecutive readonly tool calls are batched for parallel execution.
+- Stateful tools break readonly batches and run serially.
+- Exclusive tools always get their own isolated batch.
+- Unknown tools default to stateful (conservative safety).
+- Result ordering is deterministic regardless of parallel execution.
+- Empty and single-call edge cases are handled correctly.
+- Trace metadata (batch_id, parallel flag) is emitted correctly.
+- The execute_batch helper preserves index ordering under concurrency.
+
+These tests run under ``OV_AGENT_RUN_HARNESS_TESTS=1``.
+"""
+
+import asyncio
+import importlib
+import importlib.machinery
+import importlib.util
+import os
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Guard
+# ---------------------------------------------------------------------------
+
+_RUN_HARNESS = os.environ.get("OV_AGENT_RUN_HARNESS_TESTS", "").lower() in {
+    "1", "true", "yes", "on",
+}
+pytestmark = pytest.mark.skipif(
+    not _RUN_HARNESS,
+    reason="Scheduler tests require OV_AGENT_RUN_HARNESS_TESTS=1.",
+)
+
+# ---------------------------------------------------------------------------
+# Bootstrap: lightweight package stubs (matches test_runtime_contracts.py)
+# ---------------------------------------------------------------------------
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+PACKAGE_ROOT = PROJECT_ROOT / "omicverse"
+
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+_SAVED = {
+    name: sys.modules.get(name)
+    for name in ["omicverse", "omicverse.utils"]
+}
+for name in ["omicverse", "omicverse.utils"]:
+    sys.modules.pop(name, None)
+
+_ov_pkg = types.ModuleType("omicverse")
+_ov_pkg.__path__ = [str(PACKAGE_ROOT)]
+_ov_pkg.__spec__ = importlib.machinery.ModuleSpec(
+    "omicverse", loader=None, is_package=True
+)
+sys.modules["omicverse"] = _ov_pkg
+
+_utils_pkg = types.ModuleType("omicverse.utils")
+_utils_pkg.__path__ = [str(PACKAGE_ROOT / "utils")]
+_utils_pkg.__spec__ = importlib.machinery.ModuleSpec(
+    "omicverse.utils", loader=None, is_package=True
+)
+sys.modules["omicverse.utils"] = _utils_pkg
+_ov_pkg.utils = _utils_pkg
+
+from omicverse.utils.ovagent.tool_scheduler import (
+    ExecutionBatch,
+    ScheduleResult,
+    ScheduledCall,
+    ToolScheduler,
+    execute_batch,
+)
+from omicverse.utils.ovagent.tool_registry import (
+    ApprovalClass,
+    IsolationMode,
+    OutputTier,
+    ParallelClass,
+    ToolMetadata,
+    ToolRegistry,
+    build_default_registry,
+)
+
+for name, mod in _SAVED.items():
+    if mod is None:
+        sys.modules.pop(name, None)
+    else:
+        sys.modules[name] = mod
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class FakeToolCall:
+    """Minimal tool-call double with .name, .id, .arguments."""
+
+    def __init__(self, name: str, tc_id: str = "", arguments: dict = None):
+        self.name = name
+        self.id = tc_id or f"call_{name}"
+        self.arguments = arguments or {}
+
+
+def _build_test_registry() -> ToolRegistry:
+    """Build a registry with known tools for deterministic scheduling tests."""
+    registry = build_default_registry()
+    return registry
+
+
+# ---------------------------------------------------------------------------
+# ToolScheduler.schedule — partitioning tests
+# ---------------------------------------------------------------------------
+
+
+class TestSchedulePartitioning:
+    """Test that schedule() correctly partitions tool calls into batches."""
+
+    def setup_method(self):
+        self.registry = _build_test_registry()
+        self.scheduler = ToolScheduler(self.registry)
+
+    def test_empty_tool_calls(self):
+        result = self.scheduler.schedule([])
+        assert result.total_calls == 0
+        assert result.total_batches == 0
+        assert result.batches == []
+        assert not result.has_parallel
+
+    def test_single_readonly_tool(self):
+        calls = [FakeToolCall("Read")]
+        result = self.scheduler.schedule(calls)
+        assert result.total_calls == 1
+        assert result.total_batches == 1
+        batch = result.batches[0]
+        assert batch.parallel is True  # single readonly → parallel batch
+        assert batch.size == 1
+        assert batch.calls[0].canonical_name == "Read"
+        assert batch.calls[0].parallel_class == ParallelClass.readonly
+
+    def test_consecutive_readonly_batched(self):
+        """Multiple consecutive readonly tools should be in one parallel batch."""
+        calls = [
+            FakeToolCall("Read"),
+            FakeToolCall("Glob"),
+            FakeToolCall("Grep"),
+        ]
+        result = self.scheduler.schedule(calls)
+        assert result.total_calls == 3
+        assert result.total_batches == 1
+        batch = result.batches[0]
+        assert batch.parallel is True
+        assert batch.size == 3
+        assert result.has_parallel
+
+    def test_stateful_breaks_batch(self):
+        """A stateful tool should flush the readonly batch."""
+        calls = [
+            FakeToolCall("Read"),
+            FakeToolCall("Glob"),
+            FakeToolCall("Bash"),  # stateful
+            FakeToolCall("Grep"),
+        ]
+        result = self.scheduler.schedule(calls)
+        assert result.total_batches == 3
+        # Batch 0: Read + Glob (parallel)
+        assert result.batches[0].parallel is True
+        assert result.batches[0].size == 2
+        # Batch 1: Bash (serial)
+        assert result.batches[1].parallel is False
+        assert result.batches[1].size == 1
+        assert result.batches[1].calls[0].canonical_name == "Bash"
+        # Batch 2: Grep (parallel, single)
+        assert result.batches[2].parallel is True
+        assert result.batches[2].size == 1
+
+    def test_exclusive_isolates(self):
+        """Exclusive tools get their own batch and flush predecessors."""
+        calls = [
+            FakeToolCall("Read"),
+            FakeToolCall("AskUserQuestion"),  # exclusive
+            FakeToolCall("Glob"),
+        ]
+        result = self.scheduler.schedule(calls)
+        assert result.total_batches == 3
+        # Batch 0: Read (parallel)
+        assert result.batches[0].parallel is True
+        assert result.batches[0].calls[0].canonical_name == "Read"
+        # Batch 1: AskUserQuestion (serial/exclusive)
+        assert result.batches[1].parallel is False
+        assert result.batches[1].calls[0].canonical_name == "AskUserQuestion"
+        # Batch 2: Glob (parallel)
+        assert result.batches[2].parallel is True
+        assert result.batches[2].calls[0].canonical_name == "Glob"
+
+    def test_all_stateful_all_serial(self):
+        """All stateful tools should each get their own serial batch."""
+        calls = [
+            FakeToolCall("Bash"),
+            FakeToolCall("Edit"),
+            FakeToolCall("Write"),
+        ]
+        result = self.scheduler.schedule(calls)
+        assert result.total_batches == 3
+        for batch in result.batches:
+            assert batch.parallel is False
+            assert batch.size == 1
+        assert not result.has_parallel
+
+    def test_unknown_tool_defaults_stateful(self):
+        """Tools not in the registry should default to stateful."""
+        calls = [
+            FakeToolCall("Read"),
+            FakeToolCall("totally_unknown_tool"),
+            FakeToolCall("Glob"),
+        ]
+        result = self.scheduler.schedule(calls)
+        assert result.total_batches == 3
+        # Unknown tool breaks the readonly batch
+        assert result.batches[1].parallel is False
+        assert result.batches[1].calls[0].canonical_name == "totally_unknown_tool"
+
+    def test_mixed_sequence_preserves_order(self):
+        """Complex mixed sequence should produce correct batch ordering."""
+        calls = [
+            FakeToolCall("Read"),       # readonly
+            FakeToolCall("Grep"),       # readonly
+            FakeToolCall("Bash"),       # stateful → flush
+            FakeToolCall("Read"),       # readonly
+            FakeToolCall("finish"),     # exclusive → flush
+            FakeToolCall("Read"),       # readonly
+        ]
+        result = self.scheduler.schedule(calls)
+        assert result.total_calls == 6
+        # Batch 0: Read + Grep
+        assert result.batches[0].parallel is True
+        assert result.batches[0].size == 2
+        # Batch 1: Bash
+        assert result.batches[1].parallel is False
+        # Batch 2: Read
+        assert result.batches[2].parallel is True
+        assert result.batches[2].size == 1
+        # Batch 3: finish (exclusive)
+        assert result.batches[3].parallel is False
+        # Batch 4: Read
+        assert result.batches[4].parallel is True
+
+    def test_index_preserved_across_batches(self):
+        """Each ScheduledCall should carry its original index."""
+        calls = [
+            FakeToolCall("Read"),
+            FakeToolCall("Bash"),
+            FakeToolCall("Glob"),
+        ]
+        result = self.scheduler.schedule(calls)
+        all_indices = []
+        for batch in result.batches:
+            for sc in batch.calls:
+                all_indices.append(sc.index)
+        assert all_indices == [0, 1, 2]
+
+    def test_batch_ids_unique(self):
+        """Each batch should have a unique batch_id."""
+        calls = [
+            FakeToolCall("Read"),
+            FakeToolCall("Bash"),
+            FakeToolCall("Glob"),
+        ]
+        result = self.scheduler.schedule(calls)
+        batch_ids = [b.batch_id for b in result.batches]
+        assert len(set(batch_ids)) == len(batch_ids)
+
+    def test_calls_carry_batch_id(self):
+        """ScheduledCalls within a batch should carry the batch's ID."""
+        calls = [FakeToolCall("Read"), FakeToolCall("Glob")]
+        result = self.scheduler.schedule(calls)
+        batch = result.batches[0]
+        for sc in batch.calls:
+            assert sc.batch_id == batch.batch_id
+
+    def test_legacy_tool_names_resolved(self):
+        """Legacy tool names should resolve through the registry."""
+        calls = [FakeToolCall("inspect_data")]
+        result = self.scheduler.schedule(calls)
+        assert result.total_calls == 1
+        sc = result.batches[0].calls[0]
+        assert sc.canonical_name == "inspect_data"
+        assert sc.parallel_class == ParallelClass.readonly
+
+
+# ---------------------------------------------------------------------------
+# ScheduleResult serialisation
+# ---------------------------------------------------------------------------
+
+
+class TestScheduleResultSerialization:
+    """Test to_dict() serialisation for trace/debug coherence."""
+
+    def test_to_dict_round_trip(self):
+        registry = _build_test_registry()
+        scheduler = ToolScheduler(registry)
+        calls = [FakeToolCall("Read"), FakeToolCall("Bash")]
+        result = scheduler.schedule(calls)
+        d = result.to_dict()
+        assert d["total_calls"] == 2
+        assert d["total_batches"] == 2
+        assert isinstance(d["batches"], list)
+        for batch_dict in d["batches"]:
+            assert "batch_id" in batch_dict
+            assert "parallel" in batch_dict
+            assert "size" in batch_dict
+            assert "calls" in batch_dict
+
+
+# ---------------------------------------------------------------------------
+# execute_batch — async execution tests
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteBatch:
+    """Test the execute_batch helper for deterministic result ordering."""
+
+    def _run(self, coro):
+        return asyncio.run(coro)
+
+    def test_serial_batch_single_call(self):
+        sc = ScheduledCall(
+            index=0,
+            tool_call=FakeToolCall("Read"),
+            canonical_name="Read",
+            parallel_class=ParallelClass.readonly,
+            batch_id="batch_1",
+        )
+        batch = ExecutionBatch(
+            batch_id="batch_1", calls=[sc], parallel=False,
+        )
+
+        async def dispatch(s):
+            return f"result_{s.canonical_name}"
+
+        results = self._run(execute_batch(batch, dispatch))
+        assert len(results) == 1
+        assert results[0] == (0, "result_Read")
+
+    def test_parallel_batch_deterministic_order(self):
+        """Results from parallel execution must come back in index order."""
+        calls = []
+        for i, name in enumerate(["Read", "Glob", "Grep"]):
+            calls.append(ScheduledCall(
+                index=i,
+                tool_call=FakeToolCall(name),
+                canonical_name=name,
+                parallel_class=ParallelClass.readonly,
+                batch_id="batch_p",
+            ))
+        batch = ExecutionBatch(
+            batch_id="batch_p", calls=calls, parallel=True,
+        )
+
+        # Simulate varying execution times to verify ordering
+        async def dispatch(sc):
+            # Reverse delay: last index finishes first
+            await asyncio.sleep(0.01 * (3 - sc.index))
+            return f"result_{sc.index}"
+
+        results = self._run(execute_batch(batch, dispatch))
+        assert len(results) == 3
+        # Must be in original index order despite reverse completion
+        assert results[0] == (0, "result_0")
+        assert results[1] == (1, "result_1")
+        assert results[2] == (2, "result_2")
+
+    def test_empty_batch(self):
+        batch = ExecutionBatch(
+            batch_id="batch_e", calls=[], parallel=True,
+        )
+
+        async def dispatch(sc):
+            return "should not be called"
+
+        results = self._run(execute_batch(batch, dispatch))
+        assert results == []
+
+    def test_parallel_single_call_runs_serial(self):
+        """A parallel batch with only one call should run serially."""
+        sc = ScheduledCall(
+            index=0,
+            tool_call=FakeToolCall("Read"),
+            canonical_name="Read",
+            parallel_class=ParallelClass.readonly,
+            batch_id="batch_s",
+        )
+        batch = ExecutionBatch(
+            batch_id="batch_s", calls=[sc], parallel=True,
+        )
+
+        call_count = 0
+
+        async def dispatch(s):
+            nonlocal call_count
+            call_count += 1
+            return "ok"
+
+        results = self._run(execute_batch(batch, dispatch))
+        assert len(results) == 1
+        assert call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Integration: scheduler + executor end-to-end
+# ---------------------------------------------------------------------------
+
+
+class TestSchedulerExecutorIntegration:
+    """End-to-end test: schedule then execute all batches."""
+
+    def _run(self, coro):
+        return asyncio.run(coro)
+
+    def test_full_pipeline_deterministic_results(self):
+        """Schedule → execute → results arrive in original call order."""
+        registry = _build_test_registry()
+        scheduler = ToolScheduler(registry)
+
+        calls = [
+            FakeToolCall("Read"),       # 0: readonly
+            FakeToolCall("Glob"),       # 1: readonly
+            FakeToolCall("Bash"),       # 2: stateful
+            FakeToolCall("Grep"),       # 3: readonly
+            FakeToolCall("Read"),       # 4: readonly
+        ]
+        schedule = scheduler.schedule(calls)
+        assert schedule.total_calls == 5
+
+        execution_log = []
+
+        async def dispatch(sc):
+            execution_log.append(sc.canonical_name)
+            return f"output_{sc.index}"
+
+        all_results = []
+
+        async def run_all():
+            for batch in schedule.batches:
+                batch_results = await execute_batch(batch, dispatch)
+                all_results.extend(batch_results)
+
+        self._run(run_all())
+
+        # Results must be in original index order
+        indices = [idx for idx, _ in all_results]
+        assert indices == [0, 1, 2, 3, 4]
+
+        # All dispatches happened
+        assert len(execution_log) == 5
+
+    def test_parallel_actually_concurrent(self):
+        """Verify that parallel batches overlap in time."""
+        registry = _build_test_registry()
+        scheduler = ToolScheduler(registry)
+
+        calls = [FakeToolCall("Read"), FakeToolCall("Glob")]
+        schedule = scheduler.schedule(calls)
+        assert schedule.total_batches == 1
+        assert schedule.batches[0].parallel is True
+
+        import time
+        timestamps = {}
+
+        async def dispatch(sc):
+            timestamps[sc.canonical_name] = time.monotonic()
+            await asyncio.sleep(0.05)
+            return "ok"
+
+        async def run():
+            await execute_batch(schedule.batches[0], dispatch)
+
+        self._run(run())
+
+        # Both should have started within a very small window
+        t_read = timestamps["Read"]
+        t_glob = timestamps["Glob"]
+        assert abs(t_read - t_glob) < 0.03, (
+            f"Expected concurrent start, got delta={abs(t_read - t_glob):.3f}s"
+        )
+
+
+# ---------------------------------------------------------------------------
+# has_parallel property
+# ---------------------------------------------------------------------------
+
+
+class TestHasParallel:
+    def test_single_readonly_not_counted(self):
+        """A single readonly call in a parallel batch is not 'has_parallel'."""
+        registry = _build_test_registry()
+        scheduler = ToolScheduler(registry)
+        result = scheduler.schedule([FakeToolCall("Read")])
+        assert not result.has_parallel
+
+    def test_two_readonly_is_parallel(self):
+        registry = _build_test_registry()
+        scheduler = ToolScheduler(registry)
+        result = scheduler.schedule([FakeToolCall("Read"), FakeToolCall("Glob")])
+        assert result.has_parallel
+
+
+# ---------------------------------------------------------------------------
+# Scheduler contract: the acceptance criterion test
+# ---------------------------------------------------------------------------
+
+
+class TestSchedulerContract:
+    """Validates the acceptance criterion:
+
+    Turn processing no longer executes every tool call in a naive serial
+    loop; scheduler policy metadata determines which calls may batch in
+    parallel; result ordering and finish semantics remain deterministic;
+    traces and tool-result messages remain coherent under concurrency.
+    """
+
+    def test_readonly_tools_batched_not_serial(self):
+        """Policy metadata drives batching: readonly → parallel batch."""
+        registry = _build_test_registry()
+        scheduler = ToolScheduler(registry)
+        calls = [FakeToolCall("Read"), FakeToolCall("Glob"), FakeToolCall("Grep")]
+        schedule = scheduler.schedule(calls)
+
+        # NOT a naive serial loop: all three in one parallel batch
+        assert schedule.total_batches == 1
+        assert schedule.batches[0].parallel is True
+        assert schedule.batches[0].size == 3
+
+    def test_stateful_forces_serial(self):
+        """Stateful tools are correctly serialized by policy."""
+        registry = _build_test_registry()
+        scheduler = ToolScheduler(registry)
+        calls = [FakeToolCall("Bash"), FakeToolCall("Edit")]
+        schedule = scheduler.schedule(calls)
+        assert all(not b.parallel for b in schedule.batches)
+
+    def test_deterministic_result_ordering(self):
+        """Results always come back in original call order."""
+        registry = _build_test_registry()
+        scheduler = ToolScheduler(registry)
+        calls = [
+            FakeToolCall("Read"),
+            FakeToolCall("Glob"),
+            FakeToolCall("Bash"),
+            FakeToolCall("Grep"),
+        ]
+        schedule = scheduler.schedule(calls)
+
+        async def dispatch(sc):
+            # Simulate reversed completion for parallel calls
+            if sc.parallel_class == ParallelClass.readonly:
+                await asyncio.sleep(0.01 * (4 - sc.index))
+            return f"r{sc.index}"
+
+        async def run():
+            all_results = []
+            for batch in schedule.batches:
+                batch_results = await execute_batch(batch, dispatch)
+                all_results.extend(batch_results)
+            return all_results
+
+        results = asyncio.run(run())
+        indices = [idx for idx, _ in results]
+        assert indices == [0, 1, 2, 3], f"Expected [0,1,2,3], got {indices}"
+
+    def test_trace_metadata_coherent(self):
+        """Each scheduled call carries batch_id and parallel_class for traces."""
+        registry = _build_test_registry()
+        scheduler = ToolScheduler(registry)
+        calls = [FakeToolCall("Read"), FakeToolCall("Bash")]
+        schedule = scheduler.schedule(calls)
+
+        for batch in schedule.batches:
+            for sc in batch.calls:
+                assert sc.batch_id == batch.batch_id
+                assert isinstance(sc.parallel_class, ParallelClass)
+
+        # Serialise for trace inspection
+        d = schedule.to_dict()
+        assert d["total_calls"] == 2
+        assert len(d["batches"]) == 2
+        for bd in d["batches"]:
+            assert "batch_id" in bd
+            assert "parallel" in bd
+            for cd in bd["calls"]:
+                assert "parallel_class" in cd


### PR DESCRIPTION
## Summary

This PR lands the OVAgent runtime upgrade wave on the live codebase and refreshes the branch on top of the latest `master`.

Core runtime changes:
- replace the hardcoded tool dispatch chain with a declarative tool metadata/registry seam
- add dependency-safe tool scheduling and parallel batch execution
- add token-aware context budgeting and compaction support
- replace regex-first execution recovery with a structured self-healing loop
- add per-tool permission policy and stronger subagent isolation contracts
- unify runtime observability around structured event emission
- template prompt composition instead of one monolithic prompt builder
- add runtime contract, prompt-template, scheduler, permission, repair-loop, and closure audit coverage

Branch refresh and follow-up fixes:
- reconcile the PR branch with the latest `master` changes, including the new execute-code debug-output / figure-delivery path
- fix the notebook-fallback CI regression caused by an implicit `executor._ctx` assumption in the structured repair loop

## Validation

- `ngagent review` passed for the live-tree upgrade tasks `task-024` through `task-037`
- PR CI is green:
  - `py310|py311` run `23575655156` passed on March 26, 2026
  - `Claude Code Review` run `23575655181` passed on March 26, 2026
- no new dependency declarations were introduced by this PR

## Notes

- the prompt/closure path in this PR is the corrected one via `task-034` and `task-035`; historical orchestration records `task-031` and `task-032` remain only as superseded planning artifacts
- the branch already includes the latest `master` at commit `834d2952`, so the previous merge-conflict state has been resolved
- an additional Taiwan-server real-world end-to-end OVAgent validation wave is running separately and is not required for this PR body update
