### PR TITLE
[codex] OmicVerse agent hardening, Jarvis unification, and integration coverage

### DIFF
--- a/omicverse/jarvis/channel_media.py
+++ b/omicverse/jarvis/channel_media.py
@@ -4,6 +4,13 @@ import time
 from pathlib import Path
 from typing import Any, Iterable, List, Optional
 
+from .media_ingest import (
+    PreparedImage,
+    looks_like_image_name,
+    prepare_image_bytes,
+    prepare_image_path,
+)
+
 
 def build_channel_request(session: Any, text: str, *, channel_label: str = "Mobile channel") -> str:
     ctx_parts: List[str] = []
@@ -102,6 +109,109 @@ def _session_workspace(session: Any) -> Optional[Path]:
         return Path(workspace_dir) / "workspace"
     return None
 
+
+# ── Inbound attachment helpers ──────────────────────────────────────────────
+
+MAX_INBOUND_IMAGES: int = 4
+"""Default per-message limit on inbound image attachments."""
+
+
+def is_image_attachment(filename: str, content_type: str = "") -> bool:
+    """Check whether an attachment looks like an image by MIME type or filename."""
+    ct = (content_type or "").strip().lower()
+    if ct.startswith("image/"):
+        return True
+    return looks_like_image_name(filename)
+
+
+def inbound_upload_dir(workspace_root: Any, channel_name: str) -> Path:
+    """Return (and create) the standard upload directory for *channel_name*.
+
+    *workspace_root* is typically ``session.workspace`` or
+    ``session.workspace_dir``; the caller decides which root is appropriate
+    for its channel.
+    """
+    root = Path(workspace_root) if not isinstance(workspace_root, Path) else workspace_root
+    upload_dir = root / "uploads" / channel_name
+    upload_dir.mkdir(parents=True, exist_ok=True)
+    return upload_dir
+
+
+def prepare_inbound_image(
+    data: bytes,
+    *,
+    workspace_root: Any,
+    channel_name: str,
+    filename: str = "",
+    mime_type: str = "",
+) -> PreparedImage:
+    """Normalize raw attachment bytes into a :class:`PreparedImage` on disk.
+
+    Standard pipeline for channels that receive attachment bytes directly
+    (Discord, QQ, WeChat).
+    """
+    upload_dir = inbound_upload_dir(workspace_root, channel_name)
+    return prepare_image_bytes(
+        data,
+        target_dir=upload_dir,
+        filename=filename or f"{channel_name}_image",
+        mime_type=mime_type,
+        prefix=f"{channel_name}_image",
+        source=channel_name,
+    )
+
+
+def prepare_inbound_image_from_file(
+    path: Path,
+    *,
+    workspace_root: Any,
+    channel_name: str,
+    mime_type: str = "",
+) -> PreparedImage:
+    """Normalize a local image file into a :class:`PreparedImage`.
+
+    Standard pipeline for channels that download attachments to a temporary
+    file first (e.g. Telegram).
+    """
+    upload_dir = inbound_upload_dir(workspace_root, channel_name)
+    return prepare_image_path(
+        path,
+        target_dir=upload_dir,
+        mime_type=mime_type,
+        prefix=f"{channel_name}_image",
+        source=channel_name,
+    )
+
+
+# ── H5AD attachment helpers ────────────────────────────────────────────────
+
+def load_h5ad_to_session(session: Any, data: bytes, filename: str) -> Any:
+    """Write raw ``.h5ad`` bytes into the session workspace and load.
+
+    Returns the loaded AnnData object on success, or ``None`` if the session's
+    ``load_from_workspace`` returns ``None``.
+    """
+    workspace = _session_workspace(session)
+    if workspace is None:
+        return None
+    target = workspace / filename
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(data)
+    return session.load_from_workspace(filename)
+
+
+def format_h5ad_load_result(loaded: Any, filename: str) -> str:
+    """Format a human-readable status string after loading an ``.h5ad`` file."""
+    if loaded is not None:
+        return (
+            f"✅ 加载成功\n"
+            f"🔬 {loaded.n_obs:,} cells × {loaded.n_vars:,} genes\n"
+            f"📁 {filename}"
+        )
+    return f"✅ 已接收 {filename}，但自动加载失败，请检查文件格式。"
+
+
+# ── Internal helpers ───────────────────────────────────────────────────────
 
 def _figure_bytes(figure: Any) -> bytes:
     if isinstance(figure, bytes):

--- a/omicverse/jarvis/channels/channel_core.py
+++ b/omicverse/jarvis/channels/channel_core.py
@@ -1,0 +1,209 @@
+"""Shared channel-core abstractions for Jarvis channel implementations.
+
+Centralizes session-resolution helpers, request-building logic, result
+processing, web-bridge interaction, and text utilities that were previously
+duplicated across every channel file.
+
+Channel-specific transport behaviour (how messages are *sent*) stays in each
+channel module.  This module only owns the runtime and gateway boilerplate that
+is identical regardless of transport.
+"""
+from __future__ import annotations
+
+import asyncio
+import re
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+from ..agent_bridge import AgentBridge
+from .._bridge_session import resolve_bridge_session_id
+from ..channel_media import build_channel_request, prepare_channel_delivery_figures
+from ..gateway.routing import GatewaySessionRegistry, SessionKey
+
+
+# ── Shared dataclass ─────────────────────────────────────────────────────────
+
+@dataclass
+class RunningTask:
+    """Track an in-flight asyncio analysis task."""
+    task: asyncio.Task
+    request: str
+    started_at: float
+
+
+# ── Text utilities ───────────────────────────────────────────────────────────
+
+_ARTIFACT_EXTS = r"pdf|csv|tsv|txt|xlsx|html|json|h5ad|png|jpg|svg"
+
+
+def text_chunks(text: str, limit: int = 2000) -> List[str]:
+    """Split *text* into paragraph-aware chunks of at most *limit* characters."""
+    text = (text or "").strip()
+    if not text:
+        return []
+    if len(text) <= limit:
+        return [text]
+    chunks: List[str] = []
+    buf = ""
+    for para in text.split("\n\n"):
+        cand = f"{buf}\n\n{para}".strip() if buf else para
+        if len(cand) <= limit:
+            buf = cand
+            continue
+        if buf:
+            chunks.append(buf)
+        if len(para) <= limit:
+            buf = para
+            continue
+        pos = 0
+        while pos < len(para):
+            chunks.append(para[pos : pos + limit])
+            pos += limit
+        buf = ""
+    if buf:
+        chunks.append(buf)
+    return chunks
+
+
+def strip_local_paths(text: str) -> str:
+    """Remove local filesystem path references from agent output text."""
+    t = text or ""
+    t = re.sub(r"`[^`\n]*(?:/[^`\n]*){2,}`", "", t)
+    t = re.sub(r"/(?:Users|home|tmp|var|opt|root|data|mnt|private)/\S+", "", t)
+    t = re.sub(r"~[/\\]\S+", "", t)
+    t = re.sub(
+        rf"\.?/?(?:\w[\w/-]*/)+\w[\w.-]*\.(?:{_ARTIFACT_EXTS})",
+        "",
+        t,
+        flags=re.IGNORECASE,
+    )
+    t = re.sub(r"[ \t]{2,}", " ", t)
+    t = re.sub(r"\n{3,}", "\n\n", t)
+    return t.strip()
+
+
+# ── Request building ─────────────────────────────────────────────────────────
+
+def build_full_request(session: Any, text: str, *, channel_label: str) -> str:
+    """Build a full analysis request enriched with session context.
+
+    Thin wrapper around :func:`channel_media.build_channel_request` so that
+    channels don't need to import that function directly.
+    """
+    return build_channel_request(session, text, channel_label=channel_label)
+
+
+# ── Web-bridge helpers ───────────────────────────────────────────────────────
+
+def get_prior_history(
+    session_manager: Any,
+    channel: str,
+    scope_type: str,
+    scope_id: str,
+    session: Any,
+) -> list:
+    """Retrieve prior conversation history from the web bridge (if attached)."""
+    web_bridge = getattr(session_manager, "gateway_web_bridge", None)
+    if not web_bridge:
+        return []
+    return web_bridge.get_prior_history_simple(
+        channel,
+        scope_type,
+        scope_id,
+        session_id=resolve_bridge_session_id(session),
+    )
+
+
+def notify_turn_complete(
+    session_manager: Any,
+    *,
+    channel: str,
+    scope_type: str,
+    scope_id: str,
+    session: Any,
+    user_text: str,
+    llm_text: str,
+    adata: Any = None,
+    figures: Optional[list] = None,
+) -> None:
+    """Mirror a completed analysis turn into the web session."""
+    web_bridge = getattr(session_manager, "gateway_web_bridge", None)
+    if web_bridge is None:
+        return
+    try:
+        kwargs: Dict[str, Any] = dict(
+            channel=channel,
+            scope_type=scope_type,
+            scope_id=scope_id,
+            user_text=user_text,
+            llm_text=llm_text,
+            adata=adata,
+            session_id=resolve_bridge_session_id(session),
+        )
+        if figures is not None:
+            kwargs["figures"] = figures
+        web_bridge.on_turn_complete_simple(**kwargs)
+    except Exception:
+        pass
+
+
+# ── Result processing ────────────────────────────────────────────────────────
+
+def process_result_state(
+    session: Any,
+    result: Any,
+    user_text: str,
+) -> tuple:
+    """Apply common post-analysis state updates to *session*.
+
+    Returns ``(delivery_figures, adata_info)`` for the channel to use when
+    composing its transport-specific reply.
+    """
+    if result.adata is not None:
+        session.adata = result.adata
+        try:
+            session.save_adata()
+            session.prompt_count += 1
+        except Exception:
+            pass
+    if result.usage is not None:
+        session.last_usage = result.usage
+    delivery_figures = prepare_channel_delivery_figures(session, result.figures)
+    try:
+        adata = session.adata
+        adata_info = (
+            f"{adata.n_obs:,} cells x {adata.n_vars:,} genes"
+            if adata is not None
+            else ""
+        )
+    except Exception:
+        adata_info = ""
+    try:
+        session.append_memory_log(
+            request=user_text,
+            summary=(result.summary or "分析完成"),
+            adata_info=adata_info,
+        )
+    except Exception:
+        pass
+    return delivery_figures, adata_info
+
+
+def format_analysis_error(result: Any, llm_buf: str, *, max_llm: int = 1200) -> str:
+    """Format a standard analysis-error message from *result*."""
+    err_text = f"分析出错: {result.error}"
+    if result.diagnostics:
+        hints = "\n".join(f"- {item}" for item in result.diagnostics[:4])
+        err_text += f"\n\n诊断:\n{hints}"
+    if llm_buf.strip():
+        err_text += f"\n\n模型输出:\n{llm_buf[:max_llm]}"
+    return err_text
+
+
+def default_summary(session: Any) -> str:
+    """Return a fallback analysis-complete summary string."""
+    if session.adata is not None:
+        adata = session.adata
+        return f"分析完成\n{adata.n_obs:,} cells x {adata.n_vars:,} genes"
+    return "分析完成"

--- a/omicverse/jarvis/channels/channel_core.py
+++ b/omicverse/jarvis/channels/channel_core.py
@@ -76,8 +76,10 @@ def strip_local_paths(text: str) -> str:
     t = re.sub(r"`[^`\n]*(?:/[^`\n]*){2,}`", "", t)
     t = re.sub(r"/(?:Users|home|tmp|private|root)/\S+", "", t)
     t = re.sub(r"~[/\\]\S+", "", t)
+    # Path segments use [^\s/]+ (cannot match '/') so partition with '/'
+    # is unambiguous — no nested-repetition backtracking risk.
     t = re.sub(
-        rf"\.?/?(?:\w[\w/-]*/)+\w[\w.-]*\.(?:{_ARTIFACT_EXTS})",
+        rf"\.?/?[^\s/]+/(?:[^\s/]+/)*[^\s/]*\.(?:{_ARTIFACT_EXTS})(?=\s|$)",
         "",
         t,
         flags=re.IGNORECASE,

--- a/omicverse/jarvis/channels/channel_core.py
+++ b/omicverse/jarvis/channels/channel_core.py
@@ -441,6 +441,34 @@ def format_workspace_plain(info: WorkspaceInfo) -> str:
     return "\n".join(lines)
 
 
+# ── Shared request-queue helpers ───────────────────────────────────────────
+
+def coalesce_pending_requests(
+    items: List[Dict[str, Any]],
+) -> Tuple[str, List[Dict[str, Any]]]:
+    """Merge a queue of pending analysis requests into one.
+
+    Each *item* is expected to have ``"text"`` and optional
+    ``"request_content"`` keys.  Returns ``(coalesced_text, merged_content)``.
+    """
+    parts: List[str] = []
+    request_content: List[Dict[str, Any]] = []
+    for item in items:
+        text = str(item.get("text") or "").strip()
+        if text:
+            parts.append(text)
+        request_content.extend(list(item.get("request_content") or []))
+    return "\n\n".join(parts).strip(), request_content
+
+
+def command_parts(text: str) -> Tuple[str, str]:
+    """Split ``/command tail`` text into ``(command, tail)`` pair."""
+    tokens = text.split()
+    cmd = tokens[0].lower() if tokens else ""
+    tail = text.split(None, 1)[1].strip() if len(tokens) > 1 else ""
+    return cmd, tail
+
+
 def format_save_result_plain(result: SaveResult) -> str:
     """Format *SaveResult* as plain text."""
     if result.no_data:

--- a/omicverse/jarvis/channels/channel_core.py
+++ b/omicverse/jarvis/channels/channel_core.py
@@ -11,6 +11,7 @@ is identical regardless of transport.
 from __future__ import annotations
 
 import asyncio
+import logging
 import re
 import time
 from dataclasses import dataclass, field
@@ -21,6 +22,8 @@ from ..agent_bridge import AgentBridge
 from .._bridge_session import resolve_bridge_session_id
 from ..channel_media import build_channel_request, prepare_channel_delivery_figures
 from ..gateway.routing import GatewaySessionRegistry, SessionKey
+
+logger = logging.getLogger(__name__)
 
 
 # ── Shared dataclass ─────────────────────────────────────────────────────────
@@ -71,7 +74,7 @@ def strip_local_paths(text: str) -> str:
     """Remove local filesystem path references from agent output text."""
     t = text or ""
     t = re.sub(r"`[^`\n]*(?:/[^`\n]*){2,}`", "", t)
-    t = re.sub(r"/(?:Users|home|tmp|var|opt|root|data|mnt|private)/\S+", "", t)
+    t = re.sub(r"/(?:Users|home|tmp|private|root)/\S+", "", t)
     t = re.sub(r"~[/\\]\S+", "", t)
     t = re.sub(
         rf"\.?/?(?:\w[\w/-]*/)+\w[\w.-]*\.(?:{_ARTIFACT_EXTS})",
@@ -146,7 +149,7 @@ def notify_turn_complete(
             kwargs["figures"] = figures
         web_bridge.on_turn_complete_simple(**kwargs)
     except Exception:
-        pass
+        logger.debug("notify_turn_complete: web bridge callback failed", exc_info=True)
 
 
 # ── Result processing ────────────────────────────────────────────────────────
@@ -167,7 +170,7 @@ def process_result_state(
             session.save_adata()
             session.prompt_count += 1
         except Exception:
-            pass
+            logger.debug("process_result_state: save_adata/prompt_count update failed", exc_info=True)
     if result.usage is not None:
         session.last_usage = result.usage
     delivery_figures = prepare_channel_delivery_figures(session, result.figures)
@@ -179,6 +182,7 @@ def process_result_state(
             else ""
         )
     except Exception:
+        logger.debug("process_result_state: adata info extraction failed", exc_info=True)
         adata_info = ""
     try:
         session.append_memory_log(
@@ -187,7 +191,7 @@ def process_result_state(
             adata_info=adata_info,
         )
     except Exception:
-        pass
+        logger.debug("process_result_state: append_memory_log failed", exc_info=True)
     return delivery_figures, adata_info
 
 
@@ -286,12 +290,12 @@ def gather_status(
         try:
             info.obs_columns = list(a.obs.columns[:8])
         except Exception:
-            pass
+            logger.debug("gather_status: obs columns extraction failed", exc_info=True)
     if session_manager is not None:
         try:
             info.kernel_name = session_manager.get_active_kernel(session.user_id)
         except Exception:
-            pass
+            logger.debug("gather_status: get_active_kernel failed", exc_info=True)
     try:
         kst = session.kernel_status()
         if kst:
@@ -299,11 +303,11 @@ def gather_status(
             info.max_prompts = kst.get("max_prompts", "?")
             info.session_id = kst.get("session_id")
     except Exception:
-        pass
+        logger.debug("gather_status: kernel_status retrieval failed", exc_info=True)
     try:
         info.workspace_path = str(session.agent.workspace_dir)
     except Exception:
-        pass
+        logger.debug("gather_status: workspace_path extraction failed", exc_info=True)
     return info
 
 

--- a/omicverse/jarvis/channels/channel_core.py
+++ b/omicverse/jarvis/channels/channel_core.py
@@ -13,8 +13,9 @@ from __future__ import annotations
 import asyncio
 import re
 import time
-from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
 
 from ..agent_bridge import AgentBridge
 from .._bridge_session import resolve_bridge_session_id
@@ -207,3 +208,250 @@ def default_summary(session: Any) -> str:
         adata = session.adata
         return f"分析完成\n{adata.n_obs:,} cells x {adata.n_vars:,} genes"
     return "分析完成"
+
+
+# ── Command data structures ─────────────────────────────────────────────────
+
+@dataclass
+class StatusInfo:
+    """Structured status data collected from session state.
+
+    Channels call :func:`gather_status` to populate this, then format it
+    for their transport (plain text, HTML, etc.).
+    """
+    adata_shape: Optional[Tuple[int, int]] = None
+    obs_columns: List[str] = field(default_factory=list)
+    kernel_name: Optional[str] = None
+    prompt_count: Optional[int] = None
+    max_prompts: Any = None
+    session_id: Optional[str] = None
+    is_running: bool = False
+    running_request: str = ""
+    workspace_path: Optional[str] = None
+
+
+@dataclass
+class UsageInfo:
+    """Structured token-usage data from the session's last run."""
+    input_tokens: str = "?"
+    output_tokens: str = "?"
+    total_tokens: str = "?"
+    cache_read: str = ""
+    cache_creation: str = ""
+    has_data: bool = False
+
+
+@dataclass
+class WorkspaceInfo:
+    """Structured workspace listing."""
+    path: str = ""
+    h5ad_files: List[Tuple[str, Optional[float]]] = field(default_factory=list)
+    h5ad_total: int = 0
+    has_agents_md: bool = False
+    has_today_memory: bool = False
+
+
+@dataclass
+class SaveResult:
+    """Outcome of a :func:`perform_save` attempt."""
+    success: bool = False
+    no_data: bool = False
+    path: Optional[str] = None
+    adata_shape: Optional[Tuple[int, int]] = None
+    error: Optional[str] = None
+
+
+# ── Command data gathering ──────────────────────────────────────────────────
+
+def gather_status(
+    session: Any,
+    *,
+    session_manager: Any = None,
+    is_running: bool = False,
+    running_request: str = "",
+) -> StatusInfo:
+    """Collect status information from session state.
+
+    Parameters
+    ----------
+    session : channel session object
+    session_manager : optional session manager (needed for kernel name)
+    is_running : whether an analysis task is currently running
+    running_request : the text of the running request (for display)
+    """
+    info = StatusInfo(is_running=is_running, running_request=running_request)
+    if session.adata is not None:
+        a = session.adata
+        info.adata_shape = (a.n_obs, a.n_vars)
+        try:
+            info.obs_columns = list(a.obs.columns[:8])
+        except Exception:
+            pass
+    if session_manager is not None:
+        try:
+            info.kernel_name = session_manager.get_active_kernel(session.user_id)
+        except Exception:
+            pass
+    try:
+        kst = session.kernel_status()
+        if kst:
+            info.prompt_count = kst.get("prompt_count", 0)
+            info.max_prompts = kst.get("max_prompts", "?")
+            info.session_id = kst.get("session_id")
+    except Exception:
+        pass
+    try:
+        info.workspace_path = str(session.agent.workspace_dir)
+    except Exception:
+        pass
+    return info
+
+
+def _usage_attr(obj: Any, *names: str, default: str = "?") -> str:
+    """Extract a formatted attribute from a usage object."""
+    for name in names:
+        v = getattr(obj, name, None)
+        if v is not None:
+            return f"{v:,}" if isinstance(v, int) else str(v)
+    return default
+
+
+def gather_usage(session: Any) -> UsageInfo:
+    """Collect token-usage data from the session's last run."""
+    usage = getattr(session, "last_usage", None)
+    if usage is None:
+        return UsageInfo(has_data=False)
+    return UsageInfo(
+        input_tokens=_usage_attr(usage, "input_tokens"),
+        output_tokens=_usage_attr(usage, "output_tokens"),
+        total_tokens=_usage_attr(usage, "total_tokens"),
+        cache_read=_usage_attr(usage, "cache_read_input_tokens", default=""),
+        cache_creation=_usage_attr(usage, "cache_creation_input_tokens", default=""),
+        has_data=True,
+    )
+
+
+def gather_workspace(session: Any) -> WorkspaceInfo:
+    """Collect workspace listing data from the session."""
+    from datetime import datetime
+
+    ws = session.workspace
+    h5ad_files = session.list_h5ad_files()
+    agents_md = session.get_agents_md()
+    today_log = session.memory_dir / f"{datetime.now().date()}.md"
+
+    files: List[Tuple[str, Optional[float]]] = []
+    for f in h5ad_files[:10]:
+        try:
+            mb = f.stat().st_size / 1_048_576
+            files.append((f.name, mb))
+        except OSError:
+            files.append((f.name, None))
+
+    return WorkspaceInfo(
+        path=str(ws),
+        h5ad_files=files,
+        h5ad_total=len(h5ad_files),
+        has_agents_md=bool(agents_md),
+        has_today_memory=today_log.exists(),
+    )
+
+
+def perform_save(session: Any) -> SaveResult:
+    """Execute the /save command: persist current adata and return a result.
+
+    This is a *synchronous* call.  Channels that need async should wrap it
+    with ``asyncio.to_thread``.
+    """
+    if session.adata is None:
+        return SaveResult(no_data=True)
+    try:
+        path = session.save_adata()
+        if not path or not Path(path).exists():
+            return SaveResult(error="保存失败，请重试。")
+        a = session.adata
+        return SaveResult(
+            success=True,
+            path=str(path),
+            adata_shape=(a.n_obs, a.n_vars),
+        )
+    except Exception as exc:
+        return SaveResult(error=str(exc))
+
+
+# ── Default plain-text formatters ───────────────────────────────────────────
+
+def format_status_plain(info: StatusInfo) -> str:
+    """Format *StatusInfo* as plain text (QQ, Discord, WeChat, iMessage, …)."""
+    lines: List[str] = []
+    if info.adata_shape:
+        n_obs, n_vars = info.adata_shape
+        lines.append(f"{n_obs:,} cells x {n_vars:,} genes")
+        if info.obs_columns:
+            lines.append(f"obs: {', '.join(info.obs_columns)}")
+    else:
+        lines.append("暂无数据")
+    if info.kernel_name:
+        lines.append(f"kernel: {info.kernel_name}")
+    if info.prompt_count is not None:
+        lines.append(f"prompts: {info.prompt_count}/{info.max_prompts or '?'}")
+    if info.is_running:
+        lines.append("分析中（可 /cancel）")
+    if info.workspace_path:
+        lines.append(f"工作区: {info.workspace_path}")
+    return "\n".join(lines)
+
+
+def format_usage_plain(info: UsageInfo) -> str:
+    """Format *UsageInfo* as plain text."""
+    if not info.has_data:
+        return "暂无用量数据，请先进行一次分析。"
+    lines = [
+        "Token 用量（最近一次）",
+        f"输入: {info.input_tokens}",
+        f"输出: {info.output_tokens}",
+        f"合计: {info.total_tokens}",
+    ]
+    if info.cache_read and info.cache_read != "?":
+        lines.append(f"缓存读取: {info.cache_read}")
+    if info.cache_creation and info.cache_creation != "?":
+        lines.append(f"缓存写入: {info.cache_creation}")
+    return "\n".join(lines)
+
+
+def format_workspace_plain(info: WorkspaceInfo) -> str:
+    """Format *WorkspaceInfo* as plain text."""
+    lines = [f"Workspace: {info.path}", ""]
+    if info.h5ad_files:
+        lines.append(f"数据文件 ({info.h5ad_total})")
+        for name, mb in info.h5ad_files:
+            if mb is not None:
+                lines.append(f"- {name} ({mb:.1f} MB)")
+            else:
+                lines.append(f"- {name}")
+        if info.h5ad_total > len(info.h5ad_files):
+            lines.append(f"... 还有 {info.h5ad_total - len(info.h5ad_files)} 个")
+    else:
+        lines.append("数据文件 (空)")
+    lines += [
+        "",
+        f"AGENTS.md {'OK' if info.has_agents_md else '-'}",
+        f"今日记忆 {'OK' if info.has_today_memory else '-'}",
+    ]
+    return "\n".join(lines)
+
+
+def format_save_result_plain(result: SaveResult) -> str:
+    """Format *SaveResult* as plain text."""
+    if result.no_data:
+        return "没有数据，请先 /load 或完成分析。"
+    if result.error:
+        return f"保存失败: {result.error}"
+    if result.success and result.adata_shape:
+        n_obs, n_vars = result.adata_shape
+        return (
+            f"已保存 current.h5ad\n"
+            f"{n_obs:,} cells x {n_vars:,} genes\n"
+            f"路径: {result.path}"
+        )
+    return "保存失败，请重试。"

--- a/omicverse/jarvis/channels/discord.py
+++ b/omicverse/jarvis/channels/discord.py
@@ -34,12 +34,17 @@ from .channel_core import (
     format_analysis_error,
     default_summary,
 )
+from ..channel_media import (
+    MAX_INBOUND_IMAGES,
+    format_h5ad_load_result,
+    is_image_attachment,
+    load_h5ad_to_session,
+    prepare_inbound_image,
+)
 from ..media_ingest import (
     PreparedImage,
     build_workspace_note,
     compose_multimodal_user_text,
-    looks_like_image_name,
-    prepare_image_bytes,
 )
 from ..model_help import render_model_help
 
@@ -499,23 +504,12 @@ class DiscordJarvisBot:
         await self._send_text(message.channel, "⏳ 正在下载并加载…", reply_to=message)
         try:
             data = await attachment.read()
-            target = session.workspace / filename
-            target.parent.mkdir(parents=True, exist_ok=True)
-            target.write_bytes(data)
-            loaded = await asyncio.to_thread(session.load_from_workspace, filename)
-            if loaded is not None:
-                a = loaded
-                await self._send_text(
-                    message.channel,
-                    f"✅ 加载成功\n🔬 {a.n_obs:,} cells × {a.n_vars:,} genes\n📁 {filename}",
-                    reply_to=message,
-                )
-            else:
-                await self._send_text(
-                    message.channel,
-                    f"✅ 已接收 {filename}，但自动加载失败，请检查文件格式。",
-                    reply_to=message,
-                )
+            loaded = await asyncio.to_thread(load_h5ad_to_session, session, data, filename)
+            await self._send_text(
+                message.channel,
+                format_h5ad_load_result(loaded, filename),
+                reply_to=message,
+            )
         except Exception as exc:
             logger.exception("Discord failed to load h5ad attachment")
             await self._send_text(message.channel, f"❌ 文件处理失败: {exc}", reply_to=message)
@@ -524,25 +518,23 @@ class DiscordJarvisBot:
         attachments = list(getattr(message, "attachments", None) or [])
         if not attachments:
             return []
-        upload_dir = session.workspace / "uploads" / "discord"
         prepared: List[PreparedImage] = []
-        for attachment in attachments[:4]:
+        for attachment in attachments[:MAX_INBOUND_IMAGES]:
             filename = getattr(attachment, "filename", None) or ""
             content_type = str(getattr(attachment, "content_type", None) or "").strip().lower()
             if filename.lower().endswith(".h5ad"):
                 continue
-            if not (content_type.startswith("image/") or looks_like_image_name(filename)):
+            if not is_image_attachment(filename, content_type):
                 continue
             try:
                 data = await attachment.read()
                 prepared.append(
-                    prepare_image_bytes(
+                    prepare_inbound_image(
                         data,
-                        target_dir=upload_dir,
-                        filename=filename or "discord_image",
+                        workspace_root=session.workspace,
+                        channel_name="discord",
+                        filename=filename,
                         mime_type=content_type,
-                        prefix="discord_image",
-                        source="discord",
                     )
                 )
             except Exception:

--- a/omicverse/jarvis/channels/discord.py
+++ b/omicverse/jarvis/channels/discord.py
@@ -5,6 +5,10 @@ Behavior mirrors OpenClaw's default Discord mode:
 - direct messages are handled directly
 - guild messages require @bot mention
 - analysis replies are streamed back as text and file attachments
+
+Migrated to shared MessageRuntime / MessagePresenter abstractions so that
+task management, analysis orchestration, web-bridge mirroring, and result
+persistence are handled by the common runtime layer.
 """
 from __future__ import annotations
 
@@ -13,26 +17,16 @@ import io
 import logging
 import re
 import threading
-import time
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 try:
     import discord as _discord
 except ImportError:  # pragma: no cover - optional dependency
     _discord = None
 
-from ..agent_bridge import AgentBridge
-from ..gateway.routing import GatewaySessionRegistry, SessionKey
 from .channel_core import (
-    RunningTask,
     text_chunks,
     strip_local_paths,
-    build_full_request,
-    get_prior_history,
-    notify_turn_complete,
-    process_result_state,
-    format_analysis_error,
-    default_summary,
     gather_status,
     format_status_plain,
 )
@@ -49,14 +43,435 @@ from ..media_ingest import (
     compose_multimodal_user_text,
 )
 from ..model_help import render_model_help
+from ..runtime import (
+    AgentBridgeExecutionAdapter,
+    ConversationRoute,
+    DeliveryEvent,
+    MessageEnvelope,
+    MessageRuntime,
+    MessageRouter,
+)
 
 logger = logging.getLogger("omicverse.jarvis.discord")
 logger.setLevel(logging.INFO)
 
 discord = _discord
 _MAX_TEXT = 1900
-_PROGRESS_GAP = 12.0
 _BORING_SUMMARIES = {"分析完成", "分析完成。", "task completed", "done", "完成"}
+
+
+# ---------------------------------------------------------------------------
+# Routing helpers
+# ---------------------------------------------------------------------------
+
+
+def discord_route_from_message(message: Any) -> ConversationRoute:
+    """Build a :class:`ConversationRoute` from a ``discord.Message``."""
+    channel = getattr(message, "channel", None)
+    author = getattr(message, "author", None)
+    sender_id = str(getattr(author, "id", "")) if author else None
+
+    if _discord is not None and isinstance(channel, _discord.Thread):
+        return ConversationRoute(
+            channel="discord",
+            scope_type="thread",
+            scope_id=str(getattr(channel, "parent_id", None) or getattr(channel, "id", "")),
+            thread_id=str(getattr(channel, "id", "")),
+            sender_id=sender_id,
+        )
+    if getattr(channel, "guild", None) is not None:
+        return ConversationRoute(
+            channel="discord",
+            scope_type="channel",
+            scope_id=str(getattr(channel, "id", "")),
+            sender_id=sender_id,
+        )
+    return ConversationRoute(
+        channel="discord",
+        scope_type="dm",
+        scope_id=str(getattr(channel, "id", "")),
+        sender_id=sender_id,
+    )
+
+
+def discord_runtime_envelope(
+    message: Any,
+    text: str,
+    *,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> Optional[MessageEnvelope]:
+    """Build a :class:`MessageEnvelope` from a Discord message."""
+    author = getattr(message, "author", None)
+    if author is None or not text.strip():
+        return None
+    route = discord_route_from_message(message)
+    return MessageEnvelope(
+        route=route,
+        text=text.strip(),
+        sender_id=str(getattr(author, "id", "")),
+        sender_username=getattr(author, "name", None),
+        message_id=str(getattr(message, "id", "")) or None,
+        trigger="direct" if route.is_direct else "mention",
+        explicit_trigger=True,
+        metadata=dict(metadata or {}),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Presenter  (implements ``MessagePresenter`` protocol)
+# ---------------------------------------------------------------------------
+
+
+class DiscordRuntimePresenter:
+    """Produce :class:`DeliveryEvent` instances for Discord rendering."""
+
+    _BORING = _BORING_SUMMARIES
+
+    def ack(self, envelope: MessageEnvelope, session: Any) -> List[DeliveryEvent]:
+        if session.adata is not None:
+            adata = session.adata
+            text = f"⏳ 已收到，开始分析。\n当前数据: {adata.n_obs:,} cells x {adata.n_vars:,} genes"
+        else:
+            try:
+                h5ad_files = session.list_h5ad_files()
+            except Exception:
+                h5ad_files = []
+            if h5ad_files:
+                names = ", ".join(item.name for item in h5ad_files[:5])
+                text = f"⏳ 已收到，开始分析。\n检测到工作区数据文件: {names}"
+            else:
+                text = "⏳ 已收到，开始分析。"
+        image_count = len(list((envelope.metadata or {}).get("request_content") or []))
+        if image_count:
+            text += f"\n检测到图片: {image_count} 张（已保存到 workspace/uploads/discord）"
+        return [
+            DeliveryEvent(
+                route=envelope.route,
+                kind="text",
+                text=text,
+                metadata={"reply_to": True},
+            )
+        ]
+
+    def queue_started(self, route: ConversationRoute, queued_count: int) -> List[DeliveryEvent]:
+        return [
+            DeliveryEvent(
+                route=route,
+                kind="text",
+                text=f"开始执行队列中的 {queued_count} 条请求...",
+            )
+        ]
+
+    def draft_open(self, route: ConversationRoute) -> DeliveryEvent:
+        return DeliveryEvent(
+            route=route,
+            kind="text",
+            mode="open",
+            target="analysis-draft",
+            text="💭 分析中…",
+        )
+
+    def draft_update(self, route: ConversationRoute, llm_text: str, progress: str) -> DeliveryEvent:
+        if progress:
+            text = f"⚙️ {progress[:200]}"
+        elif llm_text.strip():
+            trimmed = llm_text.strip()[-200:]
+            text = f"💭 {trimmed}"
+        else:
+            text = "💭 分析中…"
+        return DeliveryEvent(
+            route=route,
+            kind="text",
+            mode="edit",
+            target="analysis-draft",
+            text=text,
+        )
+
+    def draft_cancelled(self, route: ConversationRoute) -> DeliveryEvent:
+        return DeliveryEvent(
+            route=route,
+            kind="text",
+            mode="edit",
+            target="analysis-draft",
+            text="🚫 分析已取消。",
+        )
+
+    def analysis_error(self, route: ConversationRoute, error_text: str) -> DeliveryEvent:
+        return DeliveryEvent(
+            route=route,
+            kind="text",
+            mode="edit",
+            target="analysis-draft",
+            text=f"❌ {error_text}",
+        )
+
+    def typing(self, route: ConversationRoute) -> Optional[DeliveryEvent]:
+        return DeliveryEvent(route=route, kind="typing")
+
+    def quick_chat_reply(self, route: ConversationRoute, text: str) -> DeliveryEvent:
+        return DeliveryEvent(route=route, kind="text", text=text)
+
+    def quick_chat_fallback(self, route: ConversationRoute) -> DeliveryEvent:
+        return DeliveryEvent(
+            route=route,
+            kind="text",
+            text="⏳ 后台分析进行中，请等待完成。使用 /cancel 取消。",
+        )
+
+    def analysis_status(
+        self,
+        route: ConversationRoute,
+        *,
+        has_media: bool,
+        has_reports: bool,
+        has_artifacts: bool,
+    ) -> Optional[DeliveryEvent]:
+        if has_media:
+            status = "✅ 正在发送图片…"
+        elif has_reports:
+            status = "✅ 正在发送报告…"
+        elif has_artifacts:
+            status = "✅ 结果如下"
+        else:
+            return None
+        return DeliveryEvent(
+            route=route,
+            kind="text",
+            mode="edit",
+            target="analysis-draft",
+            text=status,
+        )
+
+    def final_events(
+        self,
+        route: ConversationRoute,
+        *,
+        session: Any,
+        user_text: str,
+        llm_text: str,
+        result: Any,
+    ) -> List[DeliveryEvent]:
+        del user_text
+        events: List[DeliveryEvent] = []
+
+        # Reports
+        for report in list(result.reports or []):
+            for chunk in text_chunks(report, limit=_MAX_TEXT):
+                events.append(DeliveryEvent(route=route, kind="text", text=chunk))
+
+        # Figures (already converted to delivery bytes by the runtime)
+        for index, figure_data in enumerate(result.figures or [], start=1):
+            data = figure_data if isinstance(figure_data, bytes) else b""
+            events.append(
+                DeliveryEvent(
+                    route=route,
+                    kind="photo",
+                    binary=data,
+                    filename=f"figure_{index}.png",
+                    caption=f"图 {index}",
+                    metadata={"reply_first": index == 1},
+                )
+            )
+
+        # Artifacts
+        for artifact in list(result.artifacts or []):
+            events.append(
+                DeliveryEvent(
+                    route=route,
+                    kind="document",
+                    binary=getattr(artifact, "data", b""),
+                    filename=getattr(artifact, "filename", None) or "artifact.bin",
+                    caption=f"附件: {getattr(artifact, 'filename', 'artifact.bin')}",
+                )
+            )
+
+        # Summary text
+        summary = strip_local_paths((result.summary or "").strip())
+        if not summary or summary.lower() in self._BORING:
+            summary = strip_local_paths(llm_text.strip()) if llm_text.strip() else ""
+        if not summary:
+            if session.adata is not None:
+                adata = session.adata
+                summary = f"分析完成\n{adata.n_obs:,} cells x {adata.n_vars:,} genes"
+            else:
+                summary = "分析完成"
+        for chunk in text_chunks(summary, limit=_MAX_TEXT):
+            events.append(DeliveryEvent(route=route, kind="text", text=chunk))
+
+        # Mark draft as complete
+        events.append(
+            DeliveryEvent(
+                route=route,
+                kind="text",
+                mode="edit",
+                target="analysis-draft",
+                text="✅ 分析完成",
+            )
+        )
+
+        return events
+
+
+# ---------------------------------------------------------------------------
+# Delivery  (Discord transport layer)
+# ---------------------------------------------------------------------------
+
+
+class DiscordDelivery:
+    """Translate :class:`DeliveryEvent` instances into Discord API calls."""
+
+    def __init__(self, *, client: Any) -> None:
+        self._client = client
+        self._channels: Dict[str, Any] = {}
+        self._source_messages: Dict[str, Any] = {}
+        self._targets: Dict[str, Any] = {}
+
+    def register_channel(
+        self,
+        route: ConversationRoute,
+        channel: Any,
+        source_message: Any = None,
+    ) -> None:
+        """Cache the Discord channel (and optional source message) for a route."""
+        key = route.route_key()
+        self._channels[key] = channel
+        if source_message is not None:
+            self._source_messages[key] = source_message
+
+    async def deliver(self, event: DeliveryEvent) -> None:
+        key = event.route.route_key()
+        channel = self._channels.get(key)
+        if channel is None:
+            channel_id = int(event.route.thread_id or event.route.scope_id)
+            channel = self._client.get_channel(channel_id)
+        if channel is None:
+            logger.warning("Cannot resolve Discord channel for %s", key)
+            return
+
+        source = self._source_messages.get(key)
+
+        if event.kind == "typing":
+            try:
+                await channel.typing()
+            except Exception:
+                pass
+            return
+
+        if event.kind == "photo":
+            reply_to = source if event.metadata.get("reply_first") else None
+            await self._send_file(
+                channel,
+                event.binary or b"",
+                filename=event.filename or "figure.png",
+                caption=event.caption,
+                reply_to=reply_to,
+            )
+            return
+
+        if event.kind == "document":
+            await self._send_file(
+                channel,
+                event.binary or b"",
+                filename=event.filename or "artifact.bin",
+                caption=event.caption,
+            )
+            return
+
+        if event.kind != "text":
+            return
+
+        reply_to = source if event.metadata.get("reply_to") else None
+
+        if event.mode == "open":
+            msg = await self._send_text_msg(channel, event.text, reply_to=reply_to)
+            if msg is not None and event.target:
+                self._targets[self._target_key(event)] = msg
+            return
+
+        if event.mode == "edit":
+            target_msg = self._targets.get(self._target_key(event))
+            if target_msg is not None:
+                ok = await self._edit_message(target_msg, event.text)
+                if ok:
+                    return
+            msg = await self._send_text_msg(channel, event.text, reply_to=reply_to)
+            if msg is not None and event.target:
+                self._targets[self._target_key(event)] = msg
+            return
+
+        # Default: send new message(s), chunked if necessary
+        first = True
+        for chunk in text_chunks(event.text, limit=_MAX_TEXT):
+            kwargs: Dict[str, Any] = {}
+            if first and reply_to is not None:
+                kwargs["reference"] = reply_to
+                kwargs["mention_author"] = False
+            await channel.send(chunk, **kwargs)
+            first = False
+
+    @staticmethod
+    def _target_key(event: DeliveryEvent) -> str:
+        return f"{event.route.route_key()}::{event.target or ''}"
+
+    @staticmethod
+    async def _send_text_msg(channel: Any, text: str, *, reply_to: Any = None) -> Any:
+        try:
+            first = True
+            sent = None
+            for chunk in text_chunks(text, limit=_MAX_TEXT):
+                kwargs: Dict[str, Any] = {}
+                if first and reply_to is not None:
+                    kwargs["reference"] = reply_to
+                    kwargs["mention_author"] = False
+                msg = await channel.send(chunk, **kwargs)
+                if first:
+                    sent = msg
+                first = False
+            return sent
+        except Exception as exc:
+            logger.warning("Failed to send Discord message: %s", exc)
+            return None
+
+    @staticmethod
+    async def _edit_message(message: Any, text: str) -> bool:
+        try:
+            trimmed = text[:_MAX_TEXT] if len(text) > _MAX_TEXT else text
+            await message.edit(content=trimmed)
+            return True
+        except Exception:
+            return False
+
+    @staticmethod
+    async def _send_file(
+        channel: Any,
+        data: bytes,
+        *,
+        filename: str,
+        caption: str = "",
+        reply_to: Any = None,
+    ) -> None:
+        file_obj = (
+            discord.File(fp=io.BytesIO(data), filename=filename)
+            if discord is not None
+            else io.BytesIO(data)
+        )
+        kwargs: Dict[str, Any] = {
+            "file": file_obj,
+        }
+        if caption:
+            kwargs["content"] = caption[:_MAX_TEXT]
+        if reply_to is not None:
+            kwargs["reference"] = reply_to
+            kwargs["mention_author"] = False
+        try:
+            await channel.send(**kwargs)
+        except Exception as exc:
+            logger.warning("Failed to send Discord file %s: %s", filename, exc)
+
+
+# ---------------------------------------------------------------------------
+# Bot
+# ---------------------------------------------------------------------------
 
 
 class DiscordJarvisBot:
@@ -70,10 +485,15 @@ class DiscordJarvisBot:
         self._token = token
         self._sm = session_manager
         self._stop_event = stop_event or threading.Event()
-        self._registry = GatewaySessionRegistry(session_manager)
-        self._tasks: Dict[str, RunningTask] = {}
-        self._pending: Dict[str, List[Dict[str, Any]]] = {}
         self._client = self._build_client()
+        self._delivery = DiscordDelivery(client=self._client)
+        self._runtime = MessageRuntime(
+            router=MessageRouter(session_manager),
+            presenter=DiscordRuntimePresenter(),
+            execution_adapter=AgentBridgeExecutionAdapter(),
+            deliver=self._delivery.deliver,
+            web_bridge=getattr(session_manager, "gateway_web_bridge", None),
+        )
 
     def _build_client(self):
         if discord is None:
@@ -139,6 +559,10 @@ class DiscordJarvisBot:
         if not self._client.is_closed():
             await self._client.close()
 
+    # ------------------------------------------------------------------
+    # Message dispatch
+    # ------------------------------------------------------------------
+
     async def _on_message(self, message) -> None:
         author = getattr(message, "author", None)
         if author is None or getattr(author, "bot", False):
@@ -152,13 +576,13 @@ class DiscordJarvisBot:
             if (getattr(a, "filename", "") or "").lower().endswith(".h5ad")
         ]
         if h5ad_list:
-            session_key = self._session_key(message)
-            session = self._registry.get_or_create(session_key)
+            route = discord_route_from_message(message)
+            session = self._runtime.get_session(route)
             await self._handle_h5ad_attachment(message, session, h5ad_list[0])
             return
 
-        session_key = self._session_key(message)
-        session = self._registry.get_or_create(session_key)
+        route = discord_route_from_message(message)
+        session = self._runtime.get_session(route)
         inbound_images = await self._prepare_inbound_images(message, session)
         text = self._normalize_message_text(message)
         logger.info(
@@ -177,7 +601,6 @@ class DiscordJarvisBot:
             )
             return
 
-        route = session_key.as_key()
         cmd, tail = self._command_parts(text)
         image_note = build_workspace_note(
             session.workspace,
@@ -187,6 +610,7 @@ class DiscordJarvisBot:
         user_text = compose_multimodal_user_text(text, image_note)
         request_content = [item.request_block for item in inbound_images]
 
+        # ── Command routing ──────────────────────────────────────────
         if cmd == "/help":
             await self._send_text(
                 message.channel,
@@ -205,12 +629,17 @@ class DiscordJarvisBot:
             return
 
         if cmd == "/reset":
+            await self._runtime.cancel(route)
             session.reset()
             await self._send_text(message.channel, "✅ 已重置当前会话。", reply_to=message)
             return
 
         if cmd == "/cancel":
-            await self._handle_cancel(message.channel, message, route)
+            cancelled = await self._runtime.cancel(route)
+            if cancelled:
+                await self._send_text(message.channel, "🚫 已发送取消信号。", reply_to=message)
+            else:
+                await self._send_text(message.channel, "当前没有正在运行的分析任务。", reply_to=message)
             return
 
         if cmd == "/model":
@@ -230,235 +659,37 @@ class DiscordJarvisBot:
             await self._send_text(message.channel, f"未知命令: {cmd}\n发送 /help 查看帮助。", reply_to=message)
             return
 
-        running = self._tasks.get(route)
-        if running and not running.task.done():
-            self._pending.setdefault(route, []).append(
-                {
-                    "text": user_text,
-                    "request_content": request_content,
-                }
-            )
-            await self._send_text(
-                message.channel,
-                "⏭ 已加入当前会话队列，当前分析完成后继续处理。",
-                reply_to=message,
-            )
-            return
-
-        await self._send_ack(message.channel, message, session, image_count=len(inbound_images))
-        await self._spawn_analysis(
-            message.channel,
+        # ── Analysis: route through the shared runtime ───────────────
+        self._delivery.register_channel(route, message.channel, source_message=message)
+        envelope = discord_runtime_envelope(
             message,
-            session_key,
-            session,
             user_text,
-            request_content=request_content,
+            metadata={"request_content": request_content} if request_content else {},
         )
+        if envelope is None:
+            return
+        try:
+            await self._runtime.handle_message(envelope)
+        except Exception as exc:
+            logger.exception("Failed to handle Discord analysis message")
+            await self._send_text(message.channel, f"分析异常: {exc}")
 
-    async def _handle_status(self, channel, source_message, session: Any, route: str) -> None:
-        running = self._tasks.get(route)
+    # ------------------------------------------------------------------
+    # Command helpers
+    # ------------------------------------------------------------------
+
+    async def _handle_status(self, channel, source_message, session: Any, route: ConversationRoute) -> None:
+        state = self._runtime.task_state(route)
         info = gather_status(
             session,
-            is_running=bool(running and not running.task.done()),
-            running_request=running.request[:300] if (running and not running.task.done()) else "",
+            is_running=state.running,
+            running_request=state.request[:300] if state.running else "",
         )
         await self._send_text(channel, format_status_plain(info), reply_to=source_message)
 
-    async def _handle_cancel(self, channel, source_message, route: str) -> None:
-        self._pending.pop(route, None)
-        running = self._tasks.get(route)
-        if not running or running.task.done():
-            await self._send_text(channel, "当前没有正在运行的分析任务。", reply_to=source_message)
-            return
-        running.task.cancel()
-        await self._send_text(channel, "🚫 已发送取消信号。", reply_to=source_message)
-
-    async def _send_ack(self, channel, source_message, session: Any, *, image_count: int = 0) -> None:
-        if session.adata is not None:
-            adata = session.adata
-            text = f"⏳ 已收到，开始分析。\n当前数据: {adata.n_obs:,} cells x {adata.n_vars:,} genes"
-        else:
-            try:
-                h5ad_files = session.list_h5ad_files()
-            except Exception:
-                h5ad_files = []
-            if h5ad_files:
-                names = ", ".join(item.name for item in h5ad_files[:5])
-                text = f"⏳ 已收到，开始分析。\n检测到工作区数据文件: {names}"
-            else:
-                text = "⏳ 已收到，开始分析。"
-        if image_count:
-            text += f"\n检测到图片: {image_count} 张（已保存到 workspace/uploads/discord）"
-        await self._send_text(channel, text, reply_to=source_message)
-
-    async def _spawn_analysis(
-        self,
-        channel,
-        source_message,
-        session_key: SessionKey,
-        session: Any,
-        user_text: str,
-        request_content: Optional[List[Dict[str, Any]]] = None,
-    ) -> None:
-        route = session_key.as_key()
-        task = asyncio.create_task(
-            self._analysis_wrapper(
-                channel,
-                source_message,
-                session_key,
-                session,
-                user_text,
-                request_content or [],
-            )
-        )
-        self._tasks[route] = RunningTask(task=task, request=user_text, started_at=time.time())
-
-    async def _analysis_wrapper(
-        self,
-        channel,
-        source_message,
-        session_key: SessionKey,
-        session: Any,
-        user_text: str,
-        request_content: List[Dict[str, Any]],
-    ) -> None:
-        route = session_key.as_key()
-        try:
-            await self._run_analysis(
-                channel,
-                source_message,
-                session_key,
-                session,
-                user_text,
-                request_content,
-            )
-        except asyncio.CancelledError:
-            raise
-        except Exception as exc:
-            logger.exception("Discord analysis wrapper failed")
-            await self._send_text(channel, f"分析异常: {exc}")
-        finally:
-            self._tasks.pop(route, None)
-            queued = self._pending.pop(route, [])
-            if queued:
-                await self._send_text(channel, f"开始执行队列中的 {len(queued)} 条请求...")
-                next_session = self._registry.get_or_create(session_key)
-                coalesced, request_content = self._coalesce_pending_requests(queued)
-                await self._spawn_analysis(
-                    channel,
-                    None,
-                    session_key,
-                    next_session,
-                    coalesced,
-                    request_content=request_content,
-                )
-
-    async def _run_analysis(
-        self,
-        channel,
-        source_message,
-        session_key: SessionKey,
-        session: Any,
-        user_text: str,
-        request_content: List[Dict[str, Any]],
-    ) -> None:
-        llm_buf = ""
-        last_progress_sent = 0.0
-        full_request = self._build_full_request(session, user_text)
-
-        async def progress_cb(msg: str) -> None:
-            nonlocal last_progress_sent
-            now = asyncio.get_running_loop().time()
-            if now - last_progress_sent < _PROGRESS_GAP:
-                return
-            last_progress_sent = now
-            await self._send_text(channel, f"⚙️ {msg[:200]}")
-
-        async def llm_chunk_cb(chunk: str) -> None:
-            nonlocal llm_buf
-            if chunk:
-                llm_buf += chunk
-
-        prior_history = get_prior_history(
-            self._sm, "discord", session_key.scope_type, session_key.scope_id, session,
-        )
-
-        bridge = AgentBridge(session.agent, progress_cb=progress_cb, llm_chunk_cb=llm_chunk_cb)
-        try:
-            result = await bridge.run(
-                full_request,
-                session.adata,
-                history=prior_history,
-                request_content=request_content,
-            )
-        except asyncio.CancelledError:
-            raise
-        except Exception as exc:
-            logger.exception("Discord analysis failed")
-            await self._send_text(channel, f"分析失败: {exc}", reply_to=source_message)
-            return
-
-        delivery_figures, _adata_info = process_result_state(session, result, user_text)
-
-        notify_turn_complete(
-            self._sm,
-            channel="discord",
-            scope_type=session_key.scope_type,
-            scope_id=session_key.scope_id,
-            session=session,
-            user_text=user_text,
-            llm_text=llm_buf,
-            adata=result.adata,
-        )
-
-        if result.error:
-            await self._send_text(
-                channel, format_analysis_error(result, llm_buf), reply_to=source_message,
-            )
-            return
-
-        for report in list(result.reports or []):
-            for chunk in text_chunks(report, limit=_MAX_TEXT):
-                await self._send_text(channel, chunk)
-
-        for index, figure in enumerate(delivery_figures, start=1):
-            await self._send_file(
-                channel,
-                figure,
-                filename=f"figure_{index}.png",
-                caption=f"图 {index}",
-                reply_to=source_message if index == 1 else None,
-            )
-
-        for artifact in list(result.artifacts or []):
-            await self._send_file(
-                channel,
-                artifact.data,
-                filename=artifact.filename or "artifact.bin",
-                caption=f"附件: {artifact.filename}",
-            )
-
-        summary = strip_local_paths(bridge.pick_reply_text(result, llm_buf))
-        if not summary:
-            summary = default_summary(session)
-        for chunk in text_chunks(summary, limit=_MAX_TEXT):
-            await self._send_text(channel, chunk)
-
-    def _build_full_request(self, session: Any, text: str) -> str:
-        return build_full_request(session, text, channel_label="Discord")
-
-    def _session_key(self, message) -> SessionKey:
-        channel = message.channel
-        if discord is not None and isinstance(channel, discord.Thread):
-            return SessionKey(
-                channel="discord",
-                scope_type="thread",
-                scope_id=str(channel.parent_id or channel.id),
-                thread_id=str(channel.id),
-            )
-        if getattr(channel, "guild", None) is not None:
-            return SessionKey(channel="discord", scope_type="channel", scope_id=str(channel.id))
-        return SessionKey(channel="discord", scope_type="dm", scope_id=str(channel.id))
+    # ------------------------------------------------------------------
+    # Message helpers
+    # ------------------------------------------------------------------
 
     def _normalize_message_text(self, message) -> str:
         raw = (getattr(message, "content", None) or "").strip()
@@ -490,6 +721,10 @@ class DiscordJarvisBot:
                 kwargs["mention_author"] = False
             await channel.send(chunk, **kwargs)
             first = False
+
+    # ------------------------------------------------------------------
+    # Attachment helpers
+    # ------------------------------------------------------------------
 
     async def _handle_h5ad_attachment(self, message, session: Any, attachment) -> None:
         """Download a .h5ad attachment sent by the user and load it into the session."""
@@ -537,36 +772,6 @@ class DiscordJarvisBot:
                     exc_info=True,
                 )
         return prepared
-
-    @staticmethod
-    def _coalesce_pending_requests(items: List[Dict[str, Any]]) -> tuple[str, List[Dict[str, Any]]]:
-        parts: List[str] = []
-        request_content: List[Dict[str, Any]] = []
-        for item in items:
-            text = str(item.get("text") or "").strip()
-            if text:
-                parts.append(text)
-            request_content.extend(list(item.get("request_content") or []))
-        return "\n\n".join(parts).strip(), request_content
-
-    async def _send_file(
-        self,
-        channel,
-        data: bytes,
-        *,
-        filename: str,
-        caption: str = "",
-        reply_to=None,
-    ) -> None:
-        kwargs: Dict[str, Any] = {
-            "file": discord.File(fp=io.BytesIO(data), filename=filename),
-        }
-        if caption:
-            kwargs["content"] = caption[:_MAX_TEXT]
-        if reply_to is not None:
-            kwargs["reference"] = reply_to
-            kwargs["mention_author"] = False
-        await channel.send(**kwargs)
 
 
 def run_discord_bot(

--- a/omicverse/jarvis/channels/discord.py
+++ b/omicverse/jarvis/channels/discord.py
@@ -33,6 +33,8 @@ from .channel_core import (
     process_result_state,
     format_analysis_error,
     default_summary,
+    gather_status,
+    format_status_plain,
 )
 from ..media_ingest import (
     PreparedImage,
@@ -249,22 +251,13 @@ class DiscordJarvisBot:
         )
 
     async def _handle_status(self, channel, source_message, session: Any, route: str) -> None:
-        parts: List[str] = []
         running = self._tasks.get(route)
-        if running and not running.task.done():
-            parts.append(f"当前状态: 运行中\n请求: {running.request[:300]}")
-        else:
-            parts.append("当前状态: 空闲")
-        if session.adata is not None:
-            adata = session.adata
-            parts.append(f"当前数据: {adata.n_obs:,} cells x {adata.n_vars:,} genes")
-        try:
-            workspace = session.agent.workspace_dir
-        except Exception:
-            workspace = None
-        if workspace:
-            parts.append(f"工作区: {workspace}")
-        await self._send_text(channel, "\n".join(parts), reply_to=source_message)
+        info = gather_status(
+            session,
+            is_running=bool(running and not running.task.done()),
+            running_request=running.request[:300] if (running and not running.task.done()) else "",
+        )
+        await self._send_text(channel, format_status_plain(info), reply_to=source_message)
 
     async def _handle_cancel(self, channel, source_message, route: str) -> None:
         self._pending.pop(route, None)

--- a/omicverse/jarvis/channels/discord.py
+++ b/omicverse/jarvis/channels/discord.py
@@ -14,7 +14,6 @@ import logging
 import re
 import threading
 import time
-from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
 try:
@@ -23,9 +22,18 @@ except ImportError:  # pragma: no cover - optional dependency
     _discord = None
 
 from ..agent_bridge import AgentBridge
-from .._bridge_session import resolve_bridge_session_id
-from ..channel_media import build_channel_request, prepare_channel_delivery_figures
 from ..gateway.routing import GatewaySessionRegistry, SessionKey
+from .channel_core import (
+    RunningTask,
+    text_chunks,
+    strip_local_paths,
+    build_full_request,
+    get_prior_history,
+    notify_turn_complete,
+    process_result_state,
+    format_analysis_error,
+    default_summary,
+)
 from ..media_ingest import (
     PreparedImage,
     build_workspace_note,
@@ -42,53 +50,6 @@ discord = _discord
 _MAX_TEXT = 1900
 _PROGRESS_GAP = 12.0
 _BORING_SUMMARIES = {"分析完成", "分析完成。", "task completed", "done", "完成"}
-
-
-@dataclass
-class RunningTask:
-    task: asyncio.Task
-    request: str
-    started_at: float
-
-
-def _text_chunks(text: str, limit: int = _MAX_TEXT) -> List[str]:
-    text = (text or "").strip()
-    if not text:
-        return []
-    if len(text) <= limit:
-        return [text]
-    chunks: List[str] = []
-    buf = ""
-    for para in text.split("\n\n"):
-        cand = f"{buf}\n\n{para}".strip() if buf else para
-        if len(cand) <= limit:
-            buf = cand
-            continue
-        if buf:
-            chunks.append(buf)
-        if len(para) <= limit:
-            buf = para
-            continue
-        pos = 0
-        while pos < len(para):
-            chunks.append(para[pos : pos + limit])
-            pos += limit
-        buf = ""
-    if buf:
-        chunks.append(buf)
-    return chunks
-
-
-def _strip_local_paths(text: str) -> str:
-    value = text or ""
-    value = re.sub(r"`[^`\n]*(?:/[^`\n]*){2,}`", "", value)
-    value = re.sub(r"/(?:Users|home|tmp|var|opt|root|data|mnt|private)/\S+", "", value)
-    value = re.sub(r"~[/\\]\S+", "", value)
-    ext = r"pdf|csv|tsv|txt|xlsx|html|json|h5ad|png|jpg|svg"
-    value = re.sub(rf"\.?/?(?:\w[\w/-]*/)+\w[\w.-]*\.(?:{ext})", "", value, flags=re.IGNORECASE)
-    value = re.sub(r"[ \t]{2,}", " ", value)
-    value = re.sub(r"\n{3,}", "\n\n", value)
-    return value.strip()
 
 
 class DiscordJarvisBot:
@@ -247,7 +208,7 @@ class DiscordJarvisBot:
 
         if cmd == "/model":
             if not tail:
-                for chunk in _text_chunks(render_model_help(getattr(self._sm, "_model", "unknown"))):
+                for chunk in text_chunks(render_model_help(getattr(self._sm, "_model", "unknown")), limit=_MAX_TEXT):
                     await self._send_text(message.channel, chunk, reply_to=message)
                 return
             self._sm._model = tail
@@ -420,13 +381,9 @@ class DiscordJarvisBot:
             if chunk:
                 llm_buf += chunk
 
-        web_bridge = getattr(self._sm, "gateway_web_bridge", None)
-        prior_history = web_bridge.get_prior_history_simple(
-            "discord",
-            session_key.scope_type,
-            session_key.scope_id,
-            session_id=resolve_bridge_session_id(session),
-        ) if web_bridge else []
+        prior_history = get_prior_history(
+            self._sm, "discord", session_key.scope_type, session_key.scope_id, session,
+        )
 
         bridge = AgentBridge(session.agent, progress_cb=progress_cb, llm_chunk_cb=llm_chunk_cb)
         try:
@@ -443,53 +400,27 @@ class DiscordJarvisBot:
             await self._send_text(channel, f"分析失败: {exc}", reply_to=source_message)
             return
 
-        if result.adata is not None:
-            session.adata = result.adata
-            try:
-                session.save_adata()
-                session.prompt_count += 1
-            except Exception:
-                pass
-        if result.usage is not None:
-            session.last_usage = result.usage
-        delivery_figures = prepare_channel_delivery_figures(session, result.figures)
-        try:
-            adata = session.adata
-            adata_info = f"{adata.n_obs:,} cells x {adata.n_vars:,} genes" if adata is not None else ""
-            session.append_memory_log(
-                request=user_text,
-                summary=(result.summary or "分析完成"),
-                adata_info=adata_info,
-            )
-        except Exception:
-            pass
+        delivery_figures, _adata_info = process_result_state(session, result, user_text)
 
-        if web_bridge is not None:
-            try:
-                web_bridge.on_turn_complete_simple(
-                    channel="discord",
-                    scope_type=session_key.scope_type,
-                    scope_id=session_key.scope_id,
-                    user_text=user_text,
-                    llm_text=llm_buf,
-                    adata=result.adata,
-                    session_id=resolve_bridge_session_id(session),
-                )
-            except Exception:
-                pass
+        notify_turn_complete(
+            self._sm,
+            channel="discord",
+            scope_type=session_key.scope_type,
+            scope_id=session_key.scope_id,
+            session=session,
+            user_text=user_text,
+            llm_text=llm_buf,
+            adata=result.adata,
+        )
 
         if result.error:
-            err_text = f"分析出错: {result.error}"
-            if result.diagnostics:
-                hints = "\n".join(f"- {item}" for item in result.diagnostics[:4])
-                err_text += f"\n\n诊断:\n{hints}"
-            if llm_buf.strip():
-                err_text += f"\n\n模型输出:\n{llm_buf[:1200]}"
-            await self._send_text(channel, err_text, reply_to=source_message)
+            await self._send_text(
+                channel, format_analysis_error(result, llm_buf), reply_to=source_message,
+            )
             return
 
         for report in list(result.reports or []):
-            for chunk in _text_chunks(report):
+            for chunk in text_chunks(report, limit=_MAX_TEXT):
                 await self._send_text(channel, chunk)
 
         for index, figure in enumerate(delivery_figures, start=1):
@@ -509,18 +440,14 @@ class DiscordJarvisBot:
                 caption=f"附件: {artifact.filename}",
             )
 
-        summary = _strip_local_paths(bridge.pick_reply_text(result, llm_buf))
+        summary = strip_local_paths(bridge.pick_reply_text(result, llm_buf))
         if not summary:
-            if session.adata is not None:
-                adata = session.adata
-                summary = f"分析完成\n{adata.n_obs:,} cells x {adata.n_vars:,} genes"
-            else:
-                summary = "分析完成"
-        for chunk in _text_chunks(summary):
+            summary = default_summary(session)
+        for chunk in text_chunks(summary, limit=_MAX_TEXT):
             await self._send_text(channel, chunk)
 
     def _build_full_request(self, session: Any, text: str) -> str:
-        return build_channel_request(session, text, channel_label="Discord")
+        return build_full_request(session, text, channel_label="Discord")
 
     def _session_key(self, message) -> SessionKey:
         channel = message.channel
@@ -558,7 +485,7 @@ class DiscordJarvisBot:
 
     async def _send_text(self, channel, text: str, *, reply_to=None) -> None:
         first = True
-        for chunk in _text_chunks(text):
+        for chunk in text_chunks(text, limit=_MAX_TEXT):
             kwargs: Dict[str, Any] = {}
             if first and reply_to is not None:
                 kwargs["reference"] = reply_to

--- a/omicverse/jarvis/channels/feishu.py
+++ b/omicverse/jarvis/channels/feishu.py
@@ -18,11 +18,9 @@ import hashlib
 import json
 import logging
 import os
-import re
 import threading
 import time
 from datetime import datetime
-from dataclasses import dataclass
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import Any, Dict, List, Mapping, Optional, Tuple
@@ -30,11 +28,18 @@ from typing import Any, Dict, List, Mapping, Optional, Tuple
 import requests
 
 from ..agent_bridge import AgentBridge
-from .._bridge_session import resolve_bridge_session_id
-from ..channel_media import build_channel_request, prepare_channel_delivery_figures
 from ..gateway.routing import GatewaySessionRegistry, SessionKey
 from ..model_help import render_model_help
 from ..runtime import ConversationRoute
+from .channel_core import (
+    RunningTask,
+    build_full_request,
+    get_prior_history,
+    notify_turn_complete,
+    process_result_state,
+    strip_local_paths,
+    text_chunks,
+)
 
 logger = logging.getLogger("omicverse.jarvis.feishu")
 
@@ -44,13 +49,6 @@ _MAX_BODY_BYTES = 2 * 1024 * 1024
 _DEDUP_TTL_SECONDS = 24 * 60 * 60
 _DEDUP_MAX_ENTRIES = 10000
 _FEISHU_EVENT_MESSAGE_RECEIVE = "im.message.receive_v1"
-
-
-@dataclass
-class RunningTask:
-    task: asyncio.Task
-    request: str
-    started_at: float
 
 
 class FeishuClient:
@@ -619,19 +617,10 @@ class FeishuRuntime:
 
     @staticmethod
     def _strip_local_paths(text: str) -> str:
-        """Remove local filesystem path references from result text."""
-        t = text or ""
-        t = re.sub(r'`[^`\n]*(?:/[^`\n]*){2,}`', '', t)
-        t = re.sub(r'/(?:Users|home|tmp|var|opt|root|data|mnt|private)/\S+', '', t)
-        t = re.sub(r'~[/\\]\S+', '', t)
-        _ext = r"pdf|csv|tsv|txt|xlsx|html|json|h5ad|png|jpg|svg"
-        t = re.sub(rf'\.?/?(?:\w[\w/-]*/)+\w[\w.-]*\.(?:{_ext})', '', t, flags=re.IGNORECASE)
-        t = re.sub(r'[ \t]{2,}', ' ', t)
-        t = re.sub(r'\n{3,}', '\n\n', t)
-        return t.strip()
+        return strip_local_paths(text)
 
     def _build_full_request(self, session: Any, text: str) -> str:
-        return build_channel_request(session, text, channel_label="Feishu")
+        return build_full_request(session, text, channel_label="Feishu")
 
     async def _spawn_analysis(
         self, chat_id: str, route: str, session: Any, user_text: str
@@ -721,7 +710,7 @@ class FeishuRuntime:
             ]
             response = await session.agent._llm.chat(messages, tools=None, tool_choice=None)
             reply = (response.content or "").strip() or "⏳ 后台分析进行中，请等待完成。"
-            for chunk in self._text_chunks(reply):
+            for chunk in text_chunks(reply):
                 await asyncio.to_thread(self._client.send_text, chat_id, chunk)
         except Exception as exc:
             logger.warning("Feishu quick_chat failed: %s", exc)
@@ -922,13 +911,7 @@ class FeishuRuntime:
             last_progress = msg
             await _edit(force=True)
 
-        _wb = getattr(self._sm, "gateway_web_bridge", None)
-        _prior_history = _wb.get_prior_history_simple(
-            "feishu",
-            "dm",
-            chat_id,
-            session_id=resolve_bridge_session_id(session),
-        ) if _wb else []
+        _prior_history = get_prior_history(self._sm, "feishu", "dm", chat_id, session)
 
         bridge = AgentBridge(session.agent, progress_cb=progress_cb, llm_chunk_cb=llm_chunk_cb)
         try:
@@ -954,43 +937,19 @@ class FeishuRuntime:
                 await asyncio.to_thread(self._client.send_text, chat_id, err_msg)
             return
 
-        if result.adata is not None:
-            session.adata = result.adata
-            try:
-                session.save_adata()
-                session.prompt_count += 1
-            except Exception:
-                pass
-        if result.usage is not None:
-            session.last_usage = result.usage
-        delivery_figures = prepare_channel_delivery_figures(session, result.figures)
-        try:
-            a = session.adata
-            adata_info = f"{a.n_obs:,} cells × {a.n_vars:,} genes" if a is not None else ""
-            session.append_memory_log(
-                request=user_text,
-                summary=(result.summary or "分析完成"),
-                adata_info=adata_info,
-            )
-        except Exception:
-            pass
+        delivery_figures, _adata_info = process_result_state(session, result, user_text)
 
-        # Mirror the completed turn into the web session (gateway mode)
-        _web_bridge = getattr(self._sm, "gateway_web_bridge", None)
-        if _web_bridge is not None:
-            try:
-                _web_bridge.on_turn_complete_simple(
-                    channel="feishu",
-                    scope_type="dm",
-                    scope_id=chat_id,
-                    user_text=user_text,
-                    llm_text=llm_buf,
-                    adata=result.adata,
-                    figures=result.figures or [],
-                    session_id=resolve_bridge_session_id(session),
-                )
-            except Exception:
-                pass
+        notify_turn_complete(
+            self._sm,
+            channel="feishu",
+            scope_type="dm",
+            scope_id=chat_id,
+            session=session,
+            user_text=user_text,
+            llm_text=llm_buf,
+            adata=result.adata,
+            figures=result.figures or [],
+        )
 
         if result.error:
             err_text = f"❌ {result.error}"
@@ -1022,7 +981,7 @@ class FeishuRuntime:
                     self._client.send_markdown_card, chat_id, rep, "📊 分析报告"
                 )
             else:
-                for chunk in self._text_chunks(rep):
+                for chunk in text_chunks(rep):
                     await asyncio.to_thread(self._client.send_text, chat_id, chunk)
 
         for i, fig in enumerate(delivery_figures, start=1):
@@ -1046,7 +1005,7 @@ class FeishuRuntime:
             except Exception:
                 logger.warning("Failed to send artifact %s", art.filename)
 
-        summary = self._strip_local_paths(
+        summary = strip_local_paths(
             bridge.pick_reply_text(result, llm_buf, max_len=3600)
         )
         if not summary:
@@ -1060,7 +1019,7 @@ class FeishuRuntime:
                 self._client.send_markdown_card, chat_id, summary, "✅ 分析完成", "green"
             )
         else:
-            for chunk in self._text_chunks(summary):
+            for chunk in text_chunks(summary):
                 await asyncio.to_thread(self._client.send_text, chat_id, chunk)
         if draft_id:
             ok = await asyncio.to_thread(
@@ -1163,7 +1122,7 @@ class FeishuRuntime:
     async def _handle_ls(self, chat_id: str, session: Any, subpath: str) -> None:
         cmd = f"ls -lh {subpath}".strip() if subpath else "ls -lh"
         out = session.shell.exec(cmd, cwd=session.workspace)
-        for chunk in self._text_chunks(f"$ {cmd}\n{out}", limit=3200):
+        for chunk in text_chunks(f"$ {cmd}\n{out}", limit=3200):
             self._client.send_text(chat_id, chunk)
 
     async def _handle_find(self, chat_id: str, session: Any, pattern: str) -> None:
@@ -1173,7 +1132,7 @@ class FeishuRuntime:
             return
         cmd = f"find . -name {pattern}"
         out = session.shell.exec(cmd, cwd=session.workspace)
-        for chunk in self._text_chunks(f"$ {cmd}\n{out}", limit=3200):
+        for chunk in text_chunks(f"$ {cmd}\n{out}", limit=3200):
             self._client.send_text(chat_id, chunk)
 
     async def _handle_load(self, chat_id: str, session: Any, filename: str) -> None:
@@ -1209,12 +1168,12 @@ class FeishuRuntime:
             )
             return
         out = session.shell.exec(cmd, cwd=session.workspace)
-        for chunk in self._text_chunks(f"$ {cmd}\n{out}", limit=3200):
+        for chunk in text_chunks(f"$ {cmd}\n{out}", limit=3200):
             self._client.send_text(chat_id, chunk)
 
     async def _handle_memory(self, chat_id: str, session: Any) -> None:
         text = session.get_recent_memory_text()
-        for chunk in self._text_chunks(f"🧠 分析历史（近两天）\n\n{text}", limit=3200):
+        for chunk in text_chunks(f"🧠 分析历史（近两天）\n\n{text}", limit=3200):
             self._client.send_text(chat_id, chunk)
 
     async def _handle_usage(self, chat_id: str, session: Any) -> None:
@@ -1249,7 +1208,7 @@ class FeishuRuntime:
         model_name = (model_name or "").strip()
         if not model_name:
             text = render_model_help(getattr(self._sm, "_model", "unknown"))
-            for chunk in self._text_chunks(text):
+            for chunk in text_chunks(text):
                 self._client.send_text(chat_id, chunk)
             return
         self._sm._model = model_name
@@ -1322,35 +1281,6 @@ class FeishuRuntime:
                 self._client.send_text(chat_id, f"❌ kernel 操作失败: {exc}")
             return
         self._client.send_text(chat_id, "用法: /kernel | /kernel ls | /kernel new 名称 | /kernel use 名称")
-
-    @staticmethod
-    def _text_chunks(text: str, limit: int = _MAX_TEXT) -> List[str]:
-        text = (text or "").strip()
-        if not text:
-            return []
-        if len(text) <= limit:
-            return [text]
-        chunks: List[str] = []
-        buf = ""
-        for para in text.split("\n\n"):
-            cand = f"{buf}\n\n{para}".strip() if buf else para
-            if len(cand) <= limit:
-                buf = cand
-                continue
-            if buf:
-                chunks.append(buf)
-            if len(para) <= limit:
-                buf = para
-            else:
-                pos = 0
-                while pos < len(para):
-                    chunks.append(para[pos:pos + limit])
-                    pos += limit
-                buf = ""
-        if buf:
-            chunks.append(buf)
-        return chunks
-
 
 def run_feishu_bot(
     *,

--- a/omicverse/jarvis/channels/feishu.py
+++ b/omicverse/jarvis/channels/feishu.py
@@ -33,6 +33,12 @@ from ..runtime import ConversationRoute
 from .channel_core import (
     RunningTask,
     build_full_request,
+    default_summary,
+    format_analysis_error,
+    format_save_result_plain,
+    format_status_plain,
+    format_usage_plain,
+    format_workspace_plain,
     gather_status,
     gather_usage,
     gather_workspace,
@@ -955,12 +961,7 @@ class FeishuRuntime:
         )
 
         if result.error:
-            err_text = f"❌ {result.error}"
-            if result.diagnostics:
-                hints = "\n".join(f"- {x}" for x in result.diagnostics[:4])
-                err_text += f"\n\n诊断信息:\n{hints}"
-            if llm_buf.strip():
-                err_text += f"\n\n最后模型输出片段:\n{_trim(llm_buf, max_len=1200)}"
+            err_text = format_analysis_error(result, llm_buf)
             if draft_id:
                 ok = await asyncio.to_thread(
                     self._client.edit_card, draft_id, err_text, "❌ 分析失败", "red"
@@ -1012,11 +1013,7 @@ class FeishuRuntime:
             bridge.pick_reply_text(result, llm_buf, max_len=3600)
         )
         if not summary:
-            if session.adata is not None:
-                a = session.adata
-                summary = f"✅ 分析完成\n🔬 {a.n_obs:,} cells × {a.n_vars:,} genes"
-            else:
-                summary = "✅ 分析完成"
+            summary = default_summary(session)
         if len(summary) <= 4800:
             await asyncio.to_thread(
                 self._client.send_markdown_card, chat_id, summary, "✅ 分析完成", "green"

--- a/omicverse/jarvis/channels/feishu.py
+++ b/omicverse/jarvis/channels/feishu.py
@@ -20,7 +20,6 @@ import logging
 import os
 import threading
 import time
-from datetime import datetime
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import Any, Dict, List, Mapping, Optional, Tuple
@@ -34,8 +33,12 @@ from ..runtime import ConversationRoute
 from .channel_core import (
     RunningTask,
     build_full_request,
+    gather_status,
+    gather_usage,
+    gather_workspace,
     get_prior_history,
     notify_turn_complete,
+    perform_save,
     process_result_state,
     strip_local_paths,
     text_chunks,
@@ -1060,60 +1063,53 @@ class FeishuRuntime:
         self._client.send_text(chat_id, text)
 
     async def _handle_status(self, chat_id: str, session: Any, route: str) -> None:
+        running = self._tasks.get(route)
+        info = gather_status(
+            session,
+            session_manager=self._sm,
+            is_running=bool(running and not running.task.done()),
+        )
         lines: List[str] = []
-        if session.adata is not None:
-            a = session.adata
-            lines.append(f"🔬 {a.n_obs:,} cells × {a.n_vars:,} genes")
-            try:
-                cols = ", ".join(list(a.obs.columns[:8]))
-                if cols:
-                    lines.append(f"📋 obs: {cols}")
-            except Exception:
-                pass
+        if info.adata_shape:
+            n_obs, n_vars = info.adata_shape
+            lines.append(f"🔬 {n_obs:,} cells × {n_vars:,} genes")
+            if info.obs_columns:
+                lines.append(f"📋 obs: {', '.join(info.obs_columns)}")
         else:
             lines.append("📭 暂无数据")
-        try:
-            kname = self._sm.get_active_kernel(session.user_id)
-            lines.append(f"🧩 kernel: {kname}")
-        except Exception:
-            pass
-        kst = session.kernel_status()
-        if kst:
-            lines.append(f"💬 prompts: {kst.get('prompt_count', 0)}/{kst.get('max_prompts', '?')}")
-            if kst.get("session_id"):
-                lines.append(f"🆔 session: {kst.get('session_id')}")
-        running = self._tasks.get(route)
-        if running and not running.task.done():
+        if info.kernel_name:
+            lines.append(f"🧩 kernel: {info.kernel_name}")
+        if info.prompt_count is not None:
+            lines.append(f"💬 prompts: {info.prompt_count}/{info.max_prompts or '?'}")
+            if info.session_id:
+                lines.append(f"🆔 session: {info.session_id}")
+        if info.is_running:
             lines.append("⚙️ 分析中（可 /cancel）")
         self._client.send_text(chat_id, "\n".join(lines))
 
     async def _handle_workspace(self, chat_id: str, session: Any) -> None:
-        ws = session.workspace
-        h5ad_files = session.list_h5ad_files()
-        agents_md = session.get_agents_md()
-        today_log = session.memory_dir / f"{datetime.now().date()}.md"
+        info = gather_workspace(session)
         lines = [
             "📁 Workspace",
             "--------------------",
-            str(ws),
+            info.path,
             "",
         ]
-        if h5ad_files:
-            lines.append(f"📊 数据文件 ({len(h5ad_files)})")
-            for f in h5ad_files[:10]:
-                try:
-                    mb = f.stat().st_size / 1_048_576
-                    lines.append(f"- {f.name} ({mb:.1f} MB)")
-                except OSError:
-                    lines.append(f"- {f.name}")
-            if len(h5ad_files) > 10:
-                lines.append(f"... 还有 {len(h5ad_files) - 10} 个")
+        if info.h5ad_files:
+            lines.append(f"📊 数据文件 ({info.h5ad_total})")
+            for name, mb in info.h5ad_files:
+                if mb is not None:
+                    lines.append(f"- {name} ({mb:.1f} MB)")
+                else:
+                    lines.append(f"- {name}")
+            if info.h5ad_total > len(info.h5ad_files):
+                lines.append(f"... 还有 {info.h5ad_total - len(info.h5ad_files)} 个")
         else:
             lines.append("📊 数据文件 (空)")
         lines += [
             "",
-            f"📋 AGENTS.md {'✅' if agents_md else '—'}",
-            f"🧠 今日记忆 {'✅' if today_log.exists() else '—'}",
+            f"📋 AGENTS.md {'✅' if info.has_agents_md else '—'}",
+            f"🧠 今日记忆 {'✅' if info.has_today_memory else '—'}",
             "",
             "可用: /load <文件名> | /ls | /memory",
         ]
@@ -1177,31 +1173,21 @@ class FeishuRuntime:
             self._client.send_text(chat_id, chunk)
 
     async def _handle_usage(self, chat_id: str, session: Any) -> None:
-        usage = session.last_usage
-        if usage is None:
+        info = gather_usage(session)
+        if not info.has_data:
             self._client.send_text(chat_id, "ℹ️ 暂无用量数据，请先进行一次分析。")
             return
-
-        def _attr(obj: Any, *names: str, default: str = "?") -> str:
-            for name in names:
-                v = getattr(obj, name, None)
-                if v is not None:
-                    return f"{v:,}" if isinstance(v, int) else str(v)
-            return default
-
         lines = [
             "📊 Token 用量（最近一次）",
             "--------------------",
-            f"输入: {_attr(usage, 'input_tokens')}",
-            f"输出: {_attr(usage, 'output_tokens')}",
-            f"合计: {_attr(usage, 'total_tokens')}",
+            f"输入: {info.input_tokens}",
+            f"输出: {info.output_tokens}",
+            f"合计: {info.total_tokens}",
         ]
-        cr = _attr(usage, "cache_read_input_tokens", default="")
-        cc = _attr(usage, "cache_creation_input_tokens", default="")
-        if cr and cr != "?":
-            lines.append(f"缓存读取: {cr}")
-        if cc and cc != "?":
-            lines.append(f"缓存写入: {cc}")
+        if info.cache_read and info.cache_read != "?":
+            lines.append(f"缓存读取: {info.cache_read}")
+        if info.cache_creation and info.cache_creation != "?":
+            lines.append(f"缓存写入: {info.cache_creation}")
         self._client.send_text(chat_id, "\n".join(lines))
 
     async def _handle_model(self, chat_id: str, model_name: str) -> None:
@@ -1222,18 +1208,20 @@ class FeishuRuntime:
             self._client.send_text(chat_id, "❌ 没有数据，请先 /load 或完成分析。")
             return
         self._client.send_text(chat_id, "⏳ 正在保存 current.h5ad ...")
-        try:
-            path = await asyncio.to_thread(session.save_adata)
-            if not path or not Path(path).exists():
-                self._client.send_text(chat_id, "❌ 保存失败，请重试。")
-                return
-            data = Path(path).read_bytes()
-            await asyncio.to_thread(self._client.send_file_bytes, chat_id, data, "current.h5ad")
-            a = session.adata
-            self._client.send_text(chat_id, f"💾 已发送 current.h5ad\n🔬 {a.n_obs:,} cells × {a.n_vars:,} genes")
-        except Exception as exc:
-            logger.exception("Feishu /save failed")
-            self._client.send_text(chat_id, f"❌ 保存失败: {exc}")
+        result = await asyncio.to_thread(perform_save, session)
+        if result.success and result.path:
+            try:
+                data = Path(result.path).read_bytes()
+                await asyncio.to_thread(self._client.send_file_bytes, chat_id, data, "current.h5ad")
+                n_obs, n_vars = result.adata_shape
+                self._client.send_text(chat_id, f"💾 已发送 current.h5ad\n🔬 {n_obs:,} cells × {n_vars:,} genes")
+            except Exception as exc:
+                logger.exception("Feishu /save failed")
+                self._client.send_text(chat_id, f"❌ 保存失败: {exc}")
+        elif result.error:
+            self._client.send_text(chat_id, f"❌ {result.error}")
+        else:
+            self._client.send_text(chat_id, "❌ 保存失败，请重试。")
 
     async def _handle_kernel(self, chat_id: str, session: Any, route: str, args: List[str]) -> None:
         if not args:

--- a/omicverse/jarvis/channels/imessage.py
+++ b/omicverse/jarvis/channels/imessage.py
@@ -16,10 +16,18 @@ from pathlib import Path
 from typing import Any, Awaitable, Callable, Dict, List, Optional
 
 from ..agent_bridge import AgentBridge
-from .._bridge_session import resolve_bridge_session_id
-from ..channel_media import build_channel_request, prepare_channel_delivery_figures
 from ..gateway.routing import GatewaySessionRegistry, SessionKey
 from ..model_help import render_model_help
+from .channel_core import (
+    text_chunks,
+    strip_local_paths,
+    build_full_request,
+    get_prior_history,
+    notify_turn_complete,
+    process_result_state,
+    format_analysis_error,
+    default_summary,
+)
 
 logger = logging.getLogger("omicverse.jarvis.imessage")
 
@@ -38,46 +46,6 @@ class IMessageTarget:
     kind: str
     value: str
     service: str = "auto"
-
-
-def _strip_local_paths(text: str) -> str:
-    t = text or ""
-    t = re.sub(r'`[^`\n]*(?:/[^`\n]*){2,}`', '', t)
-    t = re.sub(r'/(?:Users|home|tmp|var|opt|root|data|mnt|private)/\S+', '', t)
-    t = re.sub(r'~[/\\]\S+', '', t)
-    _ext = r"pdf|csv|tsv|txt|xlsx|html|json|h5ad|png|jpg|svg"
-    t = re.sub(rf'\.?/?(?:\w[\w/-]*/)+\w[\w.-]*\.(?:{_ext})', '', t, flags=re.IGNORECASE)
-    t = re.sub(r'[ \t]{2,}', ' ', t)
-    t = re.sub(r'\n{3,}', '\n\n', t)
-    return t.strip()
-
-
-def _text_chunks(text: str, limit: int = _MAX_TEXT) -> List[str]:
-    text = (text or "").strip()
-    if not text:
-        return []
-    if len(text) <= limit:
-        return [text]
-    chunks: List[str] = []
-    buf = ""
-    for para in text.split("\n\n"):
-        cand = f"{buf}\n\n{para}".strip() if buf else para
-        if len(cand) <= limit:
-            buf = cand
-            continue
-        if buf:
-            chunks.append(buf)
-        if len(para) <= limit:
-            buf = para
-            continue
-        pos = 0
-        while pos < len(para):
-            chunks.append(para[pos:pos + limit])
-            pos += limit
-        buf = ""
-    if buf:
-        chunks.append(buf)
-    return chunks
 
 
 def _normalize_handle(raw: str) -> str:
@@ -518,7 +486,7 @@ class IMessageJarvisBot:
         )
 
     def _build_full_request(self, session: Any, text: str) -> str:
-        return build_channel_request(session, text, channel_label="iMessage")
+        return build_full_request(session, text, channel_label="iMessage")
 
     async def _handle_command(self, session_key: SessionKey, target: str, text: str) -> None:
         session = self._route_registry.get_or_create(session_key)
@@ -553,7 +521,7 @@ class IMessageJarvisBot:
 
         if cmd == "/model":
             if not tail:
-                for chunk in _text_chunks(render_model_help(getattr(self._sm, "_model", "unknown"))):
+                for chunk in text_chunks(render_model_help(getattr(self._sm, "_model", "unknown"))):
                     await self._send_text(target, chunk)
                 return
             self._sm._model = tail
@@ -590,13 +558,9 @@ class IMessageJarvisBot:
             if chunk:
                 llm_buf += chunk
 
-        _wb = getattr(self._sm, "gateway_web_bridge", None)
-        _prior_history = _wb.get_prior_history_simple(
-            "imessage",
-            session_key.scope_type,
-            session_key.scope_id,
-            session_id=resolve_bridge_session_id(session),
-        ) if _wb else []
+        _prior_history = get_prior_history(
+            self._sm, "imessage", session_key.scope_type, session_key.scope_id, session,
+        )
 
         await self._send_text(target, "⏳ 已收到，开始分析。")
         bridge = AgentBridge(session.agent, progress_cb=progress_cb, llm_chunk_cb=llm_chunk_cb)
@@ -612,56 +576,26 @@ class IMessageJarvisBot:
         finally:
             self._tasks.pop(task_key, None)
 
-        if result.adata is not None:
-            session.adata = result.adata
-            try:
-                session.save_adata()
-                session.prompt_count += 1
-            except Exception:
-                pass
-        if result.usage is not None:
-            session.last_usage = result.usage
-        delivery_figures = prepare_channel_delivery_figures(session, result.figures)
-        try:
-            a = session.adata
-            adata_info = f"{a.n_obs:,} cells x {a.n_vars:,} genes" if a is not None else ""
-            session.append_memory_log(
-                request=user_text,
-                summary=(result.summary or "分析完成"),
-                adata_info=adata_info,
-            )
-        except Exception:
-            pass
+        delivery_figures, _adata_info = process_result_state(session, result, user_text)
 
-        # Mirror the completed turn into the web session (gateway mode)
-        _web_bridge = getattr(self._sm, "gateway_web_bridge", None)
-        if _web_bridge is not None:
-            try:
-                _web_bridge.on_turn_complete_simple(
-                    channel="imessage",
-                    scope_type=session_key.scope_type,
-                    scope_id=session_key.scope_id,
-                    user_text=user_text,
-                    llm_text=llm_buf,
-                    adata=result.adata,
-                    figures=result.figures or [],
-                    session_id=resolve_bridge_session_id(session),
-                )
-            except Exception:
-                pass
+        notify_turn_complete(
+            self._sm,
+            channel="imessage",
+            scope_type=session_key.scope_type,
+            scope_id=session_key.scope_id,
+            session=session,
+            user_text=user_text,
+            llm_text=llm_buf,
+            adata=result.adata,
+            figures=result.figures or [],
+        )
 
         if result.error:
-            err_text = f"分析出错: {result.error}"
-            if result.diagnostics:
-                hints = "\n".join(f"- {item}" for item in result.diagnostics[:4])
-                err_text += f"\n\n诊断:\n{hints}"
-            if llm_buf.strip():
-                err_text += f"\n\n模型输出:\n{llm_buf[:1200]}"
-            await self._send_text(target, err_text)
+            await self._send_text(target, format_analysis_error(result, llm_buf))
             return
 
         for report in list(result.reports or []):
-            for chunk in _text_chunks(report):
+            for chunk in text_chunks(report):
                 await self._send_text(target, chunk)
 
         for index, figure in enumerate(delivery_figures, start=1):
@@ -680,18 +614,14 @@ class IMessageJarvisBot:
                 caption=f"附件: {artifact.filename}",
             )
 
-        summary = _strip_local_paths(bridge.pick_reply_text(result, llm_buf))
+        summary = strip_local_paths(bridge.pick_reply_text(result, llm_buf))
         if not summary:
-            if session.adata is not None:
-                a = session.adata
-                summary = f"分析完成\n{a.n_obs:,} cells x {a.n_vars:,} genes"
-            else:
-                summary = "分析完成"
-        for chunk in _text_chunks(summary):
+            summary = default_summary(session)
+        for chunk in text_chunks(summary):
             await self._send_text(target, chunk)
 
     async def _send_text(self, target: str, text: str) -> None:
-        for chunk in _text_chunks(text):
+        for chunk in text_chunks(text):
             await self._client.send_message(target, chunk)
 
     async def _handle_h5ad_attachment(

--- a/omicverse/jarvis/channels/imessage.py
+++ b/omicverse/jarvis/channels/imessage.py
@@ -10,6 +10,7 @@ import os
 import re
 import shutil
 import tempfile
+import time
 import threading
 from dataclasses import dataclass
 from pathlib import Path
@@ -19,6 +20,8 @@ from ..agent_bridge import AgentBridge
 from ..gateway.routing import GatewaySessionRegistry, SessionKey
 from ..model_help import render_model_help
 from .channel_core import (
+    RunningTask,
+    command_parts,
     text_chunks,
     strip_local_paths,
     build_full_request,
@@ -27,6 +30,8 @@ from .channel_core import (
     process_result_state,
     format_analysis_error,
     default_summary,
+    gather_status,
+    format_status_plain,
 )
 
 logger = logging.getLogger("omicverse.jarvis.imessage")
@@ -369,7 +374,7 @@ class IMessageJarvisBot:
         self._db_path = db_path
         self._include_attachments = include_attachments
         self._route_registry = GatewaySessionRegistry(session_manager)
-        self._tasks: Dict[str, asyncio.Task] = {}
+        self._tasks: Dict[str, RunningTask] = {}
         self._stop_event = stop_event
         self._client = IMessageRpcClient(
             cli_path=self._cli_path,
@@ -458,12 +463,12 @@ class IMessageJarvisBot:
 
         task_key = session_key.as_key()
         running = self._tasks.get(task_key)
-        if running is not None and not running.done():
+        if running is not None and not running.task.done():
             await self._send_text(target, "⏳ 当前会话已有任务在运行，请等待完成或发送 /cancel。")
             return
 
         task = asyncio.create_task(self._run_analysis(task_key, session_key, target, text))
-        self._tasks[task_key] = task
+        self._tasks[task_key] = RunningTask(task=task, request=text, started_at=time.time())
 
     def _session_key_for_message(self, message: Dict[str, Any]) -> Optional[SessionKey]:
         is_group = bool(message.get("is_group"))
@@ -490,9 +495,7 @@ class IMessageJarvisBot:
 
     async def _handle_command(self, session_key: SessionKey, target: str, text: str) -> None:
         session = self._route_registry.get_or_create(session_key)
-        parts = text.strip().split(maxsplit=1)
-        cmd = parts[0].lower()
-        tail = parts[1].strip() if len(parts) > 1 else ""
+        cmd, tail = command_parts(text)
 
         if cmd == "/help":
             await self._send_text(
@@ -511,12 +514,17 @@ class IMessageJarvisBot:
             return
 
         if cmd == "/cancel":
-            task = self._tasks.get(session_key.as_key())
-            if task and not task.done():
-                task.cancel()
+            running = self._tasks.get(session_key.as_key())
+            if running and not running.task.done():
+                running.task.cancel()
                 await self._send_text(target, "🚫 已取消当前分析。")
             else:
                 await self._send_text(target, "当前没有正在运行的分析任务。")
+            return
+
+        if cmd == "/status":
+            info = gather_status(session)
+            await self._send_text(target, format_status_plain(info))
             return
 
         if cmd == "/model":

--- a/omicverse/jarvis/channels/qq.py
+++ b/omicverse/jarvis/channels/qq.py
@@ -50,7 +50,10 @@ from ..gateway.routing import GatewaySessionRegistry, SessionKey
 from .channel_core import (
     RunningTask,
     build_full_request,
+    coalesce_pending_requests,
+    command_parts,
     default_summary,
+    format_analysis_error,
     format_save_result_plain,
     format_status_plain,
     format_usage_plain,
@@ -696,14 +699,7 @@ class QQRuntime:
 
     @staticmethod
     def _coalesce_pending_requests(items: List[Dict[str, Any]]) -> tuple[str, List[Dict[str, Any]]]:
-        parts: List[str] = []
-        request_content: List[Dict[str, Any]] = []
-        for item in items:
-            text = str(item.get("text") or "").strip()
-            if text:
-                parts.append(text)
-            request_content.extend(list(item.get("request_content") or []))
-        return "\n\n".join(parts).strip(), request_content
+        return coalesce_pending_requests(items)
 
     @staticmethod
     def _text_chunks(text: str, limit: int = _MAX_TEXT) -> List[str]:
@@ -931,13 +927,7 @@ class QQRuntime:
         )
 
         if result.error:
-            err_text = f"分析出错: {result.error}"
-            if result.diagnostics:
-                hints = "\n".join(f"- {x}" for x in result.diagnostics[:4])
-                err_text += f"\n\n诊断:\n{hints}"
-            if llm_buf.strip():
-                err_text += f"\n\n模型输出:\n{_trim(llm_buf, 1200)}"
-            # Use markdown for error detail (mirrors Feishu edit_card red)
+            err_text = format_analysis_error(result, llm_buf)
             await asyncio.to_thread(self._send_markdown, target, err_text, msg_id)
             return
 

--- a/omicverse/jarvis/channels/qq.py
+++ b/omicverse/jarvis/channels/qq.py
@@ -39,7 +39,6 @@ import re
 import threading
 import time
 from dataclasses import dataclass
-from datetime import datetime
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
@@ -52,8 +51,16 @@ from .channel_core import (
     RunningTask,
     build_full_request,
     default_summary,
+    format_save_result_plain,
+    format_status_plain,
+    format_usage_plain,
+    format_workspace_plain,
+    gather_status,
+    gather_usage,
+    gather_workspace,
     get_prior_history,
     notify_turn_complete,
+    perform_save,
     process_result_state,
     strip_local_paths,
     text_chunks,
@@ -1161,53 +1168,17 @@ class QQRuntime:
         await asyncio.to_thread(self._send_text, target, text, msg_id)
 
     async def _handle_status(self, target: QQTarget, msg_id: Optional[str], session: Any, route: str) -> None:
-        lines: List[str] = []
-        if session.adata is not None:
-            a = session.adata
-            lines.append(f"{a.n_obs:,} cells x {a.n_vars:,} genes")
-            try:
-                cols = ", ".join(list(a.obs.columns[:8]))
-                if cols:
-                    lines.append(f"obs: {cols}")
-            except Exception:
-                pass
-        else:
-            lines.append("暂无数据")
-        try:
-            kname = self._sm.get_active_kernel(session.user_id)
-            lines.append(f"kernel: {kname}")
-        except Exception:
-            pass
-        kst = session.kernel_status()
-        if kst:
-            lines.append(f"prompts: {kst.get('prompt_count', 0)}/{kst.get('max_prompts', '?')}")
         running = self._tasks.get(route)
-        if running and not running.task.done():
-            lines.append("分析中（可 /cancel）")
-        await asyncio.to_thread(self._send_text, target, "\n".join(lines), msg_id)
+        info = gather_status(
+            session,
+            session_manager=self._sm,
+            is_running=bool(running and not running.task.done()),
+        )
+        await asyncio.to_thread(self._send_text, target, format_status_plain(info), msg_id)
 
     async def _handle_workspace(self, target: QQTarget, msg_id: Optional[str], session: Any) -> None:
-        ws = session.workspace
-        h5ad_files = session.list_h5ad_files()
-        agents_md = session.get_agents_md()
-        today_log = session.memory_dir / f"{datetime.now().date()}.md"
-        lines = [f"Workspace: {ws}", ""]
-        if h5ad_files:
-            lines.append(f"数据文件 ({len(h5ad_files)})")
-            for f in h5ad_files[:10]:
-                try:
-                    mb = f.stat().st_size / 1_048_576
-                    lines.append(f"- {f.name} ({mb:.1f} MB)")
-                except OSError:
-                    lines.append(f"- {f.name}")
-        else:
-            lines.append("数据文件 (空)")
-        lines += [
-            "",
-            f"AGENTS.md {'OK' if agents_md else '-'}",
-            f"今日记忆 {'OK' if today_log.exists() else '-'}",
-        ]
-        await asyncio.to_thread(self._send_text, target, "\n".join(lines), msg_id)
+        info = gather_workspace(session)
+        await asyncio.to_thread(self._send_text, target, format_workspace_plain(info), msg_id)
 
     async def _handle_ls(self, target: QQTarget, msg_id: Optional[str], session: Any, subpath: str) -> None:
         cmd = f"ls -lh {subpath}".strip() if subpath else "ls -lh"
@@ -1268,25 +1239,8 @@ class QQRuntime:
             await asyncio.to_thread(self._send_text, target, chunk, msg_id)
 
     async def _handle_usage(self, target: QQTarget, msg_id: Optional[str], session: Any) -> None:
-        usage = session.last_usage
-        if usage is None:
-            await asyncio.to_thread(self._send_text, target, "暂无用量数据，请先进行一次分析。", msg_id)
-            return
-
-        def _attr(obj: Any, *names: str) -> str:
-            for n in names:
-                v = getattr(obj, n, None)
-                if v is not None:
-                    return f"{v:,}" if isinstance(v, int) else str(v)
-            return "?"
-
-        lines = [
-            "Token 用量（最近一次）",
-            f"输入: {_attr(usage, 'input_tokens')}",
-            f"输出: {_attr(usage, 'output_tokens')}",
-            f"合计: {_attr(usage, 'total_tokens')}",
-        ]
-        await asyncio.to_thread(self._send_text, target, "\n".join(lines), msg_id)
+        info = gather_usage(session)
+        await asyncio.to_thread(self._send_text, target, format_usage_plain(info), msg_id)
 
     async def _handle_model(self, target: QQTarget, msg_id: Optional[str], model_name: str) -> None:
         model_name = (model_name or "").strip()
@@ -1307,20 +1261,8 @@ class QQRuntime:
             await asyncio.to_thread(self._send_text, target, "没有数据，请先 /load 或完成分析。", msg_id)
             return
         await asyncio.to_thread(self._send_text, target, "正在保存 current.h5ad...", msg_id)
-        try:
-            path = await asyncio.to_thread(session.save_adata)
-            if not path or not Path(path).exists():
-                await asyncio.to_thread(self._send_text, target, "保存失败，请重试。", msg_id)
-                return
-            a = session.adata
-            # QQ Bot doesn't support raw file uploads; note location only
-            await asyncio.to_thread(
-                self._send_text, target,
-                f"已保存 current.h5ad\n{a.n_obs:,} cells x {a.n_vars:,} genes\n路径: {path}",
-                msg_id,
-            )
-        except Exception as exc:
-            await asyncio.to_thread(self._send_text, target, f"保存失败: {exc}", msg_id)
+        result = await asyncio.to_thread(perform_save, session)
+        await asyncio.to_thread(self._send_text, target, format_save_result_plain(result), msg_id)
 
     async def _handle_kernel(
         self,

--- a/omicverse/jarvis/channels/qq.py
+++ b/omicverse/jarvis/channels/qq.py
@@ -47,9 +47,17 @@ from typing import Any, Dict, List, Optional, Tuple
 import requests
 
 from ..agent_bridge import AgentBridge
-from .._bridge_session import resolve_bridge_session_id
-from ..channel_media import build_channel_request, prepare_channel_delivery_figures
 from ..gateway.routing import GatewaySessionRegistry, SessionKey
+from .channel_core import (
+    RunningTask,
+    build_full_request,
+    default_summary,
+    get_prior_history,
+    notify_turn_complete,
+    process_result_state,
+    strip_local_paths,
+    text_chunks,
+)
 from ..media_ingest import (
     PreparedImage,
     build_workspace_note,
@@ -97,13 +105,6 @@ _OP_RECONNECT = 7
 _OP_INVALID_SESSION = 9
 _OP_HELLO = 10
 _OP_HEARTBEAT_ACK = 11
-
-
-@dataclass
-class RunningTask:
-    task: asyncio.Task
-    request: str
-    started_at: float
 
 
 class QQDeduper:
@@ -521,18 +522,10 @@ class QQRuntime:
 
     @staticmethod
     def _strip_local_paths(text: str) -> str:
-        t = text or ""
-        t = re.sub(r'`[^`\n]*(?:/[^`\n]*){2,}`', '', t)
-        t = re.sub(r'/(?:Users|home|tmp|var|opt|root|data|mnt|private)/\S+', '', t)
-        t = re.sub(r'~[/\\]\S+', '', t)
-        _ext = r"pdf|csv|tsv|txt|xlsx|html|json|h5ad|png|jpg|svg"
-        t = re.sub(rf'\.?/?(?:\w[\w/-]*/)+\w[\w.-]*\.(?:{_ext})', '', t, flags=re.IGNORECASE)
-        t = re.sub(r'[ \t]{2,}', ' ', t)
-        t = re.sub(r'\n{3,}', '\n\n', t)
-        return t.strip()
+        return strip_local_paths(text)
 
     def _build_full_request(self, session: Any, text: str) -> str:
-        return build_channel_request(session, text, channel_label="QQ")
+        return build_full_request(session, text, channel_label="QQ")
 
     @staticmethod
     def _looks_like_image_name(name: str) -> bool:
@@ -715,31 +708,7 @@ class QQRuntime:
 
     @staticmethod
     def _text_chunks(text: str, limit: int = _MAX_TEXT) -> List[str]:
-        text = (text or "").strip()
-        if not text:
-            return []
-        if len(text) <= limit:
-            return [text]
-        chunks: List[str] = []
-        buf = ""
-        for para in text.split("\n\n"):
-            cand = f"{buf}\n\n{para}".strip() if buf else para
-            if len(cand) <= limit:
-                buf = cand
-                continue
-            if buf:
-                chunks.append(buf)
-            if len(para) <= limit:
-                buf = para
-            else:
-                pos = 0
-                while pos < len(para):
-                    chunks.append(para[pos:pos + limit])
-                    pos += limit
-                buf = ""
-        if buf:
-            chunks.append(buf)
-        return chunks
+        return text_chunks(text, limit=limit)
 
     def _send_markdown(self, target: QQTarget, text: str, msg_id: Optional[str] = None) -> Optional[str]:
         """Send markdown content (mirrors Feishu send_markdown_card).
@@ -805,7 +774,7 @@ class QQRuntime:
             ]
             response = await session.agent._llm.chat(messages, tools=None, tool_choice=None)
             reply = (response.content or "").strip() or "正在分析，请稍候..."
-            for chunk in self._text_chunks(reply):
+            for chunk in text_chunks(reply):
                 await asyncio.to_thread(self._send_text, target, chunk, msg_id)
         except Exception as exc:
             logger.warning("QQ quick_chat failed: %s", exc)
@@ -930,13 +899,7 @@ class QQRuntime:
                 pass
 
         _scope_id = str(target.channel_id if hasattr(target, "channel_id") else target)
-        _wb = getattr(self._sm, "gateway_web_bridge", None)
-        _prior_history = _wb.get_prior_history_simple(
-            "qq",
-            "dm",
-            _scope_id,
-            session_id=resolve_bridge_session_id(session),
-        ) if _wb else []
+        _prior_history = get_prior_history(self._sm, "qq", "dm", _scope_id, session)
 
         bridge = AgentBridge(session.agent, progress_cb=progress_cb, llm_chunk_cb=llm_chunk_cb)
         try:
@@ -954,44 +917,19 @@ class QQRuntime:
             await asyncio.to_thread(self._send_text, target, f"分析失败: {exc}", msg_id)
             return
 
-        if result.adata is not None:
-            session.adata = result.adata
-            try:
-                session.save_adata()
-                session.prompt_count += 1
-            except Exception:
-                pass
-        if result.usage is not None:
-            session.last_usage = result.usage
-        delivery_figures = prepare_channel_delivery_figures(session, result.figures)
-        try:
-            a = session.adata
-            adata_info = f"{a.n_obs:,} cells x {a.n_vars:,} genes" if a is not None else ""
-            session.append_memory_log(
-                request=user_text,
-                summary=(result.summary or "分析完成"),
-                adata_info=adata_info,
-            )
-        except Exception:
-            pass
+        delivery_figures, _adata_info = process_result_state(session, result, user_text)
 
-        # Mirror the completed turn into the web session (gateway mode)
-        _web_bridge = getattr(self._sm, "gateway_web_bridge", None)
-        if _web_bridge is not None:
-            try:
-                scope_id = str(target.channel_id if hasattr(target, "channel_id") else target)
-                _web_bridge.on_turn_complete_simple(
-                    channel="qq",
-                    scope_type="dm",
-                    scope_id=scope_id,
-                    user_text=user_text,
-                    llm_text=llm_buf,
-                    adata=result.adata,
-                    figures=result.figures or [],
-                    session_id=resolve_bridge_session_id(session),
-                )
-            except Exception:
-                pass
+        notify_turn_complete(
+            self._sm,
+            channel="qq",
+            scope_type="dm",
+            scope_id=_scope_id,
+            session=session,
+            user_text=user_text,
+            llm_text=llm_buf,
+            adata=result.adata,
+            figures=result.figures or [],
+        )
 
         if result.error:
             err_text = f"分析出错: {result.error}"
@@ -1006,7 +944,7 @@ class QQRuntime:
 
         # Send reports — markdown rendering (mirrors Feishu send_markdown_card "📊 分析报告")
         for rep in list(result.reports or []):
-            for chunk in self._text_chunks(rep, limit=_MAX_TEXT):
+            for chunk in text_chunks(rep, limit=_MAX_TEXT):
                 await asyncio.to_thread(self._send_markdown, target, chunk, msg_id)
 
         # Send figures
@@ -1029,13 +967,12 @@ class QQRuntime:
             logger.info("QQ: artifact '%s' generated (file send not supported in QQ Bot API)", art.filename)
 
         # Send summary
-        summary = self._strip_local_paths(
+        summary = strip_local_paths(
             bridge.pick_reply_text(result, llm_buf, max_len=1800)
         )
-        if not summary and session.adata is not None:
-            a = session.adata
-            summary = f"分析完成\n{a.n_obs:,} cells x {a.n_vars:,} genes"
-        for chunk in self._text_chunks(summary or "分析完成", limit=_MAX_TEXT):
+        if not summary:
+            summary = default_summary(session)
+        for chunk in text_chunks(summary, limit=_MAX_TEXT):
             await asyncio.to_thread(self._send_markdown, target, chunk, msg_id)
 
     # ── Message dispatcher ────────────────────────────────────────────────────
@@ -1275,7 +1212,7 @@ class QQRuntime:
     async def _handle_ls(self, target: QQTarget, msg_id: Optional[str], session: Any, subpath: str) -> None:
         cmd = f"ls -lh {subpath}".strip() if subpath else "ls -lh"
         out = session.shell.exec(cmd, cwd=session.workspace)
-        for chunk in self._text_chunks(f"$ {cmd}\n{out}", limit=1800):
+        for chunk in text_chunks(f"$ {cmd}\n{out}", limit=1800):
             await asyncio.to_thread(self._send_text, target, chunk, msg_id)
 
     async def _handle_find(self, target: QQTarget, msg_id: Optional[str], session: Any, pattern: str) -> None:
@@ -1285,7 +1222,7 @@ class QQRuntime:
             return
         cmd = f"find . -name {pattern}"
         out = session.shell.exec(cmd, cwd=session.workspace)
-        for chunk in self._text_chunks(f"$ {cmd}\n{out}", limit=1800):
+        for chunk in text_chunks(f"$ {cmd}\n{out}", limit=1800):
             await asyncio.to_thread(self._send_text, target, chunk, msg_id)
 
     async def _handle_load(self, target: QQTarget, msg_id: Optional[str], session: Any, filename: str) -> None:
@@ -1322,12 +1259,12 @@ class QQRuntime:
             )
             return
         out = session.shell.exec(cmd, cwd=session.workspace)
-        for chunk in self._text_chunks(f"$ {cmd}\n{out}", limit=1800):
+        for chunk in text_chunks(f"$ {cmd}\n{out}", limit=1800):
             await asyncio.to_thread(self._send_text, target, chunk, msg_id)
 
     async def _handle_memory(self, target: QQTarget, msg_id: Optional[str], session: Any) -> None:
         text = session.get_recent_memory_text()
-        for chunk in self._text_chunks(f"分析历史（近两天）\n\n{text}", limit=1800):
+        for chunk in text_chunks(f"分析历史（近两天）\n\n{text}", limit=1800):
             await asyncio.to_thread(self._send_text, target, chunk, msg_id)
 
     async def _handle_usage(self, target: QQTarget, msg_id: Optional[str], session: Any) -> None:
@@ -1355,7 +1292,7 @@ class QQRuntime:
         model_name = (model_name or "").strip()
         if not model_name:
             text = render_model_help(getattr(self._sm, "_model", "unknown"))
-            for chunk in self._text_chunks(text, limit=1800):
+            for chunk in text_chunks(text, limit=1800):
                 await asyncio.to_thread(self._send_text, target, chunk, msg_id)
             return
         self._sm._model = model_name

--- a/omicverse/jarvis/channels/qq.py
+++ b/omicverse/jarvis/channels/qq.py
@@ -58,12 +58,11 @@ from .channel_core import (
     strip_local_paths,
     text_chunks,
 )
+from ..channel_media import is_image_attachment, prepare_inbound_image, MAX_INBOUND_IMAGES
 from ..media_ingest import (
     PreparedImage,
     build_workspace_note,
     compose_multimodal_user_text,
-    looks_like_image_name,
-    prepare_image_bytes,
 )
 from ..model_help import render_model_help
 
@@ -527,17 +526,13 @@ class QQRuntime:
     def _build_full_request(self, session: Any, text: str) -> str:
         return build_full_request(session, text, channel_label="QQ")
 
-    @staticmethod
-    def _looks_like_image_name(name: str) -> bool:
-        return looks_like_image_name(name)
-
     @classmethod
     def _looks_like_image_url(cls, url: str) -> bool:
         lowered = (url or "").strip().lower()
         if not lowered.startswith(("http://", "https://", "data:")):
             return False
         stem = lowered.split("?", 1)[0]
-        return cls._looks_like_image_name(stem) or any(
+        return is_image_attachment(stem) or any(
             marker in lowered
             for marker in ("/image", "image/", "content-type=image", "qpic.cn")
         )
@@ -582,7 +577,7 @@ class QQRuntime:
             ).strip()
             if not (
                 mime_type.startswith("image/")
-                or cls._looks_like_image_name(filename)
+                or is_image_attachment(filename)
                 or cls._looks_like_image_url(url)
             ):
                 return
@@ -626,14 +621,13 @@ class QQRuntime:
     def _download_inbound_image(
         self,
         candidate: Dict[str, str],
-        target_dir: Path,
+        session: Any,
         index: int,
     ) -> Optional[PreparedImage]:
         url = candidate.get("url", "").strip()
         if not url:
             return None
 
-        target_dir.mkdir(parents=True, exist_ok=True)
         response = None
         errors: List[str] = []
         for headers in ({}, self._client._headers()):
@@ -662,13 +656,12 @@ class QQRuntime:
             or response.headers.get("Content-Type")
             or "application/octet-stream"
         ).split(";", 1)[0].strip()
-        prepared = prepare_image_bytes(
+        prepared = prepare_inbound_image(
             response.content,
-            target_dir=target_dir,
+            workspace_root=session.workspace,
+            channel_name="qq",
             filename=candidate.get("filename") or f"qq_image_{index}",
             mime_type=mime_type,
-            prefix="qq_image",
-            source="qq",
         )
         logger.info(
             "QQ inbound image stored path=%s size=%d",
@@ -686,10 +679,9 @@ class QQRuntime:
         if not candidates:
             return []
 
-        upload_dir = session.workspace / "uploads" / "qq"
         prepared: List[PreparedImage] = []
-        for index, candidate in enumerate(candidates[:4], start=1):
-            downloaded = self._download_inbound_image(candidate, upload_dir, index)
+        for index, candidate in enumerate(candidates[:MAX_INBOUND_IMAGES], start=1):
+            downloaded = self._download_inbound_image(candidate, session, index)
             if downloaded is None:
                 continue
             prepared.append(downloaded)

--- a/omicverse/jarvis/channels/telegram.py
+++ b/omicverse/jarvis/channels/telegram.py
@@ -34,7 +34,11 @@ from ..media_ingest import (
     PreparedImage,
     build_workspace_note,
     compose_multimodal_user_text,
-    prepare_image_path,
+)
+from ..channel_media import (
+    inbound_upload_dir,
+    prepare_inbound_image_from_file,
+    MAX_INBOUND_IMAGES,
 )
 from ..runtime import (
     AgentBridgeExecutionAdapter,
@@ -1079,14 +1083,13 @@ def _register_handlers(app: Any, sm: Any, ac: AccessControl, verbose: bool) -> N
         session: Any,
     ) -> List[PreparedImage]:
         prepared: List[PreparedImage] = []
-        upload_dir = session.workspace_dir / "uploads" / "telegram"
+        upload_dir = inbound_upload_dir(session.workspace_dir, "telegram")
         if getattr(message, "photo", None):
             photo = message.photo[-1]
             tg_file = await bot.get_file(photo.file_id)
             raw_path = upload_dir / f"telegram_photo_{getattr(photo, 'file_unique_id', photo.file_id)}.jpg"
-            raw_path.parent.mkdir(parents=True, exist_ok=True)
             await tg_file.download_to_drive(raw_path)
-            image = prepare_image_path(raw_path, prefix="telegram_image", source="telegram")
+            image = prepare_inbound_image_from_file(raw_path, workspace_root=session.workspace_dir, channel_name="telegram")
             if image.path != raw_path and raw_path.exists():
                 raw_path.unlink(missing_ok=True)
             prepared.append(image)
@@ -1097,19 +1100,13 @@ def _register_handlers(app: Any, sm: Any, ac: AccessControl, verbose: bool) -> N
         if document is not None and doc_mime.startswith("image/") and not doc_name.lower().endswith(".h5ad"):
             tg_file = await bot.get_file(document.file_id)
             raw_path = upload_dir / (doc_name or f"telegram_image_{document.file_unique_id}")
-            raw_path.parent.mkdir(parents=True, exist_ok=True)
             await tg_file.download_to_drive(raw_path)
-            image = prepare_image_path(
-                raw_path,
-                mime_type=doc_mime,
-                prefix="telegram_image",
-                source="telegram",
-            )
+            image = prepare_inbound_image_from_file(raw_path, workspace_root=session.workspace_dir, channel_name="telegram", mime_type=doc_mime)
             if image.path != raw_path and raw_path.exists():
                 raw_path.unlink(missing_ok=True)
             prepared.append(image)
 
-        return prepared[:4]
+        return prepared[:MAX_INBOUND_IMAGES]
 
     async def _handle_incoming_analysis(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         route = telegram_route_from_update(update)

--- a/omicverse/jarvis/channels/telegram.py
+++ b/omicverse/jarvis/channels/telegram.py
@@ -26,6 +26,7 @@ from io import BytesIO
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple
 
+from .channel_core import strip_local_paths as _core_strip_local_paths
 from .. import _fmt
 from ..config import default_state_dir
 from ..model_help import render_model_help
@@ -527,19 +528,7 @@ class TelegramRuntimePresenter:
 
     @classmethod
     def _strip_local_paths(cls, text: str) -> str:
-        t = text or ""
-        t = re.sub(r'`[^`\n]*(?:/[^`\n]*){2,}`', '', t)
-        t = re.sub(r'/(?:Users|home|tmp|var|opt|root|data|mnt|private)/\S+', '', t)
-        t = re.sub(r'~[/\\]\S+', '', t)
-        t = re.sub(
-            rf'\.?/?(?:\w[\w/-]*/)+\w[\w.-]*\.(?:{cls._ARTIFACT_EXTS})',
-            '',
-            t,
-            flags=re.IGNORECASE,
-        )
-        t = re.sub(r'[ \t]{2,}', ' ', t)
-        t = re.sub(r'\n{3,}', '\n\n', t)
-        return t.strip()
+        return _core_strip_local_paths(text)
 
 
 class TelegramDelivery:

--- a/omicverse/jarvis/channels/telegram.py
+++ b/omicverse/jarvis/channels/telegram.py
@@ -26,7 +26,13 @@ from io import BytesIO
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple
 
-from .channel_core import strip_local_paths as _core_strip_local_paths
+from .channel_core import (
+    gather_status,
+    gather_usage,
+    gather_workspace,
+    perform_save,
+    strip_local_paths as _core_strip_local_paths,
+)
 from .. import _fmt
 from ..config import default_state_dir
 from ..model_help import render_model_help
@@ -1257,35 +1263,32 @@ def _register_handlers(app: Any, sm: Any, ac: AccessControl, verbose: bool) -> N
         if session is None:
             return
 
+        info = gather_status(
+            session,
+            session_manager=sm,
+            is_running=runtime.task_state(route).running,
+        )
+
         lines = [f"👤  <b>用户</b>  <code>{user.id}</code>"]
-        try:
-            kname = sm.get_active_kernel(user.id)
-            lines.append(f"🧩  Kernel：<code>{_fmt.esc(kname)}</code>")
-        except Exception:
-            pass
-        if session.adata is not None:
-            a = session.adata
-            lines.append(f"🔬  {a.n_obs:,} cells × {a.n_vars:,} genes")
-            if a.obs.columns.tolist():
-                cols = ", ".join(a.obs.columns.tolist()[:8])
+        if info.kernel_name:
+            lines.append(f"🧩  Kernel：<code>{_fmt.esc(info.kernel_name)}</code>")
+        if info.adata_shape:
+            n_obs, n_vars = info.adata_shape
+            lines.append(f"🔬  {n_obs:,} cells × {n_vars:,} genes")
+            if info.obs_columns:
+                cols = ", ".join(info.obs_columns)
                 lines.append(f"📋  obs: <code>{_fmt.esc(cols)}</code>")
         else:
             lines.append("📭  暂无数据  ·  使用 <code>/load</code> 加载")
 
-        # Task status
-        if runtime.task_state(route).running:
+        if info.is_running:
             lines.append("⚙️  分析中…  ·  <code>/cancel</code> 取消")
 
-        try:
-            info = session.agent.get_current_session_info()
-            if info:
-                p  = info.get("prompt_count", 0)
-                mp = info.get("max_prompts", "?")
-                if getattr(session, "max_prompts_setting", 0) <= 0:
-                    mp = "∞"
-                lines.append(f"💬  会话  {p}/{mp}")
-        except Exception:
-            pass
+        if info.prompt_count is not None:
+            mp = info.max_prompts
+            if getattr(session, "max_prompts_setting", 0) <= 0:
+                mp = "∞"
+            lines.append(f"💬  会话  {info.prompt_count}/{mp}")
 
         await update.message.reply_text("\n".join(lines), parse_mode="HTML")
 
@@ -1336,18 +1339,18 @@ def _register_handlers(app: Any, sm: Any, ac: AccessControl, verbose: bool) -> N
             return
 
         await update.message.reply_text("⏳  正在保存…")
-        path = session.save_adata()
-        if path and path.exists():
-            a = session.adata
-            with open(str(path), "rb") as fh:
+        result = perform_save(session)
+        if result.success and result.path:
+            n_obs, n_vars = result.adata_shape
+            with open(result.path, "rb") as fh:
                 await context.bot.send_document(
                     chat_id=update.effective_chat.id,
                     document=fh,
                     filename="current.h5ad",
-                    caption=f"💾  {a.n_obs:,} cells × {a.n_vars:,} genes",
+                    caption=f"💾  {n_obs:,} cells × {n_vars:,} genes",
                 )
         else:
-            await update.message.reply_text("❌  保存失败，请重试。")
+            await update.message.reply_text(f"❌  {result.error or '保存失败，请重试。'}")
 
     # ------------------------------------------------------------------
     # /usage
@@ -1360,32 +1363,22 @@ def _register_handlers(app: Any, sm: Any, ac: AccessControl, verbose: bool) -> N
         if session is None:
             return
 
-        usage = session.last_usage
-        if usage is None:
+        info = gather_usage(session)
+        if not info.has_data:
             await update.message.reply_text("ℹ️  暂无用量数据，请先进行一次分析。")
             return
-
-        def _attr(obj: Any, *names: str, default: str = "?") -> str:
-            for name in names:
-                v = getattr(obj, name, None)
-                if v is not None:
-                    return f"{v:,}" if isinstance(v, int) else str(v)
-            return default
 
         lines = [
             "📊  <b>Token 用量</b>  （最近一次）",
             _fmt._DIV,
-            f"输入：<code>{_attr(usage, 'input_tokens')}</code>",
-            f"输出：<code>{_attr(usage, 'output_tokens')}</code>",
-            f"合计：<code>{_attr(usage, 'total_tokens')}</code>",
+            f"输入：<code>{info.input_tokens}</code>",
+            f"输出：<code>{info.output_tokens}</code>",
+            f"合计：<code>{info.total_tokens}</code>",
         ]
-        # cache_read / cache_creation if present (Anthropic prompt caching)
-        cr = _attr(usage, "cache_read_input_tokens", default="")
-        cc = _attr(usage, "cache_creation_input_tokens", default="")
-        if cr and cr != "?":
-            lines.append(f"缓存读取：<code>{cr}</code>")
-        if cc and cc != "?":
-            lines.append(f"缓存写入：<code>{cc}</code>")
+        if info.cache_read and info.cache_read != "?":
+            lines.append(f"缓存读取：<code>{info.cache_read}</code>")
+        if info.cache_creation and info.cache_creation != "?":
+            lines.append(f"缓存写入：<code>{info.cache_creation}</code>")
         await update.message.reply_text("\n".join(lines), parse_mode="HTML")
 
     # ------------------------------------------------------------------
@@ -1528,36 +1521,31 @@ def _register_handlers(app: Any, sm: Any, ac: AccessControl, verbose: bool) -> N
         if session is None:
             return
 
-        from datetime import datetime
-        ws         = session.workspace
-        h5ad_files = session.list_h5ad_files()
-        agents_md  = session.get_agents_md()
-        today_log  = session.memory_dir / f"{datetime.now().date()}.md"
+        ws_info = gather_workspace(session)
 
         lines = [
             "📁  <b>Workspace</b>",
             _fmt._DIV,
-            f"<code>{ws}</code>",
+            f"<code>{ws_info.path}</code>",
             "",
         ]
-        if h5ad_files:
-            lines.append(f"📊  <b>数据文件</b>  ({len(h5ad_files)})")
-            for f in h5ad_files[:10]:
-                try:
-                    mb = f.stat().st_size / 1_048_576
-                    lines.append(f"  • <code>{_fmt.esc(f.name)}</code>  <i>{mb:.1f} MB</i>")
-                except OSError:
-                    lines.append(f"  • <code>{_fmt.esc(f.name)}</code>")
-            if len(h5ad_files) > 10:
-                lines.append(f"  <i>… 还有 {len(h5ad_files) - 10} 个</i>")
+        if ws_info.h5ad_files:
+            lines.append(f"📊  <b>数据文件</b>  ({ws_info.h5ad_total})")
+            for name, mb in ws_info.h5ad_files:
+                if mb is not None:
+                    lines.append(f"  • <code>{_fmt.esc(name)}</code>  <i>{mb:.1f} MB</i>")
+                else:
+                    lines.append(f"  • <code>{_fmt.esc(name)}</code>")
+            if ws_info.h5ad_total > len(ws_info.h5ad_files):
+                lines.append(f"  <i>… 还有 {ws_info.h5ad_total - len(ws_info.h5ad_files)} 个</i>")
         else:
             lines.append("📊  <b>数据文件</b>  (空)")
-            lines.append(f"  <i>scp *.h5ad user@host:{ws}</i>")
+            lines.append(f"  <i>scp *.h5ad user@host:{ws_info.path}</i>")
 
         lines += [
             "",
-            f"📋  AGENTS.md  {'✅' if agents_md else '—'}",
-            f"🧠  今日记忆  {'✅' if today_log.exists() else '—'}",
+            f"📋  AGENTS.md  {'✅' if ws_info.has_agents_md else '—'}",
+            f"🧠  今日记忆  {'✅' if ws_info.has_today_memory else '—'}",
             "",
             "<code>/load &lt;文件名&gt;</code>  ·  <code>/ls</code>  ·  <code>/memory</code>",
         ]

--- a/omicverse/jarvis/channels/wechat.py
+++ b/omicverse/jarvis/channels/wechat.py
@@ -48,11 +48,11 @@ from .channel_core import (
 )
 from ..config import default_state_dir
 from ..gateway.routing import GatewaySessionRegistry, SessionKey
+from ..channel_media import prepare_inbound_image, MAX_INBOUND_IMAGES
 from ..media_ingest import (
     PreparedImage,
     build_workspace_note,
     compose_multimodal_user_text,
-    prepare_image_bytes,
 )
 from ..model_help import render_model_help
 
@@ -1030,7 +1030,6 @@ class WeChatJarvisBot:
         item_list = raw.get("item_list") or []
         if not isinstance(item_list, list):
             return []
-        upload_dir = session.workspace / "uploads" / "wechat"
         prepared: List[PreparedImage] = []
         for item in item_list:
             if not isinstance(item, dict) or item.get("type") != 2:
@@ -1066,13 +1065,12 @@ class WeChatJarvisBot:
             try:
                 data = await asyncio.to_thread(self._download_inbound_image_bytes, payload, file_name)
                 prepared.append(
-                    prepare_image_bytes(
+                    prepare_inbound_image(
                         data,
-                        target_dir=upload_dir,
+                        workspace_root=session.workspace,
+                        channel_name="wechat",
                         filename=file_name,
                         mime_type=mime_type,
-                        prefix="wechat_image",
-                        source="wechat",
                     )
                 )
             except Exception:
@@ -1081,7 +1079,7 @@ class WeChatJarvisBot:
                     file_key,
                     exc_info=True,
                 )
-            if len(prepared) >= 4:
+            if len(prepared) >= MAX_INBOUND_IMAGES:
                 break
         return prepared
 

--- a/omicverse/jarvis/channels/wechat.py
+++ b/omicverse/jarvis/channels/wechat.py
@@ -45,6 +45,8 @@ from .channel_core import (
     process_result_state,
     format_analysis_error,
     default_summary,
+    gather_status,
+    format_status_plain,
 )
 from ..config import default_state_dir
 from ..gateway.routing import GatewaySessionRegistry, SessionKey
@@ -781,22 +783,13 @@ class WeChatJarvisBot:
         route: str,
         context_token: str,
     ) -> None:
-        parts: List[str] = []
         running = self._tasks.get(route)
-        if running and not running.task.done():
-            parts.append(f"当前状态: 运行中\n请求: {running.request[:300]}")
-        else:
-            parts.append("当前状态: 空闲")
-        if session.adata is not None:
-            adata = session.adata
-            parts.append(f"当前数据: {adata.n_obs:,} cells x {adata.n_vars:,} genes")
-        try:
-            workspace = session.agent.workspace_dir
-        except Exception:
-            workspace = None
-        if workspace:
-            parts.append(f"工作区: {workspace}")
-        await self._send_session_text(session_key, "\n".join(parts), context_token=context_token)
+        info = gather_status(
+            session,
+            is_running=bool(running and not running.task.done()),
+            running_request=running.request[:300] if (running and not running.task.done()) else "",
+        )
+        await self._send_session_text(session_key, format_status_plain(info), context_token=context_token)
 
     async def _handle_cancel(self, session_key: SessionKey, route: str, context_token: str) -> None:
         self._pending.pop(route, None)

--- a/omicverse/jarvis/channels/wechat.py
+++ b/omicverse/jarvis/channels/wechat.py
@@ -37,6 +37,9 @@ except ImportError:  # pragma: no cover
 
 from ..agent_bridge import AgentBridge
 from .channel_core import (
+    RunningTask,
+    coalesce_pending_requests,
+    command_parts,
     text_chunks,
     strip_local_paths,
     build_full_request,
@@ -153,12 +156,6 @@ def _parse_cdn_aes_key(*, aes_key_b64: str = "", aeskey_hex: str = "") -> Option
         f"WeChat aes_key must decode to 16 raw bytes or 32-char hex string, got {len(decoded)} bytes"
     )
 
-
-@dataclass
-class RunningTask:
-    task: asyncio.Task
-    request: str
-    started_at: float
 
 
 
@@ -1014,10 +1011,7 @@ class WeChatJarvisBot:
 
     @staticmethod
     def _command_parts(text: str) -> tuple[str, str]:
-        tokens = text.split()
-        cmd = tokens[0].lower() if tokens else ""
-        tail = text.split(None, 1)[1].strip() if len(tokens) > 1 else ""
-        return cmd, tail
+        return command_parts(text)
 
     async def _prepare_inbound_images(self, raw: Dict[str, Any], session: Any) -> List[PreparedImage]:
         item_list = raw.get("item_list") or []
@@ -1122,14 +1116,7 @@ class WeChatJarvisBot:
 
     @staticmethod
     def _coalesce_pending_requests(items: List[Dict[str, Any]]) -> tuple[str, List[Dict[str, Any]]]:
-        parts: List[str] = []
-        request_content: List[Dict[str, Any]] = []
-        for item in items:
-            text = str(item.get("text") or "").strip()
-            if text:
-                parts.append(text)
-            request_content.extend(list(item.get("request_content") or []))
-        return "\n\n".join(parts).strip(), request_content
+        return coalesce_pending_requests(items)
 
     async def _send_figures(self, session_key: SessionKey, figures: List[Any]) -> None:
         """Upload and send each figure as a WeChat image message."""

--- a/omicverse/jarvis/channels/wechat.py
+++ b/omicverse/jarvis/channels/wechat.py
@@ -36,8 +36,16 @@ except ImportError:  # pragma: no cover
     _CRYPTO_AVAILABLE = False
 
 from ..agent_bridge import AgentBridge
-from .._bridge_session import resolve_bridge_session_id
-from ..channel_media import build_channel_request, prepare_channel_delivery_figures
+from .channel_core import (
+    text_chunks,
+    strip_local_paths,
+    build_full_request,
+    get_prior_history,
+    notify_turn_complete,
+    process_result_state,
+    format_analysis_error,
+    default_summary,
+)
 from ..config import default_state_dir
 from ..gateway.routing import GatewaySessionRegistry, SessionKey
 from ..media_ingest import (
@@ -151,51 +159,6 @@ class RunningTask:
     started_at: float
 
 
-def _text_chunks(text: str, limit: int = _MAX_TEXT) -> List[str]:
-    text = (text or "").strip()
-    if not text:
-        return []
-    if len(text) <= limit:
-        return [text]
-    chunks: List[str] = []
-    buf = ""
-    for para in text.split("\n\n"):
-        cand = f"{buf}\n\n{para}".strip() if buf else para
-        if len(cand) <= limit:
-            buf = cand
-            continue
-        if buf:
-            chunks.append(buf)
-        if len(para) <= limit:
-            buf = para
-            continue
-        pos = 0
-        while pos < len(para):
-            chunks.append(para[pos : pos + limit])
-            pos += limit
-        buf = ""
-    if buf:
-        chunks.append(buf)
-    return chunks
-
-
-def _strip_local_paths(text: str) -> str:
-    value = text or ""
-    # Markdown links/images whose href is a local or sandbox path:
-    #   [label](sandbox:/mnt/...)  ![img](./output/foo.png)
-    value = re.sub(r"!?\[[^\]]*\]\((?:sandbox:|file:)?[./~]?[^\)]*\)", "", value)
-    # Inline code containing multi-segment paths
-    value = re.sub(r"`[^`\n]*(?:/[^`\n]*){2,}`", "", value)
-    # Absolute system paths
-    value = re.sub(r"/(?:Users|home|tmp|var|opt|root|data|mnt|private)/\S+", "", value)
-    # Tilde-relative paths
-    value = re.sub(r"~[/\\]\S+", "", value)
-    # Relative file references with known extensions
-    ext = r"pdf|csv|tsv|txt|xlsx|html|json|h5ad|png|jpg|svg"
-    value = re.sub(rf"\.?/?(?:\w[\w/-]*/)+\w[\w.-]*\.(?:{ext})", "", value, flags=re.IGNORECASE)
-    value = re.sub(r"[ \t]{2,}", " ", value)
-    value = re.sub(r"\n{3,}", "\n\n", value)
-    return value.strip()
 
 
 def _extract_text(item_list: Any) -> str:
@@ -769,7 +732,7 @@ class WeChatJarvisBot:
 
         if cmd == "/model":
             if not tail:
-                for chunk in _text_chunks(render_model_help(getattr(self._sm, "_model", "unknown"))):
+                for chunk in text_chunks(render_model_help(getattr(self._sm, "_model", "unknown")), limit=_MAX_TEXT):
                     await self._send_session_text(session_key, chunk, context_token=context_token)
                 return
             self._sm._model = tail
@@ -986,13 +949,9 @@ class WeChatJarvisBot:
             if chunk:
                 llm_buf += chunk
 
-        _wb = getattr(self._sm, "gateway_web_bridge", None)
-        _prior_history = _wb.get_prior_history_simple(
-            "wechat",
-            session_key.scope_type,
-            session_key.scope_id,
-            session_id=resolve_bridge_session_id(session),
-        ) if _wb else []
+        _prior_history = get_prior_history(
+            self._sm, "wechat", session_key.scope_type, session_key.scope_id, session,
+        )
 
         bridge = AgentBridge(session.agent, progress_cb=progress_cb, llm_chunk_cb=llm_chunk_cb)
         try:
@@ -1016,55 +975,26 @@ class WeChatJarvisBot:
             result.error,
         )
 
-        if result.adata is not None:
-            session.adata = result.adata
-            try:
-                session.save_adata()
-                session.prompt_count += 1
-            except Exception:
-                pass
-        if result.usage is not None:
-            session.last_usage = result.usage
-        delivery_figures = prepare_channel_delivery_figures(session, result.figures)
-        try:
-            adata = session.adata
-            adata_info = f"{adata.n_obs:,} cells x {adata.n_vars:,} genes" if adata is not None else ""
-            session.append_memory_log(
-                request=user_text,
-                summary=(result.summary or "分析完成"),
-                adata_info=adata_info,
-            )
-        except Exception:
-            pass
+        delivery_figures, _adata_info = process_result_state(session, result, user_text)
 
-        web_bridge = getattr(self._sm, "gateway_web_bridge", None)
-        if web_bridge is not None:
-            try:
-                web_bridge.on_turn_complete_simple(
-                    channel="wechat",
-                    scope_type=session_key.scope_type,
-                    scope_id=session_key.scope_id,
-                    user_text=user_text,
-                    llm_text=llm_buf,
-                    adata=result.adata,
-                    figures=result.figures or [],
-                    session_id=resolve_bridge_session_id(session),
-                )
-            except Exception:
-                pass
+        notify_turn_complete(
+            self._sm,
+            channel="wechat",
+            scope_type=session_key.scope_type,
+            scope_id=session_key.scope_id,
+            session=session,
+            user_text=user_text,
+            llm_text=llm_buf,
+            adata=result.adata,
+            figures=result.figures or [],
+        )
 
         if result.error:
-            err_text = f"分析出错: {result.error}"
-            if result.diagnostics:
-                hints = "\n".join(f"- {item}" for item in result.diagnostics[:4])
-                err_text += f"\n\n诊断:\n{hints}"
-            if llm_buf.strip():
-                err_text += f"\n\n模型输出:\n{llm_buf[:1200]}"
-            await self._send_session_text(session_key, err_text)
+            await self._send_session_text(session_key, format_analysis_error(result, llm_buf))
             return
 
         for report in list(result.reports or []):
-            for chunk in _text_chunks(report):
+            for chunk in text_chunks(report, limit=_MAX_TEXT):
                 await self._send_session_text(session_key, chunk)
 
         if delivery_figures:
@@ -1077,21 +1007,17 @@ class WeChatJarvisBot:
 
         # pick_reply_text handles has_artifacts + llm_buf priority; WeChat then
         # additionally strips agent meta-commentary fragments.
-        summary = _strip_local_paths(bridge.pick_reply_text(result, llm_buf))
+        summary = strip_local_paths(bridge.pick_reply_text(result, llm_buf))
         if summary and _META_COMMENTARY_RE.search(summary):
             logger.debug("WeChat: suppressing meta-commentary summary: %.120s", summary)
             summary = ""
         if not summary:
-            if session.adata is not None:
-                adata = session.adata
-                summary = f"分析完成\n{adata.n_obs:,} cells x {adata.n_vars:,} genes"
-            else:
-                summary = "分析完成"
-        for chunk in _text_chunks(summary):
+            summary = default_summary(session)
+        for chunk in text_chunks(summary, limit=_MAX_TEXT):
             await self._send_session_text(session_key, chunk)
 
     def _build_full_request(self, session: Any, text: str) -> str:
-        return build_channel_request(session, text, channel_label="WeChat")
+        return build_full_request(session, text, channel_label="WeChat")
 
     @staticmethod
     def _command_parts(text: str) -> tuple[str, str]:
@@ -1295,7 +1221,7 @@ class WeChatJarvisBot:
         if not token:
             logger.warning("Skipping WeChat send because context_token is missing: scope_id=%s", session_key.scope_id)
             return
-        for chunk in _text_chunks(text):
+        for chunk in text_chunks(text, limit=_MAX_TEXT):
             await asyncio.to_thread(
                 self._client.send_text,
                 to_user_id=session_key.scope_id,

--- a/omicverse/utils/agent_backend.py
+++ b/omicverse/utils/agent_backend.py
@@ -29,7 +29,6 @@ facade; all other modules are implementation details.
 from __future__ import annotations
 
 import asyncio
-import builtins as _builtins_mod
 import contextlib
 import io
 import json
@@ -407,13 +406,6 @@ class OmicVerseLLMBackend:
 
     # --- Local Python executor ---
 
-    # Builtins removed from the sandbox to prevent code-evaluation and
-    # unchecked import bypass.  A safe __import__ replacement is injected
-    # separately so that normal ``import`` statements still work.
-    _DENIED_BUILTINS: frozenset = frozenset({
-        "eval", "exec", "compile", "__import__", "breakpoint",
-    })
-
     def _run_python_local(self, user_prompt: str) -> str:
         """Execute Python code locally when provider is set to 'python'."""
 
@@ -435,7 +427,7 @@ class OmicVerseLLMBackend:
         # Pre-execution security scan — SyntaxError is NOT swallowed so that
         # callers receive a diagnosable failure instead of silently falling
         # through to compile().
-        from .agent_sandbox import CodeSecurityScanner, SafeOsProxy
+        from .agent_sandbox import CodeSecurityScanner, build_sandbox_globals
         from .agent_errors import SecurityViolationError
         scanner = CodeSecurityScanner()
         try:
@@ -451,47 +443,7 @@ class OmicVerseLLMBackend:
 
         stdout = io.StringIO()
         stderr = io.StringIO()
-
-        # -- Restricted builtins surface --
-        safe_builtins = {
-            k: v for k, v in vars(_builtins_mod).items()
-            if k not in self._DENIED_BUILTINS
-        }
-
-        # Inject a safe __import__ that returns SafeOsProxy for ``os`` while
-        # delegating all other imports to the real implementation.
-        _real_import = _builtins_mod.__import__
-        _os_proxy = SafeOsProxy()
-
-        _RUNTIME_BLOCKED_IMPORTS = frozenset({"importlib", "ctypes", "cffi"})
-
-        def _safe_import(name, globals=None, locals=None, fromlist=(), level=0):
-            if name == "os":
-                return _os_proxy
-            if name.startswith("os."):
-                if fromlist:
-                    # from os.path import join — return the deepest submodule
-                    parts = name.split(".")[1:]
-                    mod = _os_proxy
-                    for part in parts:
-                        mod = getattr(mod, part)
-                    return mod
-                # import os.path — return proxy (bound to name 'os')
-                return _os_proxy
-            root = name.split(".")[0]
-            if root in _RUNTIME_BLOCKED_IMPORTS:
-                raise SecurityViolationError(
-                    f"Import of '{name}' is blocked in the sandbox (restricted module: {root})",
-                    violations=[])
-            return _real_import(name, globals, locals, fromlist, level)
-
-        safe_builtins["__import__"] = _safe_import
-
-        sandbox_globals: Dict[str, Any] = {
-            "__name__": "__main__",
-            "__builtins__": safe_builtins,
-            "os": _os_proxy,
-        }
+        sandbox_globals = build_sandbox_globals()
         sandbox_locals: Dict[str, Any] = {}
 
         try:

--- a/omicverse/utils/agent_backend.py
+++ b/omicverse/utils/agent_backend.py
@@ -29,6 +29,7 @@ facade; all other modules are implementation details.
 from __future__ import annotations
 
 import asyncio
+import builtins as _builtins_mod
 import contextlib
 import io
 import json
@@ -607,6 +608,14 @@ class OmicVerseLLMBackend:
         return _ds._chat_via_dashscope(self, user_prompt)
 
     # --- Local Python executor ---
+
+    # Builtins removed from the sandbox to prevent code-evaluation and
+    # unchecked import bypass.  A safe __import__ replacement is injected
+    # separately so that normal ``import`` statements still work.
+    _DENIED_BUILTINS: frozenset = frozenset({
+        "eval", "exec", "compile", "__import__", "breakpoint",
+    })
+
     def _run_python_local(self, user_prompt: str) -> str:
         """Execute Python code locally when provider is set to 'python'."""
 
@@ -625,8 +634,10 @@ class OmicVerseLLMBackend:
         if not code:
             raise ValueError("No Python code provided for execution")
 
-        # Pre-execution security scan
-        from .agent_sandbox import CodeSecurityScanner
+        # Pre-execution security scan — SyntaxError is NOT swallowed so that
+        # callers receive a diagnosable failure instead of silently falling
+        # through to compile().
+        from .agent_sandbox import CodeSecurityScanner, SafeOsProxy
         from .agent_errors import SecurityViolationError
         scanner = CodeSecurityScanner()
         try:
@@ -637,12 +648,45 @@ class OmicVerseLLMBackend:
                     f"Code blocked by security scanner:\n{report}",
                     violations=violations,
                 )
-        except SyntaxError:
-            pass  # Syntax errors handled downstream by compile()
+        except SyntaxError as exc:
+            raise RuntimeError(f"Python execution failed: {exc}") from exc
 
         stdout = io.StringIO()
         stderr = io.StringIO()
-        sandbox_globals: Dict[str, Any] = {"__name__": "__main__"}
+
+        # -- Restricted builtins surface --
+        safe_builtins = {
+            k: v for k, v in vars(_builtins_mod).items()
+            if k not in self._DENIED_BUILTINS
+        }
+
+        # Inject a safe __import__ that returns SafeOsProxy for ``os`` while
+        # delegating all other imports to the real implementation.
+        _real_import = _builtins_mod.__import__
+        _os_proxy = SafeOsProxy()
+
+        def _safe_import(name, globals=None, locals=None, fromlist=(), level=0):
+            if name == "os":
+                return _os_proxy
+            if name.startswith("os."):
+                if fromlist:
+                    # from os.path import join — return the deepest submodule
+                    parts = name.split(".")[1:]
+                    mod = _os_proxy
+                    for part in parts:
+                        mod = getattr(mod, part)
+                    return mod
+                # import os.path — return proxy (bound to name 'os')
+                return _os_proxy
+            return _real_import(name, globals, locals, fromlist, level)
+
+        safe_builtins["__import__"] = _safe_import
+
+        sandbox_globals: Dict[str, Any] = {
+            "__name__": "__main__",
+            "__builtins__": safe_builtins,
+            "os": _os_proxy,
+        }
         sandbox_locals: Dict[str, Any] = {}
 
         try:

--- a/omicverse/utils/agent_backend.py
+++ b/omicverse/utils/agent_backend.py
@@ -373,18 +373,12 @@ class OmicVerseLLMBackend:
             )
 
         wire = self._effective_wire_api(provider_info)
-        if wire == WireAPI.CHAT_COMPLETIONS:
-            return self._chat_tools_openai(messages, tools, tool_choice)
-        elif wire == WireAPI.ANTHROPIC_MESSAGES:
-            return self._chat_tools_anthropic(messages, tools, tool_choice)
-        elif wire == WireAPI.GEMINI_GENERATE:
-            return self._chat_tools_gemini(messages, tools, tool_choice)
-        elif wire == WireAPI.DASHSCOPE:
-            return self._chat_tools_openai(messages, tools, tool_choice)
-        else:
+        method_name = _CHAT_DISPATCH.get(wire)
+        if method_name is None:
             raise RuntimeError(
                 f"Tool-calling chat not supported for wire API '{wire.value}'"
             )
+        return getattr(self, method_name)(messages, tools, tool_choice)
 
     async def _stream_async(self, user_prompt: str):
         """Internal async generator that dispatches to provider-specific streaming."""
@@ -412,200 +406,6 @@ class OmicVerseLLMBackend:
         method = getattr(self, method_name)
         async for chunk in method(user_prompt):
             yield chunk
-
-    # -----------------------------------------------------------------
-    # Provider-specific delegates (thin wrappers calling helper modules)
-    # -----------------------------------------------------------------
-
-    # --- OpenAI ---
-    def _apply_openai_chat_param_policy(self, kwargs):
-        return _oai._apply_openai_chat_param_policy(self, kwargs)
-
-    def _extract_openai_error_text(self, exc):
-        return _oai._extract_openai_error_text(self, exc)
-
-    def _adapt_openai_chat_kwargs_from_error(self, kwargs, exc):
-        return _oai._adapt_openai_chat_kwargs_from_error(self, kwargs, exc)
-
-    def _call_openai_chat_with_adaptation(self, request_fn, kwargs, *, base_url):
-        return _oai._call_openai_chat_with_adaptation(self, request_fn, kwargs, base_url=base_url)
-
-    @staticmethod
-    def _is_openai_codex_base_url(base_url):
-        return _oai._is_openai_codex_base_url(base_url)
-
-    @staticmethod
-    def _resolve_openai_codex_url(base_url):
-        return _oai._resolve_openai_codex_url(base_url)
-
-    @staticmethod
-    def _decode_openai_codex_jwt(token):
-        return _oai._decode_openai_codex_jwt(token)
-
-    @classmethod
-    def _extract_openai_codex_account_id(cls, token):
-        return _oai._extract_openai_codex_account_id(token)
-
-    @staticmethod
-    def _openai_codex_user_agent():
-        return _oai._openai_codex_user_agent()
-
-    @staticmethod
-    def _is_ollama_endpoint(base_url):
-        return _oai._is_ollama_endpoint(base_url)
-
-    def _wrap_openai_connection_error(self, exc, base_url):
-        return _oai._wrap_openai_connection_error(self, exc, base_url)
-
-    @staticmethod
-    def _responses_jsonable(value):
-        return _oai._responses_jsonable(value)
-
-    @staticmethod
-    def _extract_responses_output_items(payload):
-        return _oai._extract_responses_output_items(payload)
-
-    @staticmethod
-    def _extract_responses_text_from_items(items):
-        return _oai._extract_responses_text_from_items(items)
-
-    @staticmethod
-    def _extract_responses_tool_calls_from_items(items):
-        return _oai._extract_responses_tool_calls_from_items(items)
-
-    @staticmethod
-    def _extract_responses_text_from_dict(payload):
-        return _oai._extract_responses_text_from_dict(payload)
-
-    def _build_openai_responses_request(self, *, messages, tools, tool_choice, include_system_messages):
-        return _oai._build_openai_responses_request(self, messages=messages, tools=tools, tool_choice=tool_choice, include_system_messages=include_system_messages)
-
-    @staticmethod
-    def _iter_openai_codex_sse_events(raw_bytes):
-        return _oai._iter_openai_codex_sse_events(raw_bytes)
-
-    def _extract_openai_codex_final_response(self, events):
-        return _oai._extract_openai_codex_final_response(self, events)
-
-    def _call_openai_codex_responses(self, *, base_url, api_key, messages, tools, tool_choice):
-        return _oai._call_openai_codex_responses(self, base_url=base_url, api_key=api_key, messages=messages, tools=tools, tool_choice=tool_choice)
-
-    def _convert_messages_openai_responses(self, messages):
-        return _oai._convert_messages_openai_responses(self, messages)
-
-    def _build_chat_response_from_responses_payload(self, payload):
-        return _oai._build_chat_response_from_responses_payload(self, payload)
-
-    def _convert_tools_openai(self, tools):
-        return _oai._convert_tools_openai(tools)
-
-    def _convert_tools_openai_responses(self, tools):
-        return _oai._convert_tools_openai_responses(tools)
-
-    def _chat_via_openai_compatible(self, user_prompt):
-        return _oai._chat_via_openai_compatible(self, user_prompt)
-
-    def _chat_via_openai_http(self, base_url, api_key, user_prompt):
-        return _oai._chat_via_openai_http(self, base_url, api_key, user_prompt)
-
-    def _chat_via_openai_responses(self, base_url, api_key, user_prompt):
-        return _oai._chat_via_openai_responses(self, base_url, api_key, user_prompt)
-
-    def _chat_via_openai_responses_http(self, base_url, api_key, user_prompt):
-        return _oai._chat_via_openai_responses_http(self, base_url, api_key, user_prompt)
-
-    def _chat_tools_openai(self, messages, tools, tool_choice):
-        return _oai._chat_tools_openai(self, messages, tools, tool_choice)
-
-    def _chat_tools_openai_responses(self, messages, tools, tool_choice):
-        return _oai._chat_tools_openai_responses(self, messages, tools, tool_choice)
-
-    # --- Anthropic ---
-    def _convert_tools_anthropic(self, tools):
-        return _ant._convert_tools_anthropic(tools)
-
-    def _chat_via_anthropic(self, user_prompt):
-        return _ant._chat_via_anthropic(self, user_prompt)
-
-    def _chat_tools_anthropic(self, messages, tools, tool_choice):
-        return _ant._chat_tools_anthropic(self, messages, tools, tool_choice)
-
-    # --- Gemini ---
-    @staticmethod
-    def _json_schema_to_gemini_schema(schema):
-        return _gem._json_schema_to_gemini_schema(schema)
-
-    @staticmethod
-    def _messages_to_gemini_contents(messages):
-        return _gem._messages_to_gemini_contents(messages)
-
-    def _chat_via_gemini(self, user_prompt):
-        return _gem._chat_via_gemini(self, user_prompt)
-
-    def _chat_tools_gemini(self, messages, tools, tool_choice):
-        return _gem._chat_tools_gemini(self, messages, tools, tool_choice)
-
-    # --- Gemini CLI OAuth helpers ---
-    @staticmethod
-    def _gemini_uses_oauth_bearer(api_key):
-        return _gem._gemini_uses_oauth_bearer(api_key)
-
-    @staticmethod
-    def _gemini_auth_headers(api_key):
-        return _gem._gemini_auth_headers(api_key)
-
-    @staticmethod
-    def _gemini_oauth_payload(api_key):
-        return _gem._gemini_oauth_payload(api_key)
-
-    def _gemini_base_url(self):
-        return _gem._gemini_base_url(self)
-
-    def _gemini_generate_content_url(self):
-        return _gem._gemini_generate_content_url(self)
-
-    def _gemini_cli_base_url(self):
-        return _gem._gemini_cli_base_url(self)
-
-    def _gemini_cli_generate_content_url(self, stream=False):
-        return _gem._gemini_cli_generate_content_url(self, stream=stream)
-
-    @staticmethod
-    def _gemini_function_response_payload(result):
-        return _gem._gemini_function_response_payload(result)
-
-    @staticmethod
-    def _clean_schema_for_gemini_cli(schema):
-        return _gem._clean_schema_for_gemini_cli(schema)
-
-    def _messages_to_gemini_rest_contents(self, messages):
-        return _gem._messages_to_gemini_rest_contents(self, messages)
-
-    def _gemini_rest_generation_config(self):
-        return _gem._gemini_rest_generation_config(self)
-
-    def _gemini_rest_request(self, body, api_key):
-        return _gem._gemini_rest_request(self, body, api_key)
-
-    def _gemini_cli_request(self, body, api_key):
-        return _gem._gemini_cli_request(self, body, api_key)
-
-    def _capture_gemini_usage(self, payload):
-        return _gem._capture_gemini_usage(self, payload)
-
-    @staticmethod
-    def _extract_gemini_text_and_tool_calls(payload):
-        return _gem._extract_gemini_text_and_tool_calls(payload)
-
-    def _chat_tools_gemini_rest(self, messages, tools, tool_choice, api_key):
-        return _gem._chat_tools_gemini_rest(self, messages, tools, tool_choice, api_key)
-
-    def _chat_via_gemini_rest(self, user_prompt, api_key):
-        return _gem._chat_via_gemini_rest(self, user_prompt, api_key)
-
-    # --- DashScope ---
-    def _chat_via_dashscope(self, user_prompt):
-        return _ds._chat_via_dashscope(self, user_prompt)
 
     # --- Local Python executor ---
 
@@ -755,34 +555,138 @@ class OmicVerseLLMBackend:
                 "content": result,
             }
 
-    # --- Streaming delegates ---
-    async def _run_generator_in_thread(self, generator_func):
-        async for chunk in _stream._run_generator_in_thread(self, generator_func):
-            yield chunk
 
-    async def _stream_openai_compatible(self, user_prompt):
-        async for chunk in _stream._stream_openai_compatible(self, user_prompt):
-            yield chunk
+# ---------------------------------------------------------------------------
+# Provider delegation registry
+# ---------------------------------------------------------------------------
+# Instead of ~60 handwritten forwarding methods on the class, the registry
+# maps method names to their provider module and binding kind.
+# _install_provider_delegates() materializes each entry as a late-bound
+# method on OmicVerseLLMBackend so monkeypatching the module-level function
+# is picked up at call time.
+#
+# kind: 'instance'  — func(backend, *args, **kwargs)
+#       'static'    — func(*args, **kwargs), no backend arg
+#       'async_gen' — async generator func(backend, *args, **kwargs)
 
-    async def _stream_openai_http_fallback(self, base_url, api_key, user_prompt):
-        async for chunk in _stream._stream_openai_http_fallback(self, base_url, api_key, user_prompt):
-            yield chunk
+_CHAT_DISPATCH = {
+    WireAPI.CHAT_COMPLETIONS:   "_chat_tools_openai",
+    WireAPI.ANTHROPIC_MESSAGES: "_chat_tools_anthropic",
+    WireAPI.GEMINI_GENERATE:    "_chat_tools_gemini",
+    WireAPI.DASHSCOPE:          "_chat_tools_openai",
+}
 
-    async def _stream_openai_responses(self, base_url, api_key, user_prompt):
-        async for chunk in _stream._stream_openai_responses(self, base_url, api_key, user_prompt):
-            yield chunk
+_PROVIDER_DELEGATES = [
+    # --- OpenAI: instance ---
+    ("_apply_openai_chat_param_policy",          _oai, "instance"),
+    ("_extract_openai_error_text",               _oai, "instance"),
+    ("_adapt_openai_chat_kwargs_from_error",     _oai, "instance"),
+    ("_call_openai_chat_with_adaptation",        _oai, "instance"),
+    ("_wrap_openai_connection_error",            _oai, "instance"),
+    ("_build_openai_responses_request",          _oai, "instance"),
+    ("_extract_openai_codex_final_response",     _oai, "instance"),
+    ("_call_openai_codex_responses",             _oai, "instance"),
+    ("_convert_messages_openai_responses",       _oai, "instance"),
+    ("_build_chat_response_from_responses_payload", _oai, "instance"),
+    ("_chat_via_openai_compatible",              _oai, "instance"),
+    ("_chat_via_openai_http",                    _oai, "instance"),
+    ("_chat_via_openai_responses",               _oai, "instance"),
+    ("_chat_via_openai_responses_http",          _oai, "instance"),
+    ("_chat_tools_openai",                       _oai, "instance"),
+    ("_chat_tools_openai_responses",             _oai, "instance"),
+    # --- OpenAI: static ---
+    ("_convert_tools_openai",                    _oai, "static"),
+    ("_convert_tools_openai_responses",          _oai, "static"),
+    ("_is_openai_codex_base_url",                _oai, "static"),
+    ("_resolve_openai_codex_url",                _oai, "static"),
+    ("_decode_openai_codex_jwt",                 _oai, "static"),
+    ("_extract_openai_codex_account_id",         _oai, "static"),
+    ("_openai_codex_user_agent",                 _oai, "static"),
+    ("_is_ollama_endpoint",                      _oai, "static"),
+    ("_responses_jsonable",                      _oai, "static"),
+    ("_extract_responses_output_items",          _oai, "static"),
+    ("_extract_responses_text_from_items",       _oai, "static"),
+    ("_extract_responses_tool_calls_from_items", _oai, "static"),
+    ("_extract_responses_text_from_dict",        _oai, "static"),
+    ("_iter_openai_codex_sse_events",            _oai, "static"),
+    # --- Anthropic: instance ---
+    ("_chat_via_anthropic",                      _ant, "instance"),
+    ("_chat_tools_anthropic",                    _ant, "instance"),
+    # --- Anthropic: static ---
+    ("_convert_tools_anthropic",                 _ant, "static"),
+    # --- Gemini: instance ---
+    ("_chat_via_gemini",                         _gem, "instance"),
+    ("_chat_tools_gemini",                       _gem, "instance"),
+    ("_gemini_base_url",                         _gem, "instance"),
+    ("_gemini_generate_content_url",             _gem, "instance"),
+    ("_gemini_cli_base_url",                     _gem, "instance"),
+    ("_gemini_cli_generate_content_url",         _gem, "instance"),
+    ("_messages_to_gemini_rest_contents",        _gem, "instance"),
+    ("_gemini_rest_generation_config",           _gem, "instance"),
+    ("_gemini_rest_request",                     _gem, "instance"),
+    ("_gemini_cli_request",                      _gem, "instance"),
+    ("_capture_gemini_usage",                    _gem, "instance"),
+    ("_chat_tools_gemini_rest",                  _gem, "instance"),
+    ("_chat_via_gemini_rest",                    _gem, "instance"),
+    # --- Gemini: static ---
+    ("_json_schema_to_gemini_schema",            _gem, "static"),
+    ("_messages_to_gemini_contents",             _gem, "static"),
+    ("_gemini_uses_oauth_bearer",                _gem, "static"),
+    ("_gemini_auth_headers",                     _gem, "static"),
+    ("_gemini_oauth_payload",                    _gem, "static"),
+    ("_gemini_function_response_payload",        _gem, "static"),
+    ("_clean_schema_for_gemini_cli",             _gem, "static"),
+    ("_extract_gemini_text_and_tool_calls",      _gem, "static"),
+    # --- DashScope: instance ---
+    ("_chat_via_dashscope",                      _ds,  "instance"),
+    # --- Streaming: async generators ---
+    ("_run_generator_in_thread",                 _stream, "async_gen"),
+    ("_stream_openai_compatible",                _stream, "async_gen"),
+    ("_stream_openai_http_fallback",             _stream, "async_gen"),
+    ("_stream_openai_responses",                 _stream, "async_gen"),
+    ("_stream_anthropic",                        _stream, "async_gen"),
+    ("_stream_gemini",                           _stream, "async_gen"),
+    ("_stream_dashscope",                        _stream, "async_gen"),
+]
 
-    async def _stream_anthropic(self, user_prompt):
-        async for chunk in _stream._stream_anthropic(self, user_prompt):
-            yield chunk
 
-    async def _stream_gemini(self, user_prompt):
-        async for chunk in _stream._stream_gemini(self, user_prompt):
-            yield chunk
+def _install_provider_delegates(cls, delegates):
+    """Materialize provider delegate methods onto *cls* from the registry.
 
-    async def _stream_dashscope(self, user_prompt):
-        async for chunk in _stream._stream_dashscope(self, user_prompt):
-            yield chunk
+    Each wrapper resolves the target function at call time via ``getattr``
+    so that monkeypatching the module-level function is picked up.
+    """
+    for name, mod, kind in delegates:
+        if kind == "instance":
+            def _make(m, n):
+                def _delegate(self, *args, **kwargs):
+                    return getattr(m, n)(self, *args, **kwargs)
+                _delegate.__name__ = n
+                _delegate.__qualname__ = f"{cls.__name__}.{n}"
+                return _delegate
+            setattr(cls, name, _make(mod, name))
+        elif kind == "static":
+            def _make(m, n):
+                def _delegate(*args, **kwargs):
+                    return getattr(m, n)(*args, **kwargs)
+                _delegate.__name__ = n
+                _delegate.__qualname__ = f"{cls.__name__}.{n}"
+                return staticmethod(_delegate)
+            setattr(cls, name, _make(mod, name))
+        elif kind == "async_gen":
+            def _make(m, n):
+                async def _delegate(self, *args, **kwargs):
+                    async for chunk in getattr(m, n)(self, *args, **kwargs):
+                        yield chunk
+                _delegate.__name__ = n
+                _delegate.__qualname__ = f"{cls.__name__}.{n}"
+                return _delegate
+            setattr(cls, name, _make(mod, name))
+        else:
+            raise ValueError(f"Unknown delegate kind: {kind!r} for {name}")
+
+
+_install_provider_delegates(OmicVerseLLMBackend, _PROVIDER_DELEGATES)
 
 
 __all__ = ["OmicVerseLLMBackend", "Usage", "ChatResponse", "ToolCall", "BackendConfig"]

--- a/omicverse/utils/agent_backend.py
+++ b/omicverse/utils/agent_backend.py
@@ -325,15 +325,13 @@ class OmicVerseLLMBackend:
         return None
 
     def _retry(self, func: Callable[..., T], *args, **kwargs) -> T:
-        """Retry *func* using the retry settings from self.config."""
+        """Retry *func* with config retry settings, binding any args into a zero-arg closure."""
         return _retry_with_backoff(
-            func,
+            (lambda: func(*args, **kwargs)) if args or kwargs else func,
             max_attempts=self.config.max_retry_attempts,
             base_delay=self.config.retry_base_delay,
             factor=self.config.retry_backoff_factor,
             jitter=self.config.retry_jitter,
-            *args,
-            **kwargs,
         )
 
     # -----------------------------------------------------------------
@@ -465,6 +463,8 @@ class OmicVerseLLMBackend:
         _real_import = _builtins_mod.__import__
         _os_proxy = SafeOsProxy()
 
+        _RUNTIME_BLOCKED_IMPORTS = frozenset({"importlib", "ctypes", "cffi"})
+
         def _safe_import(name, globals=None, locals=None, fromlist=(), level=0):
             if name == "os":
                 return _os_proxy
@@ -478,6 +478,11 @@ class OmicVerseLLMBackend:
                     return mod
                 # import os.path — return proxy (bound to name 'os')
                 return _os_proxy
+            root = name.split(".")[0]
+            if root in _RUNTIME_BLOCKED_IMPORTS:
+                raise SecurityViolationError(
+                    f"Import of '{name}' is blocked in the sandbox (restricted module: {root})",
+                    violations=[])
             return _real_import(name, globals, locals, fromlist, level)
 
         safe_builtins["__import__"] = _safe_import

--- a/omicverse/utils/agent_backend_common.py
+++ b/omicverse/utils/agent_backend_common.py
@@ -9,6 +9,7 @@ import concurrent.futures as _cf
 import logging
 import os
 import random
+import threading
 import time
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Optional, TypeVar
@@ -78,6 +79,7 @@ _STREAM_DISPATCH = {
 
 _SHARED_EXECUTOR: Optional[_cf.ThreadPoolExecutor] = None
 _EXECUTOR_ATEXIT_REGISTERED: bool = False
+_EXECUTOR_LOCK = threading.Lock()
 
 
 def _shutdown_shared_executor() -> None:
@@ -92,15 +94,22 @@ def _shutdown_shared_executor() -> None:
 
 
 def _get_shared_executor() -> _cf.ThreadPoolExecutor:
+    """Return the module-level shared executor, creating it if needed.
+
+    Uses double-checked locking to avoid duplicate construction under
+    concurrent access from multiple threads.
+    """
     global _SHARED_EXECUTOR, _EXECUTOR_ATEXIT_REGISTERED
     if _SHARED_EXECUTOR is None:
-        _SHARED_EXECUTOR = _cf.ThreadPoolExecutor(
-            max_workers=4, thread_name_prefix="ovagent-stream",
-        )
-        if not _EXECUTOR_ATEXIT_REGISTERED:
-            import atexit
-            atexit.register(_shutdown_shared_executor)
-            _EXECUTOR_ATEXIT_REGISTERED = True
+        with _EXECUTOR_LOCK:
+            if _SHARED_EXECUTOR is None:
+                _SHARED_EXECUTOR = _cf.ThreadPoolExecutor(
+                    max_workers=4, thread_name_prefix="ovagent-stream",
+                )
+                if not _EXECUTOR_ATEXIT_REGISTERED:
+                    import atexit
+                    atexit.register(_shutdown_shared_executor)
+                    _EXECUTOR_ATEXIT_REGISTERED = True
     return _SHARED_EXECUTOR
 
 
@@ -262,12 +271,12 @@ def _should_retry(exc: Exception) -> bool:
 
 def _retry_with_backoff(
     func: Callable[..., T],
+    *args,
     max_attempts: int = 3,
     base_delay: float = 1.0,
     factor: float = 2.0,
     jitter: float = 0.5,
-    *args,
-    **kwargs
+    **kwargs,
 ) -> T:
     """Retry a function call with exponential backoff and jitter.
 
@@ -275,16 +284,18 @@ def _retry_with_backoff(
     ----------
     func : Callable
         Function to retry
+    *args
+        Positional arguments forwarded to *func*
     max_attempts : int
-        Maximum number of attempts (default: 3)
+        Maximum number of attempts (keyword-only, default: 3)
     base_delay : float
-        Base delay in seconds (default: 1.0)
+        Base delay in seconds (keyword-only, default: 1.0)
     factor : float
-        Exponential backoff factor (default: 2.0)
+        Exponential backoff factor (keyword-only, default: 2.0)
     jitter : float
-        Maximum jitter factor as proportion of delay (default: 0.5)
-    *args, **kwargs
-        Arguments to pass to func
+        Maximum jitter factor as proportion of delay (keyword-only, default: 0.5)
+    **kwargs
+        Keyword arguments forwarded to *func*
 
     Returns
     -------
@@ -292,8 +303,8 @@ def _retry_with_backoff(
 
     Raises
     ------
-    Exception
-        Last exception encountered if all retries fail
+    RuntimeError
+        If all retry attempts are exhausted
     """
     last_exception = None
 

--- a/omicverse/utils/agent_backend_common.py
+++ b/omicverse/utils/agent_backend_common.py
@@ -271,46 +271,45 @@ def _should_retry(exc: Exception) -> bool:
 
 def _retry_with_backoff(
     func: Callable[..., T],
-    *args,
     max_attempts: int = 3,
     base_delay: float = 1.0,
     factor: float = 2.0,
     jitter: float = 0.5,
-    **kwargs,
 ) -> T:
-    """Retry a function call with exponential backoff and jitter.
+    """Retry a callable with exponential backoff and jitter.
+
+    *func* must be a **zero-argument** callable (bind any arguments before
+    passing, e.g. via ``lambda`` or ``functools.partial``).  Retry
+    configuration can be passed positionally or by keyword.
 
     Parameters
     ----------
-    func : Callable
-        Function to retry
-    *args
-        Positional arguments forwarded to *func*
+    func : Callable[..., T]
+        Zero-argument callable to retry.
     max_attempts : int
-        Maximum number of attempts (keyword-only, default: 3)
+        Maximum number of attempts (default: 3).
     base_delay : float
-        Base delay in seconds (keyword-only, default: 1.0)
+        Base delay in seconds (default: 1.0).
     factor : float
-        Exponential backoff factor (keyword-only, default: 2.0)
+        Exponential backoff factor (default: 2.0).
     jitter : float
-        Maximum jitter factor as proportion of delay (keyword-only, default: 0.5)
-    **kwargs
-        Keyword arguments forwarded to *func*
+        Maximum jitter factor as proportion of delay (default: 0.5).
 
     Returns
     -------
-    Result of func(*args, **kwargs)
+    T
+        Result of ``func()``.
 
     Raises
     ------
     RuntimeError
-        If all retry attempts are exhausted
+        If all retry attempts are exhausted.
     """
     last_exception = None
 
     for attempt in range(max_attempts):
         try:
-            return func(*args, **kwargs)
+            return func()
         except Exception as exc:
             last_exception = exc
 

--- a/omicverse/utils/agent_config.py
+++ b/omicverse/utils/agent_config.py
@@ -169,7 +169,7 @@ class AgentConfig:
         if agent_type not in SUBAGENT_CONFIGS:
             raise KeyError(f"Unknown subagent type: {agent_type!r}")
 
-        base = copy.copy(SUBAGENT_CONFIGS[agent_type])
+        base = copy.deepcopy(SUBAGENT_CONFIGS[agent_type])
         overrides = self.subagent_overrides.get(agent_type, {})
 
         valid_fields = {f.name for f in dataclass_fields(SubagentConfig)}

--- a/omicverse/utils/agent_config.py
+++ b/omicverse/utils/agent_config.py
@@ -8,10 +8,11 @@ compatibility with the original constructor signature.
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+import copy
+from dataclasses import dataclass, field, fields as dataclass_fields
 from enum import Enum
 from pathlib import Path
-from typing import Any, Callable, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 from .agent_sandbox import ApprovalMode, SecurityConfig, SecurityLevel
 
@@ -146,6 +147,41 @@ class AgentConfig:
     verbose: bool = True
     history_enabled: bool = False
     history_path: Optional[Path] = None
+    subagent_overrides: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+
+    # --------------- subagent profile resolution ---------------
+
+    def get_subagent_config(self, agent_type: str) -> SubagentConfig:
+        """Return a ``SubagentConfig`` for *agent_type*, merging any overrides.
+
+        Defaults come from the module-level ``SUBAGENT_CONFIGS`` dict.
+        If ``self.subagent_overrides`` contains an entry for *agent_type*,
+        its key/value pairs are applied on top of a shallow copy of the
+        default, so callers need only specify the fields they want to change.
+
+        Raises
+        ------
+        KeyError
+            If *agent_type* is not a recognised subagent profile.
+        ValueError
+            If an override key does not match any ``SubagentConfig`` field.
+        """
+        if agent_type not in SUBAGENT_CONFIGS:
+            raise KeyError(f"Unknown subagent type: {agent_type!r}")
+
+        base = copy.copy(SUBAGENT_CONFIGS[agent_type])
+        overrides = self.subagent_overrides.get(agent_type, {})
+
+        valid_fields = {f.name for f in dataclass_fields(SubagentConfig)}
+        for key, value in overrides.items():
+            if key not in valid_fields:
+                raise ValueError(
+                    f"Unknown SubagentConfig field: {key!r}. "
+                    f"Valid fields: {sorted(valid_fields)}"
+                )
+            setattr(base, key, value)
+
+        return base
 
     # --------------- backward-compat factory ---------------
 
@@ -207,6 +243,7 @@ class AgentConfig:
                 enable_mcp_registry=kw.get("enable_mcp_registry", True),
             ),
             security=cls._build_security_config(kw, approval_raw),
+            subagent_overrides=kw.get("subagent_overrides", {}),
         )
 
     @staticmethod

--- a/omicverse/utils/agent_sandbox.py
+++ b/omicverse/utils/agent_sandbox.py
@@ -20,12 +20,13 @@ This module provides:
 from __future__ import annotations
 
 import ast
+import builtins as _builtins
 import logging
 import os
 import types
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, FrozenSet, List, Optional
+from typing import Any, Dict, FrozenSet, List, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -190,6 +191,8 @@ class CodeSecurityScanner:
         "subprocess.getoutput", "subprocess.getstatusoutput",
         # shutil dangerous ops
         "shutil.rmtree", "shutil.move",
+        # Code execution via data-science libraries
+        "pandas.eval", "pd.eval",
     })
 
     # Dangerous attribute access (sandbox escape vectors)
@@ -210,11 +213,16 @@ class CodeSecurityScanner:
         "__spec__",
     })
 
+    # Calls that represent code-execution risk (not file I/O or shell access)
+    CODE_EXECUTION_CALLS: FrozenSet[str] = frozenset({
+        "pandas.eval", "pd.eval",
+    })
+
     # Modules that should never appear in import statements
     BLOCKED_IMPORT_ROOTS: FrozenSet[str] = frozenset({
         "subprocess", "socket", "ssl", "urllib", "http",
         "ftplib", "smtplib", "telnetlib", "paramiko", "requests",
-        "importlib", "ctypes", "multiprocessing",
+        "importlib", "ctypes", "cffi", "multiprocessing",
     })
 
     SAFE_IMPORT_SUBMODULES: FrozenSet[str] = frozenset({
@@ -293,7 +301,12 @@ class CodeSecurityScanner:
             # Check exact match or prefix match (os.exec covers os.execl etc.)
             for blocked in self._blocked_calls:
                 if name == blocked or name.startswith(blocked + "."):
-                    category = "shell_access" if "os." in blocked or "subprocess" in blocked else "file_danger"
+                    if blocked in self.CODE_EXECUTION_CALLS:
+                        category = "code_execution"
+                    elif "os." in blocked or "subprocess" in blocked:
+                        category = "shell_access"
+                    else:
+                        category = "file_danger"
                     severity = self._severity_overrides.get(category, "critical")
                     violations.append(SecurityViolation(
                         category=category,
@@ -472,3 +485,105 @@ class SafeOsProxy(types.ModuleType):
 
     def __repr__(self) -> str:
         return "<SafeOsProxy: restricted os module for OmicVerse agent>"
+
+
+# ---------------------------------------------------------------------------
+# Runtime sandbox globals builder
+# ---------------------------------------------------------------------------
+
+# Modules blocked at runtime import time — superset of the scanner's
+# BLOCKED_IMPORT_ROOTS, extended with sys (path/module manipulation)
+# and cffi (foreign-function interface escape).
+BLOCKED_RUNTIME_IMPORT_ROOTS: FrozenSet[str] = frozenset({
+    "subprocess", "socket", "ssl", "urllib", "http",
+    "ftplib", "smtplib", "telnetlib", "paramiko", "requests",
+    "importlib", "ctypes", "cffi", "multiprocessing", "sys",
+})
+
+_SAFE_IMPORT_SUBMODULES: FrozenSet[str] = frozenset({
+    "importlib.metadata",
+    "importlib.resources",
+})
+
+# Builtins explicitly excluded from the runtime sandbox.
+_EXCLUDED_BUILTINS: FrozenSet[str] = frozenset({
+    "eval", "exec", "compile",   # arbitrary code execution
+    "globals", "locals",          # namespace introspection
+    "breakpoint",                 # debugger entry
+    "exit", "quit",               # interpreter termination
+    "__import__",                 # replaced with restricted version
+})
+
+
+def build_sandbox_globals(
+    *,
+    security_config: Optional[SecurityConfig] = None,
+) -> Dict[str, Any]:
+    """Build restricted globals dict for local Python ``exec()``.
+
+    Returns a namespace with:
+
+    * Allowlisted builtins (no ``eval``/``exec``/``compile``/``globals``/``locals``)
+    * A restricted ``__import__`` that blocks dangerous modules at runtime
+    * ``os`` replaced with :class:`SafeOsProxy`
+
+    This is the runtime enforcement counterpart of :class:`CodeSecurityScanner`.
+    The scanner catches patterns at AST level; these globals catch bypass
+    vectors that only manifest at execution time (e.g. ``getattr(os, 'system')``
+    or ``__import__('subprocess')``).
+    """
+    config = security_config or SecurityConfig()
+
+    # -- restricted builtins ------------------------------------------------
+    excluded = set(_EXCLUDED_BUILTINS)
+    if not config.restrict_introspection:
+        excluded -= {"globals", "locals"}
+
+    safe_builtins: Dict[str, Any] = {}
+    for name in dir(_builtins):
+        if name.startswith("_"):
+            continue
+        if name in excluded:
+            continue
+        obj = getattr(_builtins, name, None)
+        if obj is not None:
+            safe_builtins[name] = obj
+
+    # -- restricted import --------------------------------------------------
+    deny_roots = BLOCKED_RUNTIME_IMPORT_ROOTS | config.extra_blocked_modules
+    os_proxy = SafeOsProxy()
+
+    def limited_import(name, globals=None, locals=None, fromlist=(), level=0):
+        root = name.split(".")[0]
+        fromlist_names = {str(f) for f in (fromlist or ())}
+        allow_safe = (
+            name in _SAFE_IMPORT_SUBMODULES
+            or any(name.startswith(f"{sm}.") for sm in _SAFE_IMPORT_SUBMODULES)
+            or (name == "importlib" and fromlist_names
+                and fromlist_names <= {"metadata", "resources"})
+        )
+        if root in deny_roots and not allow_safe:
+            raise ImportError(
+                f"Module '{name}' is blocked inside the OmicVerse agent sandbox."
+            )
+        # Redirect os imports to SafeOsProxy so getattr(os, 'system') is
+        # caught at runtime rather than returning the real os attribute.
+        if root == "os":
+            if fromlist and name != "os":
+                # e.g. from os.path import join — return real submodule
+                return _real_import(name, globals, locals, fromlist, level)
+            # import os / import os.path / from os import X — proxy
+            _real_import(name, globals, locals, fromlist, level)
+            return os_proxy
+        return _real_import(name, globals, locals, fromlist, level)
+
+    _real_import = __import__
+    safe_builtins["__import__"] = limited_import
+
+    # -- assemble globals ---------------------------------------------------
+    sandbox_globals: Dict[str, Any] = {
+        "__name__": "__main__",
+        "__builtins__": safe_builtins,
+        "os": os_proxy,
+    }
+    return sandbox_globals

--- a/omicverse/utils/agent_sandbox.py
+++ b/omicverse/utils/agent_sandbox.py
@@ -433,6 +433,12 @@ class CodeSecurityScanner:
 # Safe os module proxy
 # ---------------------------------------------------------------------------
 
+# Module-level reference to the real os module.  Intentionally NOT stored on
+# SafeOsProxy instances so that proxy.__dict__ never exposes a path back to
+# unrestricted os behaviour.
+_REAL_OS_MODULE = os
+
+
 class SafeOsProxy(types.ModuleType):
     """Drop-in proxy for the ``os`` module that blocks dangerous operations.
 
@@ -442,6 +448,10 @@ class SafeOsProxy(types.ModuleType):
 
     Blocked operations include shell execution, process management, file
     deletion, permission changes, and environment mutation.
+
+    The proxy uses an **explicit allowlist** model: only attributes listed in
+    ``_SAFE_ATTRS`` are forwarded to the real ``os`` module.  Everything else
+    — including unknown future ``os`` additions — is denied by default.
     """
 
     _BLOCKED_ATTRS: FrozenSet[str] = frozenset({
@@ -465,23 +475,49 @@ class SafeOsProxy(types.ModuleType):
         "putenv", "unsetenv",
     })
 
+    _SAFE_ATTRS: FrozenSet[str] = frozenset({
+        # Directory / file-status operations (read-only or create-only)
+        "getcwd", "listdir", "scandir", "walk",
+        "makedirs", "mkdir",
+        "stat", "lstat", "access",
+        "readlink",
+        # Platform constants
+        "sep", "altsep", "extsep", "linesep", "pathsep",
+        "curdir", "pardir", "devnull", "name",
+        # Environment reading (mutation stays blocked above)
+        "environ", "getenv", "environb", "getenvb",
+        # System info (read-only)
+        "cpu_count", "getpid", "getppid", "uname", "getlogin",
+        # Path encoding helpers
+        "fspath", "fsencode", "fsdecode",
+        # Misc safe
+        "urandom", "strerror", "get_terminal_size",
+    })
+
     def __init__(self) -> None:
         super().__init__("os")
-        self.__dict__["_real_os"] = os
-        # Expose os.path directly — it's entirely safe
+        # Expose os.path directly — it's entirely safe.
+        # NOTE: the real os module is NOT stored on the instance; see
+        # _REAL_OS_MODULE at module scope.
         self.__dict__["path"] = os.path
 
     def __getattr__(self, name: str) -> Any:
+        # Blocked attrs get an explicit, descriptive error.
         if name in self._BLOCKED_ATTRS:
             from .agent_errors import SecurityViolationError
             raise SecurityViolationError(
                 f"os.{name}() is blocked in the OmicVerse agent sandbox. "
                 f"This operation is not needed for bioinformatics analysis."
             )
-        real = self.__dict__.get("_real_os")
-        if real is not None:
-            return getattr(real, name)
-        return getattr(os, name)
+        # Only explicitly safe attrs are forwarded to the real os module.
+        if name in self._SAFE_ATTRS:
+            return getattr(_REAL_OS_MODULE, name)
+        raise AttributeError(
+            f"module 'os' has no attribute '{name}' in the OmicVerse agent sandbox"
+        )
+
+    def __dir__(self) -> List[str]:
+        return sorted(set(self._SAFE_ATTRS) | {"path"})
 
     def __repr__(self) -> str:
         return "<SafeOsProxy: restricted os module for OmicVerse agent>"

--- a/omicverse/utils/inspector/agent_context_injector.py
+++ b/omicverse/utils/inspector/agent_context_injector.py
@@ -17,11 +17,11 @@ Reference: https://blog.langchain.com/how-agents-can-use-filesystems-for-context
 from typing import Dict, List, Optional, Any, Set, TYPE_CHECKING
 from dataclasses import dataclass, field
 from datetime import datetime
-from anndata import AnnData
 
 from .inspector import DataStateInspector
 
 if TYPE_CHECKING:
+    from anndata import AnnData
     from ..filesystem_context import FilesystemContextManager
 
 
@@ -111,16 +111,19 @@ class AgentContextInjector:
 
     def __init__(
         self,
-        adata: AnnData,
-        registry: Any,
+        adata: Optional['AnnData'] = None,
+        registry: Any = None,
         filesystem_context: Optional['FilesystemContextManager'] = None,
         enable_filesystem_context: bool = True,
     ):
         """Initialize the context injector.
 
         Args:
-            adata: AnnData object to inspect and track.
-            registry: Function registry with prerequisite metadata.
+            adata: AnnData object to inspect and track.  Pass ``None`` (or
+                omit) to create a no-dataset injector suitable for pure
+                knowledge queries that do not require a live dataset.
+            registry: Function registry with prerequisite metadata.  May be
+                ``None`` when *adata* is also ``None``.
             filesystem_context: Optional FilesystemContextManager for persistent context.
                 If not provided and enable_filesystem_context is True, one will be created.
             enable_filesystem_context: Whether to enable filesystem-based context management.
@@ -128,7 +131,13 @@ class AgentContextInjector:
         """
         self.adata = adata
         self.registry = registry
-        self.inspector = DataStateInspector(adata, registry)
+
+        # Only create the data-state inspector when a dataset is available.
+        if adata is not None:
+            self.inspector: Optional[DataStateInspector] = DataStateInspector(adata, registry)
+        else:
+            self.inspector = None
+
         self.conversation_state = ConversationState()
 
         # Filesystem context management
@@ -142,9 +151,10 @@ class AgentContextInjector:
                 # Lazy initialization - create on first use
                 pass
 
-        # Take initial snapshot
-        initial_state = self._get_current_state()
-        self.conversation_state.snapshot_data_state(initial_state)
+        # Take initial snapshot only when a dataset is present.
+        if adata is not None:
+            initial_state = self._get_current_state()
+            self.conversation_state.snapshot_data_state(initial_state)
 
         # Store session ID if filesystem context is available
         if self._filesystem_context is not None:
@@ -237,12 +247,24 @@ class AgentContextInjector:
 
         return enhanced_prompt
 
+    @property
+    def has_dataset(self) -> bool:
+        """Return True when a live AnnData instance is available."""
+        return self.adata is not None
+
     def _build_general_state_section(self) -> str:
         """Build general data state section.
 
         Returns:
             Formatted section describing current data state.
         """
+        if not self.has_dataset:
+            return (
+                "## Data State\n\n"
+                "No dataset is currently loaded. "
+                "You are operating in knowledge-query mode."
+            )
+
         state = self._get_current_state()
         executed_funcs = self._detect_executed_functions()
 
@@ -300,6 +322,13 @@ class AgentContextInjector:
             Formatted section with function prerequisites and requirements.
         """
         lines = [f"## Target Function: {target_function}\n"]
+
+        if self.inspector is None:
+            lines.append(
+                "No dataset loaded — prerequisite validation is unavailable. "
+                "Load an AnnData object to enable prerequisite checking."
+            )
+            return "\n".join(lines)
 
         # Validate prerequisites
         result = self.inspector.validate_prerequisites(target_function)
@@ -394,8 +423,20 @@ REMEMBER: The user should be able to run your generated code WITHOUT errors!
         """Get current AnnData state.
 
         Returns:
-            Dictionary with current data structures.
+            Dictionary with current data structures, or an empty-state dict
+            when no dataset is loaded.
         """
+        if self.adata is None:
+            return {
+                'shape': (0, 0),
+                'obsm': [],
+                'obsp': [],
+                'uns': {},
+                'layers': [],
+                'obs_columns': [],
+                'var_columns': [],
+            }
+
         return {
             'shape': (self.adata.n_obs, self.adata.n_vars),
             'obsm': list(self.adata.obsm.keys()),
@@ -410,10 +451,14 @@ REMEMBER: The user should be able to run your generated code WITHOUT errors!
         """Detect which functions have been executed.
 
         Uses PrerequisiteChecker to detect executed functions with confidence scores.
+        Returns an empty dict when no dataset/inspector is available.
 
         Returns:
             Dict mapping function names to confidence scores.
         """
+        if self.inspector is None:
+            return {}
+
         # Get common function names to check
         common_functions = [
             'qc', 'preprocess', 'scale', 'pca',
@@ -436,7 +481,8 @@ REMEMBER: The user should be able to run your generated code WITHOUT errors!
         """Update state after a function has been executed.
 
         Call this after executing any OmicVerse function to keep the context
-        injector's state synchronized.
+        injector's state synchronized.  Works in no-dataset mode too — execution
+        history is tracked even without a live AnnData.
 
         Args:
             function_name: Name of the function that was just executed.
@@ -447,7 +493,7 @@ REMEMBER: The user should be able to run your generated code WITHOUT errors!
         """
         self.conversation_state.add_execution(function_name)
 
-        # Take new snapshot
+        # Take new snapshot (safe even without dataset — returns empty state)
         state = self._get_current_state()
         self.conversation_state.snapshot_data_state(state)
 
@@ -491,9 +537,10 @@ REMEMBER: The user should be able to run your generated code WITHOUT errors!
         """
         self.conversation_state = ConversationState()
 
-        # Take fresh snapshot
-        initial_state = self._get_current_state()
-        self.conversation_state.snapshot_data_state(initial_state)
+        # Take fresh snapshot only when a dataset is available.
+        if self.has_dataset:
+            initial_state = self._get_current_state()
+            self.conversation_state.snapshot_data_state(initial_state)
 
     # =========================================================================
     # Filesystem Context Methods
@@ -708,12 +755,13 @@ REMEMBER: The user should be able to run your generated code WITHOUT errors!
 
     def create_sub_agent_injector(
         self,
-        adata: Optional[AnnData] = None,
+        adata: Optional['AnnData'] = None,
     ) -> 'AgentContextInjector':
         """Create a context injector for a sub-agent that shares the workspace.
 
         Args:
-            adata: AnnData to use for the sub-agent. If None, uses the same adata.
+            adata: AnnData to use for the sub-agent.  If ``None``, inherits the
+                parent's adata (which itself may be ``None`` in no-dataset mode).
 
         Returns:
             New AgentContextInjector that shares the filesystem workspace.

--- a/omicverse/utils/ovagent/__init__.py
+++ b/omicverse/utils/ovagent/__init__.py
@@ -32,6 +32,7 @@ from .context_budget import (
 )
 from .subagent_controller import SubagentController, SubagentRuntime
 from .repair_loop import (
+    DEFAULT_LLM_TIMEOUT,
     DEFAULT_MAX_RETRIES,
     ExecutionRepairLoop,
     FailureEnvelope,
@@ -92,6 +93,7 @@ __all__ = [
     "ContextBudgetManager",
     "ContextService",
     "ConvergenceMonitor",
+    "DEFAULT_LLM_TIMEOUT",
     "DEFAULT_MAX_RETRIES",
     "ExecutionBatch",
     "ExecutionRepairLoop",

--- a/omicverse/utils/ovagent/__init__.py
+++ b/omicverse/utils/ovagent/__init__.py
@@ -58,6 +58,7 @@ from .event_stream import RuntimeEventEmitter
 from .turn_controller import TurnController, FollowUpGate
 from .turn_followup import ConvergenceMonitor
 from .session_context import SessionService, ContextService
+from .session_facade import SessionContextFacadeMixin
 from .registry_scanner import RegistryScanner
 from .auth import (
     ResolvedBackend,
@@ -109,6 +110,7 @@ __all__ = [
     "RepairResult",
     "ResolvedBackend",
     "RunStore",
+    "SessionContextFacadeMixin",
     "SessionService",
     "SubagentController",
     "SubagentRuntime",

--- a/omicverse/utils/ovagent/auth.py
+++ b/omicverse/utils/ovagent/auth.py
@@ -226,7 +226,22 @@ def collect_api_key_env(
 
 @contextmanager
 def temporary_api_keys(env_mapping: Dict[str, str]):
-    """Temporarily inject API keys into ``os.environ`` and clean up afterwards."""
+    """Temporarily inject API keys into ``os.environ`` and clean up afterwards.
+
+    **Environment-exposure tradeoff:** While the ``with`` block executes,
+    the API keys are visible in ``os.environ`` to any code running in the
+    same process — including spawned subprocesses that inherit the
+    environment.  This is an intentional trade-off: many provider SDKs
+    read credentials exclusively from environment variables, so injection
+    is the only way to authenticate without modifying those libraries.
+
+    The exposure window is strictly bounded by the ``with`` block.  The
+    ``finally`` clause unconditionally restores the previous environment
+    state (or removes the variable if it was not previously set), so keys
+    never persist beyond the caller's intent even if an exception
+    propagates.  Callers should keep the ``with`` block as short as
+    possible to minimize the exposure window.
+    """
     if not env_mapping:
         yield
         return

--- a/omicverse/utils/ovagent/auth.py
+++ b/omicverse/utils/ovagent/auth.py
@@ -4,6 +4,14 @@ Extracted from ``OmicVerseAgent.__init__`` so that auth and backend
 selection logic lives in one focused module.  All functions are
 side-effect-free except for ``temporary_api_keys`` which temporarily
 mutates ``os.environ``.
+
+The main entry point is :func:`resolve_credentials`, which dispatches to
+named resolver helpers for each auth flow:
+
+- :func:`_resolve_gemini_cli_oauth` — Gemini CLI OAuth token flow
+- :func:`_resolve_openai_oauth` — OpenAI Codex / ChatGPT OAuth flow
+- :func:`_resolve_saved_openai_key` — saved ``api_key`` from auth file
+- passthrough — explicit key or environment-based resolution
 """
 
 from __future__ import annotations
@@ -12,11 +20,127 @@ import logging
 import os
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import Dict, Optional
+from pathlib import Path
+from typing import Dict, Optional, Tuple, Union
 
 from ..model_config import ModelConfig, PROVIDER_API_KEYS
+from ...jarvis.config import load_auth
+from ...jarvis.gemini_cli_oauth import (
+    GOOGLE_CODE_ASSIST_ENDPOINT_PROD,
+    GeminiCliOAuthError,
+    GeminiCliOAuthManager,
+)
+from ...jarvis.openai_oauth import OPENAI_CODEX_BASE_URL, OpenAIOAuthManager
+from ..agent_backend_openai import (
+    _extract_openai_codex_account_id as _backend_extract_codex_account_id,
+)
 
 logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants (moved from smart_agent.py)
+# ---------------------------------------------------------------------------
+
+_LEGACY_OPENAI_CODEX_BASE_URL = "https://api.openai.com/v1"
+OPENAI_CODEX_DEFAULT_MODEL = "gpt-5.3-codex"
+_OPENAI_OAUTH_SUPPORTED_MODELS = {
+    "gpt-5.3-codex",
+    "gpt-5.3-codex-spark",
+    "gpt-5.2-codex",
+    "gpt-5.2",
+    "gpt-5.1",
+    "gpt-5.1-codex",
+    "gpt-5.1-codex-mini",
+    "gpt-5.1-codex-max",
+    "gpt-5.4",
+    "gpt-5.4-mini",
+}
+_OPENAI_EXPLICIT_OAUTH_MODELS = {
+    model_name
+    for model_name in _OPENAI_OAUTH_SUPPORTED_MODELS
+    if "codex" in model_name
+}
+
+
+# ---------------------------------------------------------------------------
+# Small helpers (moved from smart_agent.py)
+# ---------------------------------------------------------------------------
+
+def _normalize_auth_mode(auth_mode: Optional[str]) -> str:
+    if auth_mode == "openai_api_key":
+        return "saved_api_key"
+    if auth_mode == "openai_codex":
+        return "openai_oauth"
+    if auth_mode in {"google_oauth", "gemini_cli_oauth"}:
+        return str(auth_mode)
+    return str(auth_mode or "environment")
+
+
+def _is_openai_oauth_supported_model(model: str) -> bool:
+    return str(model or "").strip().lower() in {
+        name.lower() for name in _OPENAI_OAUTH_SUPPORTED_MODELS
+    }
+
+
+def _is_explicit_openai_oauth_model(model: str) -> bool:
+    return str(model or "").strip().lower() in {
+        name.lower() for name in _OPENAI_EXPLICIT_OAUTH_MODELS
+    }
+
+
+def _normalize_model_for_routing(model: str) -> str:
+    normalized = str(model or "").strip()
+    if not normalized:
+        return normalized
+    try:
+        return ModelConfig.normalize_model_id(normalized)
+    except (AttributeError, KeyError, ValueError, TypeError) as exc:
+        logger.debug("_normalize_model_for_routing fallback for %r: %s", normalized, exc)
+        return normalized
+
+
+def _is_custom_openai_endpoint(endpoint: Optional[str]) -> bool:
+    normalized = str(endpoint or "").strip().rstrip("/")
+    return bool(normalized) and normalized not in {
+        _LEGACY_OPENAI_CODEX_BASE_URL,
+        OPENAI_CODEX_BASE_URL,
+    }
+
+
+def _looks_like_openai_endpoint(endpoint: Optional[str]) -> bool:
+    normalized = str(endpoint or "").strip().rstrip("/").lower()
+    if not normalized:
+        return False
+    return (
+        normalized == _LEGACY_OPENAI_CODEX_BASE_URL
+        or normalized == OPENAI_CODEX_BASE_URL
+        or "api.openai.com" in normalized
+        or "chatgpt.com/backend-api" in normalized
+    )
+
+
+def _extract_openai_codex_account_id(token: Optional[str]) -> str:
+    try:
+        return _backend_extract_codex_account_id(str(token or ""))
+    except (ValueError, TypeError, KeyError, IndexError, AttributeError) as exc:
+        logger.debug("_extract_openai_codex_account_id fallback: %s", exc)
+        return ""
+
+
+def _resolve_saved_provider_api_key(
+    provider_name: str, auth_path: Optional[Path]
+) -> Optional[str]:
+    auth = load_auth(auth_path)
+    providers = dict(auth.get("providers") or {})
+
+    if provider_name == "openai":
+        top_level = str(auth.get("OPENAI_API_KEY") or "").strip()
+        if top_level:
+            return top_level
+
+    provider_auth = dict(providers.get(provider_name) or {})
+    api_key = str(provider_auth.get("api_key") or "").strip()
+    return api_key or None
 
 
 @dataclass
@@ -149,3 +273,173 @@ def display_backend_info(
     else:
         logger.warning("API key availability check did not pass for %s: %s", model, key_msg)
         print(f"   ⚠️  {key_msg}")
+
+
+# ---------------------------------------------------------------------------
+# Named credential resolver paths
+# ---------------------------------------------------------------------------
+
+# Type alias for the credential tuple contract used by the bootstrap path.
+CredentialTuple = Tuple[str, Optional[str], Optional[str], str]
+
+
+def _resolve_gemini_cli_oauth(
+    resolved_model: str,
+    resolved_endpoint: Optional[str],
+    auth_path: Optional[Path],
+) -> CredentialTuple:
+    """Resolve credentials via the Gemini CLI OAuth flow.
+
+    Returns ``(model, api_key, endpoint, "gemini_cli_oauth")``.
+    Raises ``ValueError`` on failure.
+    """
+    manager = GeminiCliOAuthManager(auth_path)
+    try:
+        payload = manager.build_api_key_payload(
+            refresh_if_needed=True,
+            import_if_missing=True,
+        )
+    except GeminiCliOAuthError as exc:
+        raise ValueError(
+            "Failed to load saved Gemini CLI OAuth credentials. "
+            "This is an unofficial integration; some users report account restrictions. "
+            "Use at your own risk."
+        ) from exc
+    if not payload:
+        raise ValueError(
+            "No saved Gemini CLI OAuth login found. Complete Gemini CLI OAuth first. "
+            "This is an unofficial integration; some users report account restrictions. "
+            "Use at your own risk."
+        )
+    if (
+        not resolved_endpoint
+        or _looks_like_openai_endpoint(resolved_endpoint)
+        or "generativelanguage.googleapis.com" in str(resolved_endpoint)
+    ):
+        resolved_endpoint = GOOGLE_CODE_ASSIST_ENDPOINT_PROD
+    return resolved_model, payload, resolved_endpoint, "gemini_cli_oauth"
+
+
+def _resolve_openai_oauth(
+    resolved_model: str,
+    resolved_api_key: Optional[str],
+    resolved_endpoint: Optional[str],
+    normalized_model: str,
+    api_key_source: Optional[str],
+    auth_path: Optional[Path],
+) -> CredentialTuple:
+    """Resolve credentials via the OpenAI Codex / ChatGPT OAuth flow.
+
+    Returns ``(model, api_key, endpoint, "openai_oauth")``.
+    Raises ``ValueError`` on failure.
+    """
+    preserve_model_id = _is_custom_openai_endpoint(resolved_endpoint)
+    if not resolved_endpoint or resolved_endpoint.rstrip("/") == _LEGACY_OPENAI_CODEX_BASE_URL:
+        resolved_endpoint = OPENAI_CODEX_BASE_URL
+        preserve_model_id = False
+    if _is_openai_oauth_supported_model(normalized_model):
+        if not preserve_model_id:
+            resolved_model = normalized_model
+    elif not preserve_model_id:
+        resolved_model = OPENAI_CODEX_DEFAULT_MODEL
+
+    if resolved_api_key:
+        if _extract_openai_codex_account_id(resolved_api_key):
+            return resolved_model, resolved_api_key, resolved_endpoint, "openai_oauth"
+        if api_key_source == "explicit":
+            raise ValueError(
+                "OpenAI Codex models require a ChatGPT OAuth access token with "
+                "chatgpt_account_id. Run `omicverse jarvis --codex-login` or "
+                "pass a valid OpenAI OAuth access token."
+            )
+        resolved_api_key = None
+
+    manager = OpenAIOAuthManager(auth_path)
+    resolved_api_key = manager.ensure_access_token_with_codex_fallback(
+        refresh_if_needed=True,
+        import_codex_if_missing=True,
+    )
+    if resolved_api_key and _extract_openai_codex_account_id(resolved_api_key):
+        return resolved_model, resolved_api_key, resolved_endpoint, "openai_oauth"
+    if resolved_api_key:
+        raise ValueError(
+            "Saved OpenAI Codex login is missing chatgpt_account_id. "
+            "Run `omicverse jarvis --codex-login` again."
+        )
+
+    raise ValueError(
+        "No saved OpenAI Codex login found. Run `omicverse jarvis --codex-login` "
+        "or pass a valid OpenAI OAuth access token."
+    )
+
+
+def _resolve_saved_openai_key(
+    auth_path: Optional[Path],
+) -> Optional[str]:
+    """Look up a previously saved OpenAI API key from the auth file."""
+    return _resolve_saved_provider_api_key("openai", auth_path)
+
+
+def resolve_credentials(
+    *,
+    model: str,
+    api_key: Optional[str],
+    endpoint: Optional[str],
+    auth_mode: Optional[str],
+    auth_provider: Optional[str],
+    auth_file: Optional[Union[str, Path]],
+) -> CredentialTuple:
+    """Resolve model/auth settings across all supported credential flows.
+
+    This is the main dispatcher that routes to the appropriate resolver
+    based on the detected provider and requested auth mode.
+
+    Returns a ``(model, api_key, endpoint, auth_mode)`` tuple that
+    matches the contract expected by the ``OmicVerseAgent`` bootstrap.
+    """
+    normalized_mode = _normalize_auth_mode(auth_mode)
+    resolved_model = model
+    normalized_model = _normalize_model_for_routing(model)
+    resolved_api_key = api_key
+    api_key_source = "explicit" if resolved_api_key else None
+    resolved_endpoint = endpoint
+    resolved_auth_path = Path(auth_file).expanduser() if auth_file else None
+    normalized_auth_provider = str(auth_provider or "").strip().lower() or "codex"
+
+    provider = ModelConfig.get_provider_from_model(
+        normalized_model or resolved_model, resolved_endpoint
+    )
+
+    # --- Gemini CLI OAuth path ---
+    wants_gemini_cli_oauth = provider == "google" and (
+        normalized_mode in {"google_oauth", "gemini_cli_oauth"}
+        or (normalized_mode == "openai_oauth" and normalized_auth_provider == "gemini_cli")
+    )
+    if wants_gemini_cli_oauth:
+        return _resolve_gemini_cli_oauth(resolved_model, resolved_endpoint, resolved_auth_path)
+
+    # --- OpenAI OAuth detection ---
+    wants_codex_oauth = provider == "openai" and (
+        normalized_mode == "openai_oauth"
+        or _is_explicit_openai_oauth_model(normalized_model)
+        or str(resolved_endpoint or "").rstrip("/") == OPENAI_CODEX_BASE_URL
+    )
+
+    # --- Saved OpenAI API key path ---
+    if provider == "openai" and normalized_mode == "saved_api_key" and not resolved_api_key:
+        resolved_api_key = _resolve_saved_openai_key(resolved_auth_path)
+        api_key_source = "saved_api_key" if resolved_api_key else None
+
+    # --- Passthrough (explicit key / environment) ---
+    if not wants_codex_oauth:
+        return resolved_model, resolved_api_key, resolved_endpoint, normalized_mode
+
+    # --- OpenAI Codex OAuth path ---
+    return _resolve_openai_oauth(
+        resolved_model,
+        resolved_api_key,
+        resolved_endpoint,
+        normalized_model,
+        api_key_source,
+        resolved_auth_path,
+    )

--- a/omicverse/utils/ovagent/auth.py
+++ b/omicverse/utils/ovagent/auth.py
@@ -22,6 +22,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, Optional, Tuple, Union
+from urllib.parse import urlparse
 
 from ..model_config import ModelConfig, PROVIDER_API_KEYS
 from ...jarvis.config import load_auth
@@ -107,15 +108,29 @@ def _is_custom_openai_endpoint(endpoint: Optional[str]) -> bool:
     }
 
 
+def _endpoint_has_hostname(url: Optional[str], expected_hostname: str) -> bool:
+    """Return True only when *url* has exactly *expected_hostname* as its parsed host."""
+    try:
+        parsed = urlparse(str(url or ""))
+        return (parsed.hostname or "").lower() == expected_hostname.lower()
+    except Exception:
+        return False
+
+
 def _looks_like_openai_endpoint(endpoint: Optional[str]) -> bool:
     normalized = str(endpoint or "").strip().rstrip("/").lower()
     if not normalized:
         return False
+    if normalized == _LEGACY_OPENAI_CODEX_BASE_URL or normalized == OPENAI_CODEX_BASE_URL:
+        return True
+    try:
+        parsed = urlparse(normalized)
+        host = (parsed.hostname or "").lower()
+    except Exception:
+        return False
     return (
-        normalized == _LEGACY_OPENAI_CODEX_BASE_URL
-        or normalized == OPENAI_CODEX_BASE_URL
-        or "api.openai.com" in normalized
-        or "chatgpt.com/backend-api" in normalized
+        host == "api.openai.com"
+        or (host == "chatgpt.com" and parsed.path.startswith("/backend-api"))
     )
 
 
@@ -329,7 +344,7 @@ def _resolve_gemini_cli_oauth(
     if (
         not resolved_endpoint
         or _looks_like_openai_endpoint(resolved_endpoint)
-        or "generativelanguage.googleapis.com" in str(resolved_endpoint)
+        or _endpoint_has_hostname(resolved_endpoint, "generativelanguage.googleapis.com")
     ):
         resolved_endpoint = GOOGLE_CODE_ASSIST_ENDPOINT_PROD
     return resolved_model, payload, resolved_endpoint, "gemini_cli_oauth"

--- a/omicverse/utils/ovagent/codegen_tool_facade.py
+++ b/omicverse/utils/ovagent/codegen_tool_facade.py
@@ -1,0 +1,397 @@
+"""Codegen / tool-dispatch / repair-loop facade mixin — extracted from OmicVerseAgent.
+
+Owns the thin delegation layer between the public ``OmicVerseAgent`` surface
+and the extracted subsystem classes:
+
+* **CodegenPipeline** — code extraction, review, reflection, code-only mode
+* **ToolRuntime**     — tool visibility, plan-mode gating, dispatch routing
+* **AnalysisExecutor** — code execution, error repair, package management
+* **RegistryScanner** — static AST registry search and scoring
+* **FollowUpGate**    — turn follow-up heuristics (tool-choice, promissory detection)
+
+The concrete agent class inherits this mixin so that the delegate methods
+appear on ``OmicVerseAgent`` without bloating its class body.
+
+The mixin relies on attributes set by the host ``__init__`` (e.g.
+``_tool_runtime``, ``_codegen_pipeline``, ``_analysis_executor``,
+``_registry_scanner``) and never stores new top-level attributes beyond
+the lazy-init properties it manages.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional
+
+if TYPE_CHECKING:
+    from ..agent_backend import Usage
+    from ..skill_registry import SkillMatch
+    from .codegen_pipeline import CodegenPipeline
+    from .registry_scanner import RegistryScanner
+    from .turn_controller import FollowUpGate
+
+logger = logging.getLogger(__name__)
+
+
+class CodegenToolDispatchFacadeMixin:
+    """Mixin providing codegen, tool-dispatch, and analysis-executor delegation.
+
+    Expects the host class to set the following attributes before any
+    delegate method is called:
+
+    * ``_tool_runtime`` — :class:`ToolRuntime` instance
+    * ``_codegen_pipeline`` — :class:`CodegenPipeline` instance
+    * ``_analysis_executor`` — :class:`AnalysisExecutor` instance
+    * ``_registry_scanner`` — :class:`RegistryScanner` instance
+    """
+
+    # ================================================================
+    # Lazy service constructors (for __new__-based instances in tests)
+    # ================================================================
+
+    @property
+    def _codegen(self) -> "CodegenPipeline":
+        """Lazily create CodegenPipeline for agents constructed via __new__."""
+        from .codegen_pipeline import CodegenPipeline as _CodegenPipeline
+
+        pipeline = getattr(self, "_codegen_pipeline", None)
+        if pipeline is None:
+            pipeline = _CodegenPipeline(self)
+            self._codegen_pipeline = pipeline  # type: ignore[attr-defined]
+        return pipeline
+
+    @property
+    def _scanner(self) -> "RegistryScanner":
+        """Lazily create RegistryScanner for agents constructed via __new__."""
+        from .registry_scanner import RegistryScanner as _RegistryScanner
+
+        scanner = getattr(self, "_registry_scanner", None)
+        if scanner is None:
+            scanner = _RegistryScanner()
+            self._registry_scanner = scanner  # type: ignore[attr-defined]
+        return scanner
+
+    # ================================================================
+    # Tool visibility delegates (ToolRuntime)
+    # ================================================================
+
+    def _get_visible_agent_tools(
+        self, *, allowed_names: Optional[set[str]] = None
+    ) -> list[dict[str, Any]]:
+        """Return the currently visible tool schemas."""
+        return self._tool_runtime.get_visible_agent_tools(  # type: ignore[attr-defined]
+            allowed_names=allowed_names
+        )
+
+    def _get_loaded_tool_names(self) -> list[str]:
+        """Return loaded tool names."""
+        return self._tool_runtime.get_loaded_tool_names()  # type: ignore[attr-defined]
+
+    def _tool_blocked_in_plan_mode(self, tool_name: str) -> bool:
+        """Check plan-mode blocking."""
+        return self._tool_runtime.tool_blocked_in_plan_mode(tool_name)  # type: ignore[attr-defined]
+
+    # ================================================================
+    # Tool dispatch delegate (ToolRuntime)
+    # ================================================================
+
+    async def _dispatch_tool(
+        self, tool_call: Any, current_adata: Any, request: str
+    ) -> Any:
+        return await self._tool_runtime.dispatch_tool(  # type: ignore[attr-defined]
+            tool_call, current_adata, request
+        )
+
+    # ================================================================
+    # FollowUp gate delegates (TurnController / FollowUpGate)
+    # ================================================================
+
+    def _request_requires_tool_action(self, request: str, adata: Any) -> bool:
+        from .turn_controller import FollowUpGate as _FollowUpGate
+
+        return _FollowUpGate.request_requires_tool_action(request, adata)
+
+    def _response_is_promissory(self, content: str) -> bool:
+        from .turn_controller import FollowUpGate as _FollowUpGate
+
+        return _FollowUpGate.response_is_promissory(content)
+
+    def _select_agent_tool_choice(
+        self,
+        *,
+        request: str,
+        adata: Any,
+        turn_index: int,
+        had_meaningful_tool_call: bool,
+        forced_retry: bool,
+    ) -> str:
+        from .turn_controller import FollowUpGate as _FollowUpGate
+
+        return _FollowUpGate.select_tool_choice(
+            request=request,
+            adata=adata,
+            turn_index=turn_index,
+            had_meaningful_tool_call=had_meaningful_tool_call,
+            forced_retry=forced_retry,
+        )
+
+    # ================================================================
+    # Registry scanner delegates
+    # ================================================================
+
+    def _load_static_registry_entries(self) -> List[Dict[str, Any]]:
+        """Parse @register_function metadata plus nested method/branch capabilities."""
+        return self._scanner.load_static_entries()
+
+    def _collect_relevant_registry_entries(
+        self, request: str, max_entries: int = 8
+    ) -> List[Dict[str, Any]]:
+        """Return a compact set of registry entries relevant to a free-form request."""
+        return self._scanner.collect_relevant_entries(request, max_entries)
+
+    def _collect_static_registry_entries(
+        self, request: str, max_entries: int = 8
+    ) -> List[Dict[str, Any]]:
+        """Search the static AST-derived registry snapshot."""
+        return self._scanner.collect_static_entries(request, max_entries)
+
+    def _score_registry_entry_for_codegen(
+        self, request: str, entry: Dict[str, Any]
+    ) -> float:
+        """Score a registry entry for lightweight code generation retrieval."""
+        from .registry_scanner import RegistryScanner as _RegistryScanner
+
+        return _RegistryScanner.score_entry(request, entry)
+
+    # ================================================================
+    # Codegen pipeline delegates
+    # ================================================================
+
+    def _extract_python_code(self, response_text: str) -> str:
+        """Extract executable Python code from the agent response using AST validation."""
+        return self._codegen.extract_python_code(response_text)
+
+    def _normalize_registry_entry_for_codegen(
+        self, entry: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """Convert registry entries to public-facing ov.* names for code generation."""
+        from .registry_scanner import RegistryScanner as _RegistryScanner
+
+        return _RegistryScanner.normalize_entry(entry)
+
+    def _capture_code_only_snippet(
+        self, code: str, description: str = ""
+    ) -> None:
+        """Store the latest code snippet captured from execute_code in code-only mode."""
+        self._codegen.capture_code_only_snippet(code, description)
+
+    def _select_codegen_skill_matches(
+        self, request: str, top_k: int = 2
+    ) -> List["SkillMatch"]:
+        return self._codegen.select_codegen_skill_matches(request, top_k)
+
+    def _format_registry_context_for_codegen(
+        self, entries: List[Dict[str, Any]]
+    ) -> str:
+        return self._codegen.format_registry_context_for_codegen(entries)
+
+    @staticmethod
+    def _format_prerequisites_for_codegen_entry(
+        entry: Dict[str, Any],
+    ) -> str:
+        from .codegen_pipeline import CodegenPipeline as _CodegenPipeline
+
+        return _CodegenPipeline.format_prerequisites_for_codegen_entry(entry)
+
+    def _build_code_generation_system_prompt(self, adata: Any) -> str:
+        return self._codegen.build_code_generation_system_prompt(adata)
+
+    @staticmethod
+    def _build_code_generation_user_prompt(request: str, adata: Any) -> str:
+        from .codegen_pipeline import CodegenPipeline as _CodegenPipeline
+
+        return _CodegenPipeline.build_code_generation_user_prompt(request, adata)
+
+    @staticmethod
+    def _contains_forbidden_scanpy_usage(code: str) -> bool:
+        from .codegen_pipeline import CodegenPipeline as _CodegenPipeline
+
+        return _CodegenPipeline.contains_forbidden_scanpy_usage(code)
+
+    def _rewrite_scanpy_calls_with_registry(
+        self, code: str, entries: List[Dict[str, Any]]
+    ) -> str:
+        return self._codegen.rewrite_scanpy_calls_with_registry(code, entries)
+
+    async def _rewrite_code_without_scanpy(
+        self,
+        code: str,
+        request: str,
+        adata: Any,
+        registry_context: str = "",
+        skill_guidance: str = "",
+    ) -> tuple:
+        return await self._codegen.rewrite_code_without_scanpy(
+            code, request, adata, registry_context, skill_guidance
+        )
+
+    async def _review_generated_code_lightweight(
+        self, code: str, request: str, adata: Any
+    ) -> tuple:
+        return await self._codegen.review_generated_code_lightweight(
+            code, request, adata
+        )
+
+    @staticmethod
+    def _build_code_only_agentic_request(request: str, adata: Any) -> str:
+        from .codegen_pipeline import CodegenPipeline as _CodegenPipeline
+
+        return _CodegenPipeline.build_code_only_agentic_request(request, adata)
+
+    async def _generate_code_via_agentic_loop(
+        self,
+        request: str,
+        adata: Any,
+        *,
+        progress_callback: Optional[Callable[[str], None]] = None,
+    ) -> str:
+        return await self._codegen.generate_code_via_agentic_loop(
+            request, adata, progress_callback=progress_callback
+        )
+
+    def _gather_code_candidates(self, response_text: str) -> List[str]:
+        return self._codegen.gather_code_candidates(response_text)
+
+    @staticmethod
+    def _looks_like_python(code: str) -> bool:
+        from .codegen_pipeline import CodegenPipeline as _CodegenPipeline
+
+        return _CodegenPipeline.looks_like_python(code)
+
+    @staticmethod
+    def _extract_inline_python(response_text: str) -> str:
+        from .codegen_pipeline import CodegenPipeline as _CodegenPipeline
+
+        return _CodegenPipeline.extract_inline_python(response_text)
+
+    @staticmethod
+    def _normalize_code_candidate(code: str) -> str:
+        from .codegen_pipeline import CodegenPipeline as _CodegenPipeline
+
+        return _CodegenPipeline.normalize_code_candidate(code)
+
+    def _extract_python_code_strict(self, response_text: str) -> str:
+        return self._codegen.extract_python_code_strict(response_text)
+
+    async def _review_result(
+        self,
+        original_adata: Any,
+        result_adata: Any,
+        request: str,
+        code: str,
+    ) -> Dict[str, Any]:
+        return await self._codegen.review_result(
+            original_adata, result_adata, request, code
+        )
+
+    async def _reflect_on_code(
+        self,
+        code: str,
+        request: str,
+        adata: Any,
+        iteration: int = 1,
+    ) -> Dict[str, Any]:
+        return await self._codegen.reflect_on_code(
+            code, request, adata, iteration
+        )
+
+    def _detect_direct_python_request(self, request: str) -> Optional[str]:
+        return self._codegen.detect_direct_python_request(request)
+
+    @staticmethod
+    def _merge_usage_stats(usages: List[Optional["Usage"]]) -> Optional["Usage"]:
+        """Merge usage records from multiple lightweight codegen calls."""
+        from ..agent_backend import Usage
+
+        valid = [usage for usage in usages if usage is not None]
+        if not valid:
+            return None
+        return Usage(
+            input_tokens=sum(max(0, usage.input_tokens) for usage in valid),
+            output_tokens=sum(max(0, usage.output_tokens) for usage in valid),
+            total_tokens=sum(max(0, usage.total_tokens) for usage in valid),
+            model=valid[-1].model,
+            provider=valid[-1].provider,
+        )
+
+    # ================================================================
+    # Analysis executor delegates (includes repair-loop adjacent)
+    # ================================================================
+
+    def _check_code_prerequisites(self, code: str, adata: Any) -> str:
+        return self._analysis_executor.check_code_prerequisites(code, adata)  # type: ignore[attr-defined]
+
+    def _apply_execution_error_fix(
+        self, code: str, error_msg: str
+    ) -> Optional[str]:
+        return self._analysis_executor.apply_execution_error_fix(code, error_msg)  # type: ignore[attr-defined]
+
+    @staticmethod
+    def _extract_package_name(error_msg: str) -> Optional[str]:
+        from .analysis_executor import AnalysisExecutor as _AnalysisExecutor
+
+        return _AnalysisExecutor.extract_package_name(error_msg)
+
+    def _auto_install_package(self, package_name: str) -> bool:
+        return self._analysis_executor.auto_install_package(package_name)  # type: ignore[attr-defined]
+
+    async def _diagnose_error_with_llm(
+        self,
+        code: str,
+        error_msg: str,
+        traceback_str: str,
+        adata: Any,
+    ) -> Optional[str]:
+        return await self._analysis_executor.diagnose_error_with_llm(  # type: ignore[attr-defined]
+            code, error_msg, traceback_str, adata
+        )
+
+    def _validate_outputs(
+        self, code: str, output_dir: Optional[str] = None
+    ) -> List[str]:
+        return self._analysis_executor.validate_outputs(code, output_dir)  # type: ignore[attr-defined]
+
+    async def _generate_completion_code(
+        self,
+        original_code: str,
+        missing_files: List[str],
+        adata: Any,
+        request: str,
+    ) -> Optional[str]:
+        return await self._analysis_executor.generate_completion_code(  # type: ignore[attr-defined]
+            original_code, missing_files, adata, request
+        )
+
+    def _request_approval(self, code: str, violations: list) -> bool:
+        return self._analysis_executor.request_approval(code, violations)  # type: ignore[attr-defined]
+
+    def _execute_generated_code(
+        self, code: str, adata: Any, capture_stdout: bool = False
+    ) -> Any:
+        return self._analysis_executor.execute_generated_code(  # type: ignore[attr-defined]
+            code, adata, capture_stdout
+        )
+
+    @staticmethod
+    def _normalize_doublet_obs(adata: Any) -> None:
+        from .analysis_executor import AnalysisExecutor as _AnalysisExecutor
+
+        _AnalysisExecutor.normalize_doublet_obs(adata)
+
+    def _process_context_directives(
+        self, code: str, local_vars: Dict[str, Any]
+    ) -> None:
+        self._analysis_executor.process_context_directives(code, local_vars)  # type: ignore[attr-defined]
+
+    def _build_sandbox_globals(self) -> Dict[str, Any]:
+        return self._analysis_executor.build_sandbox_globals()  # type: ignore[attr-defined]

--- a/omicverse/utils/ovagent/repair_loop.py
+++ b/omicverse/utils/ovagent/repair_loop.py
@@ -24,10 +24,11 @@ carries:
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import traceback as _traceback_mod
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple
 
 if TYPE_CHECKING:
     from .analysis_executor import AnalysisExecutor
@@ -215,23 +216,26 @@ def build_llm_repair_prompt(envelope: FailureEnvelope) -> str:
 # ExecutionRepairLoop
 # ---------------------------------------------------------------------------
 
-# Default maximum number of repair attempts before giving up.
+# Default maximum number of execution attempts (including the initial run).
 DEFAULT_MAX_RETRIES = 3
+
+# Default timeout in seconds for a single LLM-guided repair call.
+DEFAULT_LLM_TIMEOUT: float = 30.0
 
 
 class ExecutionRepairLoop:
     """Bounded self-healing loop for code execution failures.
 
-    The loop runs up to *max_retries* repair attempts using this strategy
-    order:
+    The loop runs up to *max_retries* total execution attempts using this
+    strategy order:
 
     1. **Guardrail pass** — ``AnalysisExecutor.apply_execution_error_fix``
        applies fast regex-based transforms.  If the guardrail produces
        different code, re-execute immediately.  This is an *optional* early
        stage; if it does not match, the loop falls through.
     2. **LLM diagnosis** — build a structured :class:`FailureEnvelope`,
-       call the LLM with a consistent diagnostic prompt, extract repaired
-       code, and re-execute.
+       call the LLM (bounded by *llm_timeout*) with a consistent diagnostic
+       prompt, extract repaired code, and re-execute.
     3. If all attempts are exhausted, return the final
        :class:`FailureEnvelope` to the caller.
 
@@ -241,7 +245,13 @@ class ExecutionRepairLoop:
         Provides ``apply_execution_error_fix``, ``diagnose_error_with_llm``,
         and ``execute_generated_code``.
     max_retries : int
-        Upper bound on repair attempts (default 3).
+        Maximum number of execution attempts including the initial run
+        (default 3).  For example ``max_retries=3`` means one initial try
+        plus up to two repair-then-retry cycles.
+    llm_timeout : float or None
+        Timeout in seconds for a single LLM-guided repair call (default 30).
+        When the timeout is exceeded the attempt is recorded as a timeout
+        rather than an exhaustion.  Pass *None* to disable the timeout.
     """
 
     def __init__(
@@ -249,13 +259,19 @@ class ExecutionRepairLoop:
         executor: "AnalysisExecutor",
         *,
         max_retries: int = DEFAULT_MAX_RETRIES,
+        llm_timeout: Optional[float] = DEFAULT_LLM_TIMEOUT,
     ) -> None:
         self._executor = executor
-        self._max_retries = max_retries
+        self._max_retries = max(max_retries, 1)
+        self._llm_timeout = llm_timeout
 
     @property
     def max_retries(self) -> int:
         return self._max_retries
+
+    @property
+    def llm_timeout(self) -> Optional[float]:
+        return self._llm_timeout
 
     async def run(
         self,
@@ -306,7 +322,7 @@ class ExecutionRepairLoop:
         current_strategy = "passthrough"
         dataset_ctx = build_dataset_context(adata)
 
-        for attempt_num in range(self._max_retries + 1):
+        for attempt_num in range(self._max_retries):
             # --- Execute current code ---
             try:
                 result = exec_fn(current_code, adata)
@@ -331,8 +347,8 @@ class ExecutionRepairLoop:
                     dataset_context=dataset_ctx,
                 )
 
-                # Exhausted all retries?
-                if attempt_num >= self._max_retries:
+                # Exhausted all attempts?
+                if attempt_num >= self._max_retries - 1:
                     attempts.append(RepairAttempt(
                         attempt=attempt_num,
                         strategy="exhausted",
@@ -340,6 +356,11 @@ class ExecutionRepairLoop:
                         success=False,
                         envelope=envelope,
                     ))
+                    logger.info(
+                        "repair_loop exhausted after %d attempt(s) phase=%s",
+                        self._max_retries,
+                        phase,
+                    )
                     return RepairResult(
                         success=False,
                         final_code=current_code,
@@ -375,9 +396,13 @@ class ExecutionRepairLoop:
                     continue
 
                 # --- Stage 2: LLM-guided repair ---
-                llm_code = await self._try_llm_repair(
+                llm_code, timed_out = await self._try_llm_repair(
                     envelope, extract_code_fn
                 )
+                if timed_out:
+                    envelope.repair_hints.append(
+                        f"llm: diagnosis timed out after {self._llm_timeout}s"
+                    )
                 if llm_code and llm_code.strip() and llm_code != current_code:
                     envelope.repair_hints.append(
                         "llm: diagnosis produced replacement code"
@@ -424,22 +449,35 @@ class ExecutionRepairLoop:
         self,
         envelope: FailureEnvelope,
         extract_code_fn: Optional[Callable[[str], str]],
-    ) -> Optional[str]:
-        """Attempt LLM-guided repair and return extracted code or None."""
+    ) -> Tuple[Optional[str], bool]:
+        """Attempt LLM-guided repair and return ``(code_or_none, timed_out)``.
+
+        The second element is ``True`` when the call was aborted by the
+        configured *llm_timeout*, allowing callers to distinguish a timeout
+        from other LLM failures.
+        """
         try:
-            diagnosed = await self._executor.diagnose_error_with_llm(
-                envelope.code,
-                envelope.summary,
-                envelope.traceback_excerpt,
-                None,  # adata not passed to LLM diagnosis — context is in envelope
+            diagnosed = await asyncio.wait_for(
+                self._executor.diagnose_error_with_llm(
+                    envelope.code,
+                    envelope.summary,
+                    envelope.traceback_excerpt,
+                    None,  # adata not passed to LLM diagnosis — context is in envelope
+                ),
+                timeout=self._llm_timeout,
             )
             if diagnosed and extract_code_fn is not None:
                 try:
-                    return extract_code_fn(diagnosed)
+                    return extract_code_fn(diagnosed), False
                 except Exception as exc:
                     logger.warning("extract_code_fn failed: %s", exc)
-                    return diagnosed
-            return diagnosed
+                    return diagnosed, False
+            return diagnosed, False
+        except asyncio.TimeoutError:
+            logger.warning(
+                "LLM repair timed out after %.1fs", self._llm_timeout,
+            )
+            return None, True
         except Exception as exc:
             logger.debug("LLM repair failed: %s", exc)
-            return None
+            return None, False

--- a/omicverse/utils/ovagent/repair_loop.py
+++ b/omicverse/utils/ovagent/repair_loop.py
@@ -157,8 +157,8 @@ def build_dataset_context(adata: Any) -> str:
     if hasattr(adata, "obsm") and hasattr(adata.obsm, "keys"):
         try:
             parts.append(f"obsm keys: {list(adata.obsm.keys())[:10]}")
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.debug("Failed to list obsm keys for dataset context: %s", exc)
     return "; ".join(parts) if parts else ""
 
 

--- a/omicverse/utils/ovagent/session_facade.py
+++ b/omicverse/utils/ovagent/session_facade.py
@@ -14,6 +14,7 @@ manages.
 from __future__ import annotations
 
 import logging
+import threading
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
@@ -79,24 +80,45 @@ class SessionContextFacadeMixin:
     # Lazy service constructors (for __new__-based instances)
     # ----------------------------------------------------------------
 
-    def _get_session_service(self) -> "SessionService":
-        """Lazily construct SessionService for legacy __new__-based instances."""
-        service = getattr(self, "_session_service", None)
-        if service is None:
-            from .session_context import SessionService
+    # Class-level lock for thread-safe lazy service initialization.
+    # Double-checked locking ensures at most one service instance is
+    # created even when multiple threads race on first access.
+    _service_init_lock = threading.Lock()
 
-            service = SessionService(self)
-            self._session_service = service
+    def _get_session_service(self) -> "SessionService":
+        """Lazily construct SessionService for legacy __new__-based instances.
+
+        Thread-safe: uses double-checked locking so concurrent callers
+        never create duplicate service instances.
+        """
+        service = getattr(self, "_session_service", None)
+        if service is not None:
+            return service
+        with self._service_init_lock:
+            service = getattr(self, "_session_service", None)
+            if service is None:
+                from .session_context import SessionService
+
+                service = SessionService(self)
+                self._session_service = service
         return service
 
     def _get_context_service(self) -> "ContextService":
-        """Lazily construct ContextService for legacy __new__-based instances."""
-        service = getattr(self, "_context_service", None)
-        if service is None:
-            from .session_context import ContextService
+        """Lazily construct ContextService for legacy __new__-based instances.
 
-            service = ContextService(self)
-            self._context_service = service
+        Thread-safe: uses double-checked locking so concurrent callers
+        never create duplicate service instances.
+        """
+        service = getattr(self, "_context_service", None)
+        if service is not None:
+            return service
+        with self._service_init_lock:
+            service = getattr(self, "_context_service", None)
+            if service is None:
+                from .session_context import ContextService
+
+                service = ContextService(self)
+                self._context_service = service
         return service
 
     # ----------------------------------------------------------------

--- a/omicverse/utils/ovagent/session_facade.py
+++ b/omicverse/utils/ovagent/session_facade.py
@@ -1,0 +1,197 @@
+"""Session/context facade mixin — extracted from OmicVerseAgent.
+
+Owns lazy-service construction, session-ID delegation, tracing/runtime
+bootstrap, and the public session/context API surface.  The concrete
+agent class inherits this mixin so that the methods appear on
+``OmicVerseAgent`` without bloating its class body.
+
+The mixin relies on attributes set by the host ``__init__`` (e.g.
+``_config``, ``_llm``, ``model``, ``enable_filesystem_context``) and
+never stores new top-level attributes beyond the service delegates it
+manages.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+
+if TYPE_CHECKING:
+    from ..filesystem_context import FilesystemContextManager
+    from .session_context import ContextService, SessionService
+
+logger = logging.getLogger(__name__)
+
+
+class SessionContextFacadeMixin:
+    """Mixin providing session, context, tracing, and service-wiring delegation.
+
+    Expects the host class to set the following attributes before calling
+    the bootstrap helpers:
+
+    * ``_config``, ``_llm``, ``model``
+    * ``_filesystem_context``, ``enable_filesystem_context``
+    * ``use_notebook_execution``, ``max_prompts_per_session``
+    * ``_notebook_executor``
+    """
+
+    # ----------------------------------------------------------------
+    # Bootstrap: session, context, tracing, and runtime initialization
+    # ----------------------------------------------------------------
+
+    def _initialize_session_context_tracing(
+        self,
+        *,
+        ctx_storage_dir: Optional[Path] = None,
+    ) -> None:
+        """Bootstrap filesystem context, session history, tracing, and OV runtime.
+
+        Called once from ``__init__`` after the LLM backend is created.
+        """
+        from .bootstrap import (
+            initialize_filesystem_context,
+            initialize_ov_runtime,
+            initialize_session_history,
+            initialize_tracing,
+        )
+
+        self.enable_filesystem_context, self._filesystem_context = (
+            initialize_filesystem_context(
+                enabled=self.enable_filesystem_context,
+                storage_dir=ctx_storage_dir,
+            )
+        )
+        self._session_history = initialize_session_history(self._config)
+        self._trace_store, self._context_compactor = initialize_tracing(
+            self._config, self._llm, self.model,
+        )
+        self._ov_runtime = initialize_ov_runtime(self._detect_repo_root())
+
+    def _wire_session_context_services(self) -> None:
+        """Construct SessionService and ContextService delegates."""
+        from .session_context import ContextService, SessionService
+
+        self._session_service = SessionService(self)
+        self._context_service = ContextService(self)
+
+    # ----------------------------------------------------------------
+    # Lazy service constructors (for __new__-based instances)
+    # ----------------------------------------------------------------
+
+    def _get_session_service(self) -> "SessionService":
+        """Lazily construct SessionService for legacy __new__-based instances."""
+        service = getattr(self, "_session_service", None)
+        if service is None:
+            from .session_context import SessionService
+
+            service = SessionService(self)
+            self._session_service = service
+        return service
+
+    def _get_context_service(self) -> "ContextService":
+        """Lazily construct ContextService for legacy __new__-based instances."""
+        service = getattr(self, "_context_service", None)
+        if service is None:
+            from .session_context import ContextService
+
+            service = ContextService(self)
+            self._context_service = service
+        return service
+
+    # ----------------------------------------------------------------
+    # Session ID delegation (used by ovagent modules via AgentContext)
+    # ----------------------------------------------------------------
+
+    def _get_harness_session_id(self) -> str:
+        """Best-effort session identifier for harness traces/history."""
+        return self._get_session_service().get_harness_session_id()
+
+    def _get_runtime_session_id(self) -> str:
+        """Return the session key used by the harness runtime registry."""
+        return self._get_session_service().get_runtime_session_id()
+
+    def _refresh_runtime_working_directory(self) -> str:
+        """Keep runtime cwd aligned with the active worktree / filesystem context."""
+        return self._get_session_service().refresh_runtime_working_directory()
+
+    # ----------------------------------------------------------------
+    # Runtime helpers
+    # ----------------------------------------------------------------
+
+    def _detect_repo_root(self, cwd: Optional[Path] = None) -> Optional[Path]:
+        """Walk up from *cwd* (or runtime working dir) to find a .git root."""
+        current = (cwd or Path(self._refresh_runtime_working_directory())).resolve()
+        for candidate in (current, *current.parents):
+            if (candidate / ".git").exists():
+                return candidate
+        return None
+
+    # ----------------------------------------------------------------
+    # Public Session Management API
+    # ----------------------------------------------------------------
+
+    def get_current_session_info(self) -> Optional[Dict[str, Any]]:
+        """Get information about current notebook session."""
+        return self._get_session_service().get_current_session_info()
+
+    def restart_session(self):
+        """Manually restart notebook session (clear memory, start fresh)."""
+        self._get_session_service().restart_session()
+
+    def get_session_history(self) -> List[Dict[str, Any]]:
+        """Get history of all archived notebook sessions."""
+        return self._get_session_service().get_session_history()
+
+    # ----------------------------------------------------------------
+    # Public Filesystem Context Management API
+    # ----------------------------------------------------------------
+
+    @property
+    def filesystem_context(self) -> Optional["FilesystemContextManager"]:
+        """Get the filesystem context manager."""
+        return self._get_context_service().filesystem_context
+
+    def write_note(
+        self,
+        key: str,
+        content: Union[str, Dict[str, Any]],
+        category: str = "notes",
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Optional[str]:
+        """Write a note to the filesystem context workspace."""
+        return self._get_context_service().write_note(key, content, category, metadata)
+
+    def search_context(
+        self,
+        pattern: str,
+        match_type: str = "glob",
+        max_results: int = 10,
+    ) -> List[Dict[str, Any]]:
+        """Search the filesystem context for relevant notes."""
+        return self._get_context_service().search_context(pattern, match_type, max_results)
+
+    def get_relevant_context(self, query: str, max_tokens: int = 1000) -> str:
+        """Get context relevant to a query."""
+        return self._get_context_service().get_relevant_context(query, max_tokens)
+
+    def save_plan(self, steps: List[Dict[str, Any]]) -> Optional[str]:
+        """Save an execution plan."""
+        return self._get_context_service().save_plan(steps)
+
+    def update_plan_step(
+        self,
+        step_index: int,
+        status: str,
+        result: Optional[str] = None,
+    ) -> None:
+        """Update the status of a plan step."""
+        self._get_context_service().update_plan_step(step_index, status, result)
+
+    def get_workspace_summary(self) -> str:
+        """Get a summary of the filesystem context workspace."""
+        return self._get_context_service().get_workspace_summary()
+
+    def get_context_stats(self) -> Dict[str, Any]:
+        """Get statistics about the filesystem context workspace."""
+        return self._get_context_service().get_context_stats()

--- a/omicverse/utils/ovagent/subagent_controller.py
+++ b/omicverse/utils/ovagent/subagent_controller.py
@@ -192,9 +192,7 @@ class SubagentController:
         dict
             ``{"result": str, "adata": AnnData, "last_usage": Any}``
         """
-        from ..agent_config import SUBAGENT_CONFIGS
-
-        config = SUBAGENT_CONFIGS[agent_type]
+        config = self._ctx._config.get_subagent_config(agent_type)
 
         # Create isolated runtime
         runtime = self._create_subagent_runtime(

--- a/omicverse/utils/ovagent/tool_runtime.py
+++ b/omicverse/utils/ovagent/tool_runtime.py
@@ -79,7 +79,7 @@ LEGACY_AGENT_TOOLS: list[dict[str, Any]] = [
     },
     {
         "name": "search_functions",
-        "description": "Search the OmicVerse function registry.",
+        "description": "Search the OmicVerse function registry by keyword. Returns signatures, parameters, prerequisites, and usage examples. Always call this before generating code to get exact API details.",
         "parameters": {
             "type": "object",
             "properties": {"query": {"type": "string"}},

--- a/omicverse/utils/ovagent/tool_runtime_exec.py
+++ b/omicverse/utils/ovagent/tool_runtime_exec.py
@@ -85,8 +85,8 @@ def handle_inspect_data(adata: Any, aspect: str) -> str:
                 parts.append(
                     f"obs.head(3):\n{adata.obs.head(3).to_string()}"
                 )
-            except Exception:
-                pass
+            except Exception as exc:
+                logger.debug("Failed to format obs.head(3): %s", exc)
         if aspect in ("var", "full") and not is_mudata:
             cols = list(adata.var.columns)
             parts.append(f"var columns ({len(cols)}): {cols}")
@@ -94,8 +94,8 @@ def handle_inspect_data(adata: Any, aspect: str) -> str:
                 parts.append(
                     f"var.head(3):\n{adata.var.head(3).to_string()}"
                 )
-            except Exception:
-                pass
+            except Exception as exc:
+                logger.debug("Failed to format var.head(3): %s", exc)
         if aspect in ("obsm", "full"):
             keys = (
                 list(adata.obsm.keys()) if hasattr(adata, "obsm") else []
@@ -104,8 +104,8 @@ def handle_inspect_data(adata: Any, aspect: str) -> str:
             for k in keys:
                 try:
                     parts.append(f"  {k}: shape {adata.obsm[k].shape}")
-                except Exception:
-                    pass
+                except Exception as exc:
+                    logger.debug("Failed to get shape for obsm[%s]: %s", k, exc)
         if aspect in ("uns", "full"):
             keys = (
                 list(adata.uns.keys()) if hasattr(adata, "uns") else []

--- a/omicverse/utils/ovagent/tool_runtime_exec.py
+++ b/omicverse/utils/ovagent/tool_runtime_exec.py
@@ -66,9 +66,9 @@ def _validate_bash_cwd(ctx: "AgentContext", cwd: str) -> str:
     resolved = os.path.realpath(cwd)
     roots = _resolve_bash_allowed_roots(ctx)
     if not roots:
-        # No roots determinable — degrade to allowing (avoid blocking
-        # legitimate use when filesystem context is absent).
-        return resolved
+        raise ValueError(
+            "Bash cwd rejected: no allowed workspace roots could be determined"
+        )
     for root in roots:
         if resolved == root or resolved.startswith(root + os.sep):
             return resolved
@@ -233,13 +233,33 @@ def handle_execute_code(
         loop = None
 
     if loop and loop.is_running():
+        # Bridge sync caller into async repair loop without blocking on
+        # executor context-manager shutdown.  A plain ThreadPoolExecutor
+        # context manager calls shutdown(wait=True) on __exit__, which
+        # would wait for the worker even after a Future.result() timeout.
+        # Instead we create the pool without a context manager, use a
+        # bounded Future.result(timeout=...) call, and then call
+        # shutdown(wait=False) so the caller always returns/raises
+        # promptly.
         import concurrent.futures
-        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
-            repair_result = pool.submit(
-                _asyncio.run,
-                repair_loop.run(code, adata, phase="execution",
-                               extract_code_fn=extract_code_fn),
-            ).result()
+
+        _BRIDGE_TIMEOUT = 300  # seconds — generous but finite
+        pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+        future = pool.submit(
+            _asyncio.run,
+            repair_loop.run(code, adata, phase="execution",
+                           extract_code_fn=extract_code_fn),
+        )
+        try:
+            repair_result = future.result(timeout=_BRIDGE_TIMEOUT)
+        except concurrent.futures.TimeoutError:
+            future.cancel()
+            pool.shutdown(wait=False)
+            raise RuntimeError(
+                f"execute_code sync bridge timed out after {_BRIDGE_TIMEOUT}s"
+            )
+        else:
+            pool.shutdown(wait=False)
     else:
         repair_result = _asyncio.run(
             repair_loop.run(code, adata, phase="execution",
@@ -513,7 +533,10 @@ def background_bash_worker(
         start_new_session=True,
     )
     runtime_state.attach_background_process(session_id, task_id, proc)
-    assert proc.stdout is not None
+    if proc.stdout is None:
+        raise RuntimeError(
+            "background_bash_worker: stdout pipe was not created"
+        )
     deadline = time.monotonic() + timeout_ms / 1000
     for line in proc.stdout:
         runtime_state.append_task_output(

--- a/omicverse/utils/ovagent/tool_runtime_exec.py
+++ b/omicverse/utils/ovagent/tool_runtime_exec.py
@@ -12,8 +12,11 @@ import asyncio
 import json
 import logging
 import os
+import signal
 import subprocess
+import tempfile
 import time
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional
 
 from ..harness.runtime_state import runtime_state
@@ -25,6 +28,70 @@ if TYPE_CHECKING:
     from .protocol import AgentContext
 
 logger = logging.getLogger(__name__)
+
+
+# ------------------------------------------------------------------
+# Bash hardening helpers
+# ------------------------------------------------------------------
+
+def _resolve_bash_allowed_roots(ctx: "AgentContext") -> List[str]:
+    """Compute the set of allowed workspace roots for Bash cwd validation.
+
+    Returns canonical (realpath-resolved) root directories under which Bash
+    commands are permitted to execute.
+    """
+    roots: List[str] = []
+    fs_ctx = getattr(ctx, "_filesystem_context", None)
+    if fs_ctx is not None:
+        ws = getattr(fs_ctx, "workspace_dir", None)
+        if ws is not None:
+            roots.append(os.path.realpath(str(ws)))
+    try:
+        roots.append(os.path.realpath(os.getcwd()))
+    except OSError:
+        pass
+    try:
+        roots.append(os.path.realpath(tempfile.gettempdir()))
+    except OSError:
+        pass
+    return roots
+
+
+def _validate_bash_cwd(ctx: "AgentContext", cwd: str) -> str:
+    """Validate *cwd* against allowed workspace roots.
+
+    Returns the canonical resolved path on success.
+    Raises ``ValueError`` if *cwd* escapes every allowed root.
+    """
+    resolved = os.path.realpath(cwd)
+    roots = _resolve_bash_allowed_roots(ctx)
+    if not roots:
+        # No roots determinable — degrade to allowing (avoid blocking
+        # legitimate use when filesystem context is absent).
+        return resolved
+    for root in roots:
+        if resolved == root or resolved.startswith(root + os.sep):
+            return resolved
+    raise ValueError(
+        f"Bash cwd rejected: '{resolved}' is outside allowed workspace roots"
+    )
+
+
+def _kill_process_tree(proc: subprocess.Popen) -> None:
+    """Kill a subprocess and its entire process group (best-effort)."""
+    try:
+        pgid = os.getpgid(proc.pid)
+        os.killpg(pgid, signal.SIGKILL)
+    except (OSError, ProcessLookupError):
+        pass
+    try:
+        proc.kill()
+    except (OSError, ProcessLookupError):
+        pass
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        pass
 
 
 def _truncate_text(text: str, limit: int) -> str:
@@ -436,22 +503,24 @@ def background_bash_worker(
 ) -> None:
     """Stream output from a background bash process into runtime state."""
     session_id = ctx._get_runtime_session_id()
+    resolved_cwd = _validate_bash_cwd(ctx, cwd)
     proc = subprocess.Popen(
-        ["bash", "-lc", command],
-        cwd=cwd,
+        ["bash", "-c", command],
+        cwd=resolved_cwd,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         text=True,
+        start_new_session=True,
     )
-    runtime_state.bind_process(session_id, task_id, proc)
+    runtime_state.attach_background_process(session_id, task_id, proc)
     assert proc.stdout is not None
-    start = time.time()
+    deadline = time.monotonic() + timeout_ms / 1000
     for line in proc.stdout:
         runtime_state.append_task_output(
             session_id, task_id, line.rstrip("\n")
         )
-        if time.time() - start > timeout_ms / 1000:
-            proc.terminate()
+        if time.monotonic() > deadline:
+            _kill_process_tree(proc)
             runtime_state.update_task(
                 session_id,
                 task_id,
@@ -492,6 +561,8 @@ def handle_bash(
         },
     )
     cwd = ctx._refresh_runtime_working_directory()
+    resolved_cwd = _validate_bash_cwd(ctx, cwd)
+
     if run_in_background:
         task = runtime_state.create_task(
             ctx._get_runtime_session_id(),
@@ -501,14 +572,15 @@ def handle_bash(
             status="in_progress",
             background=True,
             tool_name="Bash",
-            metadata={"cwd": cwd, "command": command},
+            metadata={"cwd": resolved_cwd, "command": command},
         )
         proc = subprocess.Popen(
-            ["bash", "-lc", command],
-            cwd=cwd,
+            ["bash", "-c", command],
+            cwd=resolved_cwd,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
+            start_new_session=True,
         )
         runtime_state.attach_background_process(
             ctx._get_runtime_session_id(),
@@ -519,32 +591,59 @@ def handle_bash(
             {
                 "task_id": task.task_id,
                 "status": "in_progress",
-                "cwd": cwd,
+                "cwd": resolved_cwd,
                 "command": command,
             },
             ensure_ascii=False,
             indent=2,
         )
 
-    proc_result = subprocess.run(
-        ["bash", "-lc", command],
-        cwd=cwd,
-        capture_output=True,
+    # Foreground execution with process-group isolation and hard kill
+    timeout_sec = max(1, int(timeout)) / 1000
+    proc = subprocess.Popen(
+        ["bash", "-c", command],
+        cwd=resolved_cwd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
         text=True,
-        timeout=max(1, int(timeout)) / 1000,
-        check=False,
+        start_new_session=True,
     )
-    output = (proc_result.stdout or "") + (
-        (proc_result.stderr or "") if proc_result.stderr else ""
-    )
+    try:
+        stdout, stderr = proc.communicate(timeout=timeout_sec)
+    except subprocess.TimeoutExpired:
+        _kill_process_tree(proc)
+        stdout, stderr = "", ""
+        try:
+            stdout, stderr = proc.communicate(timeout=5)
+        except (subprocess.TimeoutExpired, OSError):
+            pass
+        stdout = stdout or ""
+        stderr = stderr or ""
+        output = (stdout + stderr).strip()
+        return json.dumps(
+            {
+                "cwd": resolved_cwd,
+                "command": command,
+                "returncode": -signal.SIGKILL,
+                "stdout": stdout,
+                "stderr": stderr,
+                "output": output if output else "Command timed out",
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+
+    stdout = stdout or ""
+    stderr = stderr or ""
+    output = (stdout + stderr).strip()
     return json.dumps(
         {
-            "cwd": cwd,
+            "cwd": resolved_cwd,
             "command": command,
-            "returncode": proc_result.returncode,
-            "stdout": proc_result.stdout,
-            "stderr": proc_result.stderr,
-            "output": output.strip(),
+            "returncode": proc.returncode,
+            "stdout": stdout,
+            "stderr": stderr,
+            "output": output,
         },
         ensure_ascii=False,
         indent=2,

--- a/omicverse/utils/ovagent/tool_runtime_workspace.py
+++ b/omicverse/utils/ovagent/tool_runtime_workspace.py
@@ -8,12 +8,15 @@ plan-mode checker or read callback) as explicit parameters.
 from __future__ import annotations
 
 import json
+import logging
 import os
 import subprocess
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, List, Optional
 
 from ..harness.runtime_state import runtime_state
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from .protocol import AgentContext
@@ -265,8 +268,8 @@ def handle_search_skills(ctx: "AgentContext", query: str) -> str:
                     max_chars=4000, provider=provider
                 )
                 results.append(f"=== {full_skill.name} ===\n{body}")
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.debug("Failed to load skill %s: %s", meta.slug, exc)
 
     if not results:
         return "Skills matched but content could not be loaded."

--- a/omicverse/utils/ovagent/workflow.py
+++ b/omicverse/utils/ovagent/workflow.py
@@ -37,8 +37,8 @@ def _parse_scalar(value: str) -> Any:
     if re.fullmatch(r"-?\d+", raw):
         try:
             return int(raw)
-        except ValueError:
-            pass
+        except ValueError as exc:
+            logger.debug("Integer parse fallback for %r: %s", raw, exc)
     if raw.startswith("[") and raw.endswith("]"):
         inner = raw[1:-1].strip()
         if not inner:

--- a/omicverse/utils/smart_agent.py
+++ b/omicverse/utils/smart_agent.py
@@ -19,7 +19,9 @@ import sys
 import threading
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Coroutine, Dict, List, Optional, Tuple, TypeVar, Union
+
+_T = TypeVar("_T")
 
 # Internal LLM backend
 from .agent_backend import OmicVerseLLMBackend, Usage
@@ -157,6 +159,52 @@ def _wire_package_import_compatibility() -> None:
 
 
 _wire_package_import_compatibility()
+
+
+def _run_coroutine_sync(coro: Coroutine[Any, Any, _T]) -> _T:
+    """Run *coro* synchronously, preserving exception tracebacks.
+
+    * **No running loop** — delegates to ``asyncio.run()``.
+    * **Running loop detected** (e.g. Jupyter / Jarvis) — spawns a daemon
+      worker thread with its own event loop.  Exceptions are transported via
+      ``sys.exc_info()`` and re-raised with ``with_traceback()`` so the
+      caller sees the full original traceback chain instead of a collapsed
+      single-frame ``raise err`` from a dict container.
+
+    This function never imports or patches ``nest_asyncio``.
+    """
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = None
+
+    if loop is not None and loop.is_running():
+        _result: list = [None]
+        _exc_info: list = [None]
+
+        def _worker() -> None:
+            try:
+                _result[0] = asyncio.run(coro)
+            except BaseException:
+                _exc_info[0] = sys.exc_info()
+
+        thread = threading.Thread(
+            target=_worker, name="OmicVerseAgentSync", daemon=True,
+        )
+        thread.start()
+        thread.join()
+
+        if _exc_info[0] is not None:
+            _tp, exc, tb = _exc_info[0]
+            _exc_info[0] = None
+            try:
+                raise exc.with_traceback(tb)
+            finally:
+                del exc, tb
+
+        return _result[0]  # type: ignore[return-value]
+
+    return asyncio.run(coro)
 
 
 class OmicVerseAgent(SessionContextFacadeMixin):
@@ -1062,8 +1110,11 @@ IMPORTANT: Respond with ONLY the JSON array, nothing else."""
 
     def generate_code(self, request: str, adata: Any = None, *, max_functions: int = 8, progress_callback: Optional[Callable[[str], None]] = None) -> str:
         """Synchronous wrapper for code-only OmicVerse generation."""
-        return self._codegen.generate_code(
-            request, adata, max_functions=max_functions, progress_callback=progress_callback,
+        return _run_coroutine_sync(
+            self.generate_code_async(
+                request, adata, max_functions=max_functions,
+                progress_callback=progress_callback,
+            )
         )
 
     async def stream_async(self, request: str, adata: Any,
@@ -1162,31 +1213,7 @@ IMPORTANT: Respond with ONLY the JSON array, nothing else."""
         >>> agent = ov.Agent(model="gpt-4o-mini")
         >>> result = agent.run("quality control with nUMI>500, mito<0.2", adata)
         """
-        try:
-            loop = asyncio.get_running_loop()
-        except RuntimeError:
-            loop = None
-
-        if loop and loop.is_running():
-            result_container: Dict[str, Any] = {}
-            error_container: Dict[str, BaseException] = {}
-
-            def _run_in_thread() -> None:
-                try:
-                    result_container["value"] = asyncio.run(self.run_async(request, adata))
-                except BaseException as exc:  # pragma: no cover - propagate to caller
-                    error_container["error"] = exc
-
-            thread = threading.Thread(target=_run_in_thread, name="OmicVerseAgentRunner")
-            thread.start()
-            thread.join()
-
-            if "error" in error_container:
-                raise error_container["error"]
-
-            return result_container.get("value")
-
-        return asyncio.run(self.run_async(request, adata))
+        return _run_coroutine_sync(self.run_async(request, adata))
 
     # ===================================================================
     # Cleanup

--- a/omicverse/utils/smart_agent.py
+++ b/omicverse/utils/smart_agent.py
@@ -219,6 +219,10 @@ class OmicVerseAgent(CodegenToolDispatchFacadeMixin, SessionContextFacadeMixin):
     LEGACY_AGENT_TOOLS = _LEGACY_AGENT_TOOLS
     AGENT_TOOLS = get_visible_tool_schemas(get_default_loaded_tool_names()) + _LEGACY_AGENT_TOOLS
 
+    @staticmethod
+    def _emit(level: "EventLevel", message: str, category: str = "") -> None:
+        """No-op fallback; replaced by ``__init__`` with a reporter-backed emitter."""
+
     def __init__(self, model: str = "gpt-5.2", api_key: Optional[str] = None, endpoint: Optional[str] = None, auth_mode: str = "environment", auth_provider: Optional[str] = None, auth_file: Optional[str] = None, enable_reflection: bool = True, reflection_iterations: int = 1, enable_result_review: bool = True, use_notebook_execution: bool = True, max_prompts_per_session: int = 5, notebook_storage_dir: Optional[str] = None, keep_execution_notebooks: bool = True, notebook_timeout: int = 600, strict_kernel_validation: bool = True, enable_filesystem_context: bool = True, context_storage_dir: Optional[str] = None, approval_mode: str = "never", agent_mode: str = "agentic", max_agent_turns: int = 15, security_level: Optional[str] = None, *, config: Optional[AgentConfig] = None, reporter: Optional[Reporter] = None, verbose: bool = True):
         """
         Initialize the OmicVerse Smart Agent.
@@ -1013,7 +1017,33 @@ def list_supported_models(show_all: bool = False) -> str:
     """
     return ModelConfig.list_supported_models(show_all)
 
-def Agent(*args: Any, **kwargs: Any) -> OmicVerseAgent:
+def Agent(
+    model: str = "gpt-5.2",
+    api_key: Optional[str] = None,
+    endpoint: Optional[str] = None,
+    auth_mode: str = "environment",
+    auth_provider: Optional[str] = None,
+    auth_file: Optional[str] = None,
+    enable_reflection: bool = True,
+    reflection_iterations: int = 1,
+    enable_result_review: bool = True,
+    use_notebook_execution: bool = True,
+    max_prompts_per_session: int = 5,
+    notebook_storage_dir: Optional[str] = None,
+    keep_execution_notebooks: bool = True,
+    notebook_timeout: int = 600,
+    strict_kernel_validation: bool = True,
+    enable_filesystem_context: bool = True,
+    context_storage_dir: Optional[str] = None,
+    approval_mode: str = "never",
+    agent_mode: str = "agentic",
+    max_agent_turns: int = 15,
+    security_level: Optional[str] = None,
+    *,
+    config: Optional[AgentConfig] = None,
+    reporter: Optional[Reporter] = None,
+    verbose: bool = True,
+) -> OmicVerseAgent:
     """Convenience factory — creates an :class:`OmicVerseAgent`.
 
     Accepts the same parameters as :meth:`OmicVerseAgent.__init__`.
@@ -1024,7 +1054,24 @@ def Agent(*args: Any, **kwargs: Any) -> OmicVerseAgent:
     OmicVerseAgent
         Configured agent instance ready for use.
     """
-    return OmicVerseAgent(*args, **kwargs)
+    return OmicVerseAgent(
+        model=model, api_key=api_key, endpoint=endpoint,
+        auth_mode=auth_mode, auth_provider=auth_provider, auth_file=auth_file,
+        enable_reflection=enable_reflection,
+        reflection_iterations=reflection_iterations,
+        enable_result_review=enable_result_review,
+        use_notebook_execution=use_notebook_execution,
+        max_prompts_per_session=max_prompts_per_session,
+        notebook_storage_dir=notebook_storage_dir,
+        keep_execution_notebooks=keep_execution_notebooks,
+        notebook_timeout=notebook_timeout,
+        strict_kernel_validation=strict_kernel_validation,
+        enable_filesystem_context=enable_filesystem_context,
+        context_storage_dir=context_storage_dir,
+        approval_mode=approval_mode, agent_mode=agent_mode,
+        max_agent_turns=max_agent_turns, security_level=security_level,
+        config=config, reporter=reporter, verbose=verbose,
+    )
 
 
 __all__ = [

--- a/omicverse/utils/smart_agent.py
+++ b/omicverse/utils/smart_agent.py
@@ -91,11 +91,7 @@ from .ovagent.bootstrap import (
     format_skill_overview as _format_skill_overview,
     initialize_skill_registry as _initialize_skill_registry,
     initialize_notebook_executor as _initialize_notebook_executor,
-    initialize_filesystem_context as _initialize_filesystem_context,
-    initialize_session_history as _initialize_session_history,
-    initialize_tracing as _initialize_tracing,
     initialize_security as _initialize_security,
-    initialize_ov_runtime as _initialize_ov_runtime,
     create_llm_backend as _create_llm_backend,
     display_reflection_config as _display_reflection_config,
 )
@@ -118,10 +114,7 @@ from .ovagent.turn_controller import (
     TurnController as _TurnController,
     FollowUpGate as _FollowUpGate,
 )
-from .ovagent.session_context import (
-    SessionService as _SessionService,
-    ContextService as _ContextService,
-)
+from .ovagent.session_facade import SessionContextFacadeMixin
 from .ovagent.registry_scanner import RegistryScanner as _RegistryScanner
 
 # Session history
@@ -166,7 +159,7 @@ def _wire_package_import_compatibility() -> None:
 _wire_package_import_compatibility()
 
 
-class OmicVerseAgent:
+class OmicVerseAgent(SessionContextFacadeMixin):
     """
     Intelligent agent for OmicVerse function discovery and execution.
 
@@ -416,34 +409,17 @@ class OmicVerseAgent:
                 )
             )
 
-            # Filesystem context
+            # Session, context, tracing, OV runtime (SessionContextFacadeMixin)
             ctx_storage = Path(context_storage_dir) if context_storage_dir else None
-            self.enable_filesystem_context, self._filesystem_context = (
-                _initialize_filesystem_context(
-                    enabled=self.enable_filesystem_context,
-                    storage_dir=ctx_storage,
-                )
-            )
-
-            # Session history
-            self._session_history = _initialize_session_history(self._config)
-
-            # Harness tracing & context compaction
-            self._trace_store, self._context_compactor = _initialize_tracing(
-                self._config, self._llm, self.model,
-            )
+            self._initialize_session_context_tracing(ctx_storage_dir=ctx_storage)
 
             # Security scanner
             self._security_config, self._security_scanner = _initialize_security(
                 self._config,
             )
 
-            # OmicVerse runtime (workflow / run-store bridge)
-            self._ov_runtime = _initialize_ov_runtime(self._detect_repo_root())
-
-            # Extracted module delegates
-            self._session_service = _SessionService(self)
-            self._context_service = _ContextService(self)
+            # Session/context service delegates (SessionContextFacadeMixin)
+            self._wire_session_context_services()
             self._prompt_builder = _PromptBuilder(self)
             self._analysis_executor = _AnalysisExecutor(self)
             self._tool_runtime = _ToolRuntime(self, self._analysis_executor)
@@ -650,30 +626,6 @@ User request: "quality control with nUMI>500, mito<0.2"
         with _temporary_api_keys_cm(self._managed_api_env):
             yield
 
-    def _get_session_service(self) -> _SessionService:
-        """Lazily construct SessionService for legacy __new__-based instances."""
-        service = getattr(self, "_session_service", None)
-        if service is None:
-            service = _SessionService(self)
-            self._session_service = service
-        return service
-
-    def _get_context_service(self) -> _ContextService:
-        """Lazily construct ContextService for legacy __new__-based instances."""
-        service = getattr(self, "_context_service", None)
-        if service is None:
-            service = _ContextService(self)
-            self._context_service = service
-        return service
-
-    def _get_harness_session_id(self) -> str:
-        """Best-effort session identifier for harness traces/history."""
-        return self._get_session_service().get_harness_session_id()
-
-    def _get_runtime_session_id(self) -> str:
-        """Return the session key used by the harness runtime registry."""
-        return self._get_session_service().get_runtime_session_id()
-
     def _get_visible_agent_tools(self, *, allowed_names: Optional[set[str]] = None) -> list[dict[str, Any]]:
         """Return the currently visible tool schemas."""
         return self._tool_runtime.get_visible_agent_tools(allowed_names=allowed_names)
@@ -681,10 +633,6 @@ User request: "quality control with nUMI>500, mito<0.2"
     def _get_loaded_tool_names(self) -> list[str]:
         """Return loaded tool names."""
         return self._tool_runtime.get_loaded_tool_names()
-
-    def _refresh_runtime_working_directory(self) -> str:
-        """Keep runtime cwd aligned with the active worktree / filesystem context."""
-        return self._get_session_service().refresh_runtime_working_directory()
 
     def _tool_blocked_in_plan_mode(self, tool_name: str) -> bool:
         """Check plan-mode blocking."""
@@ -725,13 +673,6 @@ User request: "quality control with nUMI>500, mito<0.2"
         approved = self._request_interaction(interaction)
         if not approved:
             raise PermissionError(f"{tool_name} was not approved by the user.")
-
-    def _detect_repo_root(self, cwd: Optional[Path] = None) -> Optional[Path]:
-        current = (cwd or Path(self._refresh_runtime_working_directory())).resolve()
-        for candidate in (current, *current.parents):
-            if (candidate / ".git").exists():
-                return candidate
-        return None
 
     def _extract_python_code(self, response_text: str) -> str:
         """Extract executable Python code from the agent response using AST validation."""
@@ -1246,59 +1187,6 @@ IMPORTANT: Respond with ONLY the JSON array, nothing else."""
             return result_container.get("value")
 
         return asyncio.run(self.run_async(request, adata))
-
-    # ===================================================================
-    # Session Management Methods (delegated to SessionService)
-    # ===================================================================
-
-    def get_current_session_info(self) -> Optional[Dict[str, Any]]:
-        """Get information about current notebook session."""
-        return self._get_session_service().get_current_session_info()
-
-    def restart_session(self):
-        """Manually restart notebook session (clear memory, start fresh)."""
-        self._get_session_service().restart_session()
-
-    def get_session_history(self) -> List[Dict[str, Any]]:
-        """Get history of all archived notebook sessions."""
-        return self._get_session_service().get_session_history()
-
-    # ===================================================================
-    # Filesystem Context Management (delegated to ContextService)
-    # ===================================================================
-
-    @property
-    def filesystem_context(self) -> Optional[FilesystemContextManager]:
-        """Get the filesystem context manager."""
-        return self._get_context_service().filesystem_context
-
-    def write_note(self, key: str, content: Union[str, Dict[str, Any]], category: str = "notes", metadata: Optional[Dict[str, Any]] = None) -> Optional[str]:
-        """Write a note to the filesystem context workspace."""
-        return self._get_context_service().write_note(key, content, category, metadata)
-
-    def search_context(self, pattern: str, match_type: str = "glob", max_results: int = 10) -> List[Dict[str, Any]]:
-        """Search the filesystem context for relevant notes."""
-        return self._get_context_service().search_context(pattern, match_type, max_results)
-
-    def get_relevant_context(self, query: str, max_tokens: int = 1000) -> str:
-        """Get context relevant to a query."""
-        return self._get_context_service().get_relevant_context(query, max_tokens)
-
-    def save_plan(self, steps: List[Dict[str, Any]]) -> Optional[str]:
-        """Save an execution plan."""
-        return self._get_context_service().save_plan(steps)
-
-    def update_plan_step(self, step_index: int, status: str, result: Optional[str] = None) -> None:
-        """Update the status of a plan step."""
-        self._get_context_service().update_plan_step(step_index, status, result)
-
-    def get_workspace_summary(self) -> str:
-        """Get a summary of the filesystem context workspace."""
-        return self._get_context_service().get_workspace_summary()
-
-    def get_context_stats(self) -> Dict[str, Any]:
-        """Get statistics about the filesystem context workspace."""
-        return self._get_context_service().get_context_stats()
 
     # ===================================================================
     # Cleanup

--- a/omicverse/utils/smart_agent.py
+++ b/omicverse/utils/smart_agent.py
@@ -82,6 +82,10 @@ from .ovagent.auth import (
     collect_api_key_env as _collect_api_key_env,
     temporary_api_keys as _temporary_api_keys_cm,
     display_backend_info as _display_backend_info,
+    resolve_credentials as _resolve_credentials,
+    # Backward-compat re-exports (moved from this module to ovagent.auth)
+    _normalize_model_for_routing,
+    resolve_credentials as _resolve_agent_llm_credentials,
 )
 from .ovagent.bootstrap import (
     format_skill_overview as _format_skill_overview,
@@ -137,220 +141,9 @@ from .skill_registry import (
 
 # Filesystem context management
 from .filesystem_context import FilesystemContextManager
-from ..jarvis.config import load_auth
-from ..jarvis.gemini_cli_oauth import (
-    GOOGLE_CODE_ASSIST_ENDPOINT_PROD,
-    GeminiCliOAuthError,
-    GeminiCliOAuthManager,
-)
-from ..jarvis.openai_oauth import OPENAI_CODEX_BASE_URL, OpenAIOAuthManager
 
 
 logger = logging.getLogger(__name__)
-
-_LEGACY_OPENAI_CODEX_BASE_URL = "https://api.openai.com/v1"
-OPENAI_CODEX_DEFAULT_MODEL = "gpt-5.3-codex"
-_OPENAI_OAUTH_SUPPORTED_MODELS = {
-    "gpt-5.3-codex",
-    "gpt-5.3-codex-spark",
-    "gpt-5.2-codex",
-    "gpt-5.2",
-    "gpt-5.1",
-    "gpt-5.1-codex",
-    "gpt-5.1-codex-mini",
-    "gpt-5.1-codex-max",
-    "gpt-5.4",
-    "gpt-5.4-mini",
-}
-_OPENAI_EXPLICIT_OAUTH_MODELS = {
-    model_name
-    for model_name in _OPENAI_OAUTH_SUPPORTED_MODELS
-    if "codex" in model_name
-}
-
-
-def _normalize_auth_mode(auth_mode: Optional[str]) -> str:
-    if auth_mode == "openai_api_key":
-        return "saved_api_key"
-    if auth_mode == "openai_codex":
-        return "openai_oauth"
-    if auth_mode in {"google_oauth", "gemini_cli_oauth"}:
-        return str(auth_mode)
-    return str(auth_mode or "environment")
-
-
-def _is_openai_oauth_supported_model(model: str) -> bool:
-    return str(model or "").strip().lower() in {
-        name.lower() for name in _OPENAI_OAUTH_SUPPORTED_MODELS
-    }
-
-
-def _is_explicit_openai_oauth_model(model: str) -> bool:
-    return str(model or "").strip().lower() in {
-        name.lower() for name in _OPENAI_EXPLICIT_OAUTH_MODELS
-    }
-
-
-def _normalize_model_for_routing(model: str) -> str:
-    normalized = str(model or "").strip()
-    if not normalized:
-        return normalized
-    try:
-        return ModelConfig.normalize_model_id(normalized)
-    except (AttributeError, KeyError, ValueError, TypeError) as exc:
-        logger.debug("_normalize_model_for_routing fallback for %r: %s", normalized, exc)
-        return normalized
-
-
-def _is_custom_openai_endpoint(endpoint: Optional[str]) -> bool:
-    normalized = str(endpoint or "").strip().rstrip("/")
-    return bool(normalized) and normalized not in {
-        _LEGACY_OPENAI_CODEX_BASE_URL,
-        OPENAI_CODEX_BASE_URL,
-    }
-
-
-def _looks_like_openai_endpoint(endpoint: Optional[str]) -> bool:
-    normalized = str(endpoint or "").strip().rstrip("/").lower()
-    if not normalized:
-        return False
-    return (
-        normalized == _LEGACY_OPENAI_CODEX_BASE_URL
-        or normalized == OPENAI_CODEX_BASE_URL
-        or "api.openai.com" in normalized
-        or "chatgpt.com/backend-api" in normalized
-    )
-
-
-def _extract_openai_codex_account_id(token: Optional[str]) -> str:
-    try:
-        return OmicVerseLLMBackend._extract_openai_codex_account_id(str(token or ""))
-    except (ValueError, TypeError, KeyError, IndexError, AttributeError) as exc:
-        logger.debug("_extract_openai_codex_account_id fallback: %s", exc)
-        return ""
-
-
-def _resolve_saved_provider_api_key(provider_name: str, auth_path: Optional[Path]) -> Optional[str]:
-    auth = load_auth(auth_path)
-    providers = dict(auth.get("providers") or {})
-
-    if provider_name == "openai":
-        top_level = str(auth.get("OPENAI_API_KEY") or "").strip()
-        if top_level:
-            return top_level
-
-    provider_auth = dict(providers.get(provider_name) or {})
-    api_key = str(provider_auth.get("api_key") or "").strip()
-    return api_key or None
-
-
-def _resolve_agent_llm_credentials(
-    *,
-    model: str,
-    api_key: Optional[str],
-    endpoint: Optional[str],
-    auth_mode: Optional[str],
-    auth_provider: Optional[str],
-    auth_file: Optional[Union[str, Path]],
-) -> Tuple[str, Optional[str], Optional[str], str]:
-    """Resolve model/auth settings, including OpenAI Codex OAuth fallback."""
-
-    normalized_mode = _normalize_auth_mode(auth_mode)
-    resolved_model = model
-    normalized_model = _normalize_model_for_routing(model)
-    resolved_api_key = api_key
-    api_key_source = "explicit" if resolved_api_key else None
-    resolved_endpoint = endpoint
-    resolved_auth_path = Path(auth_file).expanduser() if auth_file else None
-    normalized_auth_provider = str(auth_provider or "").strip().lower() or "codex"
-
-    provider = ModelConfig.get_provider_from_model(normalized_model or resolved_model, resolved_endpoint)
-    wants_gemini_cli_oauth = provider == "google" and (
-        normalized_mode in {"google_oauth", "gemini_cli_oauth"}
-        or (normalized_mode == "openai_oauth" and normalized_auth_provider == "gemini_cli")
-    )
-    if wants_gemini_cli_oauth:
-        manager = GeminiCliOAuthManager(resolved_auth_path)
-        try:
-            payload = manager.build_api_key_payload(
-                refresh_if_needed=True,
-                import_if_missing=True,
-            )
-        except GeminiCliOAuthError as exc:
-            raise ValueError(
-                "Failed to load saved Gemini CLI OAuth credentials. "
-                "This is an unofficial integration; some users report account restrictions. "
-                "Use at your own risk."
-            ) from exc
-        if not payload:
-            raise ValueError(
-                "No saved Gemini CLI OAuth login found. Complete Gemini CLI OAuth first. "
-                "This is an unofficial integration; some users report account restrictions. "
-                "Use at your own risk."
-            )
-        resolved_api_key = payload
-        if (
-            not resolved_endpoint
-            or _looks_like_openai_endpoint(resolved_endpoint)
-            or "generativelanguage.googleapis.com" in str(resolved_endpoint)
-        ):
-            resolved_endpoint = GOOGLE_CODE_ASSIST_ENDPOINT_PROD
-        api_key_source = "gemini_cli_oauth"
-        return resolved_model, resolved_api_key, resolved_endpoint, "gemini_cli_oauth"
-
-    wants_codex_oauth = provider == "openai" and (
-        normalized_mode == "openai_oauth"
-        or _is_explicit_openai_oauth_model(normalized_model)
-        or str(resolved_endpoint or "").rstrip("/") == OPENAI_CODEX_BASE_URL
-    )
-
-    if provider == "openai" and normalized_mode == "saved_api_key" and not resolved_api_key:
-        resolved_api_key = _resolve_saved_provider_api_key("openai", resolved_auth_path)
-        api_key_source = "saved_api_key" if resolved_api_key else None
-
-    if not wants_codex_oauth:
-        return resolved_model, resolved_api_key, resolved_endpoint, normalized_mode
-
-    normalized_mode = "openai_oauth"
-    preserve_model_id = _is_custom_openai_endpoint(resolved_endpoint)
-    if not resolved_endpoint or resolved_endpoint.rstrip("/") == _LEGACY_OPENAI_CODEX_BASE_URL:
-        resolved_endpoint = OPENAI_CODEX_BASE_URL
-        preserve_model_id = False
-    if _is_openai_oauth_supported_model(normalized_model):
-        if not preserve_model_id:
-            resolved_model = normalized_model
-    elif not preserve_model_id:
-        resolved_model = OPENAI_CODEX_DEFAULT_MODEL
-
-    if resolved_api_key:
-        if _extract_openai_codex_account_id(resolved_api_key):
-            return resolved_model, resolved_api_key, resolved_endpoint, normalized_mode
-        if api_key_source == "explicit":
-            raise ValueError(
-                "OpenAI Codex models require a ChatGPT OAuth access token with "
-                "chatgpt_account_id. Run `omicverse jarvis --codex-login` or "
-                "pass a valid OpenAI OAuth access token."
-            )
-        resolved_api_key = None
-
-    manager = OpenAIOAuthManager(resolved_auth_path)
-    resolved_api_key = manager.ensure_access_token_with_codex_fallback(
-        refresh_if_needed=True,
-        import_codex_if_missing=True,
-    )
-    if resolved_api_key and _extract_openai_codex_account_id(resolved_api_key):
-        return resolved_model, resolved_api_key, resolved_endpoint, normalized_mode
-    if resolved_api_key:
-        raise ValueError(
-            "Saved OpenAI Codex login is missing chatgpt_account_id. "
-            "Run `omicverse jarvis --codex-login` again."
-        )
-
-    raise ValueError(
-        "No saved OpenAI Codex login found. Run `omicverse jarvis --codex-login` "
-        "or pass a valid OpenAI OAuth access token."
-    )
-
 
 def _wire_package_import_compatibility() -> None:
     """Expose parent package references without probing lazy __getattr__ hooks."""
@@ -500,7 +293,7 @@ class OmicVerseAgent:
 
         _emit(EventLevel.INFO, "Initializing OmicVerse Smart Agent (internal backend)...", "init")
         llm_cfg = self._config.llm
-        model, api_key, endpoint, resolved_auth_mode = _resolve_agent_llm_credentials(
+        model, api_key, endpoint, resolved_auth_mode = _resolve_credentials(
             model=llm_cfg.model,
             api_key=llm_cfg.api_key,
             endpoint=llm_cfg.endpoint,
@@ -1557,145 +1350,18 @@ def list_supported_models(show_all: bool = False) -> str:
     """
     return ModelConfig.list_supported_models(show_all)
 
-def Agent(
-    model: str = "gpt-5.2", 
-    api_key: Optional[str] = None, 
-    endpoint: Optional[str] = None, 
-    auth_mode: str = "environment", 
-    auth_provider: Optional[str] = None,
-    auth_file: Optional[str] = None, 
-    enable_reflection: bool = True, 
-    reflection_iterations: int = 1, 
-    enable_result_review: bool = True, 
-    use_notebook_execution: bool = True, 
-    max_prompts_per_session: int = 5, 
-    notebook_storage_dir: Optional[str] = None, 
-    keep_execution_notebooks: bool = True, 
-    notebook_timeout: int = 600, 
-    strict_kernel_validation: bool = True, 
-    enable_filesystem_context: bool = True, 
-    context_storage_dir: Optional[str] = None, 
-    approval_mode: str = "never", agent_mode: str = "agentic", 
-    max_agent_turns: int = 15, 
-    security_level: Optional[str] = None, *, 
-    config: Optional[AgentConfig] = None, 
-    reporter: Optional[Reporter] = None, 
-    verbose: bool = True
-) -> OmicVerseAgent:
-    """
-    Create an OmicVerse Smart Agent instance.
+def Agent(*args: Any, **kwargs: Any) -> OmicVerseAgent:
+    """Convenience factory — creates an :class:`OmicVerseAgent`.
 
-    This function creates and returns a smart agent that can execute OmicVerse functions
-    based on natural language descriptions.
-
-    Parameters
-    ----------
-    model : str, optional
-        LLM model to use (default: "gpt-5.2"). Use list_supported_models() to see all options
-    api_key : str, optional
-        API key for the model provider. If not provided, will use environment variable
-    endpoint : str, optional
-        Custom API endpoint. If not provided, will use default for the provider
-    auth_mode : str, optional
-        Authentication mode. Use ``"openai_oauth"`` to reuse saved Jarvis/Codex login state.
-    auth_provider : str, optional
-        OAuth provider identifier. Currently only ``"codex"`` is supported.
-    auth_file : str, optional
-        Path to the saved Jarvis auth file. Defaults to ``~/.ovjarvis/auth.json``.
-    enable_reflection : bool, optional
-        Enable reflection step to review and improve generated code (default: True)
-    reflection_iterations : int, optional
-        Maximum number of reflection iterations (default: 1, range: 1-3)
-    enable_result_review : bool, optional
-        Enable result review to validate output matches user intent (default: True)
-    use_notebook_execution : bool, optional
-        Execute code in separate Jupyter notebook for isolation and debugging (default: True).
-    max_prompts_per_session : int, optional
-        Number of prompts to execute in same notebook session before restart (default: 5).
-    notebook_storage_dir : str, optional
-        Directory to store session notebooks. Defaults to ~/.ovagent/sessions
-    keep_execution_notebooks : bool, optional
-        Whether to keep session notebooks after execution (default: True)
-    notebook_timeout : int, optional
-        Execution timeout in seconds (default: 600)
-    strict_kernel_validation : bool, optional
-        If True, raise error if kernel not found. If False, fall back to python3 (default: True)
-    enable_filesystem_context : bool, optional
-        Enable filesystem-based context management. Default: True.
-    context_storage_dir : str, optional
-        Directory for storing context files. Defaults to ~/.ovagent/context/
-    approval_mode : str, optional
-        When to prompt the user before executing generated code.
-    config : AgentConfig, optional
-        Grouped configuration object.
-    reporter : Reporter, optional
-        Structured event reporter.
-    verbose : bool, optional
-        Whether to emit events to stdout (default: True).
+    Accepts the same parameters as :meth:`OmicVerseAgent.__init__`.
+    See that docstring for the full parameter reference and examples.
 
     Returns
     -------
     OmicVerseAgent
-        Configured agent instance ready for use
-
-    Examples
-    --------
-    >>> import omicverse as ov
-    >>> agent = ov.Agent(model="gpt-5", api_key="your-key")
-    >>>
-    >>> # Reuse a saved ChatGPT/Codex login
-    >>> agent = ov.Agent(model="gpt-5.3-codex", auth_mode="openai_oauth")
-    >>>
-    >>> # Create agent with multiple reflection iterations
-    >>> agent = ov.Agent(model="gpt-5", api_key="your-key", reflection_iterations=2)
-    >>>
-    >>> # Create agent without validation (fastest execution)
-    >>> agent = ov.Agent(model="gpt-5", api_key="your-key", enable_reflection=False, enable_result_review=False)
-    >>>
-    >>> # Disable notebook execution (use legacy in-process execution)
-    >>> agent = ov.Agent(model="gpt-5", api_key="your-key", use_notebook_execution=False)
-    >>>
-    >>> # Maximum isolation (new session per prompt)
-    >>> agent = ov.Agent(model="gpt-5", api_key="your-key", max_prompts_per_session=1)
-    >>>
-    >>> # Longer sessions for complex workflows
-    >>> agent = ov.Agent(model="gpt-5", api_key="your-key", max_prompts_per_session=10)
-    >>>
-    >>> # Custom storage directory
-    >>> agent = ov.Agent(model="gpt-5", api_key="your-key", notebook_storage_dir="~/my_project/sessions")
-    >>>
-    >>> # Load data
-    >>> adata = sc.datasets.pbmc3k()
-    >>>
-    >>> # Use agent for quality control
-    >>> adata = agent.run("quality control with nUMI>500, mito<0.2", adata)
+        Configured agent instance ready for use.
     """
-    return OmicVerseAgent(
-        model=model,
-        api_key=api_key,
-        endpoint=endpoint,
-        auth_mode=auth_mode,
-        auth_provider=auth_provider,
-        auth_file=auth_file,
-        enable_reflection=enable_reflection,
-        reflection_iterations=reflection_iterations,
-        enable_result_review=enable_result_review,
-        use_notebook_execution=use_notebook_execution,
-        max_prompts_per_session=max_prompts_per_session,
-        notebook_storage_dir=notebook_storage_dir,
-        keep_execution_notebooks=keep_execution_notebooks,
-        notebook_timeout=notebook_timeout,
-        strict_kernel_validation=strict_kernel_validation,
-        enable_filesystem_context=enable_filesystem_context,
-        context_storage_dir=context_storage_dir,
-        approval_mode=approval_mode,
-        agent_mode=agent_mode,
-        max_agent_turns=max_agent_turns,
-        security_level=security_level,
-        config=config,
-        reporter=reporter,
-        verbose=verbose,
-    )
+    return OmicVerseAgent(*args, **kwargs)
 
 
 __all__ = [

--- a/omicverse/utils/smart_agent.py
+++ b/omicverse/utils/smart_agent.py
@@ -84,10 +84,9 @@ from .ovagent.auth import (
     collect_api_key_env as _collect_api_key_env,
     temporary_api_keys as _temporary_api_keys_cm,
     display_backend_info as _display_backend_info,
-    resolve_credentials as _resolve_credentials,
+    resolve_credentials as _resolve_agent_llm_credentials,
     # Backward-compat re-exports (moved from this module to ovagent.auth)
     _normalize_model_for_routing,
-    resolve_credentials as _resolve_agent_llm_credentials,
 )
 from .ovagent.bootstrap import (
     format_skill_overview as _format_skill_overview,
@@ -323,7 +322,7 @@ class OmicVerseAgent(CodegenToolDispatchFacadeMixin, SessionContextFacadeMixin):
 
         _emit(EventLevel.INFO, "Initializing OmicVerse Smart Agent (internal backend)...", "init")
         llm_cfg = self._config.llm
-        model, api_key, endpoint, resolved_auth_mode = _resolve_credentials(
+        model, api_key, endpoint, resolved_auth_mode = _resolve_agent_llm_credentials(
             model=llm_cfg.model,
             api_key=llm_cfg.api_key,
             endpoint=llm_cfg.endpoint,

--- a/omicverse/utils/smart_agent.py
+++ b/omicverse/utils/smart_agent.py
@@ -495,138 +495,98 @@ class OmicVerseAgent(CodegenToolDispatchFacadeMixin, SessionContextFacadeMixin):
             'category_list': list(categories)
         }
 
-    def _get_available_functions_info(self) -> str:
-        """Get formatted information about all available functions."""
-        functions_info = []
-        processed_functions = set()
-        for entry in _global_registry._registry.values():
-            full_name = entry['full_name']
-            if full_name in processed_functions:
-                continue
-            processed_functions.add(full_name)
-            info = {
-                'name': entry['short_name'],
-                'full_name': entry['full_name'],
-                'description': entry['description'],
-                'aliases': entry['aliases'],
-                'category': entry['category'],
-                'signature': entry['signature'],
-                'examples': entry['examples']
-            }
-            functions_info.append(info)
-        return json.dumps(functions_info, indent=2, ensure_ascii=False)
+    def _get_compact_registry_summary(self) -> str:
+        """Build a compact category-level summary of available functions.
+
+        Instead of dumping every function as JSON, returns a concise
+        overview keyed by domain category with representative names.
+        The LLM is directed to ``search_functions`` for details.
+        """
+        category_map: Dict[str, List[str]] = {}
+        seen: set = set()
+
+        # Prefer static entries (always available); fall back to runtime
+        entries = self._load_static_registry_entries()
+        if not entries:
+            for entry in getattr(_global_registry, "_registry", {}).values():
+                full_name = entry.get("full_name", "")
+                if full_name and full_name not in seen:
+                    seen.add(full_name)
+                    cat = entry.get("category", "other") or "other"
+                    category_map.setdefault(cat, []).append(full_name)
+        else:
+            for entry in entries:
+                full_name = entry.get("full_name", "")
+                if full_name and full_name not in seen:
+                    seen.add(full_name)
+                    cat = entry.get("category", "other") or "other"
+                    category_map.setdefault(cat, []).append(full_name)
+
+        lines: List[str] = []
+        for cat in sorted(category_map):
+            names = category_map[cat]
+            sample = ", ".join(names[:5])
+            suffix = f" (+{len(names) - 5} more)" if len(names) > 5 else ""
+            lines.append(f"- **{cat}** ({len(names)} functions): {sample}{suffix}")
+        return "\n".join(lines) if lines else "No registered functions detected."
 
     def _setup_agent(self):
-        """Setup the internal agent backend with dynamic instructions."""
-        functions_info = self._get_available_functions_info()
+        """Setup the internal agent backend with dynamic instructions.
 
-        instructions = """
-You are an intelligent OmicVerse assistant that can automatically discover and execute functions based on natural language requests.
+        Uses a compact category-level registry summary instead of
+        dumping every function as JSON.  The LLM discovers detailed
+        signatures through the ``search_functions`` tool at runtime.
+        """
+        compact_summary = self._get_compact_registry_summary()
 
-## Available OmicVerse Functions
-
-Here are all the currently registered functions in OmicVerse:
-
-""" + functions_info + """
-
-## Your Task
-
-When given a natural language request and an adata object, you should:
-
-Quick-start examples (non-experts can copy/paste):
-- "basic single-cell QC and clustering" (uses QC → preprocess → neighbors/UMAP → Leiden → markers)
-- "batch integration with harmony on this adata" (uses harmony then neighbors/UMAP/Leiden, use_raw=False)
-- "simple trajectory with DPT, root on paul15_clusters=7MEP, list top genes"
-- "find markers for each Leiden cluster (wilcoxon)".
-- "doublet check and report rate"
-
-1. **Analyze the request** to understand what the user wants to accomplish
-2. **Find the most appropriate function** from the available functions above
-3. **Extract parameters** from the user's request (e.g., "nUMI>500" means min_genes=500)
-4. **Generate and execute Python code** using the appropriate OmicVerse function
-5. **Return the modified adata object**
-
-## Parameter Extraction Rules
-
-Extract parameters dynamically based on patterns in the user request:
-
-- For qc function: Create tresh dict with 'mito_perc', 'nUMIs', 'detected_genes'
-  - "nUMI>X", "umi>X" → tresh={'nUMIs': X, 'detected_genes': 250, 'mito_perc': 0.15}
-  - "mito<X", "mitochondrial<X" → include in tresh dict as 'mito_perc': X
-  - "genes>X" → include in tresh dict as 'detected_genes': X
-  - Always provide complete tresh dict with all three keys
-- "resolution=X" → resolution=X
-- "n_pcs=X", "pca=X" → n_pcs=X
-- "max_value=X" → max_value=X
-- Mode indicators: "seurat", "mads", "pearson" → mode="seurat"
-- Boolean indicators: "no doublets", "skip doublets" → doublets=False
-
-## Code Execution Rules
-
-1. **Always import omicverse as ov** at the start
-2. **Use the exact function signature** from the available functions
-3. **Handle the adata variable** - it will be provided in the context
-4. **Update adata in place** when possible
-5. **Print success messages** and basic info about the result
-
-## Example Workflow
-
-User request: "quality control with nUMI>500, mito<0.2"
-
-1. Find function: Look for functions with aliases containing "qc", "quality", or "质控"
-2. Get function details: Check that qc requires tresh dict with 'mito_perc', 'nUMIs', 'detected_genes'
-3. Extract parameters: nUMI>500 → tresh['nUMIs']=500, mito<0.2 → tresh['mito_perc']=0.2
-4. Generate code:
-   ```python
-   import omicverse as ov
-   # Execute quality control with complete tresh dict
-   adata = ov.pp.qc(adata, tresh={'mito_perc': 0.2, 'nUMIs': 500, 'detected_genes': 250})
-   print("QC completed. Dataset shape: " + str(adata.shape[0]) + " cells × " + str(adata.shape[1]) + " genes")
-   ```
-
-## Important Notes
-
-- Always work with the provided `adata` variable
-- Use the function signatures exactly as shown in the available functions
-- Provide helpful feedback about what was executed
-- Do not create dummy AnnData objects; operate directly on the provided data
-- Prefer `use_raw=False` unless the user explicitly requests raw
-- Handle errors gracefully and suggest alternatives if needed
-
-## CRITICAL CODE PATTERNS - MANDATORY RULES
-
-### Print Statements
-- ALWAYS use string concatenation: `print("Result: " + str(value))`
-- NEVER use f-strings in print statements - they cause format errors
-
-### In-Place Functions (pca, scale, neighbors, leiden, umap, tsne)
-- ALWAYS call without assignment: `ov.pp.pca(adata, n_pcs=50)`
-- NEVER assign result: `adata = ov.pp.pca(adata)` (returns None!)
-- These functions modify adata in-place and return None
-
-### Categorical Column Access
-- ALWAYS check dtype before .cat: `if hasattr(col, 'cat'): col.cat.categories`
-- NEVER assume column is categorical - it may be string or object dtype
-- CORRECT: `adata.obs['col'].value_counts()` (works for any dtype)
-
-### HVG Selection (highly_variable_genes)
-- ALWAYS wrap in try/except with seurat fallback:
-  ```python
-  try:
-      sc.pp.highly_variable_genes(adata, flavor='seurat_v3', n_top_genes=2000)
-  except ValueError:
-      sc.pp.highly_variable_genes(adata, flavor='seurat', n_top_genes=2000)
-  ```
-- NEVER use seurat_v3 without fallback - fails on small datasets
-
-### Batch Column Handling
-- ALWAYS validate batch column before batch operations:
-  ```python
-  if 'batch' in adata.obs.columns:
-      adata.obs['batch'] = adata.obs['batch'].astype(str).fillna('unknown')
-  ```
-- NEVER assume batch column exists or has valid values
-"""
+        instructions = (
+            "You are an intelligent OmicVerse assistant that can automatically "
+            "discover and execute functions based on natural language requests.\n\n"
+            "## OmicVerse Function Registry (compact overview)\n\n"
+            "The following categories of functions are registered.  "
+            "Use the `search_functions` tool to look up signatures, parameters, "
+            "prerequisites, and examples for any function before generating code.\n\n"
+            + compact_summary + "\n\n"
+            "## Your Task\n\n"
+            "When given a natural language request and an adata object, you should:\n\n"
+            "Quick-start examples (non-experts can copy/paste):\n"
+            '- "basic single-cell QC and clustering" (uses QC -> preprocess -> neighbors/UMAP -> Leiden -> markers)\n'
+            '- "batch integration with harmony on this adata" (uses harmony then neighbors/UMAP/Leiden, use_raw=False)\n'
+            '- "simple trajectory with DPT, root on paul15_clusters=7MEP, list top genes"\n'
+            '- "find markers for each Leiden cluster (wilcoxon)"\n'
+            '- "doublet check and report rate"\n\n'
+            "1. **Analyze the request** to understand what the user wants to accomplish\n"
+            "2. **Call `search_functions`** with relevant keywords to find the appropriate function, "
+            "its exact signature, prerequisites, and examples\n"
+            "3. **Extract parameters** from the user's request (e.g., \"nUMI>500\" means min_genes=500)\n"
+            "4. **Generate and execute Python code** using the appropriate OmicVerse function\n"
+            "5. **Return the modified adata object**\n\n"
+            "## Parameter Extraction Rules\n\n"
+            "Extract parameters dynamically based on patterns in the user request:\n\n"
+            "- For qc function: Create tresh dict with 'mito_perc', 'nUMIs', 'detected_genes'\n"
+            "  - \"nUMI>X\", \"umi>X\" -> tresh={'nUMIs': X, 'detected_genes': 250, 'mito_perc': 0.15}\n"
+            "  - \"mito<X\", \"mitochondrial<X\" -> include in tresh dict as 'mito_perc': X\n"
+            "  - \"genes>X\" -> include in tresh dict as 'detected_genes': X\n"
+            "  - Always provide complete tresh dict with all three keys\n"
+            "- \"resolution=X\" -> resolution=X\n"
+            "- \"n_pcs=X\", \"pca=X\" -> n_pcs=X\n"
+            "- \"max_value=X\" -> max_value=X\n"
+            "- Mode indicators: \"seurat\", \"mads\", \"pearson\" -> mode=\"seurat\"\n"
+            "- Boolean indicators: \"no doublets\", \"skip doublets\" -> doublets=False\n\n"
+            "## Code Execution Rules\n\n"
+            "1. **Always import omicverse as ov** at the start\n"
+            "2. **Use the exact function signature** returned by search_functions\n"
+            "3. **Handle the adata variable** - it will be provided in the context\n"
+            "4. **Update adata in place** when possible\n"
+            "5. **Print success messages** and basic info about the result\n\n"
+            "## Important Notes\n\n"
+            "- Always work with the provided `adata` variable\n"
+            "- Use the function signatures exactly as returned by search_functions\n"
+            "- Provide helpful feedback about what was executed\n"
+            "- Do not create dummy AnnData objects; operate directly on the provided data\n"
+            "- Prefer `use_raw=False` unless the user explicitly requests raw\n"
+            "- Handle errors gracefully and suggest alternatives if needed\n\n"
+        ) + _CODE_QUALITY_RULES_EXT
 
         if self._skill_overview_text:
             instructions += (

--- a/omicverse/utils/smart_agent.py
+++ b/omicverse/utils/smart_agent.py
@@ -112,11 +112,9 @@ from .ovagent.tool_runtime import (
 )
 from .ovagent.codegen_pipeline import CodegenPipeline as _CodegenPipeline
 from .ovagent.subagent_controller import SubagentController as _SubagentController
-from .ovagent.turn_controller import (
-    TurnController as _TurnController,
-    FollowUpGate as _FollowUpGate,
-)
+from .ovagent.turn_controller import TurnController as _TurnController
 from .ovagent.session_facade import SessionContextFacadeMixin
+from .ovagent.codegen_tool_facade import CodegenToolDispatchFacadeMixin
 from .ovagent.registry_scanner import RegistryScanner as _RegistryScanner
 
 # Session history
@@ -207,7 +205,7 @@ def _run_coroutine_sync(coro: Coroutine[Any, Any, _T]) -> _T:
     return asyncio.run(coro)
 
 
-class OmicVerseAgent(SessionContextFacadeMixin):
+class OmicVerseAgent(CodegenToolDispatchFacadeMixin, SessionContextFacadeMixin):
     """
     Intelligent agent for OmicVerse function discovery and execution.
 
@@ -221,15 +219,6 @@ class OmicVerseAgent(SessionContextFacadeMixin):
     # Class-level tool schemas (backward-compat surface)
     LEGACY_AGENT_TOOLS = _LEGACY_AGENT_TOOLS
     AGENT_TOOLS = get_visible_tool_schemas(get_default_loaded_tool_names()) + _LEGACY_AGENT_TOOLS
-
-    @property
-    def _codegen(self) -> "_CodegenPipeline":
-        """Lazily create CodegenPipeline for agents constructed via __new__."""
-        pipeline = getattr(self, "_codegen_pipeline", None)
-        if pipeline is None:
-            pipeline = _CodegenPipeline(self)
-            self._codegen_pipeline = pipeline
-        return pipeline
 
     def __init__(self, model: str = "gpt-5.2", api_key: Optional[str] = None, endpoint: Optional[str] = None, auth_mode: str = "environment", auth_provider: Optional[str] = None, auth_file: Optional[str] = None, enable_reflection: bool = True, reflection_iterations: int = 1, enable_result_review: bool = True, use_notebook_execution: bool = True, max_prompts_per_session: int = 5, notebook_storage_dir: Optional[str] = None, keep_execution_notebooks: bool = True, notebook_timeout: int = 600, strict_kernel_validation: bool = True, enable_filesystem_context: bool = True, context_storage_dir: Optional[str] = None, approval_mode: str = "never", agent_mode: str = "agentic", max_agent_turns: int = 15, security_level: Optional[str] = None, *, config: Optional[AgentConfig] = None, reporter: Optional[Reporter] = None, verbose: bool = True):
         """
@@ -674,18 +663,6 @@ User request: "quality control with nUMI>500, mito<0.2"
         with _temporary_api_keys_cm(self._managed_api_env):
             yield
 
-    def _get_visible_agent_tools(self, *, allowed_names: Optional[set[str]] = None) -> list[dict[str, Any]]:
-        """Return the currently visible tool schemas."""
-        return self._tool_runtime.get_visible_agent_tools(allowed_names=allowed_names)
-
-    def _get_loaded_tool_names(self) -> list[str]:
-        """Return loaded tool names."""
-        return self._tool_runtime.get_loaded_tool_names()
-
-    def _tool_blocked_in_plan_mode(self, tool_name: str) -> bool:
-        """Check plan-mode blocking."""
-        return self._tool_runtime.tool_blocked_in_plan_mode(tool_name)
-
     def _resolve_local_path(self, file_path: str, *, allow_relative: bool = False) -> Path:
         path = Path(file_path).expanduser()
         if not path.is_absolute():
@@ -721,14 +698,6 @@ User request: "quality control with nUMI>500, mito<0.2"
         approved = self._request_interaction(interaction)
         if not approved:
             raise PermissionError(f"{tool_name} was not approved by the user.")
-
-    def _extract_python_code(self, response_text: str) -> str:
-        """Extract executable Python code from the agent response using AST validation."""
-        return self._codegen.extract_python_code(response_text)
-
-    def _normalize_registry_entry_for_codegen(self, entry: Dict[str, Any]) -> Dict[str, Any]:
-        """Convert registry entries to public-facing ov.* names for code generation."""
-        return _RegistryScanner.normalize_entry(entry)
 
     def _build_agentic_system_prompt(self) -> str:
         return self._prompt_builder.build_agentic_system_prompt()
@@ -768,186 +737,6 @@ User request: "quality control with nUMI>500, mito<0.2"
             },
             indent=2,
         )
-
-    # =====================================================================
-    # Registry scanner delegates (thin wrappers over RegistryScanner)
-    # =====================================================================
-
-    @property
-    def _scanner(self) -> _RegistryScanner:
-        """Lazily create RegistryScanner for agents constructed via __new__."""
-        scanner = getattr(self, "_registry_scanner", None)
-        if scanner is None:
-            scanner = _RegistryScanner()
-            self._registry_scanner = scanner
-        return scanner
-
-    def _load_static_registry_entries(self) -> List[Dict[str, Any]]:
-        """Parse @register_function metadata plus nested method/branch capabilities."""
-        return self._scanner.load_static_entries()
-
-    def _collect_relevant_registry_entries(self, request: str, max_entries: int = 8) -> List[Dict[str, Any]]:
-        """Return a compact set of registry entries relevant to a free-form request."""
-        return self._scanner.collect_relevant_entries(request, max_entries)
-
-    def _collect_static_registry_entries(self, request: str, max_entries: int = 8) -> List[Dict[str, Any]]:
-        """Search the static AST-derived registry snapshot."""
-        return self._scanner.collect_static_entries(request, max_entries)
-
-    def _score_registry_entry_for_codegen(self, request: str, entry: Dict[str, Any]) -> float:
-        """Score a registry entry for lightweight code generation retrieval."""
-        return _RegistryScanner.score_entry(request, entry)
-
-    # =====================================================================
-    # FollowUp gate delegates (used by tests via agent instance)
-    # =====================================================================
-
-    def _request_requires_tool_action(self, request: str, adata: Any) -> bool:
-        return _FollowUpGate.request_requires_tool_action(request, adata)
-
-    def _response_is_promissory(self, content: str) -> bool:
-        return _FollowUpGate.response_is_promissory(content)
-
-    def _select_agent_tool_choice(self, *, request, adata, turn_index, had_meaningful_tool_call, forced_retry) -> str:
-        return _FollowUpGate.select_tool_choice(
-            request=request, adata=adata, turn_index=turn_index,
-            had_meaningful_tool_call=had_meaningful_tool_call, forced_retry=forced_retry,
-        )
-
-    # =====================================================================
-    # Tool dispatch delegates
-    # =====================================================================
-
-    async def _dispatch_tool(self, tool_call, current_adata: Any, request: str):
-        return await self._tool_runtime.dispatch_tool(tool_call, current_adata, request)
-
-    # =====================================================================
-    # Codegen pipeline delegates
-    # =====================================================================
-
-    def _capture_code_only_snippet(self, code: str, description: str = "") -> None:
-        """Store the latest code snippet captured from execute_code in code-only mode."""
-        self._codegen.capture_code_only_snippet(code, description)
-
-    def _select_codegen_skill_matches(self, request: str, top_k: int = 2) -> List[SkillMatch]:
-        return self._codegen.select_codegen_skill_matches(request, top_k)
-
-    def _format_registry_context_for_codegen(self, entries: List[Dict[str, Any]]) -> str:
-        return self._codegen.format_registry_context_for_codegen(entries)
-
-    @staticmethod
-    def _format_prerequisites_for_codegen_entry(entry: Dict[str, Any]) -> str:
-        return _CodegenPipeline.format_prerequisites_for_codegen_entry(entry)
-
-    def _build_code_generation_system_prompt(self, adata: Any) -> str:
-        return self._codegen.build_code_generation_system_prompt(adata)
-
-    @staticmethod
-    def _build_code_generation_user_prompt(request: str, adata: Any) -> str:
-        return _CodegenPipeline.build_code_generation_user_prompt(request, adata)
-
-    @staticmethod
-    def _contains_forbidden_scanpy_usage(code: str) -> bool:
-        return _CodegenPipeline.contains_forbidden_scanpy_usage(code)
-
-    def _rewrite_scanpy_calls_with_registry(self, code: str, entries: List[Dict[str, Any]]) -> str:
-        return self._codegen.rewrite_scanpy_calls_with_registry(code, entries)
-
-    async def _rewrite_code_without_scanpy(self, code: str, request: str, adata: Any, registry_context: str = "", skill_guidance: str = "") -> tuple:
-        return await self._codegen.rewrite_code_without_scanpy(code, request, adata, registry_context, skill_guidance)
-
-    async def _review_generated_code_lightweight(self, code: str, request: str, adata: Any) -> tuple:
-        return await self._codegen.review_generated_code_lightweight(code, request, adata)
-
-    @staticmethod
-    def _build_code_only_agentic_request(request: str, adata: Any) -> str:
-        return _CodegenPipeline.build_code_only_agentic_request(request, adata)
-
-    async def _generate_code_via_agentic_loop(self, request: str, adata: Any, *, progress_callback: Optional[Callable[[str], None]] = None) -> str:
-        return await self._codegen.generate_code_via_agentic_loop(request, adata, progress_callback=progress_callback)
-
-    def _gather_code_candidates(self, response_text: str) -> List[str]:
-        return self._codegen.gather_code_candidates(response_text)
-
-    @staticmethod
-    def _looks_like_python(code: str) -> bool:
-        return _CodegenPipeline.looks_like_python(code)
-
-    @staticmethod
-    def _extract_inline_python(response_text: str) -> str:
-        return _CodegenPipeline.extract_inline_python(response_text)
-
-    @staticmethod
-    def _normalize_code_candidate(code: str) -> str:
-        return _CodegenPipeline.normalize_code_candidate(code)
-
-    def _extract_python_code_strict(self, response_text: str) -> str:
-        return self._codegen.extract_python_code_strict(response_text)
-
-    async def _review_result(self, original_adata: Any, result_adata: Any, request: str, code: str) -> Dict[str, Any]:
-        return await self._codegen.review_result(original_adata, result_adata, request, code)
-
-    async def _reflect_on_code(self, code: str, request: str, adata: Any, iteration: int = 1) -> Dict[str, Any]:
-        return await self._codegen.reflect_on_code(code, request, adata, iteration)
-
-    def _detect_direct_python_request(self, request: str) -> Optional[str]:
-        return self._codegen.detect_direct_python_request(request)
-
-    @staticmethod
-    def _merge_usage_stats(usages: List[Optional[Usage]]) -> Optional[Usage]:
-        """Merge usage records from multiple lightweight codegen calls."""
-        valid = [usage for usage in usages if usage is not None]
-        if not valid:
-            return None
-        return Usage(
-            input_tokens=sum(max(0, usage.input_tokens) for usage in valid),
-            output_tokens=sum(max(0, usage.output_tokens) for usage in valid),
-            total_tokens=sum(max(0, usage.total_tokens) for usage in valid),
-            model=valid[-1].model,
-            provider=valid[-1].provider,
-        )
-
-    # =====================================================================
-    # Analysis executor delegates
-    # =====================================================================
-
-    def _check_code_prerequisites(self, code: str, adata: Any) -> str:
-        return self._analysis_executor.check_code_prerequisites(code, adata)
-
-    def _apply_execution_error_fix(self, code: str, error_msg: str) -> Optional[str]:
-        return self._analysis_executor.apply_execution_error_fix(code, error_msg)
-
-    @staticmethod
-    def _extract_package_name(error_msg: str) -> Optional[str]:
-        return _AnalysisExecutor.extract_package_name(error_msg)
-
-    def _auto_install_package(self, package_name: str) -> bool:
-        return self._analysis_executor.auto_install_package(package_name)
-
-    async def _diagnose_error_with_llm(self, code: str, error_msg: str, traceback_str: str, adata: Any) -> Optional[str]:
-        return await self._analysis_executor.diagnose_error_with_llm(code, error_msg, traceback_str, adata)
-
-    def _validate_outputs(self, code: str, output_dir: Optional[str] = None) -> List[str]:
-        return self._analysis_executor.validate_outputs(code, output_dir)
-
-    async def _generate_completion_code(self, original_code: str, missing_files: List[str], adata: Any, request: str) -> Optional[str]:
-        return await self._analysis_executor.generate_completion_code(original_code, missing_files, adata, request)
-
-    def _request_approval(self, code: str, violations: list) -> bool:
-        return self._analysis_executor.request_approval(code, violations)
-
-    def _execute_generated_code(self, code: str, adata: Any, capture_stdout: bool = False) -> Any:
-        return self._analysis_executor.execute_generated_code(code, adata, capture_stdout)
-
-    @staticmethod
-    def _normalize_doublet_obs(adata: Any) -> None:
-        _AnalysisExecutor.normalize_doublet_obs(adata)
-
-    def _process_context_directives(self, code: str, local_vars: Dict[str, Any]) -> None:
-        self._analysis_executor.process_context_directives(code, local_vars)
-
-    def _build_sandbox_globals(self) -> Dict[str, Any]:
-        return self._analysis_executor.build_sandbox_globals()
 
     # =====================================================================
     # Skill helpers

--- a/omicverse/utils/smart_agent.py
+++ b/omicverse/utils/smart_agent.py
@@ -522,7 +522,7 @@ class OmicVerseAgent:
         # When using a custom endpoint (proxy), keep the model name as-is.
         # Proxies expect the exact model name the user typed.
         if endpoint:
-            print(f"   🔌 Proxy mode: model={model}, endpoint={endpoint}")
+            _emit(EventLevel.INFO, f"Proxy mode: model={model}, endpoint={endpoint}", "init")
         else:
             # Normalize model ID for aliases and variations, then validate
             original_model = model
@@ -532,7 +532,7 @@ class OmicVerseAgent:
                 logger.debug("Model ID normalization fallback for %r: %s", model, exc)
                 model = model
             if model != original_model:
-                print(f"   📝 Model ID normalized: {original_model} → {model}")
+                _emit(EventLevel.INFO, f"Model ID normalized: {original_model} → {model}", "init")
 
         # --- Auth & backend resolution (ovagent.auth) --------------------------
         backend = _resolve_model_and_provider(model, api_key, endpoint)
@@ -602,7 +602,7 @@ class OmicVerseAgent:
             with self._temporary_api_keys():
                 self._setup_agent()
             stats = self._get_registry_stats()
-            print(f"   📚 Function registry loaded: {stats['total_functions']} functions in {stats['categories']} categories")
+            _emit(EventLevel.INFO, f"Function registry loaded: {stats['total_functions']} functions in {stats['categories']} categories", "init")
 
             _display_reflection_config(
                 self.enable_reflection,
@@ -663,9 +663,9 @@ class OmicVerseAgent:
             )
             self._codegen_pipeline = _CodegenPipeline(self)
 
-            print("✅ Smart Agent initialized successfully!")
+            _emit(EventLevel.SUCCESS, "Smart Agent initialized successfully!", "init")
         except Exception as e:
-            print(f"❌ Agent initialization failed: {e}")
+            _emit(EventLevel.ERROR, f"Agent initialization failed: {e}", "init")
             raise
 
     # =====================================================================
@@ -1279,30 +1279,26 @@ IMPORTANT: Respond with ONLY the JSON array, nothing else."""
         Any
             Processed adata object.
         """
-        print(f"\n{'=' * 70}")
-        print(f"🤖 OmicVerse Agent Processing Request")
-        print(f"{'=' * 70}")
-        print(f"Request: \"{request}\"")
         if adata is not None and hasattr(adata, 'shape'):
-            print(f"Dataset: {adata.shape[0]} cells × {adata.shape[1]} genes")
+            dataset_desc = f"{adata.shape[0]} cells × {adata.shape[1]} genes"
         else:
-            print(f"Dataset: None (knowledge query)")
-        print(f"{'=' * 70}\n")
+            dataset_desc = "None (knowledge query)"
+        self._emit(EventLevel.INFO, f"Processing request: \"{request}\" | Dataset: {dataset_desc}", "execution")
 
         # Direct execution path for explicit Python snippets (no LLM required)
         direct_code = self._detect_direct_python_request(request)
         if direct_code:
-            print(f"🧪 Direct Python detected → executing without model calls")
+            self._emit(EventLevel.INFO, "Direct Python detected → executing without model calls", "execution")
             self.last_usage = None
             self.last_usage_breakdown = {
                 'generation': None, 'reflection': [], 'review': [], 'total': None
             }
             try:
                 result_adata = self._execute_generated_code(direct_code, adata)
-                print(f"✅ Python code executed directly.")
+                self._emit(EventLevel.SUCCESS, "Python code executed directly.", "execution")
                 return result_adata
             except Exception as exc:
-                print(f"❌ Direct Python execution failed: {exc}")
+                self._emit(EventLevel.ERROR, f"Direct Python execution failed: {exc}", "execution")
                 raise
 
         if self.provider == "python":
@@ -1312,23 +1308,16 @@ IMPORTANT: Respond with ONLY the JSON array, nothing else."""
 
     async def _run_agentic_mode(self, request: str, adata: Any) -> Any:
         """Agentic loop mode: LLM autonomously calls tools to complete the task."""
-        print(f"🤖 Mode: Agentic Loop (tool-calling)")
-        print()
+        self._emit(EventLevel.INFO, "Mode: Agentic Loop (tool-calling)", "execution")
 
         try:
             result = await self._run_agentic_loop(request, adata)
             self._turn_controller._persist_harness_history(request)
-            print()
-            print(f"{'=' * 70}")
-            print(f"✅ SUCCESS - Agentic loop completed!")
-            print(f"{'=' * 70}\n")
+            self._emit(EventLevel.SUCCESS, "Agentic loop completed!", "execution")
             return result
         except Exception as e:
             self._turn_controller._persist_harness_history(request)
-            print()
-            print(f"{'=' * 70}")
-            print(f"❌ ERROR - Agentic loop failed: {e}")
-            print(f"{'=' * 70}\n")
+            self._emit(EventLevel.ERROR, f"Agentic loop failed: {e}", "execution")
             raise
 
     async def generate_code_async(self, request: str, adata: Any = None, *, max_functions: int = 8, progress_callback: Optional[Callable[[str], None]] = None) -> str:
@@ -1532,13 +1521,13 @@ IMPORTANT: Respond with ONLY the JSON array, nothing else."""
         if hasattr(self, '_notebook_executor') and self._notebook_executor:
             try:
                 self._notebook_executor.shutdown()
-            except Exception:
-                pass
+            except Exception as exc:
+                logger.debug("__del__: notebook executor shutdown failed: %s", exc)
         if hasattr(self, '_filesystem_context') and self._filesystem_context:
             try:
                 self._filesystem_context.cleanup_session(keep_summary=True)
-            except Exception:
-                pass
+            except Exception as exc:
+                logger.debug("__del__: filesystem context cleanup failed: %s", exc)
 
 
 # =====================================================================

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,0 +1,12 @@
+"""Integration test harness for OmicVerse Agent and Jarvis layers.
+
+This package provides reusable fake implementations and helpers that let
+integration tests exercise agent and Jarvis runtime behavior without real
+LLM providers or network dependencies.
+
+Submodules
+----------
+fakes : Fake LLM, tool-runtime, and Jarvis presenter/adapter/router classes.
+helpers : Factory functions for common data objects and agent wiring.
+conftest : Pytest fixtures that expose the fakes as session-ready test doubles.
+"""

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,129 @@
+"""Pytest fixtures for the integration test harness.
+
+Fixtures in this file are automatically available to every test inside
+``tests/integration/``.  Other test directories can import the helper
+factories directly from ``tests.integration.helpers`` when needed.
+"""
+from __future__ import annotations
+
+import os
+from typing import Any, Callable, Dict, List, Optional
+
+import pytest
+
+from .fakes import (
+    AgentRunResult,
+    ChatResponse,
+    FakeExecutionAdapter,
+    FakeLLM,
+    FakePresenter,
+    FakeRouter,
+    FakeToolRuntime,
+)
+from .helpers import (
+    build_fake_llm,
+    build_fake_tool_runtime,
+    build_jarvis_runtime_deps,
+    make_chat_response,
+    make_envelope,
+    make_route,
+    make_tool_call,
+)
+
+
+_RUN_HARNESS = os.environ.get("OV_AGENT_RUN_HARNESS_TESTS", "").lower() in {
+    "1", "true", "yes", "on",
+}
+
+
+# -----------------------------------------------------------------
+# LLM fixtures
+# -----------------------------------------------------------------
+
+
+@pytest.fixture
+def fake_llm() -> Callable[..., FakeLLM]:
+    """Factory fixture: call with a list of responses to get a ``FakeLLM``."""
+    return build_fake_llm
+
+
+@pytest.fixture
+def simple_fake_llm() -> FakeLLM:
+    """Pre-built ``FakeLLM`` with a single text response."""
+    return build_fake_llm(["Hello from the fake LLM."])
+
+
+# -----------------------------------------------------------------
+# Tool-runtime fixtures
+# -----------------------------------------------------------------
+
+
+@pytest.fixture
+def fake_tool_runtime() -> Callable[..., FakeToolRuntime]:
+    """Factory fixture: call with handlers dict to get a ``FakeToolRuntime``."""
+    return build_fake_tool_runtime
+
+
+@pytest.fixture
+def echo_tool_runtime() -> FakeToolRuntime:
+    """Pre-built ``FakeToolRuntime`` with a single *echo* tool."""
+
+    def _echo(args: Dict[str, Any], adata: Any, request: str) -> str:
+        return f"echo: {args}"
+
+    return build_fake_tool_runtime(
+        {"echo": _echo},
+        tool_schemas=[
+            {
+                "name": "echo",
+                "description": "Echoes its arguments.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"text": {"type": "string"}},
+                },
+            }
+        ],
+    )
+
+
+# -----------------------------------------------------------------
+# Jarvis fixtures
+# -----------------------------------------------------------------
+
+
+@pytest.fixture
+def fake_presenter() -> FakePresenter:
+    """Fresh ``FakePresenter`` for recording Jarvis presentation calls."""
+    return FakePresenter()
+
+
+@pytest.fixture
+def fake_execution_adapter() -> Callable[..., FakeExecutionAdapter]:
+    """Factory fixture: call with an optional ``AgentRunResult``."""
+
+    def _build(result: Optional[AgentRunResult] = None) -> FakeExecutionAdapter:
+        return FakeExecutionAdapter(result=result)
+
+    return _build
+
+
+@pytest.fixture
+def fake_route():
+    """Default ``ConversationRoute`` for test channel *test*, DM scope."""
+    return make_route()
+
+
+@pytest.fixture
+def fake_envelope():
+    """Default ``MessageEnvelope`` with text ``'hello'``."""
+    return make_envelope()
+
+
+@pytest.fixture
+def jarvis_runtime_deps():
+    """Dict of fakes ready to construct a ``MessageRuntime``.
+
+    Keys: ``presenter``, ``execution_adapter``, ``router``, ``deliver``,
+    ``delivered`` (list accumulating delivery events).
+    """
+    return build_jarvis_runtime_deps()

--- a/tests/integration/fakes.py
+++ b/tests/integration/fakes.py
@@ -1,0 +1,483 @@
+"""Reusable fake implementations for integration-grade tests.
+
+All classes in this module are test doubles that satisfy the same interfaces as
+production components but operate entirely in-memory without network or disk I/O.
+
+These fakes are intentionally kept in a single module so that any integration
+test suite can ``from tests.integration.fakes import FakeLLM, ...`` without
+pulling in production dependencies.
+"""
+from __future__ import annotations
+
+import asyncio
+import uuid
+from dataclasses import dataclass, field
+from types import SimpleNamespace
+from typing import Any, AsyncIterator, Callable, Dict, List, Optional, Tuple
+
+# ---------------------------------------------------------------------------
+# Lightweight stand-ins for agent_backend_common types.
+# We re-declare minimal versions here so the test harness stays importable
+# even when the heavy production package cannot be loaded in CI.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _Usage:
+    input_tokens: int = 10
+    output_tokens: int = 20
+    total_tokens: int = 30
+    model: str = "fake-model"
+    provider: str = "fake"
+
+
+@dataclass
+class _ToolCall:
+    id: str = ""
+    name: str = ""
+    arguments: Dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.id:
+            self.id = f"call_{uuid.uuid4().hex[:12]}"
+
+
+@dataclass
+class _ChatResponse:
+    content: Optional[str] = None
+    tool_calls: List[_ToolCall] = field(default_factory=list)
+    stop_reason: str = "end_turn"
+    usage: Optional[_Usage] = None
+    raw_message: Optional[Any] = None
+
+
+# Try to import the real types so that isinstance checks in production code
+# work when the harness is used alongside the real package.  Fall back to the
+# local stand-ins when imports fail (e.g. minimal CI without full deps).
+try:
+    from omicverse.utils.agent_backend_common import (
+        BackendConfig,
+        ChatResponse,
+        ToolCall,
+        Usage,
+    )
+except Exception:  # pragma: no cover – CI-only fallback
+    Usage = _Usage  # type: ignore[misc,assignment]
+    ToolCall = _ToolCall  # type: ignore[misc,assignment]
+    ChatResponse = _ChatResponse  # type: ignore[misc,assignment]
+    BackendConfig = None  # type: ignore[misc,assignment]
+
+try:
+    from omicverse.jarvis.agent_bridge import AgentRunResult
+except Exception:  # pragma: no cover
+    @dataclass
+    class AgentRunResult:  # type: ignore[no-redef]
+        adata: Optional[Any] = None
+        figures: List[bytes] = field(default_factory=list)
+        reports: List[str] = field(default_factory=list)
+        artifacts: list = field(default_factory=list)
+        summary: str = ""
+        error: Optional[str] = None
+        usage: Optional[Any] = None
+        diagnostics: List[str] = field(default_factory=list)
+
+try:
+    from omicverse.jarvis.runtime.models import (
+        ConversationRoute,
+        DeliveryEvent,
+        MessageEnvelope,
+        PolicyDecision,
+        RuntimeTaskState,
+    )
+except Exception:  # pragma: no cover
+    ConversationRoute = None  # type: ignore[misc,assignment]
+    DeliveryEvent = None  # type: ignore[misc,assignment]
+    MessageEnvelope = None  # type: ignore[misc,assignment]
+    PolicyDecision = None  # type: ignore[misc,assignment]
+    RuntimeTaskState = None  # type: ignore[misc,assignment]
+
+
+# ===================================================================
+#  Fake LLM Backend
+# ===================================================================
+
+
+class FakeLLM:
+    """Drop-in replacement for ``OmicVerseLLMBackend`` in tests.
+
+    Parameters
+    ----------
+    responses : list
+        Ordered list of responses.  Each element is either:
+        - a ``str`` (returned verbatim from ``run`` / as ``content`` in ``chat``)
+        - a ``ChatResponse`` (returned from ``chat`` as-is)
+        Responses are consumed FIFO.  When the list is exhausted a default
+        ``ChatResponse(content="<exhausted>", ...)`` is returned.
+    model : str
+        Model name exposed on ``config.model``.
+    provider : str
+        Provider name exposed on ``config.provider``.
+    """
+
+    def __init__(
+        self,
+        responses: Optional[List[Any]] = None,
+        *,
+        model: str = "fake-model",
+        provider: str = "fake",
+    ) -> None:
+        self._responses: List[Any] = list(responses or [])
+        self.config = SimpleNamespace(
+            model=model,
+            provider=provider,
+            system_prompt="You are a test agent.",
+            api_key=None,
+            endpoint=None,
+            max_tokens=1024,
+            temperature=0.0,
+        )
+        self.last_usage: Optional[Any] = None
+
+        # Call recording — tests can inspect these after exercising the agent.
+        self.chat_calls: List[Dict[str, Any]] = []
+        self.run_calls: List[str] = []
+        self.stream_calls: List[str] = []
+
+    # -- response helpers ------------------------------------------------
+
+    def _pop_response(self) -> Any:
+        if self._responses:
+            return self._responses.pop(0)
+        return ChatResponse(
+            content="<exhausted>",
+            tool_calls=[],
+            stop_reason="end_turn",
+            usage=Usage(
+                input_tokens=0,
+                output_tokens=0,
+                total_tokens=0,
+                model=self.config.model,
+                provider=self.config.provider,
+            ),
+        )
+
+    def _to_chat_response(self, raw: Any) -> ChatResponse:
+        if isinstance(raw, str):
+            usage = Usage(
+                input_tokens=10,
+                output_tokens=len(raw),
+                total_tokens=10 + len(raw),
+                model=self.config.model,
+                provider=self.config.provider,
+            )
+            return ChatResponse(
+                content=raw,
+                tool_calls=[],
+                stop_reason="end_turn",
+                usage=usage,
+            )
+        return raw  # already a ChatResponse
+
+    # -- public interface (matches OmicVerseLLMBackend) -------------------
+
+    async def chat(
+        self,
+        messages: List[Dict[str, Any]],
+        tools: Optional[List[Dict[str, Any]]] = None,
+        tool_choice: Optional[str] = None,
+    ) -> ChatResponse:
+        self.chat_calls.append(
+            {"messages": messages, "tools": tools, "tool_choice": tool_choice}
+        )
+        resp = self._to_chat_response(self._pop_response())
+        self.last_usage = resp.usage
+        return resp
+
+    async def run(self, user_prompt: str) -> str:
+        self.run_calls.append(user_prompt)
+        resp = self._to_chat_response(self._pop_response())
+        self.last_usage = resp.usage
+        return resp.content or ""
+
+    async def stream(self, user_prompt: str) -> AsyncIterator[str]:
+        self.stream_calls.append(user_prompt)
+        resp = self._to_chat_response(self._pop_response())
+        self.last_usage = resp.usage
+        text = resp.content or ""
+        # Yield in small chunks to simulate streaming.
+        chunk_size = max(1, len(text) // 3) if text else 1
+        for i in range(0, max(len(text), 1), chunk_size):
+            yield text[i : i + chunk_size]
+
+    def format_tool_result_message(
+        self, tool_call_id: str, tool_name: str, result: str
+    ) -> Dict[str, Any]:
+        return {
+            "role": "tool",
+            "tool_call_id": tool_call_id,
+            "name": tool_name,
+            "content": result,
+        }
+
+    @property
+    def remaining_responses(self) -> int:
+        return len(self._responses)
+
+
+# ===================================================================
+#  Fake Tool Registry & Runtime
+# ===================================================================
+
+
+class FakeToolRegistry:
+    """Minimal stand-in for ``ToolRegistry``."""
+
+    def __init__(self, tools: Optional[Dict[str, Dict[str, Any]]] = None) -> None:
+        self._tools: Dict[str, Dict[str, Any]] = dict(tools or {})
+
+    def resolve_name(self, name_or_alias: str) -> str:
+        return name_or_alias
+
+    def get(self, name_or_alias: str) -> Optional[SimpleNamespace]:
+        spec = self._tools.get(name_or_alias)
+        if spec is None:
+            return None
+        return SimpleNamespace(canonical_name=name_or_alias, **spec)
+
+    def get_handler(self, name_or_alias: str) -> Optional[Callable[..., Any]]:
+        meta = self.get(name_or_alias)
+        if meta is None:
+            return None
+        return getattr(meta, "handler", None)
+
+    def validate_handlers(self) -> List[str]:
+        return []
+
+
+class FakeToolRuntime:
+    """Drop-in replacement for ``ToolRuntime`` in tests.
+
+    Parameters
+    ----------
+    handlers : dict
+        Mapping of tool name -> callable.  The callable receives
+        ``(tool_args: dict, adata: Any, request: str)`` and returns a ``str``.
+    tool_schemas : list
+        Optional list of tool-schema dicts to return from
+        ``get_visible_agent_tools``.
+    """
+
+    def __init__(
+        self,
+        handlers: Optional[Dict[str, Callable[..., str]]] = None,
+        *,
+        tool_schemas: Optional[List[Dict[str, Any]]] = None,
+    ) -> None:
+        self._handlers: Dict[str, Callable[..., str]] = dict(handlers or {})
+        self._tool_schemas = list(tool_schemas or [])
+        self.registry = FakeToolRegistry(
+            {name: {"handler": fn} for name, fn in self._handlers.items()}
+        )
+        self.dispatch_calls: List[Tuple[str, Dict[str, Any]]] = []
+
+    async def dispatch(
+        self,
+        tool_name: str,
+        tool_args: Dict[str, Any],
+        adata: Any,
+        request: str,
+    ) -> str:
+        self.dispatch_calls.append((tool_name, tool_args))
+        handler = self._handlers.get(tool_name)
+        if handler is None:
+            return f"[FakeToolRuntime] unknown tool: {tool_name}"
+        result = handler(tool_args, adata, request)
+        if asyncio.iscoroutine(result):
+            return await result
+        return result
+
+    def get_visible_agent_tools(
+        self, *, allowed_names: Optional[set] = None
+    ) -> List[Dict[str, Any]]:
+        if allowed_names is not None:
+            return [s for s in self._tool_schemas if s.get("name") in allowed_names]
+        return list(self._tool_schemas)
+
+    def set_subagent_controller(self, controller: Any) -> None:
+        pass
+
+
+# ===================================================================
+#  Jarvis fakes
+# ===================================================================
+
+
+class FakePresenter:
+    """Records every presentation call for later assertion.
+
+    Implements the ``MessagePresenter`` protocol used by ``MessageRuntime``.
+    """
+
+    def __init__(self) -> None:
+        self.events: List[Tuple[str, Any]] = []
+
+    def _record(self, method: str, **kwargs: Any) -> List[Any]:
+        self.events.append((method, kwargs))
+        return []
+
+    def ack(self, envelope: Any, session: Any) -> list:
+        return self._record("ack", envelope=envelope, session=session)
+
+    def queue_started(self, route: Any, queued_count: int) -> list:
+        return self._record("queue_started", route=route, queued_count=queued_count)
+
+    def draft_open(self, route: Any) -> Any:
+        self.events.append(("draft_open", {"route": route}))
+        if DeliveryEvent is not None:
+            return DeliveryEvent(route=route, kind="draft_open")
+        return SimpleNamespace(route=route, kind="draft_open")
+
+    def draft_update(self, route: Any, llm_text: str, progress: str) -> Any:
+        self.events.append(
+            ("draft_update", {"route": route, "llm_text": llm_text, "progress": progress})
+        )
+        if DeliveryEvent is not None:
+            return DeliveryEvent(route=route, kind="draft_update", text=llm_text)
+        return SimpleNamespace(route=route, kind="draft_update", text=llm_text)
+
+    def draft_cancelled(self, route: Any) -> Any:
+        self.events.append(("draft_cancelled", {"route": route}))
+        if DeliveryEvent is not None:
+            return DeliveryEvent(route=route, kind="draft_cancelled")
+        return SimpleNamespace(route=route, kind="draft_cancelled")
+
+    def analysis_error(self, route: Any, error_text: str) -> Any:
+        self.events.append(
+            ("analysis_error", {"route": route, "error_text": error_text})
+        )
+        if DeliveryEvent is not None:
+            return DeliveryEvent(route=route, kind="analysis_error", text=error_text)
+        return SimpleNamespace(route=route, kind="analysis_error", text=error_text)
+
+    def typing(self, route: Any) -> Optional[Any]:
+        self.events.append(("typing", {"route": route}))
+        return None
+
+    def quick_chat_reply(self, route: Any, text: str) -> Any:
+        self.events.append(("quick_chat_reply", {"route": route, "text": text}))
+        if DeliveryEvent is not None:
+            return DeliveryEvent(route=route, kind="quick_chat_reply", text=text)
+        return SimpleNamespace(route=route, kind="quick_chat_reply", text=text)
+
+    def quick_chat_fallback(self, route: Any) -> Any:
+        self.events.append(("quick_chat_fallback", {"route": route}))
+        if DeliveryEvent is not None:
+            return DeliveryEvent(route=route, kind="quick_chat_fallback")
+        return SimpleNamespace(route=route, kind="quick_chat_fallback")
+
+    def analysis_status(
+        self,
+        route: Any,
+        *,
+        has_media: bool = False,
+        has_reports: bool = False,
+        has_artifacts: bool = False,
+    ) -> Optional[Any]:
+        self.events.append(
+            (
+                "analysis_status",
+                {
+                    "route": route,
+                    "has_media": has_media,
+                    "has_reports": has_reports,
+                    "has_artifacts": has_artifacts,
+                },
+            )
+        )
+        return None
+
+    def final_events(
+        self,
+        route: Any,
+        *,
+        session: Any,
+        user_text: str,
+        llm_text: str,
+        result: Any,
+    ) -> list:
+        self.events.append(
+            (
+                "final_events",
+                {
+                    "route": route,
+                    "session": session,
+                    "user_text": user_text,
+                    "llm_text": llm_text,
+                    "result": result,
+                },
+            )
+        )
+        return []
+
+    def method_calls(self, method_name: str) -> List[Dict[str, Any]]:
+        """Return kwargs dicts for every call to *method_name*."""
+        return [kw for name, kw in self.events if name == method_name]
+
+
+class FakeExecutionAdapter:
+    """Drop-in replacement for ``ExecutionAdapter`` in tests.
+
+    Parameters
+    ----------
+    result : AgentRunResult | None
+        The result to return from ``run``.  Defaults to a blank
+        ``AgentRunResult(summary="ok")``.
+    """
+
+    def __init__(self, result: Optional[AgentRunResult] = None) -> None:
+        self._result = result or AgentRunResult(summary="ok")
+        self.run_calls: List[Dict[str, Any]] = []
+
+    async def run(
+        self,
+        session: Any,
+        request: str,
+        *,
+        adata: Optional[Any] = None,
+        callbacks: Any = None,
+        history: Optional[list] = None,
+        request_content: Optional[list] = None,
+    ) -> AgentRunResult:
+        self.run_calls.append(
+            {
+                "session": session,
+                "request": request,
+                "adata": adata,
+                "callbacks": callbacks,
+                "history": history,
+                "request_content": request_content,
+            }
+        )
+        return self._result
+
+
+class FakeRouter:
+    """Minimal stand-in for ``MessageRouter``.
+
+    Returns the same ``session`` object for every route, or per-route
+    overrides supplied at construction.
+    """
+
+    def __init__(
+        self,
+        default_session: Optional[Any] = None,
+        sessions: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        self._default = default_session or SimpleNamespace(
+            agent=None, adata=None, history=[]
+        )
+        self._sessions: Dict[str, Any] = dict(sessions or {})
+
+    def get_session(self, route: Any) -> Any:
+        key = getattr(route, "route_key", lambda: str(route))()
+        return self._sessions.get(key, self._default)

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -1,0 +1,208 @@
+"""Factory functions and assertion helpers for integration tests.
+
+Every function here creates lightweight data objects used by the harness fakes
+and by test assertions.  No function in this module touches the network, disk,
+or any production singleton.
+"""
+from __future__ import annotations
+
+import uuid
+from typing import Any, Dict, List, Optional
+
+from .fakes import (
+    AgentRunResult,
+    ChatResponse,
+    FakeExecutionAdapter,
+    FakeLLM,
+    FakePresenter,
+    FakeRouter,
+    FakeToolRuntime,
+    ToolCall,
+    Usage,
+)
+
+# Try to import Jarvis runtime models for factory helpers.
+try:
+    from omicverse.jarvis.runtime.models import (
+        ConversationRoute,
+        DeliveryEvent,
+        MessageEnvelope,
+        PolicyDecision,
+        RuntimeTaskState,
+    )
+
+    _HAS_JARVIS = True
+except Exception:  # pragma: no cover
+    _HAS_JARVIS = False
+
+
+# ===================================================================
+#  Data-object factories
+# ===================================================================
+
+
+def make_tool_call(
+    name: str,
+    arguments: Optional[Dict[str, Any]] = None,
+    *,
+    call_id: Optional[str] = None,
+) -> ToolCall:
+    """Create a ``ToolCall`` with sensible defaults."""
+    return ToolCall(
+        id=call_id or f"call_{uuid.uuid4().hex[:12]}",
+        name=name,
+        arguments=arguments or {},
+    )
+
+
+def make_usage(
+    input_tokens: int = 10,
+    output_tokens: int = 20,
+    *,
+    model: str = "fake-model",
+    provider: str = "fake",
+) -> Usage:
+    """Create a ``Usage`` with sensible defaults."""
+    return Usage(
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        total_tokens=input_tokens + output_tokens,
+        model=model,
+        provider=provider,
+    )
+
+
+def make_chat_response(
+    content: Optional[str] = None,
+    tool_calls: Optional[List[ToolCall]] = None,
+    stop_reason: str = "end_turn",
+    *,
+    usage: Optional[Usage] = None,
+) -> ChatResponse:
+    """Create a ``ChatResponse`` with sensible defaults."""
+    return ChatResponse(
+        content=content,
+        tool_calls=tool_calls or [],
+        stop_reason=stop_reason,
+        usage=usage or make_usage(),
+    )
+
+
+def make_agent_run_result(
+    summary: str = "ok",
+    *,
+    error: Optional[str] = None,
+    figures: Optional[List[bytes]] = None,
+    reports: Optional[List[str]] = None,
+) -> AgentRunResult:
+    """Create an ``AgentRunResult`` with sensible defaults."""
+    return AgentRunResult(
+        summary=summary,
+        error=error,
+        figures=figures or [],
+        reports=reports or [],
+    )
+
+
+def make_route(
+    channel: str = "test",
+    scope_type: str = "dm",
+    scope_id: str = "user-1",
+    *,
+    thread_id: Optional[str] = None,
+    sender_id: Optional[str] = None,
+) -> Any:
+    """Create a ``ConversationRoute``.
+
+    Returns ``None`` if the Jarvis runtime models are not importable.
+    """
+    if not _HAS_JARVIS:
+        return None
+    return ConversationRoute(
+        channel=channel,
+        scope_type=scope_type,
+        scope_id=scope_id,
+        thread_id=thread_id,
+        sender_id=sender_id,
+    )
+
+
+def make_envelope(
+    text: str = "hello",
+    *,
+    channel: str = "test",
+    scope_type: str = "dm",
+    scope_id: str = "user-1",
+    sender_id: str = "sender-1",
+    trigger: str = "message",
+    explicit_trigger: bool = False,
+    route: Any = None,
+) -> Any:
+    """Create a ``MessageEnvelope``.
+
+    Returns ``None`` if the Jarvis runtime models are not importable.
+    """
+    if not _HAS_JARVIS:
+        return None
+    r = route or make_route(
+        channel=channel,
+        scope_type=scope_type,
+        scope_id=scope_id,
+        sender_id=sender_id,
+    )
+    return MessageEnvelope(
+        route=r,
+        text=text,
+        sender_id=sender_id,
+        trigger=trigger,
+        explicit_trigger=explicit_trigger,
+    )
+
+
+# ===================================================================
+#  Harness wiring helpers
+# ===================================================================
+
+
+def build_fake_llm(
+    responses: Optional[List[Any]] = None,
+    *,
+    model: str = "fake-model",
+    provider: str = "fake",
+) -> FakeLLM:
+    """Convenience wrapper — same as ``FakeLLM(...)``."""
+    return FakeLLM(responses, model=model, provider=provider)
+
+
+def build_fake_tool_runtime(
+    handlers: Optional[Dict[str, Any]] = None,
+    *,
+    tool_schemas: Optional[List[Dict[str, Any]]] = None,
+) -> FakeToolRuntime:
+    """Convenience wrapper — same as ``FakeToolRuntime(...)``."""
+    return FakeToolRuntime(handlers, tool_schemas=tool_schemas)
+
+
+def build_jarvis_runtime_deps(
+    *,
+    execution_result: Optional[AgentRunResult] = None,
+    default_session: Optional[Any] = None,
+) -> Dict[str, Any]:
+    """Return a dict of fakes suitable for constructing a ``MessageRuntime``.
+
+    Keys: ``presenter``, ``execution_adapter``, ``router``, ``delivered``.
+    ``delivered`` is a list that accumulates every ``DeliveryEvent`` sent
+    through the delivery callback.
+    """
+    delivered: List[Any] = []
+
+    async def _deliver(event: Any) -> None:
+        delivered.append(event)
+
+    return {
+        "presenter": FakePresenter(),
+        "execution_adapter": FakeExecutionAdapter(result=execution_result),
+        "router": FakeRouter(default_session=default_session),
+        "deliver": _deliver,
+        "delivered": delivered,
+    }

--- a/tests/integration/test_harness_foundation.py
+++ b/tests/integration/test_harness_foundation.py
@@ -1,0 +1,609 @@
+"""Tests verifying the integration-test harness itself.
+
+These tests confirm that every fake, fixture, and helper works as specified
+so that downstream integration suites can rely on the harness without
+second-guessing its behavior.
+
+Acceptance criteria covered:
+  AC-001-1: Shared fake LLM and tool-runtime fixtures exist.
+  AC-001-2: Harness utilities exercise agent/Jarvis layers without network.
+  AC-001-3: Fixture code is reusable (single import, no duplication).
+  AC-001-4: Integrates with existing pytest structure.
+  AC-001-5: No production code depends on test-only harness helpers.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+
+import pytest
+
+# -- harness imports (AC-001-3: single import location) -------------------
+from tests.integration.fakes import (
+    AgentRunResult,
+    ChatResponse,
+    FakeExecutionAdapter,
+    FakeLLM,
+    FakePresenter,
+    FakeRouter,
+    FakeToolRuntime,
+    FakeToolRegistry,
+    ToolCall,
+    Usage,
+)
+from tests.integration.helpers import (
+    build_fake_llm,
+    build_fake_tool_runtime,
+    build_jarvis_runtime_deps,
+    make_agent_run_result,
+    make_chat_response,
+    make_envelope,
+    make_route,
+    make_tool_call,
+    make_usage,
+)
+
+
+_RUN_HARNESS = os.environ.get("OV_AGENT_RUN_HARNESS_TESTS", "").lower() in {
+    "1", "true", "yes", "on",
+}
+
+
+# ===================================================================
+#  FakeLLM — chat / run / stream
+# ===================================================================
+
+
+class TestFakeLLMChat:
+    """FakeLLM.chat() returns staged responses in FIFO order."""
+
+    @pytest.mark.asyncio
+    async def test_returns_string_as_chat_response(self):
+        llm = FakeLLM(["first", "second"])
+        r1 = await llm.chat([{"role": "user", "content": "hi"}])
+
+        assert isinstance(r1, ChatResponse)
+        assert r1.content == "first"
+        assert r1.stop_reason == "end_turn"
+        assert r1.tool_calls == []
+
+    @pytest.mark.asyncio
+    async def test_returns_chat_response_as_is(self):
+        staged = make_chat_response(content="staged", stop_reason="tool_use")
+        llm = FakeLLM([staged])
+        r = await llm.chat([])
+
+        assert r is staged
+        assert r.content == "staged"
+        assert r.stop_reason == "tool_use"
+
+    @pytest.mark.asyncio
+    async def test_returns_chat_response_with_tool_calls(self):
+        tc = make_tool_call("inspect_data", {"aspect": "shape"})
+        staged = make_chat_response(tool_calls=[tc], stop_reason="tool_use")
+        llm = FakeLLM([staged])
+        r = await llm.chat([])
+
+        assert len(r.tool_calls) == 1
+        assert r.tool_calls[0].name == "inspect_data"
+        assert r.tool_calls[0].arguments == {"aspect": "shape"}
+
+    @pytest.mark.asyncio
+    async def test_exhausted_returns_default_response(self):
+        llm = FakeLLM([])
+        r = await llm.chat([])
+
+        assert r.content == "<exhausted>"
+        assert r.stop_reason == "end_turn"
+
+    @pytest.mark.asyncio
+    async def test_records_calls(self):
+        llm = FakeLLM(["ok"])
+        msgs = [{"role": "user", "content": "test"}]
+        tools = [{"name": "t"}]
+        await llm.chat(msgs, tools=tools, tool_choice="auto")
+
+        assert len(llm.chat_calls) == 1
+        assert llm.chat_calls[0]["messages"] is msgs
+        assert llm.chat_calls[0]["tools"] is tools
+        assert llm.chat_calls[0]["tool_choice"] == "auto"
+
+    @pytest.mark.asyncio
+    async def test_updates_last_usage(self):
+        llm = FakeLLM(["hi"])
+        assert llm.last_usage is None
+        await llm.chat([])
+        assert llm.last_usage is not None
+
+
+class TestFakeLLMRun:
+    """FakeLLM.run() returns text and records prompts."""
+
+    @pytest.mark.asyncio
+    async def test_returns_text(self):
+        llm = FakeLLM(["hello world"])
+        result = await llm.run("prompt")
+
+        assert result == "hello world"
+
+    @pytest.mark.asyncio
+    async def test_records_prompts(self):
+        llm = FakeLLM(["a", "b"])
+        await llm.run("first")
+        await llm.run("second")
+
+        assert llm.run_calls == ["first", "second"]
+
+
+class TestFakeLLMStream:
+    """FakeLLM.stream() yields chunks."""
+
+    @pytest.mark.asyncio
+    async def test_yields_chunks(self):
+        llm = FakeLLM(["abcdef"])
+        chunks = []
+        async for chunk in llm.stream("prompt"):
+            chunks.append(chunk)
+
+        reassembled = "".join(chunks)
+        assert reassembled == "abcdef"
+        assert len(chunks) > 1  # actually streams, not one blob
+
+    @pytest.mark.asyncio
+    async def test_records_prompts(self):
+        llm = FakeLLM(["x"])
+        async for _ in llm.stream("my prompt"):
+            pass
+
+        assert llm.stream_calls == ["my prompt"]
+
+
+class TestFakeLLMConfig:
+    """FakeLLM exposes a config namespace matching OmicVerseLLMBackend."""
+
+    def test_config_defaults(self):
+        llm = FakeLLM()
+        assert llm.config.model == "fake-model"
+        assert llm.config.provider == "fake"
+
+    def test_config_overrides(self):
+        llm = FakeLLM(model="gpt-5.2", provider="openai")
+        assert llm.config.model == "gpt-5.2"
+        assert llm.config.provider == "openai"
+
+    def test_remaining_responses(self):
+        llm = FakeLLM(["a", "b", "c"])
+        assert llm.remaining_responses == 3
+
+    def test_format_tool_result_message(self):
+        llm = FakeLLM()
+        msg = llm.format_tool_result_message("call-1", "echo", "result-text")
+        assert msg["role"] == "tool"
+        assert msg["tool_call_id"] == "call-1"
+        assert msg["name"] == "echo"
+        assert msg["content"] == "result-text"
+
+
+# ===================================================================
+#  FakeToolRuntime & FakeToolRegistry
+# ===================================================================
+
+
+class TestFakeToolRegistry:
+    def test_resolve_name_passthrough(self):
+        reg = FakeToolRegistry()
+        assert reg.resolve_name("foo") == "foo"
+
+    def test_get_returns_none_for_unknown(self):
+        reg = FakeToolRegistry()
+        assert reg.get("unknown") is None
+
+    def test_get_returns_namespace_for_known(self):
+        reg = FakeToolRegistry({"echo": {"description": "test"}})
+        meta = reg.get("echo")
+        assert meta is not None
+        assert meta.canonical_name == "echo"
+        assert meta.description == "test"
+
+    def test_validate_handlers_empty(self):
+        reg = FakeToolRegistry()
+        assert reg.validate_handlers() == []
+
+
+class TestFakeToolRuntime:
+    @pytest.mark.asyncio
+    async def test_dispatch_calls_handler(self):
+        def _echo(args, adata, request):
+            return f"echo:{args['text']}"
+
+        rt = FakeToolRuntime({"echo": _echo})
+        result = await rt.dispatch("echo", {"text": "hi"}, None, "req")
+
+        assert result == "echo:hi"
+        assert rt.dispatch_calls == [("echo", {"text": "hi"})]
+
+    @pytest.mark.asyncio
+    async def test_dispatch_unknown_tool(self):
+        rt = FakeToolRuntime()
+        result = await rt.dispatch("missing", {}, None, "req")
+
+        assert "unknown tool" in result
+
+    @pytest.mark.asyncio
+    async def test_dispatch_async_handler(self):
+        async def _async_handler(args, adata, request):
+            return "async-result"
+
+        rt = FakeToolRuntime({"atool": _async_handler})
+        result = await rt.dispatch("atool", {}, None, "req")
+
+        assert result == "async-result"
+
+    def test_get_visible_agent_tools(self):
+        schemas = [{"name": "a"}, {"name": "b"}]
+        rt = FakeToolRuntime(tool_schemas=schemas)
+
+        assert rt.get_visible_agent_tools() == schemas
+        assert rt.get_visible_agent_tools(allowed_names={"a"}) == [{"name": "a"}]
+
+    def test_set_subagent_controller_noop(self):
+        rt = FakeToolRuntime()
+        rt.set_subagent_controller(object())  # should not raise
+
+
+# ===================================================================
+#  Jarvis fakes
+# ===================================================================
+
+
+class TestFakePresenter:
+    def test_records_ack(self):
+        p = FakePresenter()
+        p.ack("env", "sess")
+
+        assert len(p.events) == 1
+        assert p.events[0][0] == "ack"
+
+    def test_records_multiple_methods(self):
+        p = FakePresenter()
+        p.ack("e", "s")
+        p.draft_open("r")
+        p.analysis_error("r", "oops")
+
+        assert [name for name, _ in p.events] == [
+            "ack", "draft_open", "analysis_error"
+        ]
+
+    def test_method_calls_filter(self):
+        p = FakePresenter()
+        p.ack("e", "s")
+        p.draft_open("r1")
+        p.draft_open("r2")
+
+        opens = p.method_calls("draft_open")
+        assert len(opens) == 2
+        assert opens[0]["route"] == "r1"
+        assert opens[1]["route"] == "r2"
+
+    def test_typing_returns_none(self):
+        p = FakePresenter()
+        assert p.typing("route") is None
+
+    def test_final_events_returns_empty_list(self):
+        p = FakePresenter()
+        result = p.final_events(
+            "route", session="s", user_text="u", llm_text="l", result="r"
+        )
+        assert result == []
+
+
+class TestFakeExecutionAdapter:
+    @pytest.mark.asyncio
+    async def test_returns_default_result(self):
+        adapter = FakeExecutionAdapter()
+        r = await adapter.run("session", "do something")
+
+        assert r.summary == "ok"
+        assert r.error is None
+
+    @pytest.mark.asyncio
+    async def test_returns_custom_result(self):
+        custom = make_agent_run_result(summary="custom", error="boom")
+        adapter = FakeExecutionAdapter(result=custom)
+        r = await adapter.run("session", "do something")
+
+        assert r.summary == "custom"
+        assert r.error == "boom"
+
+    @pytest.mark.asyncio
+    async def test_records_calls(self):
+        adapter = FakeExecutionAdapter()
+        await adapter.run("s1", "r1", adata="adata1")
+
+        assert len(adapter.run_calls) == 1
+        assert adapter.run_calls[0]["session"] == "s1"
+        assert adapter.run_calls[0]["request"] == "r1"
+        assert adapter.run_calls[0]["adata"] == "adata1"
+
+
+class TestFakeRouter:
+    def test_returns_default_session(self):
+        router = FakeRouter()
+        s = router.get_session("anything")
+        assert s is not None
+
+    def test_returns_per_route_override(self):
+        sentinel = object()
+        router = FakeRouter(sessions={"key1": sentinel})
+
+        class _Route:
+            def route_key(self):
+                return "key1"
+
+        assert router.get_session(_Route()) is sentinel
+
+
+# ===================================================================
+#  Helper factories
+# ===================================================================
+
+
+class TestHelperFactories:
+    def test_make_tool_call(self):
+        tc = make_tool_call("execute_code", {"code": "print(1)"})
+        assert tc.name == "execute_code"
+        assert tc.arguments == {"code": "print(1)"}
+        assert tc.id.startswith("call_")
+
+    def test_make_usage(self):
+        u = make_usage(5, 15)
+        assert u.input_tokens == 5
+        assert u.output_tokens == 15
+        assert u.total_tokens == 20
+
+    def test_make_chat_response_defaults(self):
+        cr = make_chat_response()
+        assert cr.content is None
+        assert cr.tool_calls == []
+        assert cr.stop_reason == "end_turn"
+        assert cr.usage is not None
+
+    def test_make_chat_response_with_content(self):
+        cr = make_chat_response(content="hello", stop_reason="tool_use")
+        assert cr.content == "hello"
+        assert cr.stop_reason == "tool_use"
+
+    def test_make_agent_run_result(self):
+        r = make_agent_run_result(summary="done", error=None)
+        assert r.summary == "done"
+        assert r.error is None
+        assert r.figures == []
+
+    def test_build_fake_llm_shortcut(self):
+        llm = build_fake_llm(["a"], model="m", provider="p")
+        assert isinstance(llm, FakeLLM)
+        assert llm.config.model == "m"
+
+    def test_build_fake_tool_runtime_shortcut(self):
+        rt = build_fake_tool_runtime({"t": lambda a, d, r: "ok"})
+        assert isinstance(rt, FakeToolRuntime)
+
+
+# ===================================================================
+#  Jarvis model factories (conditional on import availability)
+# ===================================================================
+
+
+try:
+    from omicverse.jarvis.runtime.models import (
+        ConversationRoute,
+        MessageEnvelope,
+    )
+    _HAS_JARVIS = True
+except Exception:
+    _HAS_JARVIS = False
+
+
+@pytest.mark.skipif(not _HAS_JARVIS, reason="Jarvis runtime models not importable")
+class TestJarvisFactories:
+    def test_make_route(self):
+        route = make_route(channel="telegram", scope_id="chat-42")
+        assert isinstance(route, ConversationRoute)
+        assert route.channel == "telegram"
+        assert route.scope_id == "chat-42"
+        assert route.scope_type == "dm"
+
+    def test_make_envelope(self):
+        env = make_envelope(text="analyze this", sender_id="user-7")
+        assert isinstance(env, MessageEnvelope)
+        assert env.text == "analyze this"
+        assert env.sender_id == "user-7"
+
+    def test_make_envelope_with_custom_route(self):
+        route = make_route(channel="discord", scope_type="group", scope_id="g1")
+        env = make_envelope(text="hi", route=route)
+        assert env.route.channel == "discord"
+        assert env.route.scope_type == "group"
+
+
+# ===================================================================
+#  Jarvis runtime deps bundle
+# ===================================================================
+
+
+@pytest.mark.skipif(not _HAS_JARVIS, reason="Jarvis runtime models not importable")
+class TestJarvisRuntimeDepsBundle:
+    def test_build_returns_all_keys(self):
+        deps = build_jarvis_runtime_deps()
+        assert "presenter" in deps
+        assert "execution_adapter" in deps
+        assert "router" in deps
+        assert "deliver" in deps
+        assert "delivered" in deps
+        assert isinstance(deps["presenter"], FakePresenter)
+        assert isinstance(deps["execution_adapter"], FakeExecutionAdapter)
+        assert isinstance(deps["router"], FakeRouter)
+        assert callable(deps["deliver"])
+        assert isinstance(deps["delivered"], list)
+
+    @pytest.mark.asyncio
+    async def test_deliver_accumulates_events(self):
+        deps = build_jarvis_runtime_deps()
+        await deps["deliver"]("event-1")
+        await deps["deliver"]("event-2")
+        assert deps["delivered"] == ["event-1", "event-2"]
+
+
+# ===================================================================
+#  Fixture integration (verifies conftest wiring)
+# ===================================================================
+
+
+class TestFixtureWiring:
+    """Verify that the conftest fixtures are usable from this test file."""
+
+    def test_fake_llm_fixture_is_factory(self, fake_llm):
+        llm = fake_llm(["response"])
+        assert isinstance(llm, FakeLLM)
+        assert llm.remaining_responses == 1
+
+    def test_simple_fake_llm_fixture(self, simple_fake_llm):
+        assert isinstance(simple_fake_llm, FakeLLM)
+        assert simple_fake_llm.remaining_responses == 1
+
+    @pytest.mark.asyncio
+    async def test_echo_tool_runtime_fixture(self, echo_tool_runtime):
+        assert isinstance(echo_tool_runtime, FakeToolRuntime)
+        result = await echo_tool_runtime.dispatch("echo", {"text": "hi"}, None, "req")
+        assert "hi" in result
+        schemas = echo_tool_runtime.get_visible_agent_tools()
+        assert len(schemas) == 1
+        assert schemas[0]["name"] == "echo"
+
+    def test_fake_presenter_fixture(self, fake_presenter):
+        assert isinstance(fake_presenter, FakePresenter)
+        assert fake_presenter.events == []
+
+    def test_fake_execution_adapter_fixture(self, fake_execution_adapter):
+        adapter = fake_execution_adapter()
+        assert isinstance(adapter, FakeExecutionAdapter)
+
+    @pytest.mark.skipif(not _HAS_JARVIS, reason="Jarvis models not importable")
+    def test_fake_route_fixture(self, fake_route):
+        assert fake_route is not None
+
+    @pytest.mark.skipif(not _HAS_JARVIS, reason="Jarvis models not importable")
+    def test_fake_envelope_fixture(self, fake_envelope):
+        assert fake_envelope is not None
+
+    @pytest.mark.skipif(not _HAS_JARVIS, reason="Jarvis models not importable")
+    def test_jarvis_runtime_deps_fixture(self, jarvis_runtime_deps):
+        assert "presenter" in jarvis_runtime_deps
+        assert "delivered" in jarvis_runtime_deps
+
+
+# ===================================================================
+#  Multi-turn conversation scenario (integration smoke test)
+# ===================================================================
+
+
+class TestMultiTurnScenario:
+    """Verify that fakes compose for a realistic multi-turn agent flow."""
+
+    @pytest.mark.asyncio
+    async def test_tool_call_then_text_response(self):
+        tc = make_tool_call("inspect_data", {"aspect": "shape"})
+        responses = [
+            make_chat_response(tool_calls=[tc], stop_reason="tool_use"),
+            make_chat_response(content="The data has 100 rows.", stop_reason="end_turn"),
+        ]
+        llm = FakeLLM(responses)
+        rt = FakeToolRuntime(
+            {"inspect_data": lambda a, d, r: "shape: (100, 5)"}
+        )
+
+        # Turn 1: LLM requests a tool call
+        r1 = await llm.chat([{"role": "user", "content": "describe the data"}])
+        assert r1.stop_reason == "tool_use"
+        assert len(r1.tool_calls) == 1
+
+        # Dispatch the tool
+        tool_result = await rt.dispatch(
+            r1.tool_calls[0].name, r1.tool_calls[0].arguments, None, "describe"
+        )
+        assert "100" in tool_result
+
+        # Turn 2: Feed tool result back, get final answer
+        r2 = await llm.chat([
+            {"role": "user", "content": "describe the data"},
+            {"role": "assistant", "content": None, "tool_calls": [r1.tool_calls[0]]},
+            llm.format_tool_result_message(r1.tool_calls[0].id, "inspect_data", tool_result),
+        ])
+        assert r2.stop_reason == "end_turn"
+        assert "100 rows" in r2.content
+
+        # Verify call history
+        assert len(llm.chat_calls) == 2
+        assert len(rt.dispatch_calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_multiple_tool_calls_in_sequence(self):
+        tc1 = make_tool_call("search_functions", {"query": "pca"})
+        tc2 = make_tool_call("execute_code", {"code": "print(1)"})
+        responses = [
+            make_chat_response(tool_calls=[tc1], stop_reason="tool_use"),
+            make_chat_response(tool_calls=[tc2], stop_reason="tool_use"),
+            make_chat_response(content="Done.", stop_reason="end_turn"),
+        ]
+        llm = FakeLLM(responses)
+        rt = FakeToolRuntime({
+            "search_functions": lambda a, d, r: "found: ov.pp.pca",
+            "execute_code": lambda a, d, r: "output: 1",
+        })
+
+        turns = []
+        for _ in range(3):
+            resp = await llm.chat([])
+            turns.append(resp)
+            if resp.tool_calls:
+                for tc in resp.tool_calls:
+                    await rt.dispatch(tc.name, tc.arguments, None, "req")
+
+        assert turns[0].stop_reason == "tool_use"
+        assert turns[1].stop_reason == "tool_use"
+        assert turns[2].stop_reason == "end_turn"
+        assert len(rt.dispatch_calls) == 2
+
+
+# ===================================================================
+#  AC-001-5: No production code depends on test-only harness helpers
+# ===================================================================
+
+
+class TestNoProductionDependency:
+    """Verify that production source files do not import from the test harness."""
+
+    def test_no_production_imports_from_harness(self):
+        """Scan production Python files for imports of the integration harness."""
+        from pathlib import Path
+
+        prod_root = Path(__file__).resolve().parents[2] / "omicverse"
+        violations = []
+
+        for py_file in prod_root.rglob("*.py"):
+            try:
+                source = py_file.read_text(encoding="utf-8", errors="ignore")
+            except OSError:
+                continue
+            for i, line in enumerate(source.splitlines(), 1):
+                stripped = line.strip()
+                if stripped.startswith("#"):
+                    continue
+                if "tests.integration" in stripped or "tests/integration" in stripped:
+                    violations.append(f"{py_file}:{i}: {stripped}")
+
+        assert violations == [], (
+            f"Production code must not import from the test harness:\n"
+            + "\n".join(violations)
+        )

--- a/tests/jarvis/test_channel_core.py
+++ b/tests/jarvis/test_channel_core.py
@@ -14,6 +14,7 @@ Covers:
 from __future__ import annotations
 
 import asyncio
+import logging
 from types import SimpleNamespace
 from typing import Any, Dict, List, Optional
 
@@ -102,6 +103,43 @@ class TestStripLocalPaths:
     def test_preserves_normal_text(self) -> None:
         text = "Analysis complete: 5000 cells detected"
         assert strip_local_paths(text) == text
+
+    def test_preserves_scientific_data_paths(self) -> None:
+        """Paths under /data, /opt, /mnt, /var are legitimate scientific paths."""
+        assert "/data/shared/genome.fa" in strip_local_paths(
+            "Reference genome at /data/shared/genome.fa"
+        )
+
+    def test_preserves_opt_tool_paths(self) -> None:
+        assert "/opt/cellranger/bin" in strip_local_paths(
+            "Using tool at /opt/cellranger/bin"
+        )
+
+    def test_preserves_mnt_paths(self) -> None:
+        assert "/mnt/nfs/lab" in strip_local_paths(
+            "Lab data on /mnt/nfs/lab/experiment_1"
+        )
+
+    def test_preserves_var_paths(self) -> None:
+        assert "/var/log/analysis" in strip_local_paths(
+            "See /var/log/analysis for details"
+        )
+
+    def test_still_removes_users_paths(self) -> None:
+        result = strip_local_paths("see /Users/alice/work/project here")
+        assert "/Users/" not in result
+
+    def test_still_removes_home_paths(self) -> None:
+        result = strip_local_paths("file at /home/bob/.config/app.ini")
+        assert "/home/" not in result
+
+    def test_still_removes_tmp_paths(self) -> None:
+        result = strip_local_paths("cached in /tmp/ov_session_abc123")
+        assert "/tmp/" not in result
+
+    def test_still_removes_private_paths(self) -> None:
+        result = strip_local_paths("see /private/var/folders/xx/tmp here")
+        assert "/private/" not in result
 
 
 # ── build_full_request ───────────────────────────────────────────────────────
@@ -213,6 +251,28 @@ class TestNotifyTurnComplete:
             llm_text="y",
         )
 
+    def test_logs_debug_on_exception(self, caplog) -> None:
+        """Exception in web bridge produces a debug log with traceback."""
+        class FakeBridge:
+            def on_turn_complete_simple(self, **kwargs):
+                raise RuntimeError("bridge-error")
+
+        sm = SimpleNamespace(gateway_web_bridge=FakeBridge())
+        with caplog.at_level(logging.DEBUG, logger="omicverse.jarvis.channels.channel_core"):
+            notify_turn_complete(
+                sm,
+                channel="discord",
+                scope_type="dm",
+                scope_id="123",
+                session=SimpleNamespace(
+                    agent=SimpleNamespace(get_current_session_info=lambda: None),
+                ),
+                user_text="x",
+                llm_text="y",
+            )
+        assert any("notify_turn_complete" in r.message for r in caplog.records)
+        assert any(r.exc_info for r in caplog.records if "notify_turn_complete" in r.message)
+
 
 # ── process_result_state ─────────────────────────────────────────────────────
 
@@ -261,6 +321,24 @@ class TestProcessResultState:
         result = self._make_result()
         _, adata_info = process_result_state(session, result, "test")
         assert adata_info == ""
+
+    def test_logs_debug_on_save_adata_failure(self, caplog) -> None:
+        """save_adata failure produces a debug log entry."""
+        session = self._make_session()
+        session.save_adata = lambda: (_ for _ in ()).throw(IOError("disk"))
+        result = self._make_result(adata=SimpleNamespace(n_obs=1, n_vars=1))
+        with caplog.at_level(logging.DEBUG, logger="omicverse.jarvis.channels.channel_core"):
+            process_result_state(session, result, "test")
+        assert any("save_adata" in r.message for r in caplog.records)
+
+    def test_logs_debug_on_memory_log_failure(self, caplog) -> None:
+        """append_memory_log failure produces a debug log entry."""
+        session = self._make_session()
+        session.append_memory_log = lambda **kw: (_ for _ in ()).throw(RuntimeError("mem"))
+        result = self._make_result()
+        with caplog.at_level(logging.DEBUG, logger="omicverse.jarvis.channels.channel_core"):
+            process_result_state(session, result, "test")
+        assert any("append_memory_log" in r.message for r in caplog.records)
 
     def test_appends_memory_log(self) -> None:
         log_calls = []

--- a/tests/jarvis/test_channel_core.py
+++ b/tests/jarvis/test_channel_core.py
@@ -141,6 +141,51 @@ class TestStripLocalPaths:
         result = strip_local_paths("see /private/var/folders/xx/tmp here")
         assert "/private/" not in result
 
+    # ── ReDoS hardening: adversarial inputs ─────────────────────────────────
+
+    def test_adversarial_many_segments_wrong_ext_no_hang(self) -> None:
+        """Many slash-separated segments with wrong extension must not hang."""
+        import time
+        adversarial = "a/" * 500 + "x.notavalidext"
+        start = time.monotonic()
+        result = strip_local_paths(adversarial)
+        elapsed = time.monotonic() - start
+        assert elapsed < 2.0, f"strip_local_paths took {elapsed:.1f}s on adversarial input"
+        # Wrong extension means no match — text survives
+        assert "notavalidext" in result
+
+    def test_adversarial_deep_path_valid_ext_no_hang(self) -> None:
+        """Deeply nested path with valid extension completes quickly."""
+        import time
+        adversarial = "dir/" * 200 + "file.h5ad rest"
+        start = time.monotonic()
+        result = strip_local_paths(adversarial)
+        elapsed = time.monotonic() - start
+        assert elapsed < 2.0, f"strip_local_paths took {elapsed:.1f}s"
+        # Valid extension path should still be redacted
+        assert "h5ad" not in result
+        assert "rest" in result
+
+    def test_adversarial_no_slash_long_string_no_hang(self) -> None:
+        """Long string with no slashes must not hang."""
+        import time
+        adversarial = "a" * 5000 + ".h5ad"
+        start = time.monotonic()
+        result = strip_local_paths(adversarial)
+        elapsed = time.monotonic() - start
+        assert elapsed < 2.0, f"strip_local_paths took {elapsed:.1f}s"
+        # No slash — not a path, text preserved
+        assert "a" * 100 in result
+
+    def test_adversarial_mixed_nonmatching_no_hang(self) -> None:
+        """Mixed adversarial content with embedded slashes completes quickly."""
+        import time
+        adversarial = ("word/" * 100 + "end ") * 5
+        start = time.monotonic()
+        result = strip_local_paths(adversarial)
+        elapsed = time.monotonic() - start
+        assert elapsed < 2.0, f"strip_local_paths took {elapsed:.1f}s"
+
 
 # ── build_full_request ───────────────────────────────────────────────────────
 

--- a/tests/jarvis/test_channel_core.py
+++ b/tests/jarvis/test_channel_core.py
@@ -1,0 +1,359 @@
+"""Tests for the shared channel-core abstractions.
+
+Covers:
+- text_chunks: paragraph-aware text splitting
+- strip_local_paths: filesystem path scrubbing
+- build_full_request: session-enriched request building
+- get_prior_history: web bridge history retrieval
+- notify_turn_complete: web bridge turn mirroring
+- process_result_state: post-analysis session state updates
+- format_analysis_error: error message formatting
+- default_summary: fallback summary generation
+- RunningTask: dataclass smoke test
+"""
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from omicverse.jarvis.channels.channel_core import (
+    RunningTask,
+    build_full_request,
+    default_summary,
+    format_analysis_error,
+    get_prior_history,
+    notify_turn_complete,
+    process_result_state,
+    strip_local_paths,
+    text_chunks,
+)
+
+
+# ── text_chunks ──────────────────────────────────────────────────────────────
+
+class TestTextChunks:
+    def test_empty_string(self) -> None:
+        assert text_chunks("") == []
+        assert text_chunks(None) == []
+
+    def test_short_text_single_chunk(self) -> None:
+        assert text_chunks("hello", limit=100) == ["hello"]
+
+    def test_exact_limit(self) -> None:
+        assert text_chunks("abc", limit=3) == ["abc"]
+
+    def test_split_on_paragraphs(self) -> None:
+        text = "AAA\n\nBBB\n\nCCC"
+        result = text_chunks(text, limit=7)
+        assert result == ["AAA", "BBB", "CCC"]
+
+    def test_long_paragraph_hard_split(self) -> None:
+        text = "ABCDEFGHIJ"
+        result = text_chunks(text, limit=4)
+        assert result == ["ABCD", "EFGH", "IJ"]
+
+    def test_paragraphs_coalesce_when_possible(self) -> None:
+        text = "A\n\nB\n\nC"
+        result = text_chunks(text, limit=100)
+        assert result == ["A\n\nB\n\nC"]
+
+    def test_strips_whitespace(self) -> None:
+        assert text_chunks("  hello  ") == ["hello"]
+
+    def test_default_limit(self) -> None:
+        short = "x" * 2000
+        assert text_chunks(short) == [short]
+        long = "x" * 2001
+        result = text_chunks(long)
+        assert len(result) == 2
+
+
+# ── strip_local_paths ────────────────────────────────────────────────────────
+
+class TestStripLocalPaths:
+    def test_removes_absolute_paths(self) -> None:
+        assert strip_local_paths("see /Users/alice/data/file.txt here") == "see here"
+
+    def test_removes_home_tilde_paths(self) -> None:
+        result = strip_local_paths("saved to ~/Documents/out.csv done")
+        assert "~" not in result
+        assert "done" in result
+
+    def test_removes_backtick_paths(self) -> None:
+        assert strip_local_paths("run `cat /a/b/c/d.py`") == "run"
+
+    def test_removes_extension_paths(self) -> None:
+        result = strip_local_paths("file at ./data/subdir/result.h5ad ok")
+        assert "result.h5ad" not in result
+        assert "ok" in result
+
+    def test_collapses_whitespace(self) -> None:
+        assert "  " not in strip_local_paths("a    b")
+
+    def test_collapses_newlines(self) -> None:
+        assert "\n\n\n" not in strip_local_paths("a\n\n\n\nb")
+
+    def test_none_returns_empty(self) -> None:
+        assert strip_local_paths(None) == ""
+
+    def test_preserves_normal_text(self) -> None:
+        text = "Analysis complete: 5000 cells detected"
+        assert strip_local_paths(text) == text
+
+
+# ── build_full_request ───────────────────────────────────────────────────────
+
+class TestBuildFullRequest:
+    def test_delegates_to_channel_media(self) -> None:
+        session = SimpleNamespace(
+            get_agents_md=lambda: "",
+            get_memory_context=lambda: "",
+        )
+        result = build_full_request(session, "analyze data", channel_label="Test")
+        assert "analyze data" in result
+        assert "Test" in result
+
+    def test_includes_channel_label(self) -> None:
+        session = SimpleNamespace(
+            get_agents_md=lambda: "",
+            get_memory_context=lambda: "",
+        )
+        result = build_full_request(session, "hello", channel_label="Discord")
+        assert "Discord" in result
+
+
+# ── get_prior_history ────────────────────────────────────────────────────────
+
+class TestGetPriorHistory:
+    def test_returns_empty_when_no_web_bridge(self) -> None:
+        sm = SimpleNamespace()
+        assert get_prior_history(sm, "discord", "dm", "123", SimpleNamespace()) == []
+
+    def test_returns_empty_when_bridge_is_none(self) -> None:
+        sm = SimpleNamespace(gateway_web_bridge=None)
+        assert get_prior_history(sm, "discord", "dm", "123", SimpleNamespace()) == []
+
+    def test_calls_web_bridge(self) -> None:
+        calls = []
+
+        class FakeBridge:
+            def get_prior_history_simple(self, channel, scope_type, scope_id, session_id=""):
+                calls.append((channel, scope_type, scope_id))
+                return [{"role": "user", "content": "hi"}]
+
+        sm = SimpleNamespace(gateway_web_bridge=FakeBridge())
+        session = SimpleNamespace(
+            agent=SimpleNamespace(get_current_session_info=lambda: None),
+        )
+        result = get_prior_history(sm, "telegram", "group", "456", session)
+        assert len(result) == 1
+        assert calls == [("telegram", "group", "456")]
+
+
+# ── notify_turn_complete ─────────────────────────────────────────────────────
+
+class TestNotifyTurnComplete:
+    def test_noop_when_no_web_bridge(self) -> None:
+        sm = SimpleNamespace()
+        notify_turn_complete(
+            sm,
+            channel="discord",
+            scope_type="dm",
+            scope_id="123",
+            session=SimpleNamespace(),
+            user_text="hello",
+            llm_text="world",
+        )
+
+    def test_calls_on_turn_complete_simple(self) -> None:
+        calls = []
+
+        class FakeBridge:
+            def on_turn_complete_simple(self, **kwargs):
+                calls.append(kwargs)
+
+        sm = SimpleNamespace(gateway_web_bridge=FakeBridge())
+        session = SimpleNamespace(
+            agent=SimpleNamespace(get_current_session_info=lambda: None),
+        )
+        notify_turn_complete(
+            sm,
+            channel="wechat",
+            scope_type="dm",
+            scope_id="789",
+            session=session,
+            user_text="test",
+            llm_text="reply",
+            adata=object(),
+            figures=[b"png"],
+        )
+        assert len(calls) == 1
+        assert calls[0]["channel"] == "wechat"
+        assert calls[0]["user_text"] == "test"
+        assert calls[0]["figures"] == [b"png"]
+
+    def test_swallows_exceptions(self) -> None:
+        class FakeBridge:
+            def on_turn_complete_simple(self, **kwargs):
+                raise RuntimeError("boom")
+
+        sm = SimpleNamespace(gateway_web_bridge=FakeBridge())
+        notify_turn_complete(
+            sm,
+            channel="discord",
+            scope_type="dm",
+            scope_id="123",
+            session=SimpleNamespace(
+                agent=SimpleNamespace(get_current_session_info=lambda: None),
+            ),
+            user_text="x",
+            llm_text="y",
+        )
+
+
+# ── process_result_state ─────────────────────────────────────────────────────
+
+class TestProcessResultState:
+    def _make_session(self, adata=None):
+        return SimpleNamespace(
+            adata=adata,
+            last_usage=None,
+            prompt_count=0,
+            save_adata=lambda: None,
+            append_memory_log=lambda **kw: None,
+        )
+
+    def _make_result(self, adata=None, usage=None, figures=None, summary=None):
+        return SimpleNamespace(
+            adata=adata,
+            usage=usage,
+            figures=figures or [],
+            summary=summary,
+        )
+
+    def test_updates_session_adata(self) -> None:
+        session = self._make_session()
+        new_adata = SimpleNamespace(n_obs=100, n_vars=50)
+        result = self._make_result(adata=new_adata)
+        delivery_figures, adata_info = process_result_state(session, result, "test")
+        assert session.adata is new_adata
+        assert "100" in adata_info
+        assert "50" in adata_info
+
+    def test_increments_prompt_count(self) -> None:
+        session = self._make_session()
+        result = self._make_result(adata=SimpleNamespace(n_obs=1, n_vars=1))
+        process_result_state(session, result, "test")
+        assert session.prompt_count == 1
+
+    def test_updates_usage(self) -> None:
+        session = self._make_session()
+        usage = {"tokens": 42}
+        result = self._make_result(usage=usage)
+        process_result_state(session, result, "test")
+        assert session.last_usage == usage
+
+    def test_no_adata_returns_empty_info(self) -> None:
+        session = self._make_session()
+        result = self._make_result()
+        _, adata_info = process_result_state(session, result, "test")
+        assert adata_info == ""
+
+    def test_appends_memory_log(self) -> None:
+        log_calls = []
+        session = SimpleNamespace(
+            adata=None,
+            last_usage=None,
+            prompt_count=0,
+            save_adata=lambda: None,
+            append_memory_log=lambda **kw: log_calls.append(kw),
+        )
+        result = self._make_result(summary="done")
+        process_result_state(session, result, "my request")
+        assert len(log_calls) == 1
+        assert log_calls[0]["request"] == "my request"
+        assert log_calls[0]["summary"] == "done"
+
+
+# ── format_analysis_error ────────────────────────────────────────────────────
+
+class TestFormatAnalysisError:
+    def test_basic_error(self) -> None:
+        result = SimpleNamespace(error="timeout", diagnostics=None)
+        text = format_analysis_error(result, "")
+        assert "分析出错: timeout" in text
+
+    def test_with_diagnostics(self) -> None:
+        result = SimpleNamespace(error="fail", diagnostics=["hint1", "hint2"])
+        text = format_analysis_error(result, "")
+        assert "- hint1" in text
+        assert "- hint2" in text
+        assert "诊断" in text
+
+    def test_with_llm_buf(self) -> None:
+        result = SimpleNamespace(error="err", diagnostics=None)
+        text = format_analysis_error(result, "some model output")
+        assert "模型输出" in text
+        assert "some model output" in text
+
+    def test_max_llm_truncation(self) -> None:
+        result = SimpleNamespace(error="err", diagnostics=None)
+        long_buf = "x" * 5000
+        text = format_analysis_error(result, long_buf, max_llm=100)
+        # The llm portion should be truncated
+        assert len(text) < 5000
+
+    def test_empty_llm_buf_excluded(self) -> None:
+        result = SimpleNamespace(error="err", diagnostics=None)
+        text = format_analysis_error(result, "   ")
+        assert "模型输出" not in text
+
+
+# ── default_summary ──────────────────────────────────────────────────────────
+
+class TestDefaultSummary:
+    def test_with_adata(self) -> None:
+        session = SimpleNamespace(adata=SimpleNamespace(n_obs=5000, n_vars=2000))
+        summary = default_summary(session)
+        assert "5,000" in summary
+        assert "2,000" in summary
+        assert "分析完成" in summary
+
+    def test_without_adata(self) -> None:
+        session = SimpleNamespace(adata=None)
+        assert default_summary(session) == "分析完成"
+
+
+# ── RunningTask ──────────────────────────────────────────────────────────────
+
+class TestRunningTask:
+    def test_dataclass_fields(self) -> None:
+        task = asyncio.Future()
+        rt = RunningTask(task=task, request="test", started_at=1.0)
+        assert rt.task is task
+        assert rt.request == "test"
+        assert rt.started_at == 1.0
+
+
+# ── Channel imports use shared code ──────────────────────────────────────────
+
+class TestChannelImports:
+    """Verify that channel modules can import and that their shared helpers
+    resolve to the channel_core implementations."""
+
+    def test_discord_imports_channel_core(self) -> None:
+        from omicverse.jarvis.channels import discord as mod
+        assert hasattr(mod, "text_chunks")
+        assert mod.text_chunks is text_chunks
+
+    def test_imessage_imports_channel_core(self) -> None:
+        from omicverse.jarvis.channels import imessage as mod
+        assert hasattr(mod, "text_chunks")
+        assert mod.text_chunks is text_chunks
+
+    def test_channel_core_strip_local_paths_matches_discord(self) -> None:
+        test_str = "see /Users/foo/bar.txt end"
+        assert strip_local_paths(test_str) == strip_local_paths(test_str)

--- a/tests/jarvis/test_channel_media.py
+++ b/tests/jarvis/test_channel_media.py
@@ -1,12 +1,23 @@
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, List
 
 import pytest
 
 from omicverse.jarvis.agent_bridge import AgentRunResult
-from omicverse.jarvis.channel_media import build_channel_request, prepare_channel_delivery_figures
+from omicverse.jarvis.channel_media import (
+    MAX_INBOUND_IMAGES,
+    build_channel_request,
+    format_h5ad_load_result,
+    inbound_upload_dir,
+    is_image_attachment,
+    load_h5ad_to_session,
+    prepare_channel_delivery_figures,
+    prepare_inbound_image,
+    prepare_inbound_image_from_file,
+)
 from omicverse.jarvis.runtime.models import ConversationRoute, DeliveryEvent, MessageEnvelope
 from omicverse.jarvis.runtime.runtime import MessageRuntime
 
@@ -203,3 +214,266 @@ async def test_message_runtime_routes_only_latest_workspace_figure(tmp_path: Pat
     assert "figures/<descriptive_name>.png" in adapter.requests[0]["request"]
     assert "show=False before saving" in adapter.requests[0]["request"]
     assert "newest PNG" in adapter.requests[0]["request"]
+
+
+# ── MAX_INBOUND_IMAGES ─────────────────────────────────────────────────────
+
+class TestMaxInboundImages:
+    def test_constant_is_four(self) -> None:
+        assert MAX_INBOUND_IMAGES == 4
+
+    def test_constant_is_int(self) -> None:
+        assert isinstance(MAX_INBOUND_IMAGES, int)
+
+
+# ── is_image_attachment ────────────────────────────────────────────────────
+
+class TestIsImageAttachment:
+    def test_by_mime_type(self) -> None:
+        assert is_image_attachment("", "image/png") is True
+        assert is_image_attachment("", "image/jpeg") is True
+        assert is_image_attachment("", "image/webp") is True
+
+    def test_by_filename(self) -> None:
+        assert is_image_attachment("photo.png") is True
+        assert is_image_attachment("scan.jpg") is True
+        assert is_image_attachment("diagram.webp") is True
+
+    def test_non_image_rejected(self) -> None:
+        assert is_image_attachment("data.csv") is False
+        assert is_image_attachment("", "application/json") is False
+        assert is_image_attachment("") is False
+
+    def test_h5ad_rejected(self) -> None:
+        assert is_image_attachment("sample.h5ad") is False
+
+    def test_mime_takes_precedence(self) -> None:
+        assert is_image_attachment("data.csv", "image/png") is True
+
+    def test_case_insensitive_mime(self) -> None:
+        assert is_image_attachment("", "Image/PNG") is True
+
+    def test_whitespace_stripped(self) -> None:
+        assert is_image_attachment("", "  image/png  ") is True
+
+
+# ── inbound_upload_dir ─────────────────────────────────────────────────────
+
+class TestInboundUploadDir:
+    def test_creates_directory(self, tmp_path: Path) -> None:
+        result = inbound_upload_dir(tmp_path, "discord")
+        assert result == tmp_path / "uploads" / "discord"
+        assert result.is_dir()
+
+    def test_returns_path_object(self, tmp_path: Path) -> None:
+        result = inbound_upload_dir(str(tmp_path), "telegram")
+        assert isinstance(result, Path)
+        assert result.is_dir()
+
+    def test_idempotent(self, tmp_path: Path) -> None:
+        first = inbound_upload_dir(tmp_path, "qq")
+        second = inbound_upload_dir(tmp_path, "qq")
+        assert first == second
+
+
+# ── prepare_inbound_image ──────────────────────────────────────────────────
+
+class TestPrepareInboundImage:
+    def _make_png(self) -> bytes:
+        """Create minimal valid PNG bytes for testing."""
+        try:
+            from PIL import Image
+            import io
+            img = Image.new("RGB", (2, 2), color="red")
+            buf = io.BytesIO()
+            img.save(buf, format="PNG")
+            return buf.getvalue()
+        except ImportError:
+            pytest.skip("PIL not available")
+
+    def test_creates_file_in_upload_dir(self, tmp_path: Path) -> None:
+        png = self._make_png()
+        result = prepare_inbound_image(
+            png,
+            workspace_root=tmp_path,
+            channel_name="discord",
+            filename="photo.png",
+            mime_type="image/png",
+        )
+        assert result.path.exists()
+        assert result.path.parent == tmp_path / "uploads" / "discord"
+        assert result.mime_type == "image/png"
+        assert result.source == "discord"
+        assert result.size == len(png)
+
+    def test_uses_channel_name_as_prefix(self, tmp_path: Path) -> None:
+        png = self._make_png()
+        result = prepare_inbound_image(
+            png,
+            workspace_root=tmp_path,
+            channel_name="qq",
+            filename="test.png",
+        )
+        assert "qq_image" in result.path.name
+
+    def test_default_filename(self, tmp_path: Path) -> None:
+        png = self._make_png()
+        result = prepare_inbound_image(
+            png,
+            workspace_root=tmp_path,
+            channel_name="wechat",
+        )
+        assert "wechat_image" in result.path.name
+
+    def test_request_block_has_data_url(self, tmp_path: Path) -> None:
+        png = self._make_png()
+        result = prepare_inbound_image(
+            png,
+            workspace_root=tmp_path,
+            channel_name="discord",
+            filename="img.png",
+            mime_type="image/png",
+        )
+        assert result.request_block["type"] == "input_image"
+        assert result.request_block["image_url"].startswith("data:image/png;base64,")
+
+
+# ── prepare_inbound_image_from_file ────────────────────────────────────────
+
+class TestPrepareInboundImageFromFile:
+    def _write_png(self, path: Path) -> Path:
+        try:
+            from PIL import Image
+            import io
+            img = Image.new("RGB", (2, 2), color="blue")
+            buf = io.BytesIO()
+            img.save(buf, format="PNG")
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_bytes(buf.getvalue())
+            return path
+        except ImportError:
+            pytest.skip("PIL not available")
+
+    def test_processes_local_file(self, tmp_path: Path) -> None:
+        src = self._write_png(tmp_path / "raw" / "photo.png")
+        result = prepare_inbound_image_from_file(
+            src,
+            workspace_root=tmp_path,
+            channel_name="telegram",
+        )
+        assert result.path.exists()
+        assert result.mime_type == "image/png"
+        assert result.source == "telegram"
+
+    def test_uses_channel_prefix(self, tmp_path: Path) -> None:
+        src = self._write_png(tmp_path / "raw" / "image.png")
+        result = prepare_inbound_image_from_file(
+            src,
+            workspace_root=tmp_path,
+            channel_name="telegram",
+        )
+        assert "telegram_image" in result.path.name
+
+    def test_passes_mime_type(self, tmp_path: Path) -> None:
+        src = self._write_png(tmp_path / "raw" / "doc.png")
+        result = prepare_inbound_image_from_file(
+            src,
+            workspace_root=tmp_path,
+            channel_name="telegram",
+            mime_type="image/png",
+        )
+        assert result.mime_type == "image/png"
+
+
+# ── load_h5ad_to_session ──────────────────────────────────────────────────
+
+class TestLoadH5adToSession:
+    def test_writes_data_and_calls_load(self, tmp_path: Path) -> None:
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        load_calls: list = []
+
+        session = SimpleNamespace(
+            workspace=workspace,
+            load_from_workspace=lambda fname: (load_calls.append(fname), "mock_adata")[-1],
+        )
+        result = load_h5ad_to_session(session, b"fake-h5ad-data", "test.h5ad")
+        assert result == "mock_adata"
+        assert load_calls == ["test.h5ad"]
+        assert (workspace / "test.h5ad").read_bytes() == b"fake-h5ad-data"
+
+    def test_returns_none_when_load_fails(self, tmp_path: Path) -> None:
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        session = SimpleNamespace(
+            workspace=workspace,
+            load_from_workspace=lambda fname: None,
+        )
+        result = load_h5ad_to_session(session, b"data", "bad.h5ad")
+        assert result is None
+
+    def test_returns_none_when_no_workspace(self) -> None:
+        session = SimpleNamespace()
+        result = load_h5ad_to_session(session, b"data", "test.h5ad")
+        assert result is None
+
+    def test_creates_nested_directories(self, tmp_path: Path) -> None:
+        workspace = tmp_path / "deep" / "workspace"
+        session = SimpleNamespace(
+            workspace=workspace,
+            load_from_workspace=lambda fname: "ok",
+        )
+        result = load_h5ad_to_session(session, b"data", "test.h5ad")
+        assert result == "ok"
+        assert (workspace / "test.h5ad").exists()
+
+
+# ── format_h5ad_load_result ───────────────────────────────────────────────
+
+class TestFormatH5adLoadResult:
+    def test_success_format(self) -> None:
+        adata = SimpleNamespace(n_obs=5000, n_vars=2000)
+        text = format_h5ad_load_result(adata, "sample.h5ad")
+        assert "加载成功" in text
+        assert "5,000" in text
+        assert "2,000" in text
+        assert "sample.h5ad" in text
+
+    def test_failure_format(self) -> None:
+        text = format_h5ad_load_result(None, "bad.h5ad")
+        assert "bad.h5ad" in text
+        assert "加载失败" in text
+
+    def test_matches_discord_format(self) -> None:
+        adata = SimpleNamespace(n_obs=100, n_vars=50)
+        text = format_h5ad_load_result(adata, "data.h5ad")
+        assert "✅" in text
+        assert "🔬" in text
+        assert "📁" in text
+
+
+# ── Channel imports use shared media helpers ──────────────────────────────
+
+class TestChannelMediaImports:
+    """Verify that channel modules import and use the shared helpers."""
+
+    def test_discord_uses_shared_helpers(self) -> None:
+        from omicverse.jarvis.channels import discord as mod
+        from omicverse.jarvis import channel_media
+        assert hasattr(mod, "is_image_attachment")
+        assert mod.is_image_attachment is channel_media.is_image_attachment
+        assert mod.MAX_INBOUND_IMAGES is channel_media.MAX_INBOUND_IMAGES
+        assert mod.prepare_inbound_image is channel_media.prepare_inbound_image
+
+    def test_qq_uses_shared_helpers(self) -> None:
+        from omicverse.jarvis.channels import qq as mod
+        from omicverse.jarvis import channel_media
+        assert hasattr(mod, "is_image_attachment")
+        assert mod.is_image_attachment is channel_media.is_image_attachment
+        assert mod.MAX_INBOUND_IMAGES is channel_media.MAX_INBOUND_IMAGES
+
+    def test_telegram_uses_shared_helpers(self) -> None:
+        from omicverse.jarvis.channels import telegram as mod
+        from omicverse.jarvis import channel_media
+        assert mod.MAX_INBOUND_IMAGES is channel_media.MAX_INBOUND_IMAGES
+        assert mod.prepare_inbound_image_from_file is channel_media.prepare_inbound_image_from_file

--- a/tests/jarvis/test_channel_migration_wave2.py
+++ b/tests/jarvis/test_channel_migration_wave2.py
@@ -1,0 +1,335 @@
+"""Tests for channel migration wave 2: QQ, WeChat, Feishu, iMessage.
+
+Verifies that all four channels adopt the shared session/media/presenter
+abstractions without keeping parallel copies of the same boilerplate.
+
+Acceptance criteria addressed:
+- AC-001.1: QQ, WeChat, Feishu, and iMessage adopt the shared abstractions.
+- AC-001.2: Platform-specific transport logic remains local to each channel.
+- AC-001.5: No parallel copies of command/session boilerplate.
+"""
+from __future__ import annotations
+
+import asyncio
+import time
+from types import SimpleNamespace
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from omicverse.jarvis.channels.channel_core import (
+    RunningTask,
+    coalesce_pending_requests,
+    command_parts,
+    default_summary,
+    format_analysis_error,
+    format_status_plain,
+    gather_status,
+    text_chunks,
+)
+
+
+# ── Shared helpers unit tests ───────────────────────────────────────────────
+
+
+class TestCoalescePendingRequests:
+    """Verify the shared coalesce function that was extracted from channel duplicates."""
+
+    def test_empty_list(self) -> None:
+        text, content = coalesce_pending_requests([])
+        assert text == ""
+        assert content == []
+
+    def test_single_item(self) -> None:
+        items = [{"text": "hello", "request_content": [{"type": "image", "url": "x"}]}]
+        text, content = coalesce_pending_requests(items)
+        assert text == "hello"
+        assert len(content) == 1
+        assert content[0]["url"] == "x"
+
+    def test_multiple_items_joined(self) -> None:
+        items = [
+            {"text": "first request"},
+            {"text": "second request"},
+        ]
+        text, content = coalesce_pending_requests(items)
+        assert "first request" in text
+        assert "second request" in text
+        assert "\n\n" in text
+        assert content == []
+
+    def test_blank_text_skipped(self) -> None:
+        items = [
+            {"text": "   "},
+            {"text": "real text"},
+        ]
+        text, content = coalesce_pending_requests(items)
+        assert text == "real text"
+
+    def test_request_content_merged(self) -> None:
+        items = [
+            {"text": "a", "request_content": [{"type": "img"}]},
+            {"text": "b", "request_content": [{"type": "file"}, {"type": "img2"}]},
+        ]
+        text, content = coalesce_pending_requests(items)
+        assert len(content) == 3
+
+    def test_missing_keys(self) -> None:
+        items = [{"other": "data"}, {}]
+        text, content = coalesce_pending_requests(items)
+        assert text == ""
+        assert content == []
+
+
+class TestCommandParts:
+    """Verify the shared command-parsing function."""
+
+    def test_simple_command(self) -> None:
+        cmd, tail = command_parts("/help")
+        assert cmd == "/help"
+        assert tail == ""
+
+    def test_command_with_tail(self) -> None:
+        cmd, tail = command_parts("/model gpt-4o")
+        assert cmd == "/model"
+        assert tail == "gpt-4o"
+
+    def test_command_case_insensitive(self) -> None:
+        cmd, tail = command_parts("/RESET")
+        assert cmd == "/reset"
+
+    def test_empty_string(self) -> None:
+        cmd, tail = command_parts("")
+        assert cmd == ""
+        assert tail == ""
+
+    def test_command_with_multiword_tail(self) -> None:
+        cmd, tail = command_parts("/shell ls -la /tmp")
+        assert cmd == "/shell"
+        assert tail == "ls -la /tmp"
+
+
+# ── QQ channel uses shared abstractions ─────────────────────────────────────
+
+
+class TestQQUsesSharedAbstractions:
+    """Verify QQ imports and delegates to shared channel_core functions."""
+
+    def test_qq_imports_running_task(self) -> None:
+        from omicverse.jarvis.channels import qq as mod
+        # QQRuntime should store RunningTask instances
+        assert hasattr(mod, "RunningTask")
+        assert mod.RunningTask is RunningTask
+
+    def test_qq_imports_coalesce(self) -> None:
+        from omicverse.jarvis.channels import qq as mod
+        assert hasattr(mod, "coalesce_pending_requests")
+        assert mod.coalesce_pending_requests is coalesce_pending_requests
+
+    def test_qq_imports_format_analysis_error(self) -> None:
+        from omicverse.jarvis.channels import qq as mod
+        assert hasattr(mod, "format_analysis_error")
+        assert mod.format_analysis_error is format_analysis_error
+
+    def test_qq_imports_shared_text_utils(self) -> None:
+        from omicverse.jarvis.channels import qq as mod
+        assert mod.text_chunks is text_chunks
+
+    def test_qq_runtime_coalesce_delegates(self) -> None:
+        """QQRuntime._coalesce_pending_requests delegates to shared function."""
+        from omicverse.jarvis.channels.qq import QQRuntime
+        items = [{"text": "a", "request_content": [{"t": 1}]}, {"text": "b"}]
+        text, content = QQRuntime._coalesce_pending_requests(items)
+        expected_text, expected_content = coalesce_pending_requests(items)
+        assert text == expected_text
+        assert content == expected_content
+
+
+# ── WeChat channel uses shared abstractions ─────────────────────────────────
+
+
+class TestWeChatUsesSharedAbstractions:
+    """Verify WeChat imports and delegates to shared channel_core functions."""
+
+    def test_wechat_no_duplicate_running_task(self) -> None:
+        """WeChat must NOT define its own RunningTask class."""
+        import inspect
+        from omicverse.jarvis.channels import wechat as mod
+        source = inspect.getsource(mod)
+        # The module should import RunningTask, not define a class
+        lines = [
+            line.strip() for line in source.splitlines()
+            if line.strip().startswith("class RunningTask")
+        ]
+        assert len(lines) == 0, "WeChat still defines its own RunningTask class"
+
+    def test_wechat_imports_running_task_from_core(self) -> None:
+        from omicverse.jarvis.channels import wechat as mod
+        assert hasattr(mod, "RunningTask")
+        assert mod.RunningTask is RunningTask
+
+    def test_wechat_imports_coalesce(self) -> None:
+        from omicverse.jarvis.channels import wechat as mod
+        assert hasattr(mod, "coalesce_pending_requests")
+        assert mod.coalesce_pending_requests is coalesce_pending_requests
+
+    def test_wechat_imports_command_parts(self) -> None:
+        from omicverse.jarvis.channels import wechat as mod
+        assert hasattr(mod, "command_parts")
+        assert mod.command_parts is command_parts
+
+    def test_wechat_imports_format_analysis_error(self) -> None:
+        from omicverse.jarvis.channels import wechat as mod
+        assert hasattr(mod, "format_analysis_error")
+        assert mod.format_analysis_error is format_analysis_error
+
+    def test_wechat_coalesce_delegates(self) -> None:
+        from omicverse.jarvis.channels.wechat import WeChatJarvisBot
+        items = [{"text": "x", "request_content": []}, {"text": "y"}]
+        text, content = WeChatJarvisBot._coalesce_pending_requests(items)
+        expected_text, expected_content = coalesce_pending_requests(items)
+        assert text == expected_text
+        assert content == expected_content
+
+    def test_wechat_command_parts_delegates(self) -> None:
+        from omicverse.jarvis.channels.wechat import WeChatJarvisBot
+        cmd, tail = WeChatJarvisBot._command_parts("/model gpt-4o")
+        expected_cmd, expected_tail = command_parts("/model gpt-4o")
+        assert cmd == expected_cmd
+        assert tail == expected_tail
+
+
+# ── Feishu channel uses shared abstractions ─────────────────────────────────
+
+
+class TestFeishuUsesSharedAbstractions:
+    """Verify Feishu imports shared functions from channel_core."""
+
+    def test_feishu_imports_format_analysis_error(self) -> None:
+        from omicverse.jarvis.channels import feishu as mod
+        assert hasattr(mod, "format_analysis_error")
+        assert mod.format_analysis_error is format_analysis_error
+
+    def test_feishu_imports_default_summary(self) -> None:
+        from omicverse.jarvis.channels import feishu as mod
+        assert hasattr(mod, "default_summary")
+        assert mod.default_summary is default_summary
+
+    def test_feishu_imports_format_status_plain(self) -> None:
+        from omicverse.jarvis.channels import feishu as mod
+        assert hasattr(mod, "format_status_plain")
+        assert mod.format_status_plain is format_status_plain
+
+    def test_feishu_imports_running_task(self) -> None:
+        from omicverse.jarvis.channels import feishu as mod
+        assert hasattr(mod, "RunningTask")
+        assert mod.RunningTask is RunningTask
+
+    def test_feishu_imports_gather_status(self) -> None:
+        from omicverse.jarvis.channels import feishu as mod
+        assert hasattr(mod, "gather_status")
+        assert mod.gather_status is gather_status
+
+    def test_feishu_imports_text_chunks(self) -> None:
+        from omicverse.jarvis.channels import feishu as mod
+        assert mod.text_chunks is text_chunks
+
+
+# ── iMessage channel uses shared abstractions ───────────────────────────────
+
+
+class TestIMessageUsesSharedAbstractions:
+    """Verify iMessage imports and uses shared channel_core functions."""
+
+    def test_imessage_imports_running_task(self) -> None:
+        from omicverse.jarvis.channels import imessage as mod
+        assert hasattr(mod, "RunningTask")
+        assert mod.RunningTask is RunningTask
+
+    def test_imessage_imports_gather_status(self) -> None:
+        from omicverse.jarvis.channels import imessage as mod
+        assert hasattr(mod, "gather_status")
+        assert mod.gather_status is gather_status
+
+    def test_imessage_imports_format_status_plain(self) -> None:
+        from omicverse.jarvis.channels import imessage as mod
+        assert hasattr(mod, "format_status_plain")
+        assert mod.format_status_plain is format_status_plain
+
+    def test_imessage_imports_command_parts(self) -> None:
+        from omicverse.jarvis.channels import imessage as mod
+        assert hasattr(mod, "command_parts")
+        assert mod.command_parts is command_parts
+
+    def test_imessage_uses_running_task_in_tasks_dict(self) -> None:
+        """IMessageJarvisBot._tasks should be typed as Dict[str, RunningTask]."""
+        import typing
+        from omicverse.jarvis.channels.imessage import IMessageJarvisBot
+        hints = typing.get_type_hints(IMessageJarvisBot.__init__)
+        # Even if type hints don't propagate at runtime, we can verify via
+        # the annotation on the class attribute or via instance construction.
+        # Alternative: check that the __init__ code creates the right type.
+        import inspect
+        source = inspect.getsource(IMessageJarvisBot.__init__)
+        assert "RunningTask" in source
+
+    def test_imessage_has_status_command(self) -> None:
+        """IMessageJarvisBot._handle_command should handle /status."""
+        import inspect
+        from omicverse.jarvis.channels.imessage import IMessageJarvisBot
+        source = inspect.getsource(IMessageJarvisBot._handle_command)
+        assert '"/status"' in source or "gather_status" in source
+
+
+# ── Cross-channel consistency ───────────────────────────────────────────────
+
+
+class TestCrossChannelConsistency:
+    """Verify that no channel module defines its own RunningTask or
+    coalesce_pending_requests from scratch (only delegations allowed)."""
+
+    @pytest.mark.parametrize("channel_name", ["qq", "wechat", "feishu", "imessage", "discord"])
+    def test_all_channels_importable(self, channel_name: str) -> None:
+        """Every channel module can be imported without error."""
+        __import__(f"omicverse.jarvis.channels.{channel_name}")
+
+    def test_no_duplicate_running_task_definitions(self) -> None:
+        """Only channel_core should define RunningTask."""
+        import inspect
+        modules_to_check = []
+        for name in ("qq", "wechat", "feishu", "imessage", "discord"):
+            mod = __import__(f"omicverse.jarvis.channels.{name}", fromlist=[name])
+            modules_to_check.append((name, mod))
+
+        for name, mod in modules_to_check:
+            source = inspect.getsource(mod)
+            class_defs = [
+                line.strip() for line in source.splitlines()
+                if line.strip().startswith("class RunningTask")
+            ]
+            assert len(class_defs) == 0, (
+                f"Channel {name} defines its own RunningTask class. "
+                f"It should import from channel_core instead."
+            )
+
+    def test_format_analysis_error_used_by_all_wave2_channels(self) -> None:
+        """QQ, WeChat, Feishu, iMessage should all import format_analysis_error."""
+        for name in ("qq", "wechat", "feishu", "imessage"):
+            mod = __import__(f"omicverse.jarvis.channels.{name}", fromlist=[name])
+            assert hasattr(mod, "format_analysis_error"), (
+                f"Channel {name} does not import format_analysis_error"
+            )
+            assert mod.format_analysis_error is format_analysis_error, (
+                f"Channel {name} has a different format_analysis_error"
+            )
+
+    def test_running_task_used_by_all_wave2_channels(self) -> None:
+        """All wave 2 channels should use RunningTask from channel_core."""
+        for name in ("qq", "wechat", "feishu", "imessage"):
+            mod = __import__(f"omicverse.jarvis.channels.{name}", fromlist=[name])
+            assert hasattr(mod, "RunningTask"), (
+                f"Channel {name} does not import RunningTask"
+            )
+            assert mod.RunningTask is RunningTask, (
+                f"Channel {name} has a different RunningTask"
+            )

--- a/tests/jarvis/test_command_abstractions.py
+++ b/tests/jarvis/test_command_abstractions.py
@@ -154,6 +154,34 @@ class TestGatherStatus:
         info = gather_status(session, session_manager=sm)
         assert info.kernel_name is None
 
+    def test_logs_debug_on_kernel_status_failure(self, caplog) -> None:
+        """kernel_status() failure produces a debug log, not silent swallow."""
+        import logging
+
+        session = SimpleNamespace(
+            adata=None,
+            user_id="u1",
+            kernel_status=lambda: (_ for _ in ()).throw(RuntimeError("ks-fail")),
+            agent=SimpleNamespace(workspace_dir="/w"),
+        )
+        with caplog.at_level(logging.DEBUG, logger="omicverse.jarvis.channels.channel_core"):
+            info = gather_status(session)
+        assert info.prompt_count is None
+        assert any("kernel_status" in r.message for r in caplog.records)
+
+    def test_logs_debug_on_get_active_kernel_failure(self, caplog) -> None:
+        """get_active_kernel failure produces a debug log."""
+        import logging
+
+        session = _make_session()
+        sm = SimpleNamespace(
+            get_active_kernel=lambda uid: (_ for _ in ()).throw(RuntimeError("kern-err"))
+        )
+        with caplog.at_level(logging.DEBUG, logger="omicverse.jarvis.channels.channel_core"):
+            info = gather_status(session, session_manager=sm)
+        assert info.kernel_name is None
+        assert any("get_active_kernel" in r.message for r in caplog.records)
+
 
 # ── format_status_plain ─────────────────────────────────────────────────────
 

--- a/tests/jarvis/test_command_abstractions.py
+++ b/tests/jarvis/test_command_abstractions.py
@@ -1,0 +1,506 @@
+"""Tests for shared command data-gathering and formatting abstractions.
+
+Covers:
+- gather_status / format_status_plain: session status collection and formatting
+- gather_usage / format_usage_plain: token usage collection and formatting
+- gather_workspace / format_workspace_plain: workspace listing
+- perform_save / format_save_result_plain: save command execution
+- StatusInfo / UsageInfo / WorkspaceInfo / SaveResult dataclasses
+
+Acceptance criteria addressed:
+- AC-001.1: Shared command handling and presenter formatting in reusable abstractions
+- AC-001.2: Channels no longer duplicate common command flows
+- AC-001.3: Existing presenter outputs remain backward-compatible
+- AC-001.5: Platform-specific differences preserved (formatters are pluggable)
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, List, Optional
+
+import pytest
+
+from omicverse.jarvis.channels.channel_core import (
+    SaveResult,
+    StatusInfo,
+    UsageInfo,
+    WorkspaceInfo,
+    format_save_result_plain,
+    format_status_plain,
+    format_usage_plain,
+    format_workspace_plain,
+    gather_status,
+    gather_usage,
+    gather_workspace,
+    perform_save,
+)
+
+
+# ── Helpers ─────────────────────────────────────────────────────────────────
+
+def _make_adata(n_obs: int = 5000, n_vars: int = 2000, obs_cols: Optional[list] = None):
+    """Create a minimal adata-like object."""
+    cols = obs_cols if obs_cols is not None else ["cell_type", "batch", "n_counts"]
+    return SimpleNamespace(
+        n_obs=n_obs,
+        n_vars=n_vars,
+        obs=SimpleNamespace(columns=cols),
+    )
+
+
+def _make_session(
+    adata=None,
+    last_usage=None,
+    workspace=None,
+    h5ad_files=None,
+    agents_md="",
+    memory_dir=None,
+    kernel_status=None,
+    user_id="u1",
+    workspace_dir=None,
+):
+    """Create a minimal session-like object for testing."""
+    ws = workspace or Path("/tmp/test_workspace")
+
+    def _kernel_status():
+        if kernel_status is not None:
+            return kernel_status
+        return {"prompt_count": 3, "max_prompts": 20, "session_id": "sid-123", "alive": True}
+
+    return SimpleNamespace(
+        adata=adata,
+        last_usage=last_usage,
+        workspace=ws,
+        list_h5ad_files=lambda: h5ad_files or [],
+        get_agents_md=lambda: agents_md,
+        memory_dir=memory_dir or Path("/tmp/test_memory"),
+        kernel_status=_kernel_status,
+        user_id=user_id,
+        agent=SimpleNamespace(workspace_dir=workspace_dir or ws),
+        prompt_count=0,
+        save_adata=lambda: None,
+        append_memory_log=lambda **kw: None,
+    )
+
+
+def _make_session_manager(kernel_name: str = "default"):
+    return SimpleNamespace(
+        get_active_kernel=lambda uid: kernel_name,
+    )
+
+
+# ── gather_status ───────────────────────────────────────────────────────────
+
+class TestGatherStatus:
+    def test_with_adata(self) -> None:
+        adata = _make_adata(n_obs=1000, n_vars=500, obs_cols=["ct", "batch"])
+        session = _make_session(adata=adata)
+        info = gather_status(session)
+        assert info.adata_shape == (1000, 500)
+        assert info.obs_columns == ["ct", "batch"]
+
+    def test_without_adata(self) -> None:
+        session = _make_session()
+        info = gather_status(session)
+        assert info.adata_shape is None
+        assert info.obs_columns == []
+
+    def test_with_session_manager_kernel(self) -> None:
+        session = _make_session()
+        sm = _make_session_manager(kernel_name="my-kernel")
+        info = gather_status(session, session_manager=sm)
+        assert info.kernel_name == "my-kernel"
+
+    def test_without_session_manager(self) -> None:
+        session = _make_session()
+        info = gather_status(session)
+        assert info.kernel_name is None
+
+    def test_kernel_status_fields(self) -> None:
+        session = _make_session(
+            kernel_status={"prompt_count": 7, "max_prompts": 30, "session_id": "abc"}
+        )
+        info = gather_status(session)
+        assert info.prompt_count == 7
+        assert info.max_prompts == 30
+        assert info.session_id == "abc"
+
+    def test_running_flags(self) -> None:
+        session = _make_session()
+        info = gather_status(session, is_running=True, running_request="analyze pbmc")
+        assert info.is_running is True
+        assert info.running_request == "analyze pbmc"
+
+    def test_workspace_path(self) -> None:
+        session = _make_session(workspace_dir="/data/workspace")
+        info = gather_status(session)
+        assert info.workspace_path == "/data/workspace"
+
+    def test_resilient_to_missing_kernel_status(self) -> None:
+        session = SimpleNamespace(
+            adata=None,
+            user_id="u1",
+            agent=SimpleNamespace(workspace_dir="/w"),
+        )
+        # No kernel_status method
+        info = gather_status(session)
+        assert info.prompt_count is None
+
+    def test_resilient_to_session_manager_error(self) -> None:
+        session = _make_session()
+        sm = SimpleNamespace(get_active_kernel=lambda uid: (_ for _ in ()).throw(RuntimeError("no")))
+        info = gather_status(session, session_manager=sm)
+        assert info.kernel_name is None
+
+
+# ── format_status_plain ─────────────────────────────────────────────────────
+
+class TestFormatStatusPlain:
+    def test_with_full_info(self) -> None:
+        info = StatusInfo(
+            adata_shape=(5000, 2000),
+            obs_columns=["cell_type", "batch"],
+            kernel_name="default",
+            prompt_count=3,
+            max_prompts=20,
+            is_running=True,
+            workspace_path="/data/ws",
+        )
+        text = format_status_plain(info)
+        assert "5,000 cells x 2,000 genes" in text
+        assert "obs: cell_type, batch" in text
+        assert "kernel: default" in text
+        assert "prompts: 3/20" in text
+        assert "分析中（可 /cancel）" in text
+        assert "工作区: /data/ws" in text
+
+    def test_no_adata(self) -> None:
+        info = StatusInfo()
+        text = format_status_plain(info)
+        assert "暂无数据" in text
+
+    def test_idle(self) -> None:
+        info = StatusInfo(is_running=False)
+        text = format_status_plain(info)
+        assert "/cancel" not in text
+
+    def test_no_kernel(self) -> None:
+        info = StatusInfo(adata_shape=(100, 50))
+        text = format_status_plain(info)
+        assert "kernel" not in text
+
+    def test_no_workspace(self) -> None:
+        info = StatusInfo()
+        text = format_status_plain(info)
+        assert "工作区" not in text
+
+
+# ── gather_usage ────────────────────────────────────────────────────────────
+
+class TestGatherUsage:
+    def test_no_usage(self) -> None:
+        session = _make_session()
+        info = gather_usage(session)
+        assert info.has_data is False
+
+    def test_with_usage(self) -> None:
+        usage = SimpleNamespace(
+            input_tokens=1500,
+            output_tokens=800,
+            total_tokens=2300,
+            cache_read_input_tokens=200,
+            cache_creation_input_tokens=100,
+        )
+        session = _make_session(last_usage=usage)
+        info = gather_usage(session)
+        assert info.has_data is True
+        assert info.input_tokens == "1,500"
+        assert info.output_tokens == "800"
+        assert info.total_tokens == "2,300"
+        assert info.cache_read == "200"
+        assert info.cache_creation == "100"
+
+    def test_missing_cache_fields(self) -> None:
+        usage = SimpleNamespace(
+            input_tokens=100,
+            output_tokens=50,
+            total_tokens=150,
+        )
+        session = _make_session(last_usage=usage)
+        info = gather_usage(session)
+        assert info.has_data is True
+        assert info.cache_read == ""
+        assert info.cache_creation == ""
+
+    def test_string_token_values(self) -> None:
+        usage = SimpleNamespace(
+            input_tokens="N/A",
+            output_tokens="N/A",
+            total_tokens="N/A",
+        )
+        session = _make_session(last_usage=usage)
+        info = gather_usage(session)
+        assert info.input_tokens == "N/A"
+
+
+# ── format_usage_plain ──────────────────────────────────────────────────────
+
+class TestFormatUsagePlain:
+    def test_no_data(self) -> None:
+        info = UsageInfo(has_data=False)
+        text = format_usage_plain(info)
+        assert "暂无用量数据" in text
+
+    def test_with_data(self) -> None:
+        info = UsageInfo(
+            input_tokens="1,500",
+            output_tokens="800",
+            total_tokens="2,300",
+            has_data=True,
+        )
+        text = format_usage_plain(info)
+        assert "输入: 1,500" in text
+        assert "输出: 800" in text
+        assert "合计: 2,300" in text
+
+    def test_with_cache(self) -> None:
+        info = UsageInfo(
+            input_tokens="100",
+            output_tokens="50",
+            total_tokens="150",
+            cache_read="200",
+            cache_creation="100",
+            has_data=True,
+        )
+        text = format_usage_plain(info)
+        assert "缓存读取: 200" in text
+        assert "缓存写入: 100" in text
+
+    def test_no_cache_when_empty(self) -> None:
+        info = UsageInfo(
+            input_tokens="100",
+            output_tokens="50",
+            total_tokens="150",
+            has_data=True,
+        )
+        text = format_usage_plain(info)
+        assert "缓存" not in text
+
+
+# ── gather_workspace ────────────────────────────────────────────────────────
+
+class TestGatherWorkspace:
+    def test_empty_workspace(self, tmp_path: Path) -> None:
+        memory_dir = tmp_path / "memory"
+        memory_dir.mkdir()
+        session = _make_session(
+            workspace=tmp_path,
+            h5ad_files=[],
+            agents_md="",
+            memory_dir=memory_dir,
+        )
+        info = gather_workspace(session)
+        assert info.path == str(tmp_path)
+        assert info.h5ad_files == []
+        assert info.h5ad_total == 0
+        assert info.has_agents_md is False
+
+    def test_with_h5ad_files(self, tmp_path: Path) -> None:
+        memory_dir = tmp_path / "memory"
+        memory_dir.mkdir()
+        f1 = tmp_path / "data1.h5ad"
+        f1.write_bytes(b"x" * 2_097_152)  # 2 MB
+        f2 = tmp_path / "data2.h5ad"
+        f2.write_bytes(b"y" * 1_048_576)  # 1 MB
+        session = _make_session(
+            workspace=tmp_path,
+            h5ad_files=[f1, f2],
+            agents_md="# My instructions",
+            memory_dir=memory_dir,
+        )
+        info = gather_workspace(session)
+        assert info.h5ad_total == 2
+        assert len(info.h5ad_files) == 2
+        assert info.h5ad_files[0][0] == "data1.h5ad"
+        assert abs(info.h5ad_files[0][1] - 2.0) < 0.1
+        assert info.has_agents_md is True
+
+    def test_caps_at_10_files(self, tmp_path: Path) -> None:
+        memory_dir = tmp_path / "memory"
+        memory_dir.mkdir()
+        files = []
+        for i in range(15):
+            f = tmp_path / f"data_{i}.h5ad"
+            f.write_bytes(b"x")
+            files.append(f)
+        session = _make_session(
+            workspace=tmp_path,
+            h5ad_files=files,
+            memory_dir=memory_dir,
+        )
+        info = gather_workspace(session)
+        assert len(info.h5ad_files) == 10
+        assert info.h5ad_total == 15
+
+
+# ── format_workspace_plain ──────────────────────────────────────────────────
+
+class TestFormatWorkspacePlain:
+    def test_empty_workspace(self) -> None:
+        info = WorkspaceInfo(path="/w", h5ad_total=0)
+        text = format_workspace_plain(info)
+        assert "Workspace: /w" in text
+        assert "数据文件 (空)" in text
+
+    def test_with_files(self) -> None:
+        info = WorkspaceInfo(
+            path="/w",
+            h5ad_files=[("a.h5ad", 1.5), ("b.h5ad", None)],
+            h5ad_total=2,
+            has_agents_md=True,
+            has_today_memory=True,
+        )
+        text = format_workspace_plain(info)
+        assert "数据文件 (2)" in text
+        assert "- a.h5ad (1.5 MB)" in text
+        assert "- b.h5ad" in text
+        assert "AGENTS.md OK" in text
+        assert "今日记忆 OK" in text
+
+    def test_overflow_indicator(self) -> None:
+        info = WorkspaceInfo(
+            path="/w",
+            h5ad_files=[("a.h5ad", 1.0)],
+            h5ad_total=12,
+        )
+        text = format_workspace_plain(info)
+        assert "还有 11 个" in text
+
+
+# ── perform_save ────────────────────────────────────────────────────────────
+
+class TestPerformSave:
+    def test_no_data(self) -> None:
+        session = _make_session()
+        result = perform_save(session)
+        assert result.no_data is True
+        assert result.success is False
+
+    def test_successful_save(self, tmp_path: Path) -> None:
+        save_path = tmp_path / "current.h5ad"
+        save_path.write_bytes(b"saved")
+        adata = _make_adata(n_obs=100, n_vars=50)
+        session = _make_session(adata=adata)
+        session.save_adata = lambda: save_path
+        result = perform_save(session)
+        assert result.success is True
+        assert result.path == str(save_path)
+        assert result.adata_shape == (100, 50)
+
+    def test_save_returns_none(self) -> None:
+        adata = _make_adata()
+        session = _make_session(adata=adata)
+        session.save_adata = lambda: None
+        result = perform_save(session)
+        assert result.success is False
+        assert result.error is not None
+
+    def test_save_exception(self) -> None:
+        adata = _make_adata()
+        session = _make_session(adata=adata)
+        session.save_adata = lambda: (_ for _ in ()).throw(IOError("disk full"))
+        result = perform_save(session)
+        assert result.success is False
+        assert "disk full" in result.error
+
+
+# ── format_save_result_plain ────────────────────────────────────────────────
+
+class TestFormatSaveResultPlain:
+    def test_no_data(self) -> None:
+        result = SaveResult(no_data=True)
+        text = format_save_result_plain(result)
+        assert "没有数据" in text
+
+    def test_success(self) -> None:
+        result = SaveResult(
+            success=True,
+            path="/w/current.h5ad",
+            adata_shape=(100, 50),
+        )
+        text = format_save_result_plain(result)
+        assert "已保存" in text
+        assert "100 cells x 50 genes" in text
+        assert "/w/current.h5ad" in text
+
+    def test_error(self) -> None:
+        result = SaveResult(error="disk full")
+        text = format_save_result_plain(result)
+        assert "disk full" in text
+
+
+# ── Cross-channel consistency ───────────────────────────────────────────────
+
+class TestCrossChannelConsistency:
+    """Verify that shared gather functions produce the same data regardless
+    of which channel calls them — the core invariant of this abstraction."""
+
+    def test_status_same_for_different_channels(self) -> None:
+        adata = _make_adata(n_obs=3000, n_vars=1000)
+        sm = _make_session_manager("k1")
+        session = _make_session(adata=adata)
+
+        info1 = gather_status(session, session_manager=sm, is_running=True)
+        info2 = gather_status(session, session_manager=sm, is_running=True)
+        assert info1.adata_shape == info2.adata_shape
+        assert info1.kernel_name == info2.kernel_name
+        assert info1.obs_columns == info2.obs_columns
+
+    def test_usage_same_for_different_channels(self) -> None:
+        usage = SimpleNamespace(input_tokens=100, output_tokens=50, total_tokens=150)
+        session = _make_session(last_usage=usage)
+
+        info1 = gather_usage(session)
+        info2 = gather_usage(session)
+        assert info1.input_tokens == info2.input_tokens
+        assert info1.has_data == info2.has_data
+
+
+class TestChannelCoreImports:
+    """Verify that the new abstractions are importable alongside existing ones."""
+
+    def test_all_new_symbols_importable(self) -> None:
+        from omicverse.jarvis.channels.channel_core import (
+            StatusInfo,
+            UsageInfo,
+            WorkspaceInfo,
+            SaveResult,
+            gather_status,
+            gather_usage,
+            gather_workspace,
+            perform_save,
+            format_status_plain,
+            format_usage_plain,
+            format_workspace_plain,
+            format_save_result_plain,
+        )
+        # Smoke test: all are callable or dataclass
+        assert callable(gather_status)
+        assert callable(format_status_plain)
+
+    def test_existing_symbols_still_importable(self) -> None:
+        from omicverse.jarvis.channels.channel_core import (
+            RunningTask,
+            text_chunks,
+            strip_local_paths,
+            build_full_request,
+            get_prior_history,
+            notify_turn_complete,
+            process_result_state,
+            format_analysis_error,
+            default_summary,
+        )
+        assert callable(text_chunks)
+        assert callable(strip_local_paths)

--- a/tests/jarvis/test_discord_migration.py
+++ b/tests/jarvis/test_discord_migration.py
@@ -1,0 +1,567 @@
+"""Tests for Discord channel migration to shared runtime abstractions.
+
+Covers:
+- discord_route_from_message: ConversationRoute construction for DM, guild, thread
+- discord_runtime_envelope: MessageEnvelope construction
+- DiscordRuntimePresenter: all MessagePresenter protocol methods
+- DiscordDelivery: event delivery including text, edit, photo, document
+- DiscordJarvisBot wiring: runtime integration, command routing
+
+Acceptance criteria addressed:
+- AC-001.1: Discord migrated onto shared channel abstractions
+- AC-001.2: Existing Discord-specific behavior preserved
+- AC-001.3: No behavior regression in presenter output or attachment handling
+- AC-001.4: QQ/WeChat/Feishu/iMessage not modified
+- AC-001.5: Shared abstractions remain general for wave 2
+"""
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from omicverse.jarvis.channels.discord import (
+    DiscordDelivery,
+    DiscordJarvisBot,
+    DiscordRuntimePresenter,
+    discord_route_from_message,
+    discord_runtime_envelope,
+    _BORING_SUMMARIES,
+    _MAX_TEXT,
+)
+from omicverse.jarvis.runtime import ConversationRoute, DeliveryEvent, MessageEnvelope
+
+
+# ── Test helpers ──────────────────────────────────────────────────────────
+
+
+def _make_message(
+    *,
+    content: str = "hello",
+    author_id: int = 42,
+    author_name: str = "alice",
+    author_bot: bool = False,
+    channel_id: int = 100,
+    channel_guild: Any = None,
+    message_id: int = 999,
+    attachments: Optional[list] = None,
+) -> SimpleNamespace:
+    """Build a minimal Discord message stub."""
+    author = SimpleNamespace(id=author_id, name=author_name, bot=author_bot)
+    channel = SimpleNamespace(id=channel_id, guild=channel_guild)
+    return SimpleNamespace(
+        content=content,
+        author=author,
+        channel=channel,
+        id=message_id,
+        attachments=attachments or [],
+        mention_everyone=False,
+    )
+
+
+def _make_guild() -> SimpleNamespace:
+    return SimpleNamespace(id=1)
+
+
+def _make_session(adata=None, h5ad_files=None, workspace="/tmp/ws"):
+    files = h5ad_files or []
+    return SimpleNamespace(
+        adata=adata,
+        workspace=workspace,
+        list_h5ad_files=lambda: files,
+    )
+
+
+def _make_adata(n_obs: int = 5000, n_vars: int = 2000, obs_cols=None):
+    cols = obs_cols or ["cell_type", "batch"]
+    return SimpleNamespace(
+        n_obs=n_obs,
+        n_vars=n_vars,
+        obs=SimpleNamespace(columns=cols),
+    )
+
+
+def _make_route(scope_type="dm", scope_id="100", thread_id=None, sender_id="42"):
+    return ConversationRoute(
+        channel="discord",
+        scope_type=scope_type,
+        scope_id=scope_id,
+        thread_id=thread_id,
+        sender_id=sender_id,
+    )
+
+
+def _make_envelope(route=None, text="analyze data", sender_id="42", metadata=None):
+    route = route or _make_route()
+    return MessageEnvelope(
+        route=route,
+        text=text,
+        sender_id=sender_id,
+        sender_username="alice",
+        message_id="999",
+        trigger="direct",
+        explicit_trigger=True,
+        metadata=metadata or {},
+    )
+
+
+def _make_result(
+    summary="分析完成",
+    figures=None,
+    reports=None,
+    artifacts=None,
+    error=None,
+    adata=None,
+):
+    return SimpleNamespace(
+        summary=summary,
+        figures=figures or [],
+        reports=reports or [],
+        artifacts=artifacts or [],
+        error=error,
+        adata=adata,
+    )
+
+
+# ── Route tests ──────────────────────────────────────────────────────────
+
+
+class TestDiscordRoute:
+    def test_dm_route(self):
+        msg = _make_message(channel_id=100)
+        route = discord_route_from_message(msg)
+        assert route.channel == "discord"
+        assert route.scope_type == "dm"
+        assert route.scope_id == "100"
+        assert route.thread_id is None
+        assert route.sender_id == "42"
+        assert route.is_direct
+
+    def test_guild_route(self):
+        msg = _make_message(channel_id=200, channel_guild=_make_guild())
+        route = discord_route_from_message(msg)
+        assert route.scope_type == "channel"
+        assert route.scope_id == "200"
+        assert route.thread_id is None
+        assert not route.is_direct
+
+    def test_no_author_yields_none_sender(self):
+        msg = SimpleNamespace(
+            channel=SimpleNamespace(id=100, guild=None),
+            author=None,
+            id=999,
+        )
+        route = discord_route_from_message(msg)
+        assert route.sender_id is None
+
+
+# ── Envelope tests ───────────────────────────────────────────────────────
+
+
+class TestDiscordEnvelope:
+    def test_basic_envelope(self):
+        msg = _make_message(content="run PCA")
+        env = discord_runtime_envelope(msg, "run PCA")
+        assert env is not None
+        assert env.text == "run PCA"
+        assert env.sender_id == "42"
+        assert env.sender_username == "alice"
+        assert env.trigger == "direct"
+        assert env.explicit_trigger is True
+
+    def test_empty_text_returns_none(self):
+        msg = _make_message(content="")
+        env = discord_runtime_envelope(msg, "")
+        assert env is None
+
+    def test_whitespace_text_returns_none(self):
+        msg = _make_message(content="   ")
+        env = discord_runtime_envelope(msg, "   ")
+        assert env is None
+
+    def test_guild_trigger_is_mention(self):
+        msg = _make_message(channel_guild=_make_guild())
+        env = discord_runtime_envelope(msg, "run PCA")
+        assert env is not None
+        assert env.trigger == "mention"
+
+    def test_metadata_forwarded(self):
+        msg = _make_message()
+        env = discord_runtime_envelope(msg, "hello", metadata={"key": "val"})
+        assert env is not None
+        assert env.metadata == {"key": "val"}
+
+
+# ── Presenter tests ──────────────────────────────────────────────────────
+
+
+class TestDiscordPresenter:
+    def setup_method(self):
+        self.presenter = DiscordRuntimePresenter()
+        self.route = _make_route()
+
+    def test_ack_with_adata(self):
+        session = _make_session(adata=_make_adata(3000, 1500))
+        envelope = _make_envelope()
+        events = self.presenter.ack(envelope, session)
+        assert len(events) == 1
+        assert "3,000" in events[0].text
+        assert "1,500" in events[0].text
+        assert events[0].kind == "text"
+
+    def test_ack_with_h5ad_files(self):
+        files = [SimpleNamespace(name="data.h5ad")]
+        session = _make_session(h5ad_files=files)
+        envelope = _make_envelope()
+        events = self.presenter.ack(envelope, session)
+        assert "data.h5ad" in events[0].text
+
+    def test_ack_no_data(self):
+        session = _make_session()
+        envelope = _make_envelope()
+        events = self.presenter.ack(envelope, session)
+        assert "⏳" in events[0].text
+
+    def test_ack_with_images(self):
+        session = _make_session()
+        envelope = _make_envelope(
+            metadata={"request_content": [{"type": "image"}, {"type": "image"}]}
+        )
+        events = self.presenter.ack(envelope, session)
+        assert "2 张" in events[0].text
+
+    def test_queue_started(self):
+        events = self.presenter.queue_started(self.route, 3)
+        assert len(events) == 1
+        assert "3" in events[0].text
+
+    def test_draft_open(self):
+        event = self.presenter.draft_open(self.route)
+        assert event.mode == "open"
+        assert event.target == "analysis-draft"
+        assert "分析中" in event.text
+
+    def test_draft_update_with_progress(self):
+        event = self.presenter.draft_update(self.route, "", "running code...")
+        assert "running code" in event.text
+        assert event.mode == "edit"
+
+    def test_draft_update_with_llm_text(self):
+        event = self.presenter.draft_update(self.route, "some analysis result", "")
+        assert "some analysis result" in event.text
+
+    def test_draft_update_empty(self):
+        event = self.presenter.draft_update(self.route, "", "")
+        assert "分析中" in event.text
+
+    def test_draft_cancelled(self):
+        event = self.presenter.draft_cancelled(self.route)
+        assert "取消" in event.text
+        assert event.mode == "edit"
+
+    def test_analysis_error(self):
+        event = self.presenter.analysis_error(self.route, "something failed")
+        assert "something failed" in event.text
+        assert event.mode == "edit"
+
+    def test_typing(self):
+        event = self.presenter.typing(self.route)
+        assert event is not None
+        assert event.kind == "typing"
+
+    def test_quick_chat_reply(self):
+        event = self.presenter.quick_chat_reply(self.route, "hello")
+        assert event.text == "hello"
+
+    def test_quick_chat_fallback(self):
+        event = self.presenter.quick_chat_fallback(self.route)
+        assert "/cancel" in event.text
+
+    def test_analysis_status_media(self):
+        event = self.presenter.analysis_status(
+            self.route, has_media=True, has_reports=False, has_artifacts=False,
+        )
+        assert event is not None
+        assert "图片" in event.text
+
+    def test_analysis_status_none(self):
+        event = self.presenter.analysis_status(
+            self.route, has_media=False, has_reports=False, has_artifacts=False,
+        )
+        assert event is None
+
+    def test_final_events_with_figures(self):
+        result = _make_result(summary="good result", figures=[b"png1", b"png2"])
+        events = self.presenter.final_events(
+            self.route, session=_make_session(), user_text="test",
+            llm_text="", result=result,
+        )
+        photo_events = [e for e in events if e.kind == "photo"]
+        assert len(photo_events) == 2
+        assert photo_events[0].filename == "figure_1.png"
+        assert photo_events[1].filename == "figure_2.png"
+
+    def test_final_events_with_reports(self):
+        result = _make_result(summary="done", reports=["report text here"])
+        events = self.presenter.final_events(
+            self.route, session=_make_session(), user_text="test",
+            llm_text="", result=result,
+        )
+        text_events = [e for e in events if e.kind == "text" and e.mode == "send"]
+        report_found = any("report text here" in e.text for e in text_events)
+        assert report_found
+
+    def test_final_events_with_artifacts(self):
+        artifact = SimpleNamespace(data=b"data", filename="result.csv")
+        result = _make_result(artifacts=[artifact])
+        events = self.presenter.final_events(
+            self.route, session=_make_session(), user_text="test",
+            llm_text="", result=result,
+        )
+        doc_events = [e for e in events if e.kind == "document"]
+        assert len(doc_events) == 1
+        assert doc_events[0].filename == "result.csv"
+
+    def test_final_events_boring_summary_uses_llm(self):
+        result = _make_result(summary="分析完成")
+        events = self.presenter.final_events(
+            self.route, session=_make_session(), user_text="test",
+            llm_text="detailed LLM analysis text", result=result,
+        )
+        text_events = [e for e in events if e.kind == "text" and e.mode == "send"]
+        assert any("detailed LLM analysis text" in e.text for e in text_events)
+
+    def test_final_events_no_summary_no_llm_with_adata(self):
+        session = _make_session(adata=_make_adata(1000, 500))
+        result = _make_result(summary="分析完成")
+        events = self.presenter.final_events(
+            self.route, session=session, user_text="test",
+            llm_text="", result=result,
+        )
+        text_events = [e for e in events if e.kind == "text" and e.mode == "send"]
+        assert any("1,000" in e.text for e in text_events)
+
+    def test_final_events_draft_completion_marker(self):
+        result = _make_result(summary="good analysis")
+        events = self.presenter.final_events(
+            self.route, session=_make_session(), user_text="test",
+            llm_text="", result=result,
+        )
+        edit_events = [e for e in events if e.mode == "edit" and e.target == "analysis-draft"]
+        assert any("✅" in e.text for e in edit_events)
+
+
+# ── Delivery tests ───────────────────────────────────────────────────────
+
+
+class _FakeChannel:
+    """Mock Discord channel that records sent messages."""
+
+    def __init__(self) -> None:
+        self.sent: List[Dict[str, Any]] = []
+        self._next_id = 1
+
+    async def send(self, content: str = "", **kwargs) -> SimpleNamespace:
+        msg_id = self._next_id
+        self._next_id += 1
+        record = {"content": content, **kwargs}
+        self.sent.append(record)
+        msg = SimpleNamespace(id=msg_id, content=content)
+        msg.edit = self._make_edit(msg)
+        return msg
+
+    def _make_edit(self, msg):
+        channel = self
+
+        async def edit(content: str = "", **kwargs):
+            msg.content = content
+            channel.sent.append({"edit": True, "content": content, **kwargs})
+
+        return edit
+
+    async def typing(self):
+        self.sent.append({"typing": True})
+
+
+class _FakeClient:
+    def __init__(self, channels: Optional[Dict[int, Any]] = None) -> None:
+        self._channels = channels or {}
+
+    def get_channel(self, channel_id: int) -> Any:
+        return self._channels.get(channel_id)
+
+
+class TestDiscordDelivery:
+    def setup_method(self):
+        self.channel = _FakeChannel()
+        self.client = _FakeClient()
+        self.delivery = DiscordDelivery(client=self.client)
+        self.route = _make_route()
+        self.delivery.register_channel(self.route, self.channel)
+
+    @pytest.mark.asyncio
+    async def test_deliver_text_send(self):
+        event = DeliveryEvent(route=self.route, kind="text", text="hello world")
+        await self.delivery.deliver(event)
+        assert len(self.channel.sent) == 1
+        assert self.channel.sent[0]["content"] == "hello world"
+
+    @pytest.mark.asyncio
+    async def test_deliver_text_open_and_edit(self):
+        # Open a draft
+        open_event = DeliveryEvent(
+            route=self.route, kind="text", mode="open",
+            target="draft", text="thinking...",
+        )
+        await self.delivery.deliver(open_event)
+        assert len(self.channel.sent) == 1
+        assert self.channel.sent[0]["content"] == "thinking..."
+
+        # Edit the draft
+        edit_event = DeliveryEvent(
+            route=self.route, kind="text", mode="edit",
+            target="draft", text="done!",
+        )
+        await self.delivery.deliver(edit_event)
+        assert len(self.channel.sent) == 2
+        assert self.channel.sent[1].get("edit") is True
+        assert self.channel.sent[1]["content"] == "done!"
+
+    @pytest.mark.asyncio
+    async def test_deliver_edit_fallback_to_send(self):
+        # Edit without prior open → falls back to send
+        event = DeliveryEvent(
+            route=self.route, kind="text", mode="edit",
+            target="unknown-target", text="fallback",
+        )
+        await self.delivery.deliver(event)
+        assert len(self.channel.sent) == 1
+        assert self.channel.sent[0]["content"] == "fallback"
+
+    @pytest.mark.asyncio
+    async def test_deliver_typing(self):
+        event = DeliveryEvent(route=self.route, kind="typing")
+        await self.delivery.deliver(event)
+        assert self.channel.sent[0].get("typing") is True
+
+    @pytest.mark.asyncio
+    async def test_deliver_text_with_reply_to(self):
+        source = SimpleNamespace(id=123)
+        self.delivery.register_channel(self.route, self.channel, source_message=source)
+        event = DeliveryEvent(
+            route=self.route, kind="text", text="ack",
+            metadata={"reply_to": True},
+        )
+        await self.delivery.deliver(event)
+        assert self.channel.sent[0].get("reference") is source
+        assert self.channel.sent[0].get("mention_author") is False
+
+    @pytest.mark.asyncio
+    async def test_deliver_photo(self):
+        event = DeliveryEvent(
+            route=self.route, kind="photo",
+            binary=b"png-data", filename="fig.png", caption="Figure 1",
+        )
+        await self.delivery.deliver(event)
+        assert len(self.channel.sent) == 1
+        assert "file" in self.channel.sent[0]
+        assert self.channel.sent[0].get("content") == "Figure 1"
+
+    @pytest.mark.asyncio
+    async def test_deliver_document(self):
+        event = DeliveryEvent(
+            route=self.route, kind="document",
+            binary=b"csv-data", filename="result.csv", caption="Attachment",
+        )
+        await self.delivery.deliver(event)
+        assert len(self.channel.sent) == 1
+        assert "file" in self.channel.sent[0]
+
+    @pytest.mark.asyncio
+    async def test_unknown_route_uses_client_fallback(self):
+        other_route = _make_route(scope_id="999")
+        fallback_channel = _FakeChannel()
+        client = _FakeClient(channels={999: fallback_channel})
+        delivery = DiscordDelivery(client=client)
+        event = DeliveryEvent(route=other_route, kind="text", text="hi")
+        await delivery.deliver(event)
+        assert len(fallback_channel.sent) == 1
+
+    @pytest.mark.asyncio
+    async def test_unresolvable_route_is_noop(self):
+        other_route = _make_route(scope_id="888")
+        client = _FakeClient()
+        delivery = DiscordDelivery(client=client)
+        event = DeliveryEvent(route=other_route, kind="text", text="hi")
+        # Should not raise
+        await delivery.deliver(event)
+
+    @pytest.mark.asyncio
+    async def test_long_text_chunked(self):
+        long_text = "x" * 4000
+        event = DeliveryEvent(route=self.route, kind="text", text=long_text)
+        await self.delivery.deliver(event)
+        assert len(self.channel.sent) >= 2
+
+    @pytest.mark.asyncio
+    async def test_target_key_format(self):
+        event = DeliveryEvent(
+            route=self.route, kind="text",
+            target="analysis-draft", text="test",
+        )
+        key = DiscordDelivery._target_key(event)
+        assert "analysis-draft" in key
+        assert self.route.route_key() in key
+
+
+# ── Integration: Bot wiring ──────────────────────────────────────────────
+
+
+class TestDiscordBotWiring:
+    """Verify that the bot correctly wires the runtime components."""
+
+    def test_bot_has_runtime_and_delivery(self):
+        """Check that DiscordJarvisBot initializes with runtime and delivery."""
+        # We can't fully init without discord.py, but verify the class structure
+        assert hasattr(DiscordJarvisBot, "_on_message")
+        assert hasattr(DiscordJarvisBot, "_handle_status")
+        assert hasattr(DiscordJarvisBot, "_normalize_message_text")
+        assert hasattr(DiscordJarvisBot, "_handle_h5ad_attachment")
+        assert hasattr(DiscordJarvisBot, "_prepare_inbound_images")
+
+
+# ── Cross-channel consistency ────────────────────────────────────────────
+
+
+class TestCrossChannelConsistency:
+    """Verify Discord and Telegram presenter shapes are compatible."""
+
+    def test_discord_presenter_matches_protocol(self):
+        """All MessagePresenter protocol methods exist on DiscordRuntimePresenter."""
+        presenter = DiscordRuntimePresenter()
+        required = [
+            "ack", "queue_started", "draft_open", "draft_update",
+            "draft_cancelled", "analysis_error", "typing",
+            "quick_chat_reply", "quick_chat_fallback",
+            "analysis_status", "final_events",
+        ]
+        for method_name in required:
+            assert hasattr(presenter, method_name), f"Missing {method_name}"
+
+    def test_discord_delivery_matches_telegram_delivery(self):
+        """DiscordDelivery has the same async deliver interface as TelegramDelivery."""
+        client = _FakeClient()
+        delivery = DiscordDelivery(client=client)
+        assert asyncio.iscoroutinefunction(delivery.deliver)
+
+    def test_other_channels_not_modified(self):
+        """QQ, WeChat, Feishu, iMessage modules still import without errors."""
+        # These imports should succeed; we only touched discord.py
+        from omicverse.jarvis.channels import (
+            run_bot,
+            run_discord_bot,
+        )
+        assert callable(run_bot)
+        assert callable(run_discord_bot)

--- a/tests/jarvis/test_gemini_cli_runtime.py
+++ b/tests/jarvis/test_gemini_cli_runtime.py
@@ -5,7 +5,7 @@ from unittest import mock
 
 from omicverse.utils.ovagent.auth import collect_api_key_env
 from omicverse.utils.agent_backend import OmicVerseLLMBackend
-from omicverse.utils.smart_agent import _resolve_agent_llm_credentials
+from omicverse.utils.ovagent.auth import resolve_credentials as _resolve_agent_llm_credentials
 from omicverse.jarvis import gemini_cli_oauth
 
 
@@ -23,7 +23,7 @@ class GeminiCliRuntimeTests(unittest.TestCase):
 
     def test_resolve_agent_llm_credentials_rewrites_stale_openai_endpoint_for_gemini_oauth(self) -> None:
         with mock.patch(
-            "omicverse.utils.smart_agent.GeminiCliOAuthManager.build_api_key_payload",
+            "omicverse.utils.ovagent.auth.GeminiCliOAuthManager.build_api_key_payload",
             return_value='{"token":"oauth-token","projectId":"demo"}',
         ):
             model, api_key, endpoint, auth_mode = _resolve_agent_llm_credentials(

--- a/tests/utils/inspector/test_optional_adata.py
+++ b/tests/utils/inspector/test_optional_adata.py
@@ -1,0 +1,328 @@
+"""
+Tests for optional-adata support in AgentContextInjector.
+
+Covers AC-001: no-dataset construction, safe inspection skipping,
+and preserved dataset-aware behavior.
+"""
+
+import sys
+import importlib.util
+import numpy as np
+import pytest
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Import machinery — mirrors the existing standalone test pattern to avoid
+# circular imports via the package __init__.py.
+# ---------------------------------------------------------------------------
+
+PROJECT_ROOT = Path(__file__).parent.parent.parent.parent
+
+
+def _import(module_name: str, rel_path: str):
+    spec = importlib.util.spec_from_file_location(
+        module_name, str(PROJECT_ROOT / rel_path)
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_import(
+    "omicverse.utils.inspector.data_structures",
+    "omicverse/utils/inspector/data_structures.py",
+)
+_import(
+    "omicverse.utils.inspector.validators",
+    "omicverse/utils/inspector/validators.py",
+)
+_import(
+    "omicverse.utils.inspector.prerequisite_checker",
+    "omicverse/utils/inspector/prerequisite_checker.py",
+)
+_import(
+    "omicverse.utils.inspector.suggestion_engine",
+    "omicverse/utils/inspector/suggestion_engine.py",
+)
+_import(
+    "omicverse.utils.inspector.llm_formatter",
+    "omicverse/utils/inspector/llm_formatter.py",
+)
+_import(
+    "omicverse.utils.inspector.inspector",
+    "omicverse/utils/inspector/inspector.py",
+)
+_aci_mod = _import(
+    "omicverse.utils.inspector.agent_context_injector",
+    "omicverse/utils/inspector/agent_context_injector.py",
+)
+
+AgentContextInjector = _aci_mod.AgentContextInjector
+ConversationState = _aci_mod.ConversationState
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _MockRegistry:
+    """Minimal mock registry used by tests that supply a dataset."""
+
+    def __init__(self):
+        self.functions = {
+            "pca": {
+                "prerequisites": {"required": ["preprocess"], "optional": []},
+                "requires": {},
+                "produces": {"obsm": ["X_pca"], "uns": ["pca"]},
+                "auto_fix": "escalate",
+            },
+            "neighbors": {
+                "prerequisites": {"required": ["pca"], "optional": []},
+                "requires": {"obsm": ["X_pca"]},
+                "produces": {
+                    "obsp": ["connectivities", "distances"],
+                    "uns": ["neighbors"],
+                },
+                "auto_fix": "auto",
+            },
+            "leiden": {
+                "prerequisites": {"required": ["neighbors"], "optional": []},
+                "requires": {"obsp": ["connectivities"]},
+                "produces": {"obs": ["leiden"]},
+                "auto_fix": "auto",
+            },
+        }
+
+    def get_function(self, name):
+        return self.functions.get(name)
+
+
+def _make_adata(with_pca=False, with_neighbors=False):
+    from anndata import AnnData
+
+    np.random.seed(42)
+    adata = AnnData(np.random.rand(50, 30))
+    adata.obs_names = [f"C{i}" for i in range(50)]
+    adata.var_names = [f"G{i}" for i in range(30)]
+    if with_pca:
+        adata.obsm["X_pca"] = np.random.rand(50, 30)
+        adata.uns["pca"] = {"variance_ratio": np.random.rand(30)}
+    if with_neighbors:
+        adata.obsp["connectivities"] = np.random.rand(50, 50)
+        adata.obsp["distances"] = np.random.rand(50, 50)
+        adata.uns["neighbors"] = {"params": {"n_neighbors": 15}}
+    return adata
+
+
+# ===================================================================
+# 1. No-dataset construction
+# ===================================================================
+
+
+class TestNoDatasetConstruction:
+    """AgentContextInjector(adata=None) must not raise."""
+
+    def test_construct_none(self):
+        injector = AgentContextInjector(adata=None, registry=None)
+        assert injector.adata is None
+        assert injector.inspector is None
+        assert not injector.has_dataset
+
+    def test_construct_no_args(self):
+        """Default arguments (all None) produce a valid no-dataset injector."""
+        injector = AgentContextInjector()
+        assert not injector.has_dataset
+        assert injector.inspector is None
+
+    def test_no_initial_snapshot(self):
+        """No snapshot should be taken when there is no dataset."""
+        injector = AgentContextInjector()
+        assert len(injector.conversation_state.data_snapshots) == 0
+
+
+# ===================================================================
+# 2. No-dataset mode skips inspection safely
+# ===================================================================
+
+
+class TestNoDatasetSafeSkipping:
+    """All inspection pathways must return safe defaults without errors."""
+
+    def test_inject_context_no_dataset(self):
+        injector = AgentContextInjector()
+        prompt = "You are a helpful assistant."
+        enhanced = injector.inject_context(prompt)
+
+        assert prompt in enhanced
+        assert "knowledge-query" in enhanced or "No dataset" in enhanced
+
+    def test_general_state_section_no_dataset(self):
+        injector = AgentContextInjector()
+        section = injector._build_general_state_section()
+        assert "No dataset" in section
+        assert "knowledge-query" in section
+
+    def test_function_specific_section_no_dataset(self):
+        injector = AgentContextInjector()
+        section = injector._build_function_specific_section("leiden")
+        assert "Target Function: leiden" in section
+        assert "No dataset loaded" in section
+
+    def test_detect_executed_functions_no_dataset(self):
+        injector = AgentContextInjector()
+        assert injector._detect_executed_functions() == {}
+
+    def test_get_current_state_no_dataset(self):
+        injector = AgentContextInjector()
+        state = injector._get_current_state()
+        assert state["shape"] == (0, 0)
+        assert state["obsm"] == []
+        assert state["obsp"] == []
+
+    def test_update_after_execution_no_dataset(self):
+        """Execution history should still be tracked without a dataset."""
+        injector = AgentContextInjector()
+        injector.update_after_execution("pca")
+        assert "pca" in injector.conversation_state.executed_functions
+        assert len(injector.conversation_state.execution_history) == 1
+        # A snapshot is taken even in no-dataset mode (with empty state)
+        assert len(injector.conversation_state.data_snapshots) == 1
+
+    def test_conversation_summary_no_dataset(self):
+        injector = AgentContextInjector()
+        summary = injector.get_conversation_summary()
+        assert "No functions executed" in summary
+
+    def test_conversation_summary_after_exec_no_dataset(self):
+        injector = AgentContextInjector()
+        injector.update_after_execution("pca")
+        summary = injector.get_conversation_summary()
+        assert "pca" in summary
+
+    def test_clear_conversation_state_no_dataset(self):
+        injector = AgentContextInjector()
+        injector.update_after_execution("pca")
+        injector.clear_conversation_state()
+        assert len(injector.conversation_state.executed_functions) == 0
+        # No snapshot should be taken on clear in no-dataset mode
+        assert len(injector.conversation_state.data_snapshots) == 0
+
+    def test_create_sub_agent_injector_no_dataset(self):
+        """Sub-agent injector inherits no-dataset mode from parent."""
+        parent = AgentContextInjector()
+        child = parent.create_sub_agent_injector()
+        assert not child.has_dataset
+        assert child.inspector is None
+
+    def test_inject_context_selective_no_dataset(self):
+        injector = AgentContextInjector()
+        prompt = "base"
+        enhanced = injector.inject_context(
+            prompt,
+            target_function="leiden",
+            include_general_state=True,
+            include_function_specific=True,
+            include_instructions=True,
+        )
+        assert "base" in enhanced
+        assert "No dataset" in enhanced
+        assert "Target Function: leiden" in enhanced
+
+    def test_filesystem_methods_no_dataset(self):
+        """Filesystem helpers should not fail in no-dataset mode."""
+        injector = AgentContextInjector(enable_filesystem_context=False)
+        assert injector.write_to_context("k", "v") is None
+        assert injector.search_context("*") == []
+        assert injector.save_execution_plan([]) is None
+        assert injector.save_data_snapshot() is None
+        assert "disabled" in injector.get_workspace_summary().lower()
+
+
+# ===================================================================
+# 3. Dataset-aware behavior unchanged
+# ===================================================================
+
+
+class TestDatasetPresentBehavior:
+    """Existing dataset-aware paths must be unaffected by the refactor."""
+
+    def test_construct_with_adata(self):
+        adata = _make_adata()
+        injector = AgentContextInjector(adata=adata, registry=_MockRegistry())
+        assert injector.has_dataset
+        assert injector.inspector is not None
+        # Initial snapshot taken
+        assert len(injector.conversation_state.data_snapshots) == 1
+
+    def test_inject_context_with_adata(self):
+        adata = _make_adata()
+        injector = AgentContextInjector(adata=adata, registry=_MockRegistry())
+        enhanced = injector.inject_context("You are a helpful assistant.")
+        assert "Current AnnData State" in enhanced
+        assert "Prerequisite Handling Instructions" in enhanced
+
+    def test_general_state_with_pca(self):
+        adata = _make_adata(with_pca=True, with_neighbors=True)
+        injector = AgentContextInjector(adata=adata, registry=_MockRegistry())
+        section = injector._build_general_state_section()
+        assert "X_pca" in section
+        assert "connectivities" in section
+
+    def test_function_specific_with_adata(self):
+        adata = _make_adata(with_pca=True)
+        injector = AgentContextInjector(adata=adata, registry=_MockRegistry())
+        section = injector._build_function_specific_section("leiden")
+        assert "Target Function: leiden" in section
+        assert "neighbors" in section.lower()
+
+    def test_update_and_summary_with_adata(self):
+        adata = _make_adata()
+        injector = AgentContextInjector(adata=adata, registry=_MockRegistry())
+        injector.update_after_execution("pca")
+        injector.update_after_execution("neighbors")
+        summary = injector.get_conversation_summary()
+        assert "pca" in summary
+        assert "neighbors" in summary
+
+    def test_clear_state_with_adata(self):
+        adata = _make_adata()
+        injector = AgentContextInjector(adata=adata, registry=_MockRegistry())
+        injector.update_after_execution("pca")
+        injector.clear_conversation_state()
+        assert len(injector.conversation_state.executed_functions) == 0
+        # Fresh snapshot should be present
+        assert len(injector.conversation_state.data_snapshots) == 1
+
+    def test_sub_agent_inherits_adata(self):
+        adata = _make_adata()
+        parent = AgentContextInjector(
+            adata=adata,
+            registry=_MockRegistry(),
+            enable_filesystem_context=False,
+        )
+        child = parent.create_sub_agent_injector()
+        assert child.has_dataset
+        assert child.adata is adata
+
+    def test_sub_agent_override_adata(self):
+        adata1 = _make_adata()
+        adata2 = _make_adata(with_pca=True)
+        parent = AgentContextInjector(
+            adata=adata1,
+            registry=_MockRegistry(),
+            enable_filesystem_context=False,
+        )
+        child = parent.create_sub_agent_injector(adata=adata2)
+        assert child.adata is adata2
+
+    def test_has_dataset_property(self):
+        assert AgentContextInjector().has_dataset is False
+        assert (
+            AgentContextInjector(
+                adata=_make_adata(), registry=_MockRegistry()
+            ).has_dataset
+            is True
+        )

--- a/tests/utils/test_agent_backend_decomposition.py
+++ b/tests/utils/test_agent_backend_decomposition.py
@@ -244,8 +244,8 @@ class TestFacadeSize:
         """Facade should be well under the original 3128 lines."""
         facade_path = UTILS_DIR / "agent_backend.py"
         line_count = len(facade_path.read_text().splitlines())
-        assert line_count < 750, (
-            f"agent_backend.py is {line_count} lines; expected <750 for a facade "
+        assert line_count < 800, (
+            f"agent_backend.py is {line_count} lines; expected <800 for a facade "
             "(down from 3128)"
         )
 

--- a/tests/utils/test_agent_backend_decomposition.py
+++ b/tests/utils/test_agent_backend_decomposition.py
@@ -244,8 +244,8 @@ class TestFacadeSize:
         """Facade should be well under the original 3128 lines."""
         facade_path = UTILS_DIR / "agent_backend.py"
         line_count = len(facade_path.read_text().splitlines())
-        assert line_count < 800, (
-            f"agent_backend.py is {line_count} lines; expected <800 for a facade "
+        assert line_count < 700, (
+            f"agent_backend.py is {line_count} lines; expected <700 for a facade "
             "(down from 3128)"
         )
 
@@ -254,6 +254,82 @@ class TestFacadeSize:
         source = (UTILS_DIR / "agent_backend.py").read_text()
         for sdk in ["import openai", "import anthropic", "import google.generativeai", "import dashscope"]:
             assert sdk not in source, f"Facade still contains '{sdk}'"
+
+
+# ---------------------------------------------------------------------------
+# 4b. Delegation registry covers all providers
+# ---------------------------------------------------------------------------
+
+
+class TestDelegationRegistry:
+    """Verify the _PROVIDER_DELEGATES registry and _CHAT_DISPATCH table."""
+
+    def test_provider_delegates_registry_exists(self):
+        from omicverse.utils.agent_backend import _PROVIDER_DELEGATES
+        assert isinstance(_PROVIDER_DELEGATES, list)
+        assert len(_PROVIDER_DELEGATES) >= 60, (
+            f"Expected at least 60 delegate entries, got {len(_PROVIDER_DELEGATES)}"
+        )
+
+    def test_provider_delegates_all_tuples(self):
+        from omicverse.utils.agent_backend import _PROVIDER_DELEGATES
+        for entry in _PROVIDER_DELEGATES:
+            assert isinstance(entry, tuple) and len(entry) == 3, (
+                f"Each entry must be (name, module, kind); got {entry!r}"
+            )
+            name, mod, kind = entry
+            assert isinstance(name, str) and name.startswith("_")
+            assert kind in ("instance", "static", "async_gen"), (
+                f"Unknown kind {kind!r} for delegate {name}"
+            )
+
+    def test_chat_dispatch_table_exists(self):
+        from omicverse.utils.agent_backend import _CHAT_DISPATCH
+        from omicverse.utils.model_config import WireAPI
+        for wire in [WireAPI.CHAT_COMPLETIONS, WireAPI.ANTHROPIC_MESSAGES,
+                     WireAPI.GEMINI_GENERATE, WireAPI.DASHSCOPE]:
+            assert wire in _CHAT_DISPATCH, f"{wire} missing from _CHAT_DISPATCH"
+
+    def test_all_delegates_installed_on_class(self):
+        """Every registry entry should be accessible on OmicVerseLLMBackend."""
+        from omicverse.utils.agent_backend import OmicVerseLLMBackend, _PROVIDER_DELEGATES
+        for name, _mod, _kind in _PROVIDER_DELEGATES:
+            assert hasattr(OmicVerseLLMBackend, name), (
+                f"Delegate {name!r} not installed on OmicVerseLLMBackend"
+            )
+
+    def test_delegates_cover_expected_providers(self):
+        """Registry should have entries from all five adapter modules."""
+        from omicverse.utils.agent_backend import _PROVIDER_DELEGATES
+        from omicverse.utils import (
+            agent_backend_openai as oai,
+            agent_backend_anthropic as ant,
+            agent_backend_gemini as gem,
+            agent_backend_dashscope as ds,
+            agent_backend_streaming as st,
+        )
+        modules_used = {mod for _, mod, _ in _PROVIDER_DELEGATES}
+        assert oai in modules_used, "OpenAI module missing from delegates"
+        assert ant in modules_used, "Anthropic module missing from delegates"
+        assert gem in modules_used, "Gemini module missing from delegates"
+        assert ds in modules_used, "DashScope module missing from delegates"
+        assert st in modules_used, "Streaming module missing from delegates"
+
+    def test_no_handwritten_forwarding_methods_in_class_body(self):
+        """The class body should not contain inline forwarding methods."""
+        source = (UTILS_DIR / "agent_backend.py").read_text()
+        # Find the class body (between 'class OmicVerseLLMBackend' and the
+        # registry section that lives outside the class).
+        class_start = source.index("class OmicVerseLLMBackend")
+        registry_start = source.index("_PROVIDER_DELEGATES")
+        class_body = source[class_start:registry_start]
+        # The class body should not contain any direct forwarding patterns
+        # like 'return _oai.' or 'return _ant.' or 'return _gem.'
+        for pattern in ["return _oai.", "return _ant.", "return _gem.",
+                        "return _ds.", "return _stream."]:
+            assert pattern not in class_body, (
+                f"Class body still contains forwarding pattern '{pattern}'"
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/utils/test_agent_backend_local_sandbox.py
+++ b/tests/utils/test_agent_backend_local_sandbox.py
@@ -65,7 +65,7 @@ class TestRestrictedBuiltins:
         result = backend._run_python_local(
             "result = __import__.__name__"
         )
-        assert result == "'_safe_import'"
+        assert result == "'limited_import'"
 
     def test_breakpoint_not_accessible(self, monkeypatch):
         """breakpoint() is not caught by the AST scanner, only by builtins."""
@@ -91,9 +91,10 @@ class TestRestrictedBuiltins:
         assert result == "True"
 
     def test_denied_builtins_list(self):
-        """Verify the denied builtins set matches spec."""
-        expected = {"eval", "exec", "compile", "__import__", "breakpoint"}
-        assert OmicVerseLLMBackend._DENIED_BUILTINS == expected
+        """Verify that the sandbox excludes dangerous builtins."""
+        from omicverse.utils.agent_sandbox import _EXCLUDED_BUILTINS
+        expected_minimum = {"eval", "exec", "compile", "__import__", "breakpoint"}
+        assert expected_minimum <= _EXCLUDED_BUILTINS
 
 
 # ---------------------------------------------------------------------------

--- a/tests/utils/test_agent_backend_local_sandbox.py
+++ b/tests/utils/test_agent_backend_local_sandbox.py
@@ -1,0 +1,232 @@
+"""
+Regression tests for local Python executor security hardening (task-007).
+
+Covers:
+1. Restricted builtins — dangerous eval/import primitives removed from sandbox
+2. SafeOsProxy injection — import os returns safe proxy, blocks dangerous ops
+3. SyntaxError propagation — scanner SyntaxError surfaces as RuntimeError
+4. Benign execution — normal code still works under restricted sandbox
+5. Public signature preservation
+"""
+
+import pytest
+
+from omicverse.utils.agent_backend import OmicVerseLLMBackend
+from omicverse.utils.model_config import ModelConfig
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_local_backend(monkeypatch):
+    """Create a backend configured for local Python execution."""
+    monkeypatch.setattr(
+        ModelConfig, "get_provider_from_model", lambda *a, **kw: "python"
+    )
+    return OmicVerseLLMBackend(
+        system_prompt="test", model="python", api_key=""
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Restricted builtins
+# ---------------------------------------------------------------------------
+
+
+class TestRestrictedBuiltins:
+    """Dangerous eval/import builtins must not be available inside the sandbox.
+
+    These tests reference the names without calling them to avoid triggering
+    the AST security scanner (which independently blocks eval()/exec() calls).
+    This verifies that the restricted builtins dict itself is effective.
+    """
+
+    def test_eval_not_accessible(self, monkeypatch):
+        backend = _make_local_backend(monkeypatch)
+        with pytest.raises(RuntimeError, match="NameError"):
+            backend._run_python_local("x = eval")
+
+    def test_exec_not_accessible(self, monkeypatch):
+        backend = _make_local_backend(monkeypatch)
+        with pytest.raises(RuntimeError, match="NameError"):
+            backend._run_python_local("x = exec")
+
+    def test_compile_not_accessible(self, monkeypatch):
+        backend = _make_local_backend(monkeypatch)
+        with pytest.raises(RuntimeError, match="NameError"):
+            backend._run_python_local("x = compile")
+
+    def test_dunder_import_is_safe_replacement(self, monkeypatch):
+        """__import__ in sandbox is the safe replacement, not the real one."""
+        backend = _make_local_backend(monkeypatch)
+        # Access the name (not a call) to verify it's our safe wrapper
+        result = backend._run_python_local(
+            "result = __import__.__name__"
+        )
+        assert result == "'_safe_import'"
+
+    def test_breakpoint_not_accessible(self, monkeypatch):
+        """breakpoint() is not caught by the AST scanner, only by builtins."""
+        backend = _make_local_backend(monkeypatch)
+        with pytest.raises(RuntimeError, match="NameError"):
+            backend._run_python_local("breakpoint()")
+
+    def test_benign_builtins_still_work(self, monkeypatch):
+        """print, len, range, int, str, list, dict, etc. remain available."""
+        backend = _make_local_backend(monkeypatch)
+        result = backend._run_python_local("print(len(list(range(5))))")
+        assert result == "5"
+
+    def test_open_still_available(self, monkeypatch):
+        """open() is intentionally kept for bioinformatics file I/O."""
+        backend = _make_local_backend(monkeypatch)
+        result = backend._run_python_local("result = callable(open)")
+        assert result == "True"
+
+    def test_type_and_isinstance_work(self, monkeypatch):
+        backend = _make_local_backend(monkeypatch)
+        result = backend._run_python_local("print(isinstance(42, int))")
+        assert result == "True"
+
+    def test_denied_builtins_list(self):
+        """Verify the denied builtins set matches spec."""
+        expected = {"eval", "exec", "compile", "__import__", "breakpoint"}
+        assert OmicVerseLLMBackend._DENIED_BUILTINS == expected
+
+
+# ---------------------------------------------------------------------------
+# 2. SafeOsProxy injection
+# ---------------------------------------------------------------------------
+
+
+class TestSafeOsProxyInjection:
+    """import os inside sandbox must return SafeOsProxy, blocking dangerous ops."""
+
+    def test_os_global_is_safe_proxy(self, monkeypatch):
+        """The pre-injected os global is a SafeOsProxy."""
+        backend = _make_local_backend(monkeypatch)
+        result = backend._run_python_local("result = type(os).__name__")
+        assert result == "'SafeOsProxy'"
+
+    def test_import_os_returns_safe_proxy(self, monkeypatch):
+        """import os returns SafeOsProxy, not the real os module."""
+        backend = _make_local_backend(monkeypatch)
+        result = backend._run_python_local(
+            "import os\nresult = type(os).__name__"
+        )
+        assert result == "'SafeOsProxy'"
+
+    def test_os_putenv_blocked_at_runtime(self, monkeypatch):
+        """os.putenv() is blocked by SafeOsProxy (not caught by AST scanner)."""
+        backend = _make_local_backend(monkeypatch)
+        with pytest.raises(RuntimeError, match="blocked"):
+            backend._run_python_local("import os\nos.putenv('X', 'Y')")
+
+    def test_os_unsetenv_blocked_at_runtime(self, monkeypatch):
+        """os.unsetenv() is blocked by SafeOsProxy."""
+        backend = _make_local_backend(monkeypatch)
+        with pytest.raises(RuntimeError, match="blocked"):
+            backend._run_python_local("import os\nos.unsetenv('X')")
+
+    def test_os_path_join_works(self, monkeypatch):
+        """os.path operations remain functional through SafeOsProxy."""
+        backend = _make_local_backend(monkeypatch)
+        result = backend._run_python_local(
+            "import os\nresult = os.path.join('a', 'b', 'c')"
+        )
+        assert "a" in result and "b" in result and "c" in result
+
+    def test_os_getcwd_works(self, monkeypatch):
+        """os.getcwd() is a safe operation and should work."""
+        backend = _make_local_backend(monkeypatch)
+        result = backend._run_python_local("import os\nresult = os.getcwd()")
+        assert result  # Should return a non-empty path string
+
+    def test_from_os_path_import_works(self, monkeypatch):
+        """from os.path import join should work through SafeOsProxy."""
+        backend = _make_local_backend(monkeypatch)
+        result = backend._run_python_local(
+            "from os.path import join\nresult = join('x', 'y')"
+        )
+        assert "x" in result and "y" in result
+
+    def test_from_os_import_path(self, monkeypatch):
+        """from os import path should return real os.path via SafeOsProxy."""
+        backend = _make_local_backend(monkeypatch)
+        result = backend._run_python_local(
+            "from os import path\nresult = path.join('a', 'b')"
+        )
+        assert "a" in result and "b" in result
+
+    def test_os_environ_readable(self, monkeypatch):
+        """os.environ should be readable (not in blocked list)."""
+        backend = _make_local_backend(monkeypatch)
+        result = backend._run_python_local(
+            "import os\nresult = type(os.environ).__name__"
+        )
+        assert result  # Should return the type name without error
+
+
+# ---------------------------------------------------------------------------
+# 3. SyntaxError propagation
+# ---------------------------------------------------------------------------
+
+
+class TestSyntaxErrorPropagation:
+    """SyntaxError must surface as RuntimeError, not be silently swallowed."""
+
+    def test_syntax_error_raises_runtime_error(self, monkeypatch):
+        backend = _make_local_backend(monkeypatch)
+        with pytest.raises(RuntimeError, match="Python execution failed"):
+            backend._run_python_local("def foo(:\n  pass")
+
+    def test_syntax_error_is_diagnosable(self, monkeypatch):
+        """RuntimeError from syntax error contains useful diagnostic info."""
+        backend = _make_local_backend(monkeypatch)
+        with pytest.raises(RuntimeError) as exc_info:
+            backend._run_python_local("if True\n  print('oops')")
+        msg = str(exc_info.value)
+        assert "Python execution failed" in msg
+
+    def test_syntax_error_preserves_chain(self, monkeypatch):
+        """The original SyntaxError is chained as __cause__."""
+        backend = _make_local_backend(monkeypatch)
+        with pytest.raises(RuntimeError) as exc_info:
+            backend._run_python_local("x = =")
+        assert exc_info.value.__cause__ is not None
+        assert isinstance(exc_info.value.__cause__, SyntaxError)
+
+    def test_valid_code_no_syntax_error(self, monkeypatch):
+        """Valid code executes without SyntaxError issues."""
+        backend = _make_local_backend(monkeypatch)
+        result = backend._run_python_local("print(2 + 2)")
+        assert result == "4"
+
+
+# ---------------------------------------------------------------------------
+# 4. Public signature preservation
+# ---------------------------------------------------------------------------
+
+
+class TestPublicSignaturePreserved:
+    """OmicVerseLLMBackend public API must remain unchanged."""
+
+    def test_run_signature_unchanged(self):
+        import inspect
+        sig = inspect.signature(OmicVerseLLMBackend.run)
+        params = list(sig.parameters.keys())
+        assert params == ["self", "user_prompt"]
+
+    def test_chat_signature_unchanged(self):
+        import inspect
+        sig = inspect.signature(OmicVerseLLMBackend.chat)
+        params = list(sig.parameters.keys())
+        assert params == ["self", "messages", "tools", "tool_choice"]
+
+    def test_stream_signature_unchanged(self):
+        import inspect
+        sig = inspect.signature(OmicVerseLLMBackend.stream)
+        params = list(sig.parameters.keys())
+        assert params == ["self", "user_prompt"]

--- a/tests/utils/test_agent_codex_auth.py
+++ b/tests/utils/test_agent_codex_auth.py
@@ -55,6 +55,8 @@ def _load_smart_agent_module():
 
 
 smart_agent = _load_smart_agent_module()
+# The credential resolver and its dependencies now live in ovagent.auth
+import omicverse.utils.ovagent.auth as _auth_module
 
 
 def _make_oauth_token(account_id: str = "acct_test") -> str:
@@ -81,7 +83,7 @@ def test_resolve_agent_llm_credentials_uses_saved_codex_auth(monkeypatch):
         def ensure_access_token_with_codex_fallback(self, **kwargs):
             return _make_oauth_token()
 
-    monkeypatch.setattr(smart_agent, "OpenAIOAuthManager", DummyManager)
+    monkeypatch.setattr(_auth_module, "OpenAIOAuthManager", DummyManager)
 
     model, api_key, endpoint, auth_mode = smart_agent._resolve_agent_llm_credentials(
         model="gpt-5.2",
@@ -94,7 +96,7 @@ def test_resolve_agent_llm_credentials_uses_saved_codex_auth(monkeypatch):
 
     assert model == "gpt-5.2"
     assert api_key == _make_oauth_token()
-    assert endpoint == smart_agent.OPENAI_CODEX_BASE_URL
+    assert endpoint == _auth_module.OPENAI_CODEX_BASE_URL
     assert auth_mode == "openai_oauth"
 
 
@@ -106,7 +108,7 @@ def test_resolve_agent_llm_credentials_auto_enables_codex_oauth(monkeypatch):
         def ensure_access_token_with_codex_fallback(self, **kwargs):
             return _make_oauth_token("acct_alias")
 
-    monkeypatch.setattr(smart_agent, "OpenAIOAuthManager", DummyManager)
+    monkeypatch.setattr(_auth_module, "OpenAIOAuthManager", DummyManager)
 
     model, api_key, endpoint, auth_mode = smart_agent._resolve_agent_llm_credentials(
         model="gpt-5.3-codex",
@@ -119,7 +121,7 @@ def test_resolve_agent_llm_credentials_auto_enables_codex_oauth(monkeypatch):
 
     assert model == "gpt-5.3-codex"
     assert api_key == _make_oauth_token("acct_alias")
-    assert endpoint == smart_agent.OPENAI_CODEX_BASE_URL
+    assert endpoint == _auth_module.OPENAI_CODEX_BASE_URL
     assert auth_mode == "openai_oauth"
 
 
@@ -131,7 +133,7 @@ def test_resolve_agent_llm_credentials_auto_enables_codex_oauth_for_alias(monkey
         def ensure_access_token_with_codex_fallback(self, **kwargs):
             return _make_oauth_token("acct_alias_auto")
 
-    monkeypatch.setattr(smart_agent, "OpenAIOAuthManager", DummyManager)
+    monkeypatch.setattr(_auth_module, "OpenAIOAuthManager", DummyManager)
 
     model, api_key, endpoint, auth_mode = smart_agent._resolve_agent_llm_credentials(
         model="openai/gpt-5.3-codex",
@@ -144,7 +146,7 @@ def test_resolve_agent_llm_credentials_auto_enables_codex_oauth_for_alias(monkey
 
     assert model == "gpt-5.3-codex"
     assert api_key == _make_oauth_token("acct_alias_auto")
-    assert endpoint == smart_agent.OPENAI_CODEX_BASE_URL
+    assert endpoint == _auth_module.OPENAI_CODEX_BASE_URL
     assert auth_mode == "openai_oauth"
 
 
@@ -153,7 +155,7 @@ def test_resolve_agent_llm_credentials_keeps_standard_openai_path(monkeypatch):
         def __init__(self, auth_path=None):
             raise AssertionError("Codex OAuth manager should not be used for standard OpenAI auth")
 
-    monkeypatch.setattr(smart_agent, "OpenAIOAuthManager", DummyManager)
+    monkeypatch.setattr(_auth_module, "OpenAIOAuthManager", DummyManager)
 
     model, api_key, endpoint, auth_mode = smart_agent._resolve_agent_llm_credentials(
         model="gpt-5.2",
@@ -178,7 +180,7 @@ def test_resolve_agent_llm_credentials_keeps_supported_oauth_chat_models(monkeyp
         def ensure_access_token_with_codex_fallback(self, **kwargs):
             return _make_oauth_token("acct_chat")
 
-    monkeypatch.setattr(smart_agent, "OpenAIOAuthManager", DummyManager)
+    monkeypatch.setattr(_auth_module, "OpenAIOAuthManager", DummyManager)
 
     model, api_key, endpoint, auth_mode = smart_agent._resolve_agent_llm_credentials(
         model="gpt-5.4",
@@ -191,7 +193,7 @@ def test_resolve_agent_llm_credentials_keeps_supported_oauth_chat_models(monkeyp
 
     assert model == "gpt-5.4"
     assert api_key == _make_oauth_token("acct_chat")
-    assert endpoint == smart_agent.OPENAI_CODEX_BASE_URL
+    assert endpoint == _auth_module.OPENAI_CODEX_BASE_URL
     assert auth_mode == "openai_oauth"
 
 
@@ -203,7 +205,7 @@ def test_resolve_agent_llm_credentials_normalizes_supported_oauth_alias(monkeypa
         def ensure_access_token_with_codex_fallback(self, **kwargs):
             return _make_oauth_token("acct_spark")
 
-    monkeypatch.setattr(smart_agent, "OpenAIOAuthManager", DummyManager)
+    monkeypatch.setattr(_auth_module, "OpenAIOAuthManager", DummyManager)
 
     model, api_key, endpoint, auth_mode = smart_agent._resolve_agent_llm_credentials(
         model="openai/gpt-5.3-codex-spark",
@@ -216,7 +218,7 @@ def test_resolve_agent_llm_credentials_normalizes_supported_oauth_alias(monkeypa
 
     assert model == "gpt-5.3-codex-spark"
     assert api_key == _make_oauth_token("acct_spark")
-    assert endpoint == smart_agent.OPENAI_CODEX_BASE_URL
+    assert endpoint == _auth_module.OPENAI_CODEX_BASE_URL
     assert auth_mode == "openai_oauth"
 
 
@@ -241,11 +243,11 @@ def test_resolve_agent_llm_credentials_falls_back_when_saved_api_key_is_not_oaut
             return _make_oauth_token("acct_fallback")
 
     monkeypatch.setattr(
-        smart_agent,
+        _auth_module,
         "_resolve_saved_provider_api_key",
         lambda provider_name, auth_path: "sk-test",
     )
-    monkeypatch.setattr(smart_agent, "OpenAIOAuthManager", DummyManager)
+    monkeypatch.setattr(_auth_module, "OpenAIOAuthManager", DummyManager)
 
     model, api_key, endpoint, auth_mode = smart_agent._resolve_agent_llm_credentials(
         model="gpt-5.3-codex",
@@ -258,7 +260,7 @@ def test_resolve_agent_llm_credentials_falls_back_when_saved_api_key_is_not_oaut
 
     assert model == "gpt-5.3-codex"
     assert api_key == _make_oauth_token("acct_fallback")
-    assert endpoint == smart_agent.OPENAI_CODEX_BASE_URL
+    assert endpoint == _auth_module.OPENAI_CODEX_BASE_URL
     assert auth_mode == "openai_oauth"
 
 
@@ -270,7 +272,7 @@ def test_resolve_agent_llm_credentials_errors_without_saved_login(monkeypatch):
         def ensure_access_token_with_codex_fallback(self, **kwargs):
             return None
 
-    monkeypatch.setattr(smart_agent, "OpenAIOAuthManager", DummyManager)
+    monkeypatch.setattr(_auth_module, "OpenAIOAuthManager", DummyManager)
 
     with pytest.raises(ValueError, match="No saved OpenAI Codex login found"):
         smart_agent._resolve_agent_llm_credentials(

--- a/tests/utils/test_agent_config_subagent_overrides.py
+++ b/tests/utils/test_agent_config_subagent_overrides.py
@@ -278,3 +278,15 @@ class TestReturnedConfigIsolation:
         assert a.max_turns == 7
         a.max_turns = 100
         assert b.max_turns == 7
+
+    def test_mutating_mutable_field_does_not_leak(self):
+        """Deep copy ensures mutable list fields are independent across calls."""
+        cfg = AgentConfig()
+        a = cfg.get_subagent_config("explore")
+        original_tools = list(SUBAGENT_CONFIGS["explore"].allowed_tools)
+        a.allowed_tools.append("injected_tool")
+        # Global default must be unchanged
+        assert SUBAGENT_CONFIGS["explore"].allowed_tools == original_tools
+        # A fresh call must also be clean
+        b = cfg.get_subagent_config("explore")
+        assert "injected_tool" not in b.allowed_tools

--- a/tests/utils/test_agent_config_subagent_overrides.py
+++ b/tests/utils/test_agent_config_subagent_overrides.py
@@ -1,0 +1,280 @@
+"""Tests for configurable subagent profile overrides in AgentConfig (task-015).
+
+Covers:
+  - AgentConfig has subagent_overrides as an optional field
+  - SUBAGENT_CONFIGS remain the default when no overrides are provided
+  - Partial overrides merge cleanly with defaults
+  - Invalid override keys are rejected
+  - Unknown agent types are rejected
+  - from_flat_kwargs preserves subagent_overrides passthrough
+  - Default AgentConfig construction is unchanged
+"""
+
+import importlib
+import importlib.machinery
+import os
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Guard: require harness env-var
+# ---------------------------------------------------------------------------
+
+_RUN_HARNESS = os.environ.get("OV_AGENT_RUN_HARNESS_TESTS", "").lower() in {
+    "1", "true", "yes", "on",
+}
+pytestmark = pytest.mark.skipif(
+    not _RUN_HARNESS,
+    reason="Subagent override tests require OV_AGENT_RUN_HARNESS_TESTS=1.",
+)
+
+# ---------------------------------------------------------------------------
+# Bootstrap: lightweight package stubs
+# ---------------------------------------------------------------------------
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+PACKAGE_ROOT = PROJECT_ROOT / "omicverse"
+
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+_SAVED = {
+    name: sys.modules.get(name)
+    for name in ["omicverse", "omicverse.utils"]
+}
+for name in ["omicverse", "omicverse.utils"]:
+    sys.modules.pop(name, None)
+
+_ov_pkg = types.ModuleType("omicverse")
+_ov_pkg.__path__ = [str(PACKAGE_ROOT)]
+_ov_pkg.__spec__ = importlib.machinery.ModuleSpec(
+    "omicverse", loader=None, is_package=True
+)
+sys.modules["omicverse"] = _ov_pkg
+
+_utils_pkg = types.ModuleType("omicverse.utils")
+_utils_pkg.__path__ = [str(PACKAGE_ROOT / "utils")]
+_utils_pkg.__spec__ = importlib.machinery.ModuleSpec(
+    "omicverse.utils", loader=None, is_package=True
+)
+sys.modules["omicverse.utils"] = _utils_pkg
+_ov_pkg.utils = _utils_pkg
+
+from omicverse.utils.agent_config import (
+    AgentConfig,
+    SUBAGENT_CONFIGS,
+    SubagentConfig,
+)
+
+for name, mod in _SAVED.items():
+    if mod is None:
+        sys.modules.pop(name, None)
+    else:
+        sys.modules[name] = mod
+
+
+# ===================================================================
+# 1. subagent_overrides field exists and defaults to empty
+# ===================================================================
+
+class TestSubagentOverridesField:
+
+    def test_field_exists_on_agent_config(self):
+        cfg = AgentConfig()
+        assert hasattr(cfg, "subagent_overrides")
+
+    def test_default_is_empty_dict(self):
+        cfg = AgentConfig()
+        assert cfg.subagent_overrides == {}
+
+    def test_field_accepts_dict(self):
+        overrides = {"explore": {"max_turns": 10}}
+        cfg = AgentConfig(subagent_overrides=overrides)
+        assert cfg.subagent_overrides == overrides
+
+
+# ===================================================================
+# 2. SUBAGENT_CONFIGS remain the default source of truth
+# ===================================================================
+
+class TestDefaultSubagentConfigs:
+
+    def test_get_subagent_config_returns_default_when_no_overrides(self):
+        cfg = AgentConfig()
+        for agent_type in SUBAGENT_CONFIGS:
+            result = cfg.get_subagent_config(agent_type)
+            default = SUBAGENT_CONFIGS[agent_type]
+            assert result.agent_type == default.agent_type
+            assert result.allowed_tools == default.allowed_tools
+            assert result.max_turns == default.max_turns
+            assert result.can_mutate_adata == default.can_mutate_adata
+            assert result.temperature == default.temperature
+
+    def test_get_subagent_config_does_not_mutate_global_defaults(self):
+        overrides = {"explore": {"max_turns": 99}}
+        cfg = AgentConfig(subagent_overrides=overrides)
+        cfg.get_subagent_config("explore")
+        # Global default must be unchanged
+        assert SUBAGENT_CONFIGS["explore"].max_turns == 5
+
+    def test_all_known_agent_types_are_accessible(self):
+        cfg = AgentConfig()
+        for agent_type in ("explore", "plan", "execute"):
+            result = cfg.get_subagent_config(agent_type)
+            assert isinstance(result, SubagentConfig)
+
+
+# ===================================================================
+# 3. Partial overrides merge cleanly with defaults
+# ===================================================================
+
+class TestPartialOverrideMerge:
+
+    def test_single_field_override(self):
+        cfg = AgentConfig(subagent_overrides={"explore": {"max_turns": 20}})
+        result = cfg.get_subagent_config("explore")
+        assert result.max_turns == 20
+        # Other fields keep defaults
+        assert result.temperature == SUBAGENT_CONFIGS["explore"].temperature
+        assert result.allowed_tools == SUBAGENT_CONFIGS["explore"].allowed_tools
+        assert result.can_mutate_adata == SUBAGENT_CONFIGS["explore"].can_mutate_adata
+
+    def test_multiple_field_override(self):
+        cfg = AgentConfig(subagent_overrides={
+            "plan": {"max_turns": 15, "temperature": 0.7}
+        })
+        result = cfg.get_subagent_config("plan")
+        assert result.max_turns == 15
+        assert result.temperature == 0.7
+        # Unchanged fields
+        assert result.allowed_tools == SUBAGENT_CONFIGS["plan"].allowed_tools
+
+    def test_override_allowed_tools(self):
+        custom_tools = ["inspect_data", "finish"]
+        cfg = AgentConfig(subagent_overrides={
+            "execute": {"allowed_tools": custom_tools}
+        })
+        result = cfg.get_subagent_config("execute")
+        assert result.allowed_tools == custom_tools
+        # Other fields unchanged
+        assert result.max_turns == SUBAGENT_CONFIGS["execute"].max_turns
+
+    def test_override_can_mutate_adata(self):
+        cfg = AgentConfig(subagent_overrides={
+            "explore": {"can_mutate_adata": True}
+        })
+        result = cfg.get_subagent_config("explore")
+        assert result.can_mutate_adata is True
+
+    def test_multiple_profiles_overridden_independently(self):
+        cfg = AgentConfig(subagent_overrides={
+            "explore": {"max_turns": 3},
+            "execute": {"temperature": 0.5},
+        })
+        explore = cfg.get_subagent_config("explore")
+        execute = cfg.get_subagent_config("execute")
+        assert explore.max_turns == 3
+        assert explore.temperature == SUBAGENT_CONFIGS["explore"].temperature
+        assert execute.temperature == 0.5
+        assert execute.max_turns == SUBAGENT_CONFIGS["execute"].max_turns
+
+    def test_non_overridden_profile_returns_default(self):
+        cfg = AgentConfig(subagent_overrides={"explore": {"max_turns": 99}})
+        plan = cfg.get_subagent_config("plan")
+        assert plan.max_turns == SUBAGENT_CONFIGS["plan"].max_turns
+
+
+# ===================================================================
+# 4. Error handling
+# ===================================================================
+
+class TestSubagentOverrideErrors:
+
+    def test_unknown_agent_type_raises_key_error(self):
+        cfg = AgentConfig()
+        with pytest.raises(KeyError, match="Unknown subagent type"):
+            cfg.get_subagent_config("nonexistent")
+
+    def test_invalid_override_field_raises_value_error(self):
+        cfg = AgentConfig(subagent_overrides={
+            "explore": {"bogus_field": 42}
+        })
+        with pytest.raises(ValueError, match="Unknown SubagentConfig field"):
+            cfg.get_subagent_config("explore")
+
+    def test_error_message_lists_valid_fields(self):
+        cfg = AgentConfig(subagent_overrides={
+            "explore": {"not_a_field": True}
+        })
+        with pytest.raises(ValueError, match="max_turns"):
+            cfg.get_subagent_config("explore")
+
+
+# ===================================================================
+# 5. from_flat_kwargs compatibility
+# ===================================================================
+
+class TestFlatKwargsCompatibility:
+
+    def test_from_flat_kwargs_without_overrides(self):
+        cfg = AgentConfig.from_flat_kwargs(model="test-model")
+        assert cfg.subagent_overrides == {}
+        assert cfg.llm.model == "test-model"
+
+    def test_from_flat_kwargs_with_overrides(self):
+        overrides = {"explore": {"max_turns": 42}}
+        cfg = AgentConfig.from_flat_kwargs(
+            model="test-model",
+            subagent_overrides=overrides,
+        )
+        assert cfg.subagent_overrides == overrides
+        result = cfg.get_subagent_config("explore")
+        assert result.max_turns == 42
+
+    def test_from_flat_kwargs_preserves_all_other_fields(self):
+        """Ensure adding subagent_overrides doesn't break existing kwargs."""
+        cfg = AgentConfig.from_flat_kwargs(
+            model="gpt-4",
+            enable_reflection=False,
+            notebook_timeout=300,
+            subagent_overrides={"plan": {"temperature": 0.9}},
+        )
+        assert cfg.llm.model == "gpt-4"
+        assert cfg.reflection.enabled is False
+        assert cfg.execution.timeout == 300
+        assert cfg.subagent_overrides == {"plan": {"temperature": 0.9}}
+
+    def test_default_construction_unchanged(self):
+        """AgentConfig() with no args still works identically."""
+        cfg = AgentConfig()
+        assert cfg.llm.model == "gemini-2.5-flash"
+        assert cfg.reflection.enabled is True
+        assert cfg.subagent_overrides == {}
+        # get_subagent_config returns defaults
+        for name in SUBAGENT_CONFIGS:
+            result = cfg.get_subagent_config(name)
+            assert result.max_turns == SUBAGENT_CONFIGS[name].max_turns
+
+
+# ===================================================================
+# 6. Returned config is a copy, not a reference to the global
+# ===================================================================
+
+class TestReturnedConfigIsolation:
+
+    def test_mutating_returned_config_does_not_affect_global(self):
+        cfg = AgentConfig()
+        result = cfg.get_subagent_config("explore")
+        result.max_turns = 999
+        assert SUBAGENT_CONFIGS["explore"].max_turns == 5
+
+    def test_successive_calls_return_independent_copies(self):
+        cfg = AgentConfig(subagent_overrides={"explore": {"max_turns": 7}})
+        a = cfg.get_subagent_config("explore")
+        b = cfg.get_subagent_config("explore")
+        assert a.max_turns == 7
+        a.max_turns = 100
+        assert b.max_turns == 7

--- a/tests/utils/test_backend_common_hygiene.py
+++ b/tests/utils/test_backend_common_hygiene.py
@@ -1,0 +1,297 @@
+"""Tests for task-009: backend common hygiene fixes.
+
+Covers:
+1. Thread-safe shared executor creation (AC-001 item 1)
+2. _retry_with_backoff keyword-only signature (AC-001 item 2)
+3. WorkflowNeedsFallback compatibility alias (AC-001 item 3)
+4. No provider-specific behavior changes (AC-001 item 5)
+"""
+
+from __future__ import annotations
+
+import concurrent.futures
+import inspect
+import threading
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ===================================================================
+# 1. Thread-safe shared executor singleton
+# ===================================================================
+
+
+class TestExecutorThreadSafety:
+    """Executor creation must be protected against races."""
+
+    def _reset_executor_state(self):
+        import omicverse.utils.agent_backend_common as mod
+        old_exc = mod._SHARED_EXECUTOR
+        old_flag = mod._EXECUTOR_ATEXIT_REGISTERED
+        mod._SHARED_EXECUTOR = None
+        mod._EXECUTOR_ATEXIT_REGISTERED = False
+        return mod, old_exc, old_flag
+
+    def _restore_executor_state(self, mod, old_exc, old_flag):
+        mod._SHARED_EXECUTOR = old_exc
+        mod._EXECUTOR_ATEXIT_REGISTERED = old_flag
+
+    def test_uses_threading_lock(self):
+        """The module must define a threading.Lock for executor creation."""
+        import omicverse.utils.agent_backend_common as mod
+        assert hasattr(mod, "_EXECUTOR_LOCK")
+        assert isinstance(mod._EXECUTOR_LOCK, type(threading.Lock()))
+
+    def test_concurrent_calls_return_same_instance(self):
+        """Multiple threads calling _get_shared_executor get the same object."""
+        mod, old_exc, old_flag = self._reset_executor_state()
+        try:
+            results = []
+            barrier = threading.Barrier(8)
+
+            def worker():
+                barrier.wait()
+                results.append(mod._get_shared_executor())
+
+            threads = [threading.Thread(target=worker) for _ in range(8)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join(timeout=5)
+
+            assert len(results) == 8
+            assert all(r is results[0] for r in results)
+        finally:
+            self._restore_executor_state(mod, old_exc, old_flag)
+
+    def test_only_one_executor_constructed(self):
+        """Even under contention, only one ThreadPoolExecutor is created."""
+        mod, old_exc, old_flag = self._reset_executor_state()
+        try:
+            construction_count = 0
+            original_init = concurrent.futures.ThreadPoolExecutor.__init__
+
+            def counting_init(self_exc, *a, **kw):
+                nonlocal construction_count
+                construction_count += 1
+                original_init(self_exc, *a, **kw)
+
+            barrier = threading.Barrier(8)
+
+            def worker():
+                barrier.wait()
+                mod._get_shared_executor()
+
+            with patch.object(
+                concurrent.futures.ThreadPoolExecutor, "__init__", counting_init
+            ):
+                threads = [threading.Thread(target=worker) for _ in range(8)]
+                for t in threads:
+                    t.start()
+                for t in threads:
+                    t.join(timeout=5)
+
+            assert construction_count == 1, (
+                f"Expected 1 executor construction, got {construction_count}"
+            )
+        finally:
+            self._restore_executor_state(mod, old_exc, old_flag)
+
+    def test_lock_in_source_code(self):
+        """Source code must acquire _EXECUTOR_LOCK inside _get_shared_executor."""
+        import omicverse.utils.agent_backend_common as mod
+        source = inspect.getsource(mod._get_shared_executor)
+        assert "_EXECUTOR_LOCK" in source
+
+
+# ===================================================================
+# 2. _retry_with_backoff keyword-friendly signature
+# ===================================================================
+
+
+class TestRetrySignature:
+    """Config params must be keyword-only; *args/**kwargs forward to func."""
+
+    def test_config_params_are_keyword_only(self):
+        """max_attempts, base_delay, factor, jitter must be keyword-only."""
+        from omicverse.utils.agent_backend_common import _retry_with_backoff
+        sig = inspect.signature(_retry_with_backoff)
+        for name in ("max_attempts", "base_delay", "factor", "jitter"):
+            param = sig.parameters[name]
+            assert param.kind == inspect.Parameter.KEYWORD_ONLY, (
+                f"{name} should be KEYWORD_ONLY, got {param.kind.name}"
+            )
+
+    def test_args_forwarded_to_func(self):
+        """Positional args after func are forwarded, not consumed by config."""
+        from omicverse.utils.agent_backend_common import _retry_with_backoff
+        sentinel = object()
+
+        def echo(*args, **kwargs):
+            return args, kwargs
+
+        result_args, result_kwargs = _retry_with_backoff(
+            echo, sentinel, "b", max_attempts=1, key="val"
+        )
+        assert result_args == (sentinel, "b")
+        assert result_kwargs == {"key": "val"}
+
+    def test_kwargs_not_consumed_by_config(self):
+        """Keyword args not matching config params forward to func."""
+        from omicverse.utils.agent_backend_common import _retry_with_backoff
+
+        def capture(**kw):
+            return kw
+
+        result = _retry_with_backoff(capture, max_attempts=1, foo="bar", baz=42)
+        assert result == {"foo": "bar", "baz": 42}
+
+    def test_positional_config_raises_typeerror(self):
+        """Passing config params positionally (old style) now goes to *args."""
+        from omicverse.utils.agent_backend_common import _retry_with_backoff
+
+        def echo(*args):
+            return args
+
+        # With old signature, 5 would fill max_attempts. Now it goes to *args.
+        result = _retry_with_backoff(echo, 5, max_attempts=1)
+        assert result == (5,)
+
+    def test_retry_still_retries(self):
+        """Basic retry behavior is preserved."""
+        from omicverse.utils.agent_backend_common import _retry_with_backoff
+
+        call_count = 0
+
+        def flaky():
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                raise TimeoutError("transient")
+            return "ok"
+
+        result = _retry_with_backoff(
+            flaky, max_attempts=3, base_delay=0.0, jitter=0.0
+        )
+        assert result == "ok"
+        assert call_count == 3
+
+    def test_retry_exhaustion_raises(self):
+        """All attempts exhausted raises RuntimeError."""
+        from omicverse.utils.agent_backend_common import _retry_with_backoff
+
+        def always_fail():
+            raise TimeoutError("always")
+
+        with pytest.raises(RuntimeError, match="All 2 attempts failed"):
+            _retry_with_backoff(
+                always_fail, max_attempts=2, base_delay=0.0, jitter=0.0
+            )
+
+    def test_backend_retry_method_compatible(self, monkeypatch):
+        """OmicVerseLLMBackend._retry still works with the new signature."""
+        from omicverse.utils.agent_backend import OmicVerseLLMBackend
+        from omicverse.utils.model_config import ModelConfig
+
+        monkeypatch.setattr(
+            ModelConfig, "get_provider_from_model", lambda *a, **kw: "openai"
+        )
+        backend = OmicVerseLLMBackend(
+            system_prompt="test", model="gpt-4o", api_key="k"
+        )
+
+        def add(a, b):
+            return a + b
+
+        result = backend._retry(add, 3, 4)
+        assert result == 7
+
+
+# ===================================================================
+# 3. WorkflowNeedsFallback compatibility alias
+# ===================================================================
+
+
+class TestWorkflowNeedsFallbackCompat:
+    """WorkflowNeedsFallback must remain importable and well-documented."""
+
+    def test_importable_from_agent_errors(self):
+        from omicverse.utils.agent_errors import WorkflowNeedsFallback
+        assert WorkflowNeedsFallback is not None
+
+    def test_reexported_in_utils_init_source(self):
+        """The utils __init__.py re-exports WorkflowNeedsFallback."""
+        from pathlib import Path
+        source = (
+            Path(__file__).resolve().parents[2]
+            / "omicverse" / "utils" / "__init__.py"
+        ).read_text()
+        assert "WorkflowNeedsFallback" in source
+
+    def test_is_subclass_of_ovagent_error(self):
+        from omicverse.utils.agent_errors import OVAgentError, WorkflowNeedsFallback
+        assert issubclass(WorkflowNeedsFallback, OVAgentError)
+
+    def test_is_subclass_of_exception(self):
+        from omicverse.utils.agent_errors import WorkflowNeedsFallback
+        assert issubclass(WorkflowNeedsFallback, Exception)
+
+    def test_can_be_raised_and_caught(self):
+        from omicverse.utils.agent_errors import WorkflowNeedsFallback
+        with pytest.raises(WorkflowNeedsFallback):
+            raise WorkflowNeedsFallback("fallback needed")
+
+    def test_catchable_as_ovagent_error(self):
+        from omicverse.utils.agent_errors import OVAgentError, WorkflowNeedsFallback
+        with pytest.raises(OVAgentError):
+            raise WorkflowNeedsFallback("compat")
+
+    def test_docstring_mentions_deprecated(self):
+        from omicverse.utils.agent_errors import WorkflowNeedsFallback
+        assert "deprecated" in (WorkflowNeedsFallback.__doc__ or "").lower()
+
+    def test_identity_matches_across_import_paths(self):
+        """The class is the same object whether imported directly or via module."""
+        from omicverse.utils.agent_errors import WorkflowNeedsFallback as direct
+        import omicverse.utils.agent_errors as mod
+        assert direct is mod.WorkflowNeedsFallback
+
+
+# ===================================================================
+# 4. No provider-specific behavior changes
+# ===================================================================
+
+
+class TestNoProviderBehaviorChange:
+    """Verify hygiene fixes don't alter provider dispatch or types."""
+
+    def test_dispatch_tables_unchanged(self):
+        from omicverse.utils.agent_backend_common import _SYNC_DISPATCH, _STREAM_DISPATCH
+        from omicverse.utils.model_config import WireAPI
+
+        assert _SYNC_DISPATCH[WireAPI.CHAT_COMPLETIONS] == "_chat_via_openai_compatible"
+        assert _SYNC_DISPATCH[WireAPI.ANTHROPIC_MESSAGES] == "_chat_via_anthropic"
+        assert _SYNC_DISPATCH[WireAPI.GEMINI_GENERATE] == "_chat_via_gemini"
+        assert _SYNC_DISPATCH[WireAPI.DASHSCOPE] == "_chat_via_dashscope"
+        assert _SYNC_DISPATCH[WireAPI.LOCAL] == "_run_python_local"
+
+    def test_backend_config_fields_unchanged(self):
+        from omicverse.utils.agent_backend_common import BackendConfig
+        fields = set(BackendConfig.__dataclass_fields__.keys())
+        expected = {
+            "model", "api_key", "endpoint", "provider", "system_prompt",
+            "max_tokens", "temperature", "max_retry_attempts",
+            "retry_base_delay", "retry_backoff_factor", "retry_jitter",
+        }
+        assert fields == expected
+
+    def test_all_exports_preserved(self):
+        from omicverse.utils.agent_backend_common import __all__ as exports
+        expected = {
+            "BackendConfig", "Usage", "ToolCall", "ChatResponse",
+            "_coerce_int", "_compute_total", "_should_retry",
+            "_retry_with_backoff", "_request_timeout_seconds",
+            "_get_shared_executor",
+        }
+        assert expected == set(exports)

--- a/tests/utils/test_backend_common_hygiene.py
+++ b/tests/utils/test_backend_common_hygiene.py
@@ -111,52 +111,65 @@ class TestExecutorThreadSafety:
 
 
 class TestRetrySignature:
-    """Config params must be keyword-only; *args/**kwargs forward to func."""
+    """_retry_with_backoff accepts a zero-arg callable; config is positional-or-keyword."""
 
-    def test_config_params_are_keyword_only(self):
-        """max_attempts, base_delay, factor, jitter must be keyword-only."""
+    def test_no_varargs_in_signature(self):
+        """The helper must NOT accept *args/**kwargs (prevents silent forwarding)."""
+        from omicverse.utils.agent_backend_common import _retry_with_backoff
+        sig = inspect.signature(_retry_with_backoff)
+        kinds = {p.kind for p in sig.parameters.values()}
+        assert inspect.Parameter.VAR_POSITIONAL not in kinds, (
+            "_retry_with_backoff must not accept *args"
+        )
+        assert inspect.Parameter.VAR_KEYWORD not in kinds, (
+            "_retry_with_backoff must not accept **kwargs"
+        )
+
+    def test_config_params_accept_keyword(self):
+        """max_attempts, base_delay, factor, jitter are accepted as keywords."""
         from omicverse.utils.agent_backend_common import _retry_with_backoff
         sig = inspect.signature(_retry_with_backoff)
         for name in ("max_attempts", "base_delay", "factor", "jitter"):
             param = sig.parameters[name]
-            assert param.kind == inspect.Parameter.KEYWORD_ONLY, (
-                f"{name} should be KEYWORD_ONLY, got {param.kind.name}"
-            )
+            assert param.kind in (
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                inspect.Parameter.KEYWORD_ONLY,
+            ), f"{name} should be callable by keyword, got {param.kind.name}"
 
-    def test_args_forwarded_to_func(self):
-        """Positional args after func are forwarded, not consumed by config."""
+    def test_legacy_positional_config_works(self):
+        """Positional config (old calling convention) is interpreted as config, not forwarded."""
         from omicverse.utils.agent_backend_common import _retry_with_backoff
-        sentinel = object()
+        call_count = 0
 
-        def echo(*args, **kwargs):
-            return args, kwargs
+        def counter():
+            nonlocal call_count
+            call_count += 1
+            return "ok"
 
-        result_args, result_kwargs = _retry_with_backoff(
-            echo, sentinel, "b", max_attempts=1, key="val"
-        )
-        assert result_args == (sentinel, "b")
-        assert result_kwargs == {"key": "val"}
+        # Legacy style: _retry_with_backoff(func, max_attempts)
+        result = _retry_with_backoff(counter, 1)
+        assert result == "ok"
+        assert call_count == 1  # exactly 1 attempt, not forwarded as arg
 
-    def test_kwargs_not_consumed_by_config(self):
-        """Keyword args not matching config params forward to func."""
-        from omicverse.utils.agent_backend_common import _retry_with_backoff
-
-        def capture(**kw):
-            return kw
-
-        result = _retry_with_backoff(capture, max_attempts=1, foo="bar", baz=42)
-        assert result == {"foo": "bar", "baz": 42}
-
-    def test_positional_config_raises_typeerror(self):
-        """Passing config params positionally (old style) now goes to *args."""
+    def test_func_called_with_zero_args(self):
+        """func is called as func() — callers must bind args before passing."""
         from omicverse.utils.agent_backend_common import _retry_with_backoff
 
-        def echo(*args):
-            return args
+        def zero_arg():
+            return "zero"
 
-        # With old signature, 5 would fill max_attempts. Now it goes to *args.
-        result = _retry_with_backoff(echo, 5, max_attempts=1)
-        assert result == (5,)
+        result = _retry_with_backoff(zero_arg, max_attempts=1)
+        assert result == "zero"
+
+    def test_bound_lambda_pattern(self):
+        """Standard pattern: wrap func+args in a lambda before passing."""
+        from omicverse.utils.agent_backend_common import _retry_with_backoff
+
+        def add(a, b):
+            return a + b
+
+        result = _retry_with_backoff(lambda: add(3, 4), max_attempts=1)
+        assert result == 7
 
     def test_retry_still_retries(self):
         """Basic retry behavior is preserved."""
@@ -189,8 +202,8 @@ class TestRetrySignature:
                 always_fail, max_attempts=2, base_delay=0.0, jitter=0.0
             )
 
-    def test_backend_retry_method_compatible(self, monkeypatch):
-        """OmicVerseLLMBackend._retry still works with the new signature."""
+    def test_backend_retry_method_forwards_args(self, monkeypatch):
+        """OmicVerseLLMBackend._retry forwards positional/keyword args to func."""
         from omicverse.utils.agent_backend import OmicVerseLLMBackend
         from omicverse.utils.model_config import ModelConfig
 
@@ -206,6 +219,39 @@ class TestRetrySignature:
 
         result = backend._retry(add, 3, 4)
         assert result == 7
+
+    def test_backend_retry_method_forwards_kwargs(self, monkeypatch):
+        """OmicVerseLLMBackend._retry forwards keyword args to func."""
+        from omicverse.utils.agent_backend import OmicVerseLLMBackend
+        from omicverse.utils.model_config import ModelConfig
+
+        monkeypatch.setattr(
+            ModelConfig, "get_provider_from_model", lambda *a, **kw: "openai"
+        )
+        backend = OmicVerseLLMBackend(
+            system_prompt="test", model="gpt-4o", api_key="k"
+        )
+
+        def greet(name="world"):
+            return f"hello {name}"
+
+        result = backend._retry(greet, name="claude")
+        assert result == "hello claude"
+
+    def test_backend_retry_zero_arg_func(self, monkeypatch):
+        """OmicVerseLLMBackend._retry works with zero-arg callables."""
+        from omicverse.utils.agent_backend import OmicVerseLLMBackend
+        from omicverse.utils.model_config import ModelConfig
+
+        monkeypatch.setattr(
+            ModelConfig, "get_provider_from_model", lambda *a, **kw: "openai"
+        )
+        backend = OmicVerseLLMBackend(
+            system_prompt="test", model="gpt-4o", api_key="k"
+        )
+
+        result = backend._retry(lambda: 42)
+        assert result == 42
 
 
 # ===================================================================

--- a/tests/utils/test_e2e_agentic_loop.py
+++ b/tests/utils/test_e2e_agentic_loop.py
@@ -1,0 +1,779 @@
+"""End-to-end tests for the main agentic loop.
+
+Exercises the full OmicVerseAgent facade (``_run_agentic_loop``,
+``run_async``, ``stream_async``) using the shared integration harness
+fakes.  No real provider credentials are required.
+
+Covers:
+- Mock tool-call execution and result propagation
+- Text-only retry/recovery via the FollowUpGate
+- Final response validation (adata, summary, trace)
+- ``stream_async`` event emission
+- Multi-turn tool dispatch
+- ``finish`` tool early exit
+
+Gate: ``OV_AGENT_RUN_HARNESS_TESTS=1``
+"""
+from __future__ import annotations
+
+import asyncio
+import importlib.machinery
+import importlib.util
+import os
+import sys
+import types
+from types import MethodType, SimpleNamespace
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Module-level bootstrap: load smart_agent.py in isolation (same pattern as
+# test_smart_agent.py) so we don't need the full omicverse install tree.
+# ---------------------------------------------------------------------------
+
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, os.pardir))
+PACKAGE_ROOT = os.path.join(PROJECT_ROOT, "omicverse")
+
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+_ORIGINAL_MODULES = {
+    name: sys.modules.get(name)
+    for name in ["omicverse", "omicverse.utils", "omicverse.utils.smart_agent"]
+}
+for name in ["omicverse", "omicverse.utils", "omicverse.utils.smart_agent"]:
+    sys.modules.pop(name, None)
+
+omicverse_pkg = types.ModuleType("omicverse")
+omicverse_pkg.__path__ = [PACKAGE_ROOT]
+omicverse_pkg.__spec__ = importlib.machinery.ModuleSpec(
+    "omicverse", loader=None, is_package=True
+)
+sys.modules["omicverse"] = omicverse_pkg
+
+utils_pkg = types.ModuleType("omicverse.utils")
+utils_pkg.__path__ = [os.path.join(PACKAGE_ROOT, "utils")]
+utils_pkg.__spec__ = importlib.machinery.ModuleSpec(
+    "omicverse.utils", loader=None, is_package=True
+)
+sys.modules["omicverse.utils"] = utils_pkg
+omicverse_pkg.utils = utils_pkg
+
+smart_agent_spec = importlib.util.spec_from_file_location(
+    "omicverse.utils.smart_agent",
+    os.path.join(PACKAGE_ROOT, "utils", "smart_agent.py"),
+)
+smart_agent_module = importlib.util.module_from_spec(smart_agent_spec)
+sys.modules["omicverse.utils.smart_agent"] = smart_agent_module
+assert smart_agent_spec.loader is not None
+smart_agent_spec.loader.exec_module(smart_agent_module)
+
+OmicVerseAgent = smart_agent_module.OmicVerseAgent
+
+for name, module in _ORIGINAL_MODULES.items():
+    if module is None:
+        sys.modules.pop(name, None)
+    else:
+        sys.modules[name] = module
+
+# ---------------------------------------------------------------------------
+# Gate
+# ---------------------------------------------------------------------------
+
+_RUN_HARNESS = os.environ.get("OV_AGENT_RUN_HARNESS_TESTS", "").lower() in {
+    "1", "true", "yes", "on",
+}
+pytestmark = pytest.mark.skipif(
+    not _RUN_HARNESS,
+    reason="Agentic loop e2e tests require OV_AGENT_RUN_HARNESS_TESTS=1.",
+)
+
+# ---------------------------------------------------------------------------
+# Production imports (only under the gate)
+# ---------------------------------------------------------------------------
+
+from omicverse.utils.ovagent.turn_controller import TurnController
+from omicverse.utils.ovagent.tool_registry import OutputTier, ParallelClass
+
+# Shared integration harness fakes
+from tests.integration.fakes import (
+    ChatResponse,
+    FakeLLM,
+    FakeToolRegistry,
+    ToolCall,
+    Usage,
+)
+from tests.integration.helpers import (
+    build_fake_llm,
+    make_chat_response,
+    make_tool_call,
+    make_usage,
+)
+from omicverse.utils.harness import build_stream_event
+
+
+# ===================================================================
+#  Test doubles compatible with TurnController
+# ===================================================================
+
+
+class _E2EToolRuntime:
+    """Fake ToolRuntime matching the interface TurnController.dispatch_tool expects.
+
+    Uses the integration harness's FakeToolRegistry for name resolution and
+    metadata, while providing an async ``dispatch_tool(tool_call, adata, request)``
+    signature.
+    """
+
+    def __init__(
+        self,
+        handlers: Optional[Dict[str, Any]] = None,
+        tool_schemas: Optional[List[Dict[str, Any]]] = None,
+        registry_tools: Optional[Dict[str, Dict[str, Any]]] = None,
+    ) -> None:
+        self._handlers: Dict[str, Any] = dict(handlers or {})
+        self._tool_schemas = list(tool_schemas or [])
+        enriched: Dict[str, Dict[str, Any]] = {}
+        for name, attrs in (registry_tools or {}).items():
+            merged: Dict[str, Any] = {
+                "output_tier": OutputTier.standard,
+                "parallel_class": ParallelClass.stateful,
+            }
+            merged.update(attrs)
+            enriched[name] = merged
+        self.registry = FakeToolRegistry(enriched)
+        self.dispatch_calls: List[Dict[str, Any]] = []
+
+    async def dispatch_tool(
+        self, tool_call: Any, current_adata: Any, request: str, **kw: Any
+    ) -> Any:
+        self.dispatch_calls.append({
+            "name": tool_call.name,
+            "arguments": tool_call.arguments,
+            "adata": current_adata,
+        })
+        handler = self._handlers.get(tool_call.name)
+        if handler is None:
+            return f"[E2EToolRuntime] unknown tool: {tool_call.name}"
+        return handler(tool_call, current_adata, request)
+
+    def get_visible_agent_tools(
+        self, *, allowed_names: Optional[set] = None
+    ) -> List[Dict[str, Any]]:
+        if allowed_names is not None:
+            return [s for s in self._tool_schemas if s.get("name") in allowed_names]
+        return list(self._tool_schemas)
+
+
+class _E2EPromptBuilder:
+    """Minimal PromptBuilder satisfying the TurnController protocol."""
+
+    def build_agentic_system_prompt(self) -> str:
+        return "You are a test agent."
+
+    def build_initial_user_message(
+        self, request: str, adata: Any, extra_content: Any = None
+    ) -> str:
+        return request
+
+
+def _make_tool_schema(name: str, description: str = "") -> Dict[str, Any]:
+    return {
+        "name": name,
+        "description": description or f"{name} tool",
+        "parameters": {"type": "object", "properties": {}, "required": []},
+    }
+
+
+# ===================================================================
+#  Agent wiring helper
+# ===================================================================
+
+
+def _build_e2e_agent(
+    llm: FakeLLM,
+    tool_runtime: _E2EToolRuntime,
+    *,
+    max_agent_turns: int = 10,
+) -> OmicVerseAgent:
+    """Wire up an OmicVerseAgent with fakes for end-to-end loop testing.
+
+    The agent uses a real TurnController (production code path) but with
+    fake LLM/tool backends so no credentials are needed.
+    """
+    agent = OmicVerseAgent.__new__(OmicVerseAgent)
+
+    agent.model = llm.config.model
+    agent.provider = llm.config.provider
+    agent.last_usage = None
+    agent._approval_handler = None
+    agent._trace_store = None
+    agent._context_compactor = None
+    agent._session_history = None
+    agent._last_run_trace = None
+    agent._ov_runtime = None
+    agent._active_run_id = None
+    agent.skill_registry = None
+    agent._llm = llm
+    agent._tool_runtime = tool_runtime
+
+    agent._config = SimpleNamespace(
+        execution=SimpleNamespace(max_agent_turns=max_agent_turns),
+        harness=SimpleNamespace(
+            include_recent_failures_in_prompt=False,
+            max_recent_failures=3,
+            record_artifacts=False,
+        ),
+    )
+    agent._get_harness_session_id = MethodType(lambda self: "e2e-session", agent)
+    agent._get_runtime_session_id = MethodType(lambda self: "e2e-session", agent)
+    agent._get_visible_agent_tools = MethodType(
+        lambda self, allowed_names=None: tool_runtime.get_visible_agent_tools(
+            allowed_names=allowed_names
+        ),
+        agent,
+    )
+
+    agent._turn_controller = TurnController(
+        agent, _E2EPromptBuilder(), tool_runtime,
+    )
+
+    return agent
+
+
+def _build_raw_message_for_tool_calls(tool_calls: List[ToolCall]) -> Dict[str, Any]:
+    """Build a minimal raw_message dict for a response containing tool calls."""
+    return {
+        "role": "assistant",
+        "content": [
+            {
+                "type": "tool_use",
+                "id": tc.id,
+                "name": tc.name,
+                "input": tc.arguments,
+            }
+            for tc in tool_calls
+        ],
+    }
+
+
+def _resp_tool(
+    tool_calls: List[ToolCall],
+    usage: Optional[Usage] = None,
+) -> ChatResponse:
+    """Build a ChatResponse with tool calls and correct raw_message."""
+    return ChatResponse(
+        content=None,
+        tool_calls=tool_calls,
+        stop_reason="tool_use",
+        usage=usage or make_usage(),
+        raw_message=_build_raw_message_for_tool_calls(tool_calls),
+    )
+
+
+def _resp_text(text: str, usage: Optional[Usage] = None) -> ChatResponse:
+    """Build a text-only ChatResponse with correct raw_message."""
+    return ChatResponse(
+        content=text,
+        tool_calls=[],
+        stop_reason="end_turn",
+        usage=usage or make_usage(),
+        raw_message={"role": "assistant", "content": text},
+    )
+
+
+# ===================================================================
+#  1. Happy path: tool call → finish
+# ===================================================================
+
+
+class TestAgenticLoopHappyPath:
+    """Agent dispatches tool calls and exits when LLM calls ``finish``."""
+
+    def test_single_tool_then_finish(self):
+        """LLM calls one tool, then finish → loop returns adata."""
+        tc_inspect = make_tool_call("inspect_data", {"aspect": "shape"})
+        tc_finish = make_tool_call("finish", {"summary": "Data inspected."})
+
+        llm = build_fake_llm([
+            _resp_tool([tc_inspect]),
+            _resp_tool([tc_finish]),
+        ])
+
+        tool_runtime = _E2EToolRuntime(
+            handlers={
+                "inspect_data": lambda tc, ad, req: "shape: (100, 5)",
+                "finish": lambda tc, ad, req: f"Task finished: {tc.arguments.get('summary', '')}",
+            },
+            tool_schemas=[_make_tool_schema("inspect_data"), _make_tool_schema("finish")],
+            registry_tools={
+                "inspect_data": {"output_tier": OutputTier.standard},
+                "finish": {"output_tier": OutputTier.minimal},
+            },
+        )
+
+        sentinel_adata = SimpleNamespace(shape=(100, 5), tag="original")
+        agent = _build_e2e_agent(llm, tool_runtime)
+
+        result = asyncio.run(agent._run_agentic_loop("inspect the data", sentinel_adata))
+
+        # adata returned unchanged (no execute_code that mutates it)
+        assert result is sentinel_adata
+
+        # Tools were dispatched
+        assert len(tool_runtime.dispatch_calls) == 2
+        assert tool_runtime.dispatch_calls[0]["name"] == "inspect_data"
+        assert tool_runtime.dispatch_calls[1]["name"] == "finish"
+
+        # LLM was called exactly twice
+        assert len(llm.chat_calls) == 2
+
+    def test_text_only_final_response(self):
+        """LLM returns text without tool calls → loop exits with the text."""
+        llm = build_fake_llm([
+            make_chat_response(content="The data looks good. No action needed."),
+        ])
+        tool_runtime = _E2EToolRuntime(
+            tool_schemas=[_make_tool_schema("finish")],
+        )
+
+        agent = _build_e2e_agent(llm, tool_runtime)
+        result = asyncio.run(agent._run_agentic_loop("what does this data look like?", None))
+
+        assert result is None  # adata was None
+        assert len(llm.chat_calls) == 1
+
+
+# ===================================================================
+#  2. Text-only retry recovery
+# ===================================================================
+
+
+class TestTextOnlyRetryRecovery:
+    """FollowUpGate retries when LLM promises action but returns no tools."""
+
+    def test_promissory_text_triggers_retry_then_tool_call(self):
+        """Promissory text → retry → tool call → finish."""
+        tc_fetch = make_tool_call("WebFetch", {"url": "https://example.com"})
+        tc_finish = make_tool_call("finish", {"summary": "Fetched and analyzed."})
+
+        llm = build_fake_llm([
+            # Turn 1: promissory text-only
+            _resp_text("Let me first fetch the page to understand the data."),
+            # Turn 2: actual tool call after retry nudge
+            _resp_tool([tc_fetch]),
+            # Turn 3: finish
+            _resp_tool([tc_finish]),
+        ])
+
+        tool_runtime = _E2EToolRuntime(
+            handlers={
+                "WebFetch": lambda tc, ad, req: "Page content from example.com",
+                "finish": lambda tc, ad, req: "done",
+            },
+            tool_schemas=[
+                _make_tool_schema("WebFetch"),
+                _make_tool_schema("finish"),
+            ],
+            registry_tools={
+                "WebFetch": {"output_tier": OutputTier.standard},
+                "finish": {"output_tier": OutputTier.minimal},
+            },
+        )
+
+        agent = _build_e2e_agent(llm, tool_runtime)
+        result = asyncio.run(agent._run_agentic_loop(
+            "https://example.com\nanalyze this page",
+            None,
+        ))
+
+        # LLM called 3 times: promissory text, retry with tool, then finish
+        assert len(llm.chat_calls) == 3
+
+        # The retry should have used tool_choice="required"
+        assert llm.chat_calls[0]["tool_choice"] == "required"
+        assert llm.chat_calls[1]["tool_choice"] == "required"
+
+        # Tool was dispatched after retry
+        assert any(c["name"] == "WebFetch" for c in tool_runtime.dispatch_calls)
+
+    def test_retry_exhaustion_exits_gracefully(self):
+        """When retries exhaust, loop exits without crash."""
+        # All responses are promissory text-only → exhaustion
+        responses = [
+            _resp_text("Let me analyze this for you."),
+            _resp_text("I'll start by fetching the data now."),
+            _resp_text("Going to retrieve the dataset next."),
+            _resp_text("I will now fetch the page."),
+        ]
+
+        llm = build_fake_llm(responses)
+        tool_runtime = _E2EToolRuntime(
+            tool_schemas=[_make_tool_schema("WebFetch"), _make_tool_schema("finish")],
+        )
+
+        agent = _build_e2e_agent(llm, tool_runtime, max_agent_turns=10)
+        result = asyncio.run(agent._run_agentic_loop(
+            "https://example.com\nfetch this",
+            None,
+        ))
+
+        # Should exit without raising
+        assert result is None
+        # No tools were dispatched
+        assert len(tool_runtime.dispatch_calls) == 0
+
+
+# ===================================================================
+#  3. adata mutation through execute_code
+# ===================================================================
+
+
+class TestAdataMutationThroughTool:
+    """execute_code tool updates adata when result contains 'adata' key."""
+
+    def test_execute_code_updates_adata(self):
+        """execute_code returning {adata: X} causes loop to track the new adata."""
+        original = SimpleNamespace(shape=(100, 5), tag="original")
+        updated = SimpleNamespace(shape=(80, 5), tag="filtered")
+
+        tc_exec = make_tool_call("execute_code", {
+            "code": "adata = adata[adata.obs['n_genes'] > 200]",
+            "description": "Filter low-quality cells",
+        })
+        tc_finish = make_tool_call("finish", {"summary": "Filtered."})
+
+        llm = build_fake_llm([
+            _resp_tool([tc_exec]),
+            _resp_tool([tc_finish]),
+        ])
+
+        tool_runtime = _E2EToolRuntime(
+            handlers={
+                "execute_code": lambda tc, ad, req: {
+                    "adata": updated,
+                    "output": "Filtered to 80 cells.",
+                    "stdout": "Filtered to 80 cells.",
+                },
+                "finish": lambda tc, ad, req: "done",
+            },
+            tool_schemas=[
+                _make_tool_schema("execute_code"),
+                _make_tool_schema("finish"),
+            ],
+            registry_tools={
+                "execute_code": {"output_tier": OutputTier.verbose},
+                "finish": {"output_tier": OutputTier.minimal},
+            },
+        )
+
+        agent = _build_e2e_agent(llm, tool_runtime)
+        result = asyncio.run(agent._run_agentic_loop("filter cells", original))
+
+        # adata was updated by execute_code
+        assert result is updated
+        assert result.tag == "filtered"
+        assert result.shape == (80, 5)
+
+
+# ===================================================================
+#  4. Multi-tool dispatch in a single turn
+# ===================================================================
+
+
+class TestMultiToolDispatch:
+    """Multiple tool calls in a single LLM response are all dispatched."""
+
+    def test_two_tools_in_one_turn(self):
+        """LLM returns two tool calls; both are dispatched before next turn."""
+        tc_inspect = make_tool_call("inspect_data", {"aspect": "shape"})
+        tc_search = make_tool_call("search_functions", {"query": "qc"})
+        tc_finish = make_tool_call("finish", {"summary": "Done."})
+
+        llm = build_fake_llm([
+            _resp_tool([tc_inspect, tc_search]),
+            _resp_tool([tc_finish]),
+        ])
+
+        tool_runtime = _E2EToolRuntime(
+            handlers={
+                "inspect_data": lambda tc, ad, req: "shape: (200, 10)",
+                "search_functions": lambda tc, ad, req: "ov.pp.qc found",
+                "finish": lambda tc, ad, req: "done",
+            },
+            tool_schemas=[
+                _make_tool_schema("inspect_data"),
+                _make_tool_schema("search_functions"),
+                _make_tool_schema("finish"),
+            ],
+            registry_tools={
+                "inspect_data": {"output_tier": OutputTier.standard},
+                "search_functions": {"output_tier": OutputTier.standard},
+                "finish": {"output_tier": OutputTier.minimal},
+            },
+        )
+
+        agent = _build_e2e_agent(llm, tool_runtime)
+        result = asyncio.run(agent._run_agentic_loop("run qc", None))
+
+        # Both tools were dispatched
+        dispatched_names = [c["name"] for c in tool_runtime.dispatch_calls]
+        assert "inspect_data" in dispatched_names
+        assert "search_functions" in dispatched_names
+        assert "finish" in dispatched_names
+        assert len(tool_runtime.dispatch_calls) == 3
+
+
+# ===================================================================
+#  5. stream_async event emission
+# ===================================================================
+
+
+class TestStreamAsyncEventEmission:
+    """stream_async yields events for tool calls and lifecycle."""
+
+    def test_stream_emits_tool_and_done_events(self):
+        """stream_async yields tool_call, item_started, item_completed, and done."""
+        tc_finish = make_tool_call("finish", {"summary": "All done."})
+
+        llm = build_fake_llm([_resp_tool([tc_finish])])
+
+        tool_runtime = _E2EToolRuntime(
+            handlers={"finish": lambda tc, ad, req: "done"},
+            tool_schemas=[_make_tool_schema("finish")],
+            registry_tools={"finish": {"output_tier": OutputTier.minimal}},
+        )
+
+        agent = _build_e2e_agent(llm, tool_runtime)
+
+        async def _collect():
+            events = []
+            async for event in agent.stream_async("do it", None):
+                events.append(event)
+            return events
+
+        events = asyncio.run(_collect())
+
+        event_types = [e.get("type") for e in events]
+
+        # Must contain at minimum: status (turn_started), tool_call,
+        # item_started, item_completed, done
+        assert "tool_call" in event_types
+        assert "done" in event_types
+
+        # The done event carries the finish summary
+        done_events = [e for e in events if e.get("type") == "done"]
+        assert len(done_events) >= 1
+        assert "All done." in str(done_events[-1].get("content", ""))
+
+    def test_stream_emits_retry_status_on_text_only(self):
+        """stream_async emits follow_up_required status during text-only retries."""
+        tc_finish = make_tool_call("finish", {"summary": "Finally done."})
+
+        llm = build_fake_llm([
+            # Turn 1: promissory text
+            _resp_text("Let me fetch that for you."),
+            # Turn 2: tool call after retry
+            _resp_tool([tc_finish]),
+        ])
+
+        tool_runtime = _E2EToolRuntime(
+            handlers={"finish": lambda tc, ad, req: "done"},
+            tool_schemas=[_make_tool_schema("WebFetch"), _make_tool_schema("finish")],
+            registry_tools={"finish": {"output_tier": OutputTier.minimal}},
+        )
+
+        agent = _build_e2e_agent(llm, tool_runtime)
+
+        async def _collect():
+            events = []
+            async for event in agent.stream_async(
+                "https://example.com\nfetch this", None
+            ):
+                events.append(event)
+            return events
+
+        events = asyncio.run(_collect())
+
+        # Should contain a status event with follow_up_required
+        status_events = [
+            e for e in events
+            if e.get("type") == "status"
+            and isinstance(e.get("content"), dict)
+            and e["content"].get("follow_up_required")
+        ]
+        assert len(status_events) >= 1
+
+
+# ===================================================================
+#  6. run_async public facade exercises the full loop
+# ===================================================================
+
+
+class TestRunAsyncFacade:
+    """run_async() delegates to _run_agentic_mode which runs the full loop."""
+
+    def test_run_async_returns_adata_from_loop(self):
+        """run_async returns the adata produced by the agentic loop."""
+        sentinel = SimpleNamespace(shape=(50, 10), tag="sentinel")
+        tc_finish = make_tool_call("finish", {"summary": "Done."})
+
+        llm = build_fake_llm([_resp_tool([tc_finish])])
+
+        tool_runtime = _E2EToolRuntime(
+            handlers={"finish": lambda tc, ad, req: "done"},
+            tool_schemas=[_make_tool_schema("finish")],
+            registry_tools={"finish": {"output_tier": OutputTier.minimal}},
+        )
+
+        agent = _build_e2e_agent(llm, tool_runtime)
+        # Stub _detect_direct_python_request to return None (not direct python)
+        agent._detect_direct_python_request = lambda request: None
+        # Stub _emit to avoid reporter dependency
+        agent._emit = lambda level, message, category="": None
+
+        result = asyncio.run(agent.run_async("inspect the data", sentinel))
+
+        assert result is sentinel
+
+    def test_run_async_direct_python_bypass(self):
+        """run_async with direct python code bypasses the agentic loop."""
+        agent = OmicVerseAgent.__new__(OmicVerseAgent)
+        agent.provider = "openai"
+        agent.last_usage = None
+        agent.last_usage_breakdown = {
+            "generation": None, "reflection": [], "review": [], "total": None
+        }
+        agent._emit = lambda level, message, category="": None
+
+        executed = {}
+        agent._detect_direct_python_request = lambda request: "x = 42"
+        agent._execute_generated_code = lambda code, adata: (
+            executed.update(code=code) or adata
+        )
+
+        result = asyncio.run(agent.run_async("x = 42", None))
+
+        assert result is None  # adata was None, returned as-is
+        assert executed["code"] == "x = 42"
+        assert agent.last_usage is None
+
+
+# ===================================================================
+#  7. Trace metadata validation
+# ===================================================================
+
+
+class TestTraceMetadata:
+    """The agentic loop populates _last_run_trace with correct metadata."""
+
+    def test_trace_has_session_and_status(self):
+        """After a successful loop, _last_run_trace records status=success."""
+        tc_finish = make_tool_call("finish", {"summary": "Complete."})
+
+        llm = build_fake_llm([_resp_tool([tc_finish])])
+
+        tool_runtime = _E2EToolRuntime(
+            handlers={"finish": lambda tc, ad, req: "done"},
+            tool_schemas=[_make_tool_schema("finish")],
+            registry_tools={"finish": {"output_tier": OutputTier.minimal}},
+        )
+
+        agent = _build_e2e_agent(llm, tool_runtime)
+        asyncio.run(agent._run_agentic_loop("check data", None))
+
+        trace = agent._last_run_trace
+        assert trace is not None
+        assert trace.session_id == "e2e-session"
+        assert trace.status == "success"
+
+    def test_trace_records_steps(self):
+        """Trace steps include tool_call entries for dispatched tools."""
+        tc_inspect = make_tool_call("inspect_data", {"aspect": "shape"})
+        tc_finish = make_tool_call("finish", {"summary": "Done."})
+
+        llm = build_fake_llm([
+            _resp_tool([tc_inspect]),
+            _resp_tool([tc_finish]),
+        ])
+
+        tool_runtime = _E2EToolRuntime(
+            handlers={
+                "inspect_data": lambda tc, ad, req: "shape: (100, 5)",
+                "finish": lambda tc, ad, req: "done",
+            },
+            tool_schemas=[_make_tool_schema("inspect_data"), _make_tool_schema("finish")],
+            registry_tools={
+                "inspect_data": {"output_tier": OutputTier.standard},
+                "finish": {"output_tier": OutputTier.minimal},
+            },
+        )
+
+        agent = _build_e2e_agent(llm, tool_runtime)
+        asyncio.run(agent._run_agentic_loop("inspect", None))
+
+        trace = agent._last_run_trace
+        step_types = [s.step_type for s in trace.steps]
+        assert "tool_call" in step_types
+        assert "done" in step_types
+
+
+# ===================================================================
+#  8. Max turns enforcement
+# ===================================================================
+
+
+class TestMaxTurnsEnforcement:
+    """Loop exits when max_turns is reached."""
+
+    def test_exits_after_max_turns(self):
+        """With max_turns=2, loop stops even if LLM keeps calling tools."""
+        tc = make_tool_call("inspect_data", {"aspect": "shape"})
+        responses = [_resp_tool([tc]) for _ in range(5)]
+
+        llm = build_fake_llm(responses)
+        tool_runtime = _E2EToolRuntime(
+            handlers={"inspect_data": lambda tc, ad, req: "shape: (100, 5)"},
+            tool_schemas=[_make_tool_schema("inspect_data"), _make_tool_schema("finish")],
+            registry_tools={"inspect_data": {"output_tier": OutputTier.standard}},
+        )
+
+        agent = _build_e2e_agent(llm, tool_runtime, max_agent_turns=2)
+        result = asyncio.run(agent._run_agentic_loop("keep inspecting", None))
+
+        # Should only have made 2 LLM calls
+        assert len(llm.chat_calls) == 2
+        # Trace records max_turns status
+        assert agent._last_run_trace.status == "max_turns"
+
+
+# ===================================================================
+#  9. Cancellation support
+# ===================================================================
+
+
+class TestCancellationSupport:
+    """cancel_event stops the loop at the next safe checkpoint."""
+
+    def test_cancel_before_first_llm_call(self):
+        """Pre-set cancel_event → loop returns immediately."""
+        import threading
+
+        llm = build_fake_llm([make_chat_response(content="should not reach")])
+        tool_runtime = _E2EToolRuntime(
+            tool_schemas=[_make_tool_schema("finish")],
+        )
+
+        agent = _build_e2e_agent(llm, tool_runtime)
+        cancel = threading.Event()
+        cancel.set()  # pre-set
+
+        result = asyncio.run(agent._run_agentic_loop(
+            "test", None, cancel_event=cancel,
+        ))
+
+        assert result is None
+        # LLM was never called
+        assert len(llm.chat_calls) == 0
+        assert agent._last_run_trace.status == "cancelled"

--- a/tests/utils/test_integration_provider_switching.py
+++ b/tests/utils/test_integration_provider_switching.py
@@ -1,0 +1,346 @@
+"""Integration tests: provider switching and dispatch routing.
+
+Validates that ``OmicVerseLLMBackend`` correctly resolves providers,
+routes requests through the right dispatch tables, formats tool results
+per wire API, and maintains per-instance state isolation -- all without
+making real external API calls.
+
+Gate: ``OV_AGENT_RUN_HARNESS_TESTS=1``
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+_RUN_HARNESS = os.environ.get("OV_AGENT_RUN_HARNESS_TESTS", "").lower() in {
+    "1", "true", "yes", "on",
+}
+pytestmark = pytest.mark.skipif(
+    not _RUN_HARNESS,
+    reason="Provider switching integration tests require OV_AGENT_RUN_HARNESS_TESTS=1.",
+)
+
+# -- production imports under test ------------------------------------------
+
+from omicverse.utils.model_config import (
+    PROVIDER_REGISTRY,
+    WireAPI,
+    get_provider,
+)
+from omicverse.utils.agent_backend_common import (
+    _SYNC_DISPATCH,
+    _STREAM_DISPATCH,
+)
+from omicverse.utils.agent_backend import (
+    _CHAT_DISPATCH,
+    OmicVerseLLMBackend,
+)
+
+# -- harness imports --------------------------------------------------------
+
+from tests.integration.fakes import Usage
+from tests.integration.helpers import build_fake_llm
+
+
+# ===================================================================
+#  1. Provider dispatch resolution
+# ===================================================================
+
+
+class TestProviderDispatchResolution:
+    """Every registered provider resolves to a valid dispatch entry."""
+
+    # Subset of providers that ship with the codebase and must always
+    # resolve to a dispatch entry in _SYNC_DISPATCH.
+    _CORE_PROVIDERS = ("openai", "anthropic", "google", "dashscope", "python")
+
+    @pytest.mark.parametrize("provider_name", _CORE_PROVIDERS)
+    def test_core_provider_in_sync_dispatch(self, provider_name: str):
+        info = get_provider(provider_name)
+        assert info is not None, f"Provider {provider_name!r} not in registry"
+        assert info.wire_api in _SYNC_DISPATCH, (
+            f"wire_api {info.wire_api} for {provider_name!r} missing from _SYNC_DISPATCH"
+        )
+
+    @pytest.mark.parametrize("provider_name", _CORE_PROVIDERS)
+    def test_core_provider_in_stream_dispatch(self, provider_name: str):
+        info = get_provider(provider_name)
+        assert info is not None
+        assert info.wire_api in _STREAM_DISPATCH, (
+            f"wire_api {info.wire_api} for {provider_name!r} missing from _STREAM_DISPATCH"
+        )
+
+    def test_unregistered_provider_not_in_registry(self):
+        assert get_provider("nonexistent_provider_xyz") is None
+
+    def test_dispatch_tables_cover_all_wire_api_variants(self):
+        """Every WireAPI enum member appears in at least _SYNC_DISPATCH."""
+        for wire in WireAPI:
+            assert wire in _SYNC_DISPATCH, (
+                f"WireAPI.{wire.name} missing from _SYNC_DISPATCH"
+            )
+
+    def test_every_registered_provider_has_sync_dispatch(self):
+        """All providers in the registry have a matching sync dispatch entry."""
+        for name, info in PROVIDER_REGISTRY.items():
+            assert info.wire_api in _SYNC_DISPATCH, (
+                f"Provider {name!r} uses wire_api {info.wire_api} "
+                "which is not in _SYNC_DISPATCH"
+            )
+
+
+# ===================================================================
+#  2. Backend config immutability per provider
+# ===================================================================
+
+
+class TestBackendConfigIsolation:
+    """Two backend instances carry independent configuration."""
+
+    def test_instances_have_independent_configs(self):
+        backend_a = OmicVerseLLMBackend(model="python", system_prompt="prompt-a")
+        backend_b = OmicVerseLLMBackend(
+            model="gpt-4o", system_prompt="prompt-b", api_key="sk-fake"
+        )
+
+        assert backend_a.config.model == "python"
+        assert backend_b.config.model == "gpt-4o"
+        assert backend_a.config.provider != backend_b.config.provider
+        assert backend_a.config.system_prompt == "prompt-a"
+        assert backend_b.config.system_prompt == "prompt-b"
+
+    def test_last_usage_starts_none_for_both(self):
+        a = OmicVerseLLMBackend(model="python", system_prompt="a")
+        b = OmicVerseLLMBackend(model="python", system_prompt="b")
+
+        assert a.last_usage is None
+        assert b.last_usage is None
+
+    @pytest.mark.asyncio
+    async def test_last_usage_resets_independently(self, monkeypatch):
+        a = OmicVerseLLMBackend(model="python", system_prompt="a")
+        b = OmicVerseLLMBackend(model="python", system_prompt="b")
+
+        monkeypatch.setattr(a, "_run_python_local", lambda prompt: "result-a")
+        monkeypatch.setattr(b, "_run_python_local", lambda prompt: "result-b")
+
+        await a.run("x")
+        assert a.last_usage is None  # monkeypatched method does not set usage
+
+        await b.run("y")
+        assert b.last_usage is None
+        # The calls were independent -- neither touched the other's usage
+        assert a.last_usage is None
+
+
+# ===================================================================
+#  3. Wire API routing consistency
+# ===================================================================
+
+
+class TestWireAPIRoutingConsistency:
+    """Dispatch tables are consistent across sync / chat / stream."""
+
+    _NON_LOCAL_WIRES = [w for w in WireAPI if w != WireAPI.LOCAL]
+
+    @pytest.mark.parametrize("wire", _NON_LOCAL_WIRES, ids=lambda w: w.name)
+    def test_non_local_wire_in_all_three_dispatches(self, wire: WireAPI):
+        assert wire in _SYNC_DISPATCH, f"{wire} missing from _SYNC_DISPATCH"
+        assert wire in _CHAT_DISPATCH, f"{wire} missing from _CHAT_DISPATCH"
+        assert wire in _STREAM_DISPATCH, f"{wire} missing from _STREAM_DISPATCH"
+
+    def test_local_wire_not_in_chat_dispatch(self):
+        """LOCAL provider has no multi-turn chat support."""
+        assert WireAPI.LOCAL not in _CHAT_DISPATCH
+
+    def test_local_wire_in_sync_dispatch(self):
+        assert WireAPI.LOCAL in _SYNC_DISPATCH
+
+    def test_local_wire_in_stream_dispatch(self):
+        assert WireAPI.LOCAL in _STREAM_DISPATCH
+
+    def test_sync_and_stream_have_same_keys(self):
+        """_SYNC_DISPATCH and _STREAM_DISPATCH cover the same wire APIs."""
+        assert set(_SYNC_DISPATCH.keys()) == set(_STREAM_DISPATCH.keys())
+
+
+# ===================================================================
+#  4. Provider-to-method resolution (monkeypatch approach)
+# ===================================================================
+
+
+class TestProviderMethodResolution:
+    """Full dispatch path for the LOCAL (python) provider."""
+
+    @pytest.mark.asyncio
+    async def test_python_provider_dispatch(self, monkeypatch):
+        backend = OmicVerseLLMBackend(model="python", system_prompt="test")
+
+        # Monkeypatch the local executor to return a known sentinel.
+        monkeypatch.setattr(
+            backend, "_run_python_local", lambda prompt: "mocked_local_result"
+        )
+
+        result = await backend.run("print('hello')")
+        assert result == "mocked_local_result"
+
+    @pytest.mark.asyncio
+    async def test_python_provider_config(self):
+        backend = OmicVerseLLMBackend(model="python", system_prompt="test")
+        assert backend.config.provider == "python"
+
+        info = get_provider(backend.config.provider)
+        assert info is not None
+        assert info.wire_api == WireAPI.LOCAL
+
+    def test_unregistered_provider_raises_on_sync_dispatch(self, monkeypatch):
+        """_run_sync raises RuntimeError for an unregistered provider."""
+        backend = OmicVerseLLMBackend(model="python", system_prompt="test")
+        # Force an unregistered provider name
+        monkeypatch.setattr(backend.config, "provider", "nonexistent_provider_xyz")
+
+        with pytest.raises(RuntimeError, match="not registered"):
+            backend._run_sync("hello")
+
+    def test_sync_dispatch_resolves_method_name(self):
+        """The sync dispatch entry for LOCAL points to _run_python_local."""
+        assert _SYNC_DISPATCH[WireAPI.LOCAL] == "_run_python_local"
+
+    def test_chat_dispatch_resolves_openai_method(self):
+        """The chat dispatch entry for CHAT_COMPLETIONS points to _chat_tools_openai."""
+        assert _CHAT_DISPATCH[WireAPI.CHAT_COMPLETIONS] == "_chat_tools_openai"
+
+    def test_chat_dispatch_resolves_anthropic_method(self):
+        assert _CHAT_DISPATCH[WireAPI.ANTHROPIC_MESSAGES] == "_chat_tools_anthropic"
+
+
+# ===================================================================
+#  5. Format tool result message per wire API
+# ===================================================================
+
+
+class TestFormatToolResultByWireAPI:
+    """format_tool_result_message() returns provider-specific shapes."""
+
+    def test_openai_compatible_format(self):
+        backend = OmicVerseLLMBackend(
+            model="gpt-4o", system_prompt="test", api_key="sk-fake"
+        )
+        msg = backend.format_tool_result_message(
+            tool_call_id="call_abc123",
+            tool_name="inspect_data",
+            result='{"rows": 100}',
+        )
+
+        assert msg["role"] == "tool"
+        assert msg["tool_call_id"] == "call_abc123"
+        assert msg["name"] == "inspect_data"
+        assert msg["content"] == '{"rows": 100}'
+
+    def test_anthropic_format(self):
+        backend = OmicVerseLLMBackend(
+            model="anthropic/claude-opus-4-6-20260201",
+            system_prompt="test",
+            api_key="sk-fake",
+        )
+        msg = backend.format_tool_result_message(
+            tool_call_id="toolu_xyz789",
+            tool_name="execute_code",
+            result="output: 42",
+        )
+
+        assert msg["role"] == "user"
+        assert isinstance(msg["content"], list)
+        assert len(msg["content"]) == 1
+
+        block = msg["content"][0]
+        assert block["type"] == "tool_result"
+        assert block["tool_use_id"] == "toolu_xyz789"
+        assert block["content"] == "output: 42"
+
+    def test_gemini_uses_openai_compatible_format(self):
+        """Gemini wire API falls through to the default (OpenAI-compatible) branch."""
+        backend = OmicVerseLLMBackend(
+            model="gemini/gemini-2.5-pro",
+            system_prompt="test",
+            api_key="fake-key",
+        )
+        msg = backend.format_tool_result_message(
+            tool_call_id="call_gem1",
+            tool_name="search",
+            result="found it",
+        )
+
+        # Gemini uses the else branch (same shape as OpenAI-compatible)
+        assert msg["role"] == "tool"
+        assert msg["tool_call_id"] == "call_gem1"
+        assert msg["name"] == "search"
+        assert msg["content"] == "found it"
+
+    def test_dashscope_uses_openai_compatible_format(self):
+        """DashScope wire API falls through to the default branch."""
+        backend = OmicVerseLLMBackend(
+            model="qwen-max", system_prompt="test", api_key="fake-key"
+        )
+        msg = backend.format_tool_result_message(
+            tool_call_id="call_ds1",
+            tool_name="analyze",
+            result="done",
+        )
+
+        assert msg["role"] == "tool"
+        assert msg["tool_call_id"] == "call_ds1"
+
+
+# ===================================================================
+#  6. Multiple backend instances do not share state
+# ===================================================================
+
+
+class TestBackendStateIsolation:
+    """Independent backend instances maintain separate state."""
+
+    @pytest.mark.asyncio
+    async def test_run_on_one_does_not_affect_other(self, monkeypatch):
+        backend_a = OmicVerseLLMBackend(model="python", system_prompt="a")
+        backend_b = OmicVerseLLMBackend(model="python", system_prompt="b")
+
+        monkeypatch.setattr(
+            backend_a, "_run_python_local", lambda prompt: "result-a"
+        )
+
+        await backend_a.run("code")
+
+        # backend_b was never called -- its last_usage must still be None.
+        assert backend_b.last_usage is None
+
+    @pytest.mark.asyncio
+    async def test_usage_set_on_called_backend_only(self, monkeypatch):
+        backend_a = OmicVerseLLMBackend(model="python", system_prompt="a")
+        backend_b = OmicVerseLLMBackend(model="python", system_prompt="b")
+
+        # Provide a mock that actually sets last_usage (like the real method)
+        def _mock_local(prompt):
+            backend_a.last_usage = Usage(
+                input_tokens=0,
+                output_tokens=0,
+                total_tokens=0,
+                model="python",
+                provider="python",
+            )
+            return "done"
+
+        monkeypatch.setattr(backend_a, "_run_python_local", _mock_local)
+
+        await backend_a.run("code")
+
+        assert backend_a.last_usage is not None
+        assert backend_b.last_usage is None
+
+    def test_config_objects_are_distinct(self):
+        a = OmicVerseLLMBackend(model="python", system_prompt="a")
+        b = OmicVerseLLMBackend(model="python", system_prompt="b")
+
+        assert a.config is not b.config
+        assert a.config.system_prompt != b.config.system_prompt

--- a/tests/utils/test_integration_security_sandbox.py
+++ b/tests/utils/test_integration_security_sandbox.py
@@ -927,3 +927,140 @@ class TestPandasEvalClassification:
         assert len(violations) == 1
         assert violations[0].category == "dangerous_import"
         assert violations[0].severity == "critical"
+
+
+# ===================================================================
+# 12. SafeOsProxy metadata escape closure (task-041)
+# ===================================================================
+
+
+class TestSafeOsProxyMetadataEscape:
+    """Proxy metadata paths (__dict__, vars, dir) must not expose the real os
+    module or any callable escape back to unrestricted os behaviour.
+
+    These tests are regression guards for the escape vector identified in
+    PR #603 review comment issuecomment-4148009652 item 1: a prior fix
+    (task-039) added __getattr__ allowlisting but left _real_os recoverable
+    through proxy.__dict__.
+    """
+
+    @pytest.fixture
+    def proxy(self) -> SafeOsProxy:
+        return SafeOsProxy()
+
+    # -- __dict__ must not contain _real_os or the real os module ----------
+
+    def test_dict_does_not_contain_real_os_key(self, proxy: SafeOsProxy):
+        """proxy.__dict__ must not have a '_real_os' entry."""
+        assert "_real_os" not in proxy.__dict__
+
+    def test_dict_values_do_not_contain_os_module(self, proxy: SafeOsProxy):
+        """No value in proxy.__dict__ should be the real os module."""
+        import types as _t
+        for key, val in proxy.__dict__.items():
+            if isinstance(val, _t.ModuleType) and val is not os.path:
+                assert val is not os, (
+                    f"proxy.__dict__[{key!r}] is the real os module"
+                )
+
+    def test_vars_does_not_expose_real_os(self, proxy: SafeOsProxy):
+        """vars(proxy) must not contain a reference to the real os module."""
+        assert "_real_os" not in vars(proxy)
+        for key, val in vars(proxy).items():
+            if key == "path":
+                continue
+            assert val is not os, (
+                f"vars(proxy)[{key!r}] is the real os module"
+            )
+
+    # -- recovery via dict should not yield blocked operations ------------
+
+    def test_dict_recovery_cannot_reach_system(self, proxy: SafeOsProxy):
+        """Even iterating all dict values, os.system must not be reachable."""
+        for val in proxy.__dict__.values():
+            assert not (callable(val) and getattr(val, "__name__", "") == "system")
+            if hasattr(val, "system"):
+                # os.path doesn't have 'system', but guard generically
+                with pytest.raises((SecurityViolationError, AttributeError)):
+                    val.system("echo pwned")
+
+    # -- dir() should only show safe names --------------------------------
+
+    def test_dir_does_not_include_real_os(self, proxy: SafeOsProxy):
+        assert "_real_os" not in dir(proxy)
+
+    def test_dir_only_shows_safe_attrs(self, proxy: SafeOsProxy):
+        listed = set(dir(proxy))
+        assert "path" in listed
+        # None of the blocked attrs should appear in dir()
+        for blocked in SafeOsProxy._BLOCKED_ATTRS:
+            assert blocked not in listed, f"{blocked!r} leaked into dir(proxy)"
+
+    # -- allowlist model: unknown attrs should be denied ------------------
+
+    def test_unknown_attr_denied(self, proxy: SafeOsProxy):
+        """Attributes not in the safe allowlist should raise AttributeError."""
+        with pytest.raises(AttributeError, match="sandbox"):
+            proxy.some_hypothetical_future_os_attr
+
+    # -- existing safe capabilities still work ----------------------------
+
+    def test_getcwd_still_works(self, proxy: SafeOsProxy):
+        assert proxy.getcwd() == os.getcwd()
+
+    def test_listdir_still_works(self, proxy: SafeOsProxy):
+        assert isinstance(proxy.listdir("."), list)
+
+    def test_path_join_still_works(self, proxy: SafeOsProxy):
+        assert proxy.path.join("a", "b") == os.path.join("a", "b")
+
+    def test_sep_still_works(self, proxy: SafeOsProxy):
+        assert proxy.sep == os.sep
+
+    def test_environ_readable(self, proxy: SafeOsProxy):
+        assert isinstance(proxy.environ, os._Environ)
+
+    def test_makedirs_in_allowlist(self, proxy: SafeOsProxy):
+        """makedirs should be forwarded (caller may still get FS errors)."""
+        fn = proxy.makedirs
+        assert callable(fn)
+
+    # -- blocked operations still raise -----------------------------------
+
+    def test_system_still_blocked(self, proxy: SafeOsProxy):
+        with pytest.raises(SecurityViolationError, match="os.system"):
+            proxy.system("echo pwned")
+
+    def test_remove_still_blocked(self, proxy: SafeOsProxy):
+        with pytest.raises(SecurityViolationError, match="os.remove"):
+            proxy.remove("/tmp/x")
+
+    # -- sandbox globals integration: full chain --------------------------
+
+    def test_sandbox_exec_dict_escape_blocked(self):
+        """Inside build_sandbox_globals, proxy.__dict__ must not leak _real_os."""
+        globs = build_sandbox_globals()
+        loc = {}
+        exec("result = '_real_os' in os.__dict__", globs, loc)
+        assert loc["result"] is False
+
+    def test_sandbox_exec_vars_escape_blocked(self):
+        """vars(os) inside sandbox must not contain _real_os."""
+        globs = build_sandbox_globals()
+        loc = {}
+        exec("result = '_real_os' in vars(os)", globs, loc)
+        assert loc["result"] is False
+
+    def test_sandbox_exec_recover_real_os_impossible(self):
+        """Iterating proxy.__dict__ values must not yield a usable os.system."""
+        globs = build_sandbox_globals()
+        code = (
+            "escaped = False\n"
+            "for v in os.__dict__.values():\n"
+            "    if hasattr(v, 'system') and callable(getattr(v, 'system', None)):\n"
+            "        escaped = True\n"
+            "result = escaped\n"
+        )
+        loc = {}
+        exec(code, globs, loc)
+        assert loc["result"] is False

--- a/tests/utils/test_integration_security_sandbox.py
+++ b/tests/utils/test_integration_security_sandbox.py
@@ -557,3 +557,83 @@ class TestMultiViolationReport:
             line_numbers.append(num)
 
         assert line_numbers == sorted(line_numbers)
+
+
+# ===================================================================
+#  9. Runtime import blocking (defense-in-depth beyond scanner)
+# ===================================================================
+
+
+class TestRuntimeImportBlocking:
+    """Verify that _run_python_local blocks importlib/ctypes/cffi at runtime
+    via the _safe_import hook, not relying solely on the AST scanner.
+
+    The scanner also catches these imports, so to isolate the runtime layer
+    we monkeypatch the scanner to report no critical violations, letting
+    code reach execution where _safe_import enforces the block.
+    """
+
+    @pytest.fixture
+    def local_backend(self, monkeypatch):
+        from omicverse.utils.agent_backend import OmicVerseLLMBackend
+        from omicverse.utils.model_config import ModelConfig
+        monkeypatch.setattr(
+            ModelConfig, "get_provider_from_model", lambda *a, **kw: "python"
+        )
+        return OmicVerseLLMBackend(
+            system_prompt="test", model="python", api_key=""
+        )
+
+    @pytest.fixture
+    def _bypass_scanner(self, monkeypatch):
+        """Disable the AST scanner so code reaches the runtime import hook."""
+        monkeypatch.setattr(CodeSecurityScanner, "scan", lambda self, code: [])
+        monkeypatch.setattr(CodeSecurityScanner, "has_critical", lambda self, v: False)
+
+    def test_import_importlib_blocked_at_runtime(
+        self, local_backend, _bypass_scanner
+    ):
+        """import importlib must be blocked by _safe_import, not just scanner."""
+        with pytest.raises(RuntimeError, match="blocked.*importlib"):
+            local_backend._run_python_local("import importlib")
+
+    def test_importlib_import_module_blocked(
+        self, local_backend, _bypass_scanner
+    ):
+        """importlib.import_module escape path is blocked at runtime."""
+        with pytest.raises(RuntimeError, match="blocked.*importlib"):
+            local_backend._run_python_local(
+                "import importlib\nimportlib.import_module('subprocess')"
+            )
+
+    def test_from_importlib_import_blocked(
+        self, local_backend, _bypass_scanner
+    ):
+        """from importlib import import_module is blocked at runtime."""
+        with pytest.raises(RuntimeError, match="blocked.*importlib"):
+            local_backend._run_python_local(
+                "from importlib import import_module"
+            )
+
+    def test_import_ctypes_blocked_at_runtime(
+        self, local_backend, _bypass_scanner
+    ):
+        """import ctypes must be blocked at runtime."""
+        with pytest.raises(RuntimeError, match="blocked.*ctypes"):
+            local_backend._run_python_local("import ctypes")
+
+    def test_import_cffi_blocked_at_runtime(
+        self, local_backend, _bypass_scanner
+    ):
+        """import cffi must be blocked at runtime."""
+        with pytest.raises(RuntimeError, match="blocked.*cffi"):
+            local_backend._run_python_local("import cffi")
+
+    def test_safe_imports_still_work(
+        self, local_backend, _bypass_scanner
+    ):
+        """Non-blocked imports (json, etc.) still function with scanner bypassed."""
+        result = local_backend._run_python_local(
+            "import json\nprint(json.dumps({'ok': True}))"
+        )
+        assert '"ok": true' in result

--- a/tests/utils/test_integration_security_sandbox.py
+++ b/tests/utils/test_integration_security_sandbox.py
@@ -324,13 +324,13 @@ class TestCustomConfigComposition:
         assert violations[0].category == "dangerous_import"
         assert violations[0].severity == "critical"
 
-    def test_extra_blocked_calls_catches_pandas_eval(self):
-        cfg = SecurityConfig(extra_blocked_calls=frozenset({"pandas.eval"}))
+    def test_extra_blocked_calls_catches_custom_call(self):
+        cfg = SecurityConfig(extra_blocked_calls=frozenset({"numpy.save"}))
         scanner = CodeSecurityScanner(cfg)
-        violations = scanner.scan('pandas.eval("x")')
+        violations = scanner.scan('numpy.save("out.npy", arr)')
         assert len(violations) == 1
         assert violations[0].category == "file_danger"
-        assert "pandas.eval" in violations[0].description
+        assert "numpy.save" in violations[0].description
 
     def test_allowed_import_roots_whitelists_requests(self):
         cfg = SecurityConfig(allowed_import_roots=frozenset({"requests"}))
@@ -593,15 +593,15 @@ class TestRuntimeImportBlocking:
     def test_import_importlib_blocked_at_runtime(
         self, local_backend, _bypass_scanner
     ):
-        """import importlib must be blocked by _safe_import, not just scanner."""
-        with pytest.raises(RuntimeError, match="blocked.*importlib"):
+        """import importlib must be blocked by limited_import, not just scanner."""
+        with pytest.raises(RuntimeError, match="(?i)importlib.*blocked"):
             local_backend._run_python_local("import importlib")
 
     def test_importlib_import_module_blocked(
         self, local_backend, _bypass_scanner
     ):
         """importlib.import_module escape path is blocked at runtime."""
-        with pytest.raises(RuntimeError, match="blocked.*importlib"):
+        with pytest.raises(RuntimeError, match="(?i)importlib.*blocked"):
             local_backend._run_python_local(
                 "import importlib\nimportlib.import_module('subprocess')"
             )
@@ -610,7 +610,7 @@ class TestRuntimeImportBlocking:
         self, local_backend, _bypass_scanner
     ):
         """from importlib import import_module is blocked at runtime."""
-        with pytest.raises(RuntimeError, match="blocked.*importlib"):
+        with pytest.raises(RuntimeError, match="(?i)importlib.*blocked"):
             local_backend._run_python_local(
                 "from importlib import import_module"
             )
@@ -619,15 +619,29 @@ class TestRuntimeImportBlocking:
         self, local_backend, _bypass_scanner
     ):
         """import ctypes must be blocked at runtime."""
-        with pytest.raises(RuntimeError, match="blocked.*ctypes"):
+        with pytest.raises(RuntimeError, match="(?i)ctypes.*blocked"):
             local_backend._run_python_local("import ctypes")
 
     def test_import_cffi_blocked_at_runtime(
         self, local_backend, _bypass_scanner
     ):
         """import cffi must be blocked at runtime."""
-        with pytest.raises(RuntimeError, match="blocked.*cffi"):
+        with pytest.raises(RuntimeError, match="(?i)cffi.*blocked"):
             local_backend._run_python_local("import cffi")
+
+    def test_import_subprocess_blocked_at_runtime(
+        self, local_backend, _bypass_scanner
+    ):
+        """import subprocess must be blocked at runtime, not just scanner."""
+        with pytest.raises(RuntimeError, match="(?i)subprocess.*blocked"):
+            local_backend._run_python_local("import subprocess")
+
+    def test_import_sys_blocked_at_runtime(
+        self, local_backend, _bypass_scanner
+    ):
+        """import sys must be blocked to prevent sys.path/sys.modules access."""
+        with pytest.raises(RuntimeError, match="(?i)sys.*blocked"):
+            local_backend._run_python_local("import sys")
 
     def test_safe_imports_still_work(
         self, local_backend, _bypass_scanner
@@ -637,3 +651,279 @@ class TestRuntimeImportBlocking:
             "import json\nprint(json.dumps({'ok': True}))"
         )
         assert '"ok": true' in result
+
+
+# ===================================================================
+# 10. Runtime bypass vector enforcement (build_sandbox_globals)
+# ===================================================================
+
+from omicverse.utils.agent_sandbox import build_sandbox_globals
+
+
+class TestRuntimeGetAttrBypass:
+    """getattr(os, 'system') and similar dynamic attribute access must be
+    blocked at runtime by SafeOsProxy, not only by the AST scanner."""
+
+    def test_getattr_os_system_blocked(self):
+        globs = build_sandbox_globals()
+        with pytest.raises(SecurityViolationError, match="os.system"):
+            exec("result = getattr(os, 'system')", globs)
+
+    def test_getattr_os_popen_blocked(self):
+        globs = build_sandbox_globals()
+        with pytest.raises(SecurityViolationError, match="os.popen"):
+            exec("result = getattr(os, 'popen')", globs)
+
+    def test_getattr_os_execv_blocked(self):
+        globs = build_sandbox_globals()
+        with pytest.raises(SecurityViolationError, match="os.execv"):
+            exec("getattr(os, 'execv')", globs)
+
+    def test_getattr_os_kill_blocked(self):
+        globs = build_sandbox_globals()
+        with pytest.raises(SecurityViolationError, match="os.kill"):
+            exec("getattr(os, 'kill')", globs)
+
+    def test_getattr_os_path_allowed(self):
+        """os.path is safe and must remain accessible."""
+        globs = build_sandbox_globals()
+        loc = {}
+        exec("result = getattr(os, 'path')", globs, loc)
+        assert loc["result"] is os.path
+
+    def test_os_getcwd_allowed(self):
+        globs = build_sandbox_globals()
+        loc = {}
+        exec("result = os.getcwd()", globs, loc)
+        assert loc["result"] == os.getcwd()
+
+
+class TestRuntimeDunderImportBypass:
+    """Direct __import__ usage must go through restricted limited_import."""
+
+    def test_dunder_import_subprocess_blocked(self):
+        globs = build_sandbox_globals()
+        with pytest.raises(ImportError, match="subprocess.*blocked"):
+            exec("mod = __import__('subprocess')", globs)
+
+    def test_dunder_import_socket_blocked(self):
+        globs = build_sandbox_globals()
+        with pytest.raises(ImportError, match="socket.*blocked"):
+            exec("mod = __import__('socket')", globs)
+
+    def test_dunder_import_sys_blocked(self):
+        globs = build_sandbox_globals()
+        with pytest.raises(ImportError, match="sys.*blocked"):
+            exec("mod = __import__('sys')", globs)
+
+    def test_dunder_import_os_returns_proxy(self):
+        """__import__('os') must return SafeOsProxy, not real os."""
+        from omicverse.utils.agent_sandbox import SafeOsProxy
+        globs = build_sandbox_globals()
+        loc = {}
+        exec("mod = __import__('os')", globs, loc)
+        assert isinstance(loc["mod"], SafeOsProxy)
+
+    def test_dunder_import_json_allowed(self):
+        globs = build_sandbox_globals()
+        loc = {}
+        exec("mod = __import__('json')", globs, loc)
+        import json
+        assert loc["mod"] is json
+
+    def test_import_importlib_metadata_allowed(self):
+        """Safe importlib sub-modules must remain importable."""
+        globs = build_sandbox_globals()
+        loc = {}
+        exec("from importlib import metadata\nresult = hasattr(metadata, 'version')", globs, loc)
+        assert loc["result"] is True
+
+
+class TestRuntimeSysPathManipulation:
+    """sys.path and sys.modules manipulation must be blocked."""
+
+    def test_import_sys_blocked(self):
+        globs = build_sandbox_globals()
+        with pytest.raises(ImportError, match="sys.*blocked"):
+            exec("import sys", globs)
+
+    def test_from_sys_import_blocked(self):
+        globs = build_sandbox_globals()
+        with pytest.raises(ImportError, match="sys.*blocked"):
+            exec("from sys import path", globs)
+
+    def test_sys_modules_inaccessible(self):
+        """Without sys, sys.modules cannot be used to retrieve blocked modules."""
+        globs = build_sandbox_globals()
+        with pytest.raises(ImportError, match="sys.*blocked"):
+            exec("import sys; mod = sys.modules['os']", globs)
+
+
+class TestRuntimeIntrospectionEscapes:
+    """Dangerous builtins (eval, exec, compile, globals, locals) must not
+    be available in the sandbox namespace."""
+
+    def test_eval_not_available(self):
+        globs = build_sandbox_globals()
+        with pytest.raises(NameError):
+            exec("eval('1+1')", globs)
+
+    def test_exec_not_available(self):
+        globs = build_sandbox_globals()
+        with pytest.raises(NameError):
+            exec("exec('x = 1')", globs)
+
+    def test_compile_not_available(self):
+        globs = build_sandbox_globals()
+        with pytest.raises(NameError):
+            exec("compile('1+1', '<test>', 'exec')", globs)
+
+    def test_globals_not_available(self):
+        globs = build_sandbox_globals()
+        with pytest.raises(NameError):
+            exec("g = globals()", globs)
+
+    def test_locals_not_available(self):
+        globs = build_sandbox_globals()
+        with pytest.raises(NameError):
+            exec("l = locals()", globs)
+
+    def test_breakpoint_not_available(self):
+        globs = build_sandbox_globals()
+        with pytest.raises(NameError):
+            exec("breakpoint()", globs)
+
+    def test_standard_builtins_still_work(self):
+        """Common builtins like len, range, print must still be available."""
+        globs = build_sandbox_globals()
+        loc = {}
+        exec("result = len(list(range(5)))", globs, loc)
+        assert loc["result"] == 5
+
+    def test_import_os_then_getattr_system_blocked(self):
+        """Full chain: import os; getattr(os, 'system') must be caught."""
+        globs = build_sandbox_globals()
+        with pytest.raises(SecurityViolationError, match="os.system"):
+            exec("import os\ngetattr(os, 'system')", globs)
+
+    def test_restricted_import_still_blocks_after_getattr(self):
+        """The restricted __import__ obtained via builtins still enforces blocks."""
+        globs = build_sandbox_globals()
+        with pytest.raises(ImportError, match="blocked"):
+            exec(
+                "imp = __builtins__['__import__']\n"
+                "imp('subprocess')",
+                globs,
+            )
+
+
+class TestRuntimeLegitimateCodeWorks:
+    """Verify that legitimate data-science code runs successfully in the
+    sandboxed environment."""
+
+    def test_math_operations(self):
+        globs = build_sandbox_globals()
+        loc = {}
+        exec("import math\nresult = math.sqrt(144)", globs, loc)
+        assert loc["result"] == 12.0
+
+    def test_json_roundtrip(self):
+        globs = build_sandbox_globals()
+        loc = {}
+        exec(
+            "import json\n"
+            "data = {'key': [1, 2, 3]}\n"
+            "result = json.loads(json.dumps(data))",
+            globs, loc,
+        )
+        assert loc["result"] == {"key": [1, 2, 3]}
+
+    def test_os_path_join(self):
+        globs = build_sandbox_globals()
+        loc = {}
+        exec("result = os.path.join('a', 'b', 'c')", globs, loc)
+        assert loc["result"] == os.path.join("a", "b", "c")
+
+    def test_from_os_path_import_join(self):
+        globs = build_sandbox_globals()
+        loc = {}
+        exec("from os.path import join\nresult = join('x', 'y')", globs, loc)
+        assert loc["result"] == os.path.join("x", "y")
+
+    def test_list_comprehension_and_builtins(self):
+        globs = build_sandbox_globals()
+        loc = {}
+        exec(
+            "result = sorted([x**2 for x in range(5)], reverse=True)",
+            globs, loc,
+        )
+        assert loc["result"] == [16, 9, 4, 1, 0]
+
+    def test_exception_handling(self):
+        globs = build_sandbox_globals()
+        loc = {}
+        exec(
+            "try:\n"
+            "    1 / 0\n"
+            "except ZeroDivisionError:\n"
+            "    result = 'caught'\n",
+            globs, loc,
+        )
+        assert loc["result"] == "caught"
+
+
+# ===================================================================
+# 11. pandas.eval scanner classification correction
+# ===================================================================
+
+
+class TestPandasEvalClassification:
+    """pandas.eval / pd.eval must be categorized as code_execution,
+    not file_danger, and must have critical severity."""
+
+    def test_pd_eval_detected_as_code_execution(self):
+        scanner = CodeSecurityScanner()
+        violations = scanner.scan('pd.eval("x + 1")')
+        eval_v = [v for v in violations if "pd.eval" in v.description]
+        assert len(eval_v) == 1
+        assert eval_v[0].category == "code_execution"
+        assert eval_v[0].severity == "critical"
+
+    def test_pandas_eval_detected_as_code_execution(self):
+        scanner = CodeSecurityScanner()
+        violations = scanner.scan('pandas.eval("x + 1")')
+        eval_v = [v for v in violations if "pandas.eval" in v.description]
+        assert len(eval_v) == 1
+        assert eval_v[0].category == "code_execution"
+        assert eval_v[0].severity == "critical"
+
+    def test_pd_eval_not_file_danger(self):
+        scanner = CodeSecurityScanner()
+        violations = scanner.scan('pd.eval("something")')
+        for v in violations:
+            if "eval" in v.description.lower():
+                assert v.category != "file_danger", (
+                    f"pandas.eval must not be categorized as file_danger, "
+                    f"got: {v.category}"
+                )
+
+    def test_pd_eval_blocked_at_standard_level(self):
+        scanner = _scanner_for(SecurityLevel.STANDARD)
+        violations = scanner.scan('pd.eval("1+1")')
+        assert scanner.has_critical(violations)
+
+    def test_code_execution_severity_overridable(self):
+        cfg = SecurityConfig(severity_overrides={"code_execution": "warning"})
+        scanner = CodeSecurityScanner(cfg)
+        violations = scanner.scan('pd.eval("x")')
+        eval_v = [v for v in violations if v.category == "code_execution"]
+        assert len(eval_v) == 1
+        assert eval_v[0].severity == "warning"
+
+    def test_cffi_in_scanner_blocked_imports(self):
+        """cffi must be in the scanner's BLOCKED_IMPORT_ROOTS."""
+        scanner = CodeSecurityScanner()
+        violations = scanner.scan("import cffi")
+        assert len(violations) == 1
+        assert violations[0].category == "dangerous_import"
+        assert violations[0].severity == "critical"

--- a/tests/utils/test_integration_security_sandbox.py
+++ b/tests/utils/test_integration_security_sandbox.py
@@ -1,0 +1,559 @@
+"""Integration tests: security sandbox enforcement.
+
+Validates that CodeSecurityScanner, SafeOsProxy, and SecurityConfig compose
+correctly across security levels.  These tests exercise the layers as the
+production ``agent_backend._run_python_local`` path uses them:
+
+    1. Scan code with ``CodeSecurityScanner``
+    2. Check ``has_critical(violations)``
+    3. If critical, block execution
+
+No production behaviour is modified -- all assertions validate existing
+behaviour of the sandbox stack.
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+_RUN_HARNESS = os.environ.get("OV_AGENT_RUN_HARNESS_TESTS", "").lower() in {
+    "1", "true", "yes", "on",
+}
+pytestmark = pytest.mark.skipif(
+    not _RUN_HARNESS,
+    reason="Security sandbox integration tests require OV_AGENT_RUN_HARNESS_TESTS=1.",
+)
+
+from omicverse.utils.agent_sandbox import (
+    CodeSecurityScanner,
+    SafeOsProxy,
+    SecurityConfig,
+    SecurityLevel,
+    SecurityViolation,
+    ApprovalMode,
+)
+from omicverse.utils.agent_errors import SecurityViolationError
+
+
+# ===================================================================
+#  Helpers
+# ===================================================================
+
+def _scanner_for(level: SecurityLevel) -> CodeSecurityScanner:
+    """Return a scanner configured from a preset security level."""
+    return CodeSecurityScanner(SecurityConfig.from_level(level))
+
+
+def _categories(violations: list[SecurityViolation]) -> list[str]:
+    """Extract sorted-by-line category names."""
+    return [v.category for v in violations]
+
+
+def _severities(violations: list[SecurityViolation]) -> list[str]:
+    """Extract sorted-by-line severity strings."""
+    return [v.severity for v in violations]
+
+
+# ===================================================================
+#  1. Scanner + Config integration across security levels
+# ===================================================================
+
+
+class TestSecurityLevelPresets:
+    """Verify that from_level presets configure the scanner correctly."""
+
+    # -- STRICT --------------------------------------------------------
+
+    def test_strict_shell_access_is_critical(self):
+        scanner = _scanner_for(SecurityLevel.STRICT)
+        violations = scanner.scan('os.system("ls")')
+        assert scanner.has_critical(violations)
+        assert violations[0].category == "shell_access"
+        assert violations[0].severity == "critical"
+
+    def test_strict_file_danger_is_critical(self):
+        scanner = _scanner_for(SecurityLevel.STRICT)
+        violations = scanner.scan('shutil.rmtree("/tmp/data")')
+        assert scanner.has_critical(violations)
+        assert violations[0].category == "file_danger"
+        assert violations[0].severity == "critical"
+
+    def test_strict_dangerous_import_is_critical(self):
+        scanner = _scanner_for(SecurityLevel.STRICT)
+        violations = scanner.scan("import subprocess")
+        assert scanner.has_critical(violations)
+        assert violations[0].category == "dangerous_import"
+        assert violations[0].severity == "critical"
+
+    # -- STANDARD ------------------------------------------------------
+
+    def test_standard_file_danger_is_warning(self):
+        scanner = _scanner_for(SecurityLevel.STANDARD)
+        violations = scanner.scan('shutil.rmtree("/tmp/data")')
+        assert len(violations) == 1
+        assert violations[0].category == "file_danger"
+        assert violations[0].severity == "warning"
+        assert not scanner.has_critical(violations)
+
+    def test_standard_shell_access_still_critical(self):
+        scanner = _scanner_for(SecurityLevel.STANDARD)
+        violations = scanner.scan('os.system("cmd")')
+        assert scanner.has_critical(violations)
+        assert violations[0].severity == "critical"
+
+    def test_standard_dangerous_import_still_critical(self):
+        scanner = _scanner_for(SecurityLevel.STANDARD)
+        violations = scanner.scan("import subprocess")
+        assert scanner.has_critical(violations)
+
+    # -- PERMISSIVE ----------------------------------------------------
+
+    def test_permissive_file_danger_is_warning(self):
+        scanner = _scanner_for(SecurityLevel.PERMISSIVE)
+        violations = scanner.scan('shutil.move("a", "b")')
+        assert len(violations) == 1
+        assert violations[0].severity == "warning"
+
+    def test_permissive_dangerous_import_is_warning(self):
+        scanner = _scanner_for(SecurityLevel.PERMISSIVE)
+        violations = scanner.scan("import socket")
+        assert len(violations) == 1
+        assert violations[0].severity == "warning"
+        assert not scanner.has_critical(violations)
+
+    def test_permissive_dangerous_builtin_is_warning(self):
+        scanner = _scanner_for(SecurityLevel.PERMISSIVE)
+        violations = scanner.scan('eval("1+1")')
+        assert len(violations) == 1
+        assert violations[0].category == "dangerous_builtin"
+        assert violations[0].severity == "warning"
+
+    def test_permissive_allows_requests(self):
+        scanner = _scanner_for(SecurityLevel.PERMISSIVE)
+        violations = scanner.scan("import requests")
+        assert violations == []
+
+    def test_permissive_allows_urllib(self):
+        scanner = _scanner_for(SecurityLevel.PERMISSIVE)
+        violations = scanner.scan("import urllib")
+        assert violations == []
+
+    def test_permissive_allows_http(self):
+        scanner = _scanner_for(SecurityLevel.PERMISSIVE)
+        violations = scanner.scan("import http")
+        assert violations == []
+
+
+# ===================================================================
+#  2. End-to-end scan-then-block flow
+# ===================================================================
+
+
+class TestScanThenBlockFlow:
+    """Simulate the agent_backend._run_python_local scan-then-block pattern."""
+
+    def _should_block(self, code: str, level: SecurityLevel = SecurityLevel.STANDARD) -> bool:
+        """Return True if code would be blocked at the given level."""
+        scanner = _scanner_for(level)
+        violations = scanner.scan(code)
+        return scanner.has_critical(violations)
+
+    # -- import subprocess -> blocked at STANDARD -----------------------
+
+    def test_import_subprocess_blocked_at_standard(self):
+        assert self._should_block("import subprocess", SecurityLevel.STANDARD)
+
+    def test_import_subprocess_blocked_at_strict(self):
+        assert self._should_block("import subprocess", SecurityLevel.STRICT)
+
+    # -- os.system -> blocked at all levels -----------------------------
+
+    def test_os_system_blocked_at_strict(self):
+        assert self._should_block('os.system("ls")', SecurityLevel.STRICT)
+
+    def test_os_system_blocked_at_standard(self):
+        assert self._should_block('os.system("ls")', SecurityLevel.STANDARD)
+
+    def test_os_system_blocked_at_permissive(self):
+        assert self._should_block('os.system("ls")', SecurityLevel.PERMISSIVE)
+
+    # -- os.remove -> always shell_access (contains "os.") --------------
+
+    def test_os_remove_blocked_at_strict(self):
+        scanner = _scanner_for(SecurityLevel.STRICT)
+        violations = scanner.scan('os.remove("file.txt")')
+        assert scanner.has_critical(violations)
+        assert violations[0].category == "shell_access"
+
+    def test_os_remove_blocked_at_standard(self):
+        # os.remove is categorized as shell_access (not file_danger),
+        # so STANDARD's file_danger->warning override does not apply.
+        scanner = _scanner_for(SecurityLevel.STANDARD)
+        violations = scanner.scan('os.remove("file.txt")')
+        assert scanner.has_critical(violations)
+        assert violations[0].category == "shell_access"
+        assert violations[0].severity == "critical"
+
+    # -- eval -> blocked ------------------------------------------------
+
+    def test_eval_blocked_at_standard(self):
+        assert self._should_block('eval("1+1")', SecurityLevel.STANDARD)
+
+    def test_eval_blocked_at_strict(self):
+        assert self._should_block('eval("1+1")', SecurityLevel.STRICT)
+
+    # -- __builtins__ access -> blocked ---------------------------------
+
+    def test_builtins_access_blocked(self):
+        assert self._should_block("x = __builtins__")
+
+    # -- __subclasses__() -> blocked ------------------------------------
+
+    def test_subclasses_call_blocked(self):
+        assert self._should_block("obj.__subclasses__()")
+
+    # -- SecurityViolationError integration -----------------------------
+
+    def test_violation_error_carries_violations_list(self):
+        """Validate the pattern used in _run_python_local."""
+        scanner = _scanner_for(SecurityLevel.STANDARD)
+        code = 'os.system("rm -rf /")'
+        violations = scanner.scan(code)
+        assert scanner.has_critical(violations)
+
+        report = scanner.format_report(violations)
+        err = SecurityViolationError(
+            f"Code blocked by security scanner:\n{report}",
+            violations=violations,
+        )
+        assert isinstance(err, SecurityViolationError)
+        assert len(err.violations) > 0
+        assert "CRITICAL" in str(err)
+
+
+# ===================================================================
+#  3. SafeOsProxy enforcement
+# ===================================================================
+
+
+class TestSafeOsProxyEnforcement:
+    """SafeOsProxy blocks dangerous ops and passes through safe ones."""
+
+    @pytest.fixture
+    def proxy(self) -> SafeOsProxy:
+        return SafeOsProxy()
+
+    # -- safe operations pass through -----------------------------------
+
+    def test_path_join(self, proxy: SafeOsProxy):
+        assert proxy.path.join("a", "b") == os.path.join("a", "b")
+
+    def test_getcwd(self, proxy: SafeOsProxy):
+        assert proxy.getcwd() == os.getcwd()
+
+    def test_listdir(self, proxy: SafeOsProxy):
+        result = proxy.listdir(".")
+        assert isinstance(result, list)
+        assert len(result) > 0
+
+    def test_path_is_directly_accessible(self, proxy: SafeOsProxy):
+        assert proxy.path is os.path
+
+    def test_sep_available(self, proxy: SafeOsProxy):
+        assert proxy.sep == os.sep
+
+    # -- blocked operations raise SecurityViolationError -----------------
+
+    def test_system_blocked(self, proxy: SafeOsProxy):
+        with pytest.raises(SecurityViolationError, match="os.system"):
+            proxy.system("ls")
+
+    def test_remove_blocked(self, proxy: SafeOsProxy):
+        with pytest.raises(SecurityViolationError, match="os.remove"):
+            proxy.remove("file.txt")
+
+    def test_kill_blocked(self, proxy: SafeOsProxy):
+        with pytest.raises(SecurityViolationError, match="os.kill"):
+            proxy.kill(1, 9)
+
+    def test_popen_blocked(self, proxy: SafeOsProxy):
+        with pytest.raises(SecurityViolationError, match="os.popen"):
+            proxy.popen("ls")
+
+    def test_unlink_blocked(self, proxy: SafeOsProxy):
+        with pytest.raises(SecurityViolationError, match="os.unlink"):
+            proxy.unlink("file.txt")
+
+    def test_chmod_blocked(self, proxy: SafeOsProxy):
+        with pytest.raises(SecurityViolationError, match="os.chmod"):
+            proxy.chmod("/tmp", 0o777)
+
+    def test_fork_blocked(self, proxy: SafeOsProxy):
+        with pytest.raises(SecurityViolationError, match="os.fork"):
+            proxy.fork()
+
+    def test_putenv_blocked(self, proxy: SafeOsProxy):
+        with pytest.raises(SecurityViolationError, match="os.putenv"):
+            proxy.putenv("KEY", "VALUE")
+
+    def test_error_is_subclass_of_sandbox_denied(self, proxy: SafeOsProxy):
+        with pytest.raises(SecurityViolationError) as exc_info:
+            proxy.system("ls")
+        # SecurityViolationError -> SandboxDeniedError -> ExecutionError -> OVAgentError
+        from omicverse.utils.agent_errors import SandboxDeniedError
+        assert isinstance(exc_info.value, SandboxDeniedError)
+
+    def test_repr(self, proxy: SafeOsProxy):
+        assert "SafeOsProxy" in repr(proxy)
+
+
+# ===================================================================
+#  4. Custom config composition
+# ===================================================================
+
+
+class TestCustomConfigComposition:
+    """SecurityConfig extra_* fields compose with defaults correctly."""
+
+    def test_extra_blocked_modules_catches_pickle(self):
+        cfg = SecurityConfig(extra_blocked_modules=frozenset({"pickle"}))
+        scanner = CodeSecurityScanner(cfg)
+        violations = scanner.scan("import pickle")
+        assert len(violations) == 1
+        assert violations[0].category == "dangerous_import"
+        assert violations[0].severity == "critical"
+
+    def test_extra_blocked_calls_catches_pandas_eval(self):
+        cfg = SecurityConfig(extra_blocked_calls=frozenset({"pandas.eval"}))
+        scanner = CodeSecurityScanner(cfg)
+        violations = scanner.scan('pandas.eval("x")')
+        assert len(violations) == 1
+        assert violations[0].category == "file_danger"
+        assert "pandas.eval" in violations[0].description
+
+    def test_allowed_import_roots_whitelists_requests(self):
+        cfg = SecurityConfig(allowed_import_roots=frozenset({"requests"}))
+        scanner = CodeSecurityScanner(cfg)
+        violations = scanner.scan("import requests")
+        assert violations == []
+
+    def test_allowed_import_roots_does_not_affect_other_blocks(self):
+        cfg = SecurityConfig(allowed_import_roots=frozenset({"requests"}))
+        scanner = CodeSecurityScanner(cfg)
+        # subprocess is still blocked
+        violations = scanner.scan("import subprocess")
+        assert len(violations) == 1
+        assert scanner.has_critical(violations)
+
+    def test_extra_blocked_modules_stack_with_defaults(self):
+        cfg = SecurityConfig(extra_blocked_modules=frozenset({"pickle"}))
+        scanner = CodeSecurityScanner(cfg)
+        # Both pickle (extra) and subprocess (default) should be blocked
+        violations = scanner.scan("import pickle\nimport subprocess")
+        assert len(violations) == 2
+        categories = {v.category for v in violations}
+        assert categories == {"dangerous_import"}
+
+
+# ===================================================================
+#  5. Severity override propagation
+# ===================================================================
+
+
+class TestSeverityOverrides:
+    """severity_overrides flow from SecurityConfig through to violations."""
+
+    def test_shell_access_downgraded_to_warning(self):
+        cfg = SecurityConfig(severity_overrides={"shell_access": "warning"})
+        scanner = CodeSecurityScanner(cfg)
+        violations = scanner.scan('os.system("cmd")')
+        assert len(violations) == 1
+        assert violations[0].category == "shell_access"
+        assert violations[0].severity == "warning"
+        assert not scanner.has_critical(violations)
+
+    def test_dangerous_builtin_downgraded_to_warning(self):
+        cfg = SecurityConfig(severity_overrides={"dangerous_builtin": "warning"})
+        scanner = CodeSecurityScanner(cfg)
+        violations = scanner.scan('eval("x")')
+        assert len(violations) == 1
+        assert violations[0].severity == "warning"
+        assert not scanner.has_critical(violations)
+
+    def test_dangerous_import_downgraded_to_warning(self):
+        cfg = SecurityConfig(severity_overrides={"dangerous_import": "warning"})
+        scanner = CodeSecurityScanner(cfg)
+        violations = scanner.scan("import subprocess")
+        assert len(violations) == 1
+        assert violations[0].severity == "warning"
+
+    def test_override_does_not_affect_other_categories(self):
+        cfg = SecurityConfig(severity_overrides={"shell_access": "warning"})
+        scanner = CodeSecurityScanner(cfg)
+        # dangerous_import is not overridden -- should stay critical
+        violations = scanner.scan("import subprocess")
+        assert violations[0].severity == "critical"
+
+    def test_sandbox_escape_is_not_overridable_via_severity_overrides(self):
+        # sandbox_escape violations are hardcoded to "critical" in _check_attribute
+        # and _check_name; they do not consult severity_overrides.
+        cfg = SecurityConfig(severity_overrides={"sandbox_escape": "warning"})
+        scanner = CodeSecurityScanner(cfg)
+        violations = scanner.scan("obj.__subclasses__()")
+        escape_violations = [v for v in violations if v.category == "sandbox_escape"]
+        assert len(escape_violations) >= 1
+        assert all(v.severity == "critical" for v in escape_violations)
+
+
+# ===================================================================
+#  6. Safe imports pass through cleanly
+# ===================================================================
+
+
+class TestSafeCodePassesCleanly:
+    """Safe bioinformatics code produces zero violations at any level."""
+
+    @pytest.fixture(params=[SecurityLevel.STRICT, SecurityLevel.STANDARD, SecurityLevel.PERMISSIVE])
+    def scanner(self, request) -> CodeSecurityScanner:
+        return _scanner_for(request.param)
+
+    def test_numpy_import(self, scanner: CodeSecurityScanner):
+        assert scanner.scan("import numpy as np") == []
+
+    def test_pandas_import(self, scanner: CodeSecurityScanner):
+        assert scanner.scan("import pandas as pd") == []
+
+    def test_scanpy_import(self, scanner: CodeSecurityScanner):
+        assert scanner.scan("import scanpy as sc") == []
+
+    def test_importlib_metadata(self, scanner: CodeSecurityScanner):
+        assert scanner.scan("from importlib.metadata import version") == []
+
+    def test_simple_math(self, scanner: CodeSecurityScanner):
+        assert scanner.scan("x = 1 + 2") == []
+
+    def test_function_definition(self, scanner: CodeSecurityScanner):
+        code = "def greet(name):\n    return f'Hello, {name}!'"
+        assert scanner.scan(code) == []
+
+    def test_list_comprehension(self, scanner: CodeSecurityScanner):
+        code = "squares = [x**2 for x in range(10)]"
+        assert scanner.scan(code) == []
+
+    def test_multiline_data_pipeline(self, scanner: CodeSecurityScanner):
+        code = (
+            "import numpy as np\n"
+            "import pandas as pd\n"
+            "import scanpy as sc\n"
+            "x = np.array([1, 2, 3])\n"
+            "df = pd.DataFrame({'a': x})\n"
+        )
+        assert scanner.scan(code) == []
+
+
+# ===================================================================
+#  7. Dunder assignment detection
+# ===================================================================
+
+
+class TestDunderAssignmentDetection:
+    """Dunder assignments produce warning-level violations."""
+
+    def test_builtins_assign_produces_warning(self):
+        scanner = CodeSecurityScanner()
+        violations = scanner.scan("__builtins__ = {}")
+        dunder_violations = [v for v in violations if v.category == "dunder_assign"]
+        assert len(dunder_violations) == 1
+        assert dunder_violations[0].severity == "warning"
+        assert "__builtins__" in dunder_violations[0].description
+
+    def test_builtins_assign_also_triggers_sandbox_escape(self):
+        # __builtins__ is both in BLOCKED_NAMES (sandbox_escape, critical)
+        # and detected as a dunder assignment (dunder_assign, warning).
+        scanner = CodeSecurityScanner()
+        violations = scanner.scan("__builtins__ = {}")
+        categories = {v.category for v in violations}
+        assert "sandbox_escape" in categories
+        assert "dunder_assign" in categories
+
+    def test_class_dunder_assign(self):
+        scanner = CodeSecurityScanner()
+        violations = scanner.scan("obj.__class__ = X")
+        dunder_violations = [v for v in violations if v.category == "dunder_assign"]
+        assert len(dunder_violations) == 1
+        assert dunder_violations[0].severity == "warning"
+        assert "__class__" in dunder_violations[0].description
+
+    def test_regular_assignment_no_dunder_violation(self):
+        scanner = CodeSecurityScanner()
+        violations = scanner.scan("x = 42")
+        dunder_violations = [v for v in violations if v.category == "dunder_assign"]
+        assert dunder_violations == []
+
+
+# ===================================================================
+#  8. Multi-violation report formatting
+# ===================================================================
+
+
+class TestMultiViolationReport:
+    """format_report produces correct human-readable output."""
+
+    def test_no_violations_message(self):
+        scanner = CodeSecurityScanner()
+        report = scanner.format_report([])
+        assert report == "No security issues detected."
+
+    def test_single_violation_report(self):
+        scanner = CodeSecurityScanner()
+        violations = scanner.scan('os.system("cmd")')
+        report = scanner.format_report(violations)
+        assert "1 issue(s)" in report
+        assert "[CRITICAL]" in report
+        assert "shell_access" in report
+
+    def test_multi_violation_report_structure(self):
+        scanner = CodeSecurityScanner()
+        code = "import subprocess\nos.system('ls')\neval('1+1')"
+        violations = scanner.scan(code)
+        report = scanner.format_report(violations)
+
+        assert "3 issue(s)" in report
+
+        lines = report.splitlines()
+        # Header + 3 violation lines
+        assert len(lines) == 4
+        assert lines[0].startswith("Security scan found")
+
+        # Each violation line should contain marker, line number, and category
+        for line in lines[1:]:
+            assert "[CRITICAL]" in line or "[WARNING]" in line
+            assert "Line " in line
+
+    def test_mixed_severity_report(self):
+        # STANDARD: file_danger is warning, rest are critical
+        scanner = _scanner_for(SecurityLevel.STANDARD)
+        code = "os.system('ls')\nshutil.rmtree('/tmp')"
+        violations = scanner.scan(code)
+        report = scanner.format_report(violations)
+
+        assert "[CRITICAL]" in report
+        assert "[WARNING]" in report
+
+    def test_report_lines_ordered_by_source_line(self):
+        scanner = CodeSecurityScanner()
+        code = "eval('a')\nos.system('b')\nimport subprocess"
+        violations = scanner.scan(code)
+        report = scanner.format_report(violations)
+        lines = report.splitlines()[1:]  # skip header
+
+        # Extract line numbers from report lines
+        line_numbers = []
+        for line in lines:
+            # Format: "  [CRITICAL] Line N: ..."
+            after_line = line.split("Line ")[1]
+            num = int(after_line.split(":")[0])
+            line_numbers.append(num)
+
+        assert line_numbers == sorted(line_numbers)

--- a/tests/utils/test_integration_subagent_isolation.py
+++ b/tests/utils/test_integration_subagent_isolation.py
@@ -1,0 +1,616 @@
+"""Integration tests: subagent isolation boundaries.
+
+Validates that SubagentController's isolation guarantees hold at the
+integration level.  Each test class targets a specific isolation boundary
+documented in the SubagentRuntime / SubagentController docstrings:
+
+- Usage tracking isolation (parent vs. subagent ``last_usage``)
+- Tool schema snapshotting (frozen at creation, not live)
+- Permission policy enforcement (denied tools never reach dispatch)
+- adata mutation gating (``can_mutate_adata`` flag)
+- Budget manager isolation (subagent-local, not shared)
+- Max turns enforcement (subagent exits after ``max_turns``)
+
+Uses the shared harness fixtures from ``tests.integration`` and
+requires the ``OV_AGENT_RUN_HARNESS_TESTS=1`` environment gate.
+"""
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+from typing import Any, Dict, FrozenSet, List, Optional, Set
+
+import pytest
+
+_RUN_HARNESS = os.environ.get("OV_AGENT_RUN_HARNESS_TESTS", "").lower() in {
+    "1", "true", "yes", "on",
+}
+pytestmark = pytest.mark.skipif(
+    not _RUN_HARNESS,
+    reason="Subagent isolation integration tests require OV_AGENT_RUN_HARNESS_TESTS=1.",
+)
+
+# -- harness imports ----------------------------------------------------------
+from tests.integration.fakes import (
+    ChatResponse,
+    FakeLLM,
+    FakeToolRegistry,
+    ToolCall,
+    Usage,
+)
+from tests.integration.helpers import (
+    build_fake_llm,
+    make_chat_response,
+    make_tool_call,
+    make_usage,
+)
+
+# -- production imports -------------------------------------------------------
+from omicverse.utils.agent_config import AgentConfig, SubagentConfig
+from omicverse.utils.ovagent.context_budget import ContextBudgetManager
+from omicverse.utils.ovagent.permission_policy import (
+    PermissionDecision,
+    PermissionVerdict,
+)
+from omicverse.utils.ovagent.subagent_controller import (
+    SubagentController,
+    SubagentRuntime,
+)
+from omicverse.utils.ovagent.tool_registry import (
+    ApprovalClass,
+    IsolationMode,
+    OutputTier,
+)
+
+
+# ===================================================================
+#  Test doubles — minimal fakes scoped to SubagentController needs
+# ===================================================================
+
+
+class FakeAgentContext:
+    """Minimal AgentContext protocol implementation for SubagentController.
+
+    Exposes the exact surface that ``SubagentController.__init__`` and
+    ``run_subagent`` touch: ``_llm``, ``_config``, ``model``,
+    ``last_usage``, and ``_get_visible_agent_tools``.
+    """
+
+    def __init__(
+        self,
+        llm: FakeLLM,
+        config: AgentConfig,
+        tool_schemas: Optional[List[Dict[str, Any]]] = None,
+    ) -> None:
+        self._llm = llm
+        self._config = config
+        self.model = "fake-model"
+        self.last_usage: Any = None
+        self._tool_schemas = tool_schemas or []
+
+    def _get_visible_agent_tools(
+        self, *, allowed_names: Optional[Set[str]] = None
+    ) -> List[Dict[str, Any]]:
+        if allowed_names:
+            return [s for s in self._tool_schemas if s.get("name") in allowed_names]
+        return list(self._tool_schemas)
+
+
+class FakePromptBuilder:
+    """Minimal PromptBuilder that returns static strings."""
+
+    def build_subagent_system_prompt(self, agent_type: str, context: str) -> str:
+        return f"You are a {agent_type} subagent."
+
+    def build_subagent_user_message(self, task: str, adata: Any) -> str:
+        return f"Task: {task}"
+
+
+class FakeSubagentToolRuntime:
+    """Fake tool runtime with ``dispatch_tool`` matching the real interface.
+
+    The SubagentController calls ``self._tool_runtime.dispatch_tool(tc,
+    working_adata, task, permission_policy=...)``, and also accesses
+    ``self._tool_runtime.registry``.  This fake satisfies both.
+
+    Parameters
+    ----------
+    handlers : dict
+        Mapping of tool name to a callable ``(tool_call, adata, task) -> Any``.
+    registry_tools : dict
+        Tool name -> dict of attributes for ``FakeToolRegistry.get()`` results.
+        Must include ``output_tier`` for the budget-manager truncation path.
+    """
+
+    # Default attributes that PermissionPolicy.check() accesses on
+    # registry.get() results (steps 4-5 in the resolution chain).
+    _REGISTRY_DEFAULTS: Dict[str, Any] = {
+        "approval_class": ApprovalClass.allow,
+        "isolation_mode": IsolationMode.none,
+        "output_tier": OutputTier.standard,
+    }
+
+    def __init__(
+        self,
+        handlers: Optional[Dict[str, Any]] = None,
+        registry_tools: Optional[Dict[str, Dict[str, Any]]] = None,
+    ) -> None:
+        self._handlers = dict(handlers or {})
+        # Ensure every registry entry has the attributes PermissionPolicy needs.
+        enriched: Dict[str, Dict[str, Any]] = {}
+        for name, attrs in (registry_tools or {}).items():
+            merged = dict(self._REGISTRY_DEFAULTS)
+            merged.update(attrs)
+            enriched[name] = merged
+        self.registry = FakeToolRegistry(enriched)
+        self.dispatch_calls: List[Dict[str, Any]] = []
+
+    async def dispatch_tool(
+        self,
+        tool_call: Any,
+        current_adata: Any,
+        request: str,
+        *,
+        permission_policy: Any = None,
+    ) -> Any:
+        self.dispatch_calls.append({
+            "name": tool_call.name,
+            "arguments": tool_call.arguments,
+            "adata": current_adata,
+            "request": request,
+        })
+        handler = self._handlers.get(tool_call.name)
+        if handler is None:
+            return f"[FakeSubagentToolRuntime] unknown tool: {tool_call.name}"
+        return handler(tool_call, current_adata, request)
+
+
+# -- helper builders ----------------------------------------------------------
+
+
+def _make_tool_schema(name: str, description: str = "") -> Dict[str, Any]:
+    """Build a minimal tool-schema dict."""
+    return {
+        "name": name,
+        "description": description or f"{name} tool",
+        "parameters": {"type": "object", "properties": {}, "required": []},
+    }
+
+
+def _build_controller(
+    llm: FakeLLM,
+    tool_runtime: FakeSubagentToolRuntime,
+    tool_schemas: Optional[List[Dict[str, Any]]] = None,
+    config: Optional[AgentConfig] = None,
+) -> SubagentController:
+    """Wire up a SubagentController with all test doubles."""
+    cfg = config or AgentConfig()
+    ctx = FakeAgentContext(llm, cfg, tool_schemas=tool_schemas or [])
+    prompt_builder = FakePromptBuilder()
+    return SubagentController(ctx, prompt_builder, tool_runtime)
+
+
+# ===================================================================
+#  Test: usage tracking isolation
+# ===================================================================
+
+
+class TestSubagentUsageIsolation:
+    """Parent ``last_usage`` must NOT be mutated by a subagent run."""
+
+    @pytest.mark.asyncio
+    async def test_parent_usage_untouched_by_subagent(self):
+        """Run a subagent that records usage; verify parent is unmodified."""
+        parent_usage = make_usage(100, 200, model="parent-model")
+
+        # LLM returns a plain text response (no tool calls -> single turn)
+        subagent_usage = make_usage(5, 10, model="fake-model")
+        llm = build_fake_llm([
+            make_chat_response(content="Subagent done.", usage=subagent_usage),
+        ])
+
+        tool_runtime = FakeSubagentToolRuntime()
+        cfg = AgentConfig()
+        ctx = FakeAgentContext(llm, cfg)
+        ctx.last_usage = parent_usage  # set parent's usage
+
+        controller = SubagentController(ctx, FakePromptBuilder(), tool_runtime)
+
+        result = await controller.run_subagent(
+            agent_type="explore",
+            task="Look at the data",
+            adata=None,
+        )
+
+        # Parent usage must remain the original object, untouched
+        assert ctx.last_usage is parent_usage
+        assert ctx.last_usage.input_tokens == 100
+        assert ctx.last_usage.output_tokens == 200
+
+        # Returned usage comes from the subagent runtime
+        assert result["last_usage"] is subagent_usage
+        assert result["last_usage"].input_tokens == 5
+
+    @pytest.mark.asyncio
+    async def test_subagent_usage_returned_in_result(self):
+        """Verify the result dict carries the subagent's last_usage."""
+        usage_turn1 = make_usage(1, 2)
+        usage_turn2 = make_usage(3, 4)
+
+        tc = make_tool_call("inspect_data", {"aspect": "shape"})
+        llm = build_fake_llm([
+            make_chat_response(tool_calls=[tc], usage=usage_turn1),
+            make_chat_response(content="Done.", usage=usage_turn2),
+        ])
+
+        tool_runtime = FakeSubagentToolRuntime(
+            handlers={"inspect_data": lambda tc, ad, req: "shape: (100, 5)"},
+            registry_tools={"inspect_data": {"output_tier": OutputTier.standard}},
+        )
+        schemas = [_make_tool_schema("inspect_data"), _make_tool_schema("finish")]
+        controller = _build_controller(llm, tool_runtime, tool_schemas=schemas)
+
+        result = await controller.run_subagent(
+            agent_type="explore", task="inspect", adata=None,
+        )
+
+        # last_usage should be from the final LLM turn
+        assert result["last_usage"] is usage_turn2
+
+
+# ===================================================================
+#  Test: tool schema snapshotting
+# ===================================================================
+
+
+class TestSubagentToolSchemaSnapshot:
+    """Subagent tool schemas are frozen at creation time."""
+
+    @pytest.mark.asyncio
+    async def test_schema_snapshot_isolated_from_parent_mutations(self):
+        """Mutating parent schemas after subagent creation has no effect."""
+        schema_a = _make_tool_schema("inspect_data")
+        schema_b = _make_tool_schema("finish")
+        parent_schemas = [schema_a, schema_b]
+
+        llm = build_fake_llm([
+            make_chat_response(content="Done."),
+        ])
+
+        tool_runtime = FakeSubagentToolRuntime()
+        cfg = AgentConfig()
+        ctx = FakeAgentContext(llm, cfg, tool_schemas=parent_schemas)
+        prompt_builder = FakePromptBuilder()
+        controller = SubagentController(ctx, prompt_builder, tool_runtime)
+
+        # Create a runtime directly to inspect the snapshot
+        explore_config = cfg.get_subagent_config("explore")
+        runtime = controller._create_subagent_runtime(
+            agent_type="explore",
+            allowed_tools=frozenset(explore_config.allowed_tools),
+            max_turns=explore_config.max_turns,
+        )
+
+        # Snapshot should contain both schemas (they are in explore's allowed list)
+        snapshot_names = {s["name"] for s in runtime.tool_schemas}
+        assert "inspect_data" in snapshot_names
+        assert "finish" in snapshot_names
+        original_count = len(runtime.tool_schemas)
+
+        # Now mutate the parent's schemas
+        ctx._tool_schemas.append(_make_tool_schema("execute_code"))
+        ctx._tool_schemas.append(_make_tool_schema("new_tool"))
+
+        # Subagent snapshot is unaffected
+        assert len(runtime.tool_schemas) == original_count
+        snapshot_names_after = {s["name"] for s in runtime.tool_schemas}
+        assert "execute_code" not in snapshot_names_after
+        assert "new_tool" not in snapshot_names_after
+
+
+# ===================================================================
+#  Test: permission policy enforcement
+# ===================================================================
+
+
+class TestSubagentPermissionEnforcement:
+    """Subagent tool calls outside the allowed set must be denied."""
+
+    @pytest.mark.asyncio
+    async def test_denied_tool_never_reaches_dispatch(self):
+        """A tool NOT in the allowed set produces a denial message."""
+        # explore subagent allows: inspect_data, run_snippet, search_functions,
+        # web_fetch, web_search, finish — but NOT execute_code.
+        tc_denied = make_tool_call("execute_code", {"code": "import os"})
+        llm = build_fake_llm([
+            # Turn 1: LLM requests a denied tool
+            make_chat_response(tool_calls=[tc_denied]),
+            # Turn 2: LLM gives up after denial
+            make_chat_response(content="Cannot execute code."),
+        ])
+
+        tool_runtime = FakeSubagentToolRuntime(
+            handlers={"execute_code": lambda tc, ad, req: "should not run"},
+            registry_tools={"execute_code": {"output_tier": OutputTier.verbose}},
+        )
+        schemas = [
+            _make_tool_schema("inspect_data"),
+            _make_tool_schema("finish"),
+            _make_tool_schema("execute_code"),
+        ]
+        controller = _build_controller(llm, tool_runtime, tool_schemas=schemas)
+
+        result = await controller.run_subagent(
+            agent_type="explore", task="explore the data", adata=None,
+        )
+
+        # dispatch_tool should NEVER have been called
+        assert len(tool_runtime.dispatch_calls) == 0
+
+        # The denial message should appear in the conversation
+        # (check LLM's recorded chat calls for the tool result message)
+        all_messages = []
+        for call in llm.chat_calls:
+            all_messages.extend(call["messages"])
+
+        denial_messages = [
+            m for m in all_messages
+            if m.get("role") == "tool" and "Permission denied" in m.get("content", "")
+        ]
+        assert len(denial_messages) >= 1
+        assert "execute_code" in denial_messages[0]["content"]
+
+    @pytest.mark.asyncio
+    async def test_allowed_tool_passes_through(self):
+        """A tool IN the allowed set reaches dispatch normally."""
+        tc_allowed = make_tool_call("inspect_data", {"aspect": "shape"})
+        llm = build_fake_llm([
+            make_chat_response(tool_calls=[tc_allowed]),
+            make_chat_response(content="Data has 100 rows."),
+        ])
+
+        tool_runtime = FakeSubagentToolRuntime(
+            handlers={"inspect_data": lambda tc, ad, req: "shape: (100, 5)"},
+            registry_tools={"inspect_data": {"output_tier": OutputTier.standard}},
+        )
+        schemas = [_make_tool_schema("inspect_data"), _make_tool_schema("finish")]
+        controller = _build_controller(llm, tool_runtime, tool_schemas=schemas)
+
+        result = await controller.run_subagent(
+            agent_type="explore", task="inspect", adata=None,
+        )
+
+        # dispatch_tool SHOULD have been called for the allowed tool
+        assert len(tool_runtime.dispatch_calls) == 1
+        assert tool_runtime.dispatch_calls[0]["name"] == "inspect_data"
+
+
+# ===================================================================
+#  Test: adata mutation gating
+# ===================================================================
+
+
+class TestSubagentAdataMutationGating:
+    """adata updates are gated by ``can_mutate_adata``."""
+
+    @pytest.mark.asyncio
+    async def test_mutation_blocked_when_flag_is_false(self):
+        """With can_mutate_adata=False, original adata is preserved."""
+        original_adata = SimpleNamespace(shape=(100, 5), tag="original")
+        new_adata = SimpleNamespace(shape=(200, 10), tag="new")
+
+        tc = make_tool_call("execute_code", {"code": "adata = transform(adata)"})
+        llm = build_fake_llm([
+            make_chat_response(tool_calls=[tc]),
+            make_chat_response(content="Done."),
+        ])
+
+        def _execute_code_handler(tool_call, adata, request):
+            return {"adata": new_adata, "output": "Transformed."}
+
+        tool_runtime = FakeSubagentToolRuntime(
+            handlers={"execute_code": _execute_code_handler},
+            registry_tools={"execute_code": {"output_tier": OutputTier.verbose}},
+        )
+
+        # Use "explore" which has can_mutate_adata=False
+        schemas = [_make_tool_schema("execute_code"), _make_tool_schema("finish")]
+        # Override explore to include execute_code for this test
+        cfg = AgentConfig(subagent_overrides={
+            "explore": {"allowed_tools": ["execute_code", "inspect_data", "finish"]},
+        })
+        ctx = FakeAgentContext(llm, cfg, tool_schemas=schemas)
+        controller = SubagentController(ctx, FakePromptBuilder(), tool_runtime)
+
+        result = await controller.run_subagent(
+            agent_type="explore", task="explore", adata=original_adata,
+        )
+
+        # explore has can_mutate_adata=False -> original adata returned
+        assert result["adata"] is original_adata
+        assert result["adata"].tag == "original"
+
+    @pytest.mark.asyncio
+    async def test_mutation_allowed_when_flag_is_true(self):
+        """With can_mutate_adata=True, adata is updated from execute_code."""
+        original_adata = SimpleNamespace(shape=(100, 5), tag="original")
+        new_adata = SimpleNamespace(shape=(200, 10), tag="new")
+
+        tc = make_tool_call("execute_code", {"code": "adata = transform(adata)"})
+        llm = build_fake_llm([
+            make_chat_response(tool_calls=[tc]),
+            make_chat_response(content="Done."),
+        ])
+
+        def _execute_code_handler(tool_call, adata, request):
+            return {"adata": new_adata, "output": "Transformed."}
+
+        tool_runtime = FakeSubagentToolRuntime(
+            handlers={"execute_code": _execute_code_handler},
+            registry_tools={"execute_code": {"output_tier": OutputTier.verbose}},
+        )
+
+        # "execute" subagent has can_mutate_adata=True
+        schemas = [_make_tool_schema("execute_code"), _make_tool_schema("finish")]
+        cfg = AgentConfig()
+        ctx = FakeAgentContext(llm, cfg, tool_schemas=schemas)
+        controller = SubagentController(ctx, FakePromptBuilder(), tool_runtime)
+
+        result = await controller.run_subagent(
+            agent_type="execute", task="run code", adata=original_adata,
+        )
+
+        # execute has can_mutate_adata=True -> new adata returned
+        assert result["adata"] is new_adata
+        assert result["adata"].tag == "new"
+
+
+# ===================================================================
+#  Test: budget manager isolation
+# ===================================================================
+
+
+class TestSubagentBudgetManagerIsolation:
+    """Each subagent runtime gets its own budget manager."""
+
+    @pytest.mark.asyncio
+    async def test_each_runtime_gets_own_budget_manager(self):
+        """Two runtimes created from the same controller have distinct managers."""
+        llm = build_fake_llm([])
+        tool_runtime = FakeSubagentToolRuntime()
+        cfg = AgentConfig()
+        ctx = FakeAgentContext(llm, cfg)
+        controller = SubagentController(ctx, FakePromptBuilder(), tool_runtime)
+
+        explore_config = cfg.get_subagent_config("explore")
+        runtime_a = controller._create_subagent_runtime(
+            agent_type="explore",
+            allowed_tools=frozenset(explore_config.allowed_tools),
+            max_turns=explore_config.max_turns,
+        )
+        runtime_b = controller._create_subagent_runtime(
+            agent_type="explore",
+            allowed_tools=frozenset(explore_config.allowed_tools),
+            max_turns=explore_config.max_turns,
+        )
+
+        # Distinct instances
+        assert runtime_a.budget_manager is not runtime_b.budget_manager
+        assert isinstance(runtime_a.budget_manager, ContextBudgetManager)
+        assert isinstance(runtime_b.budget_manager, ContextBudgetManager)
+
+    @pytest.mark.asyncio
+    async def test_budget_manager_uses_subagent_tier_policies(self):
+        """Subagent budget managers use tighter truncation policies."""
+        llm = build_fake_llm([])
+        tool_runtime = FakeSubagentToolRuntime()
+        cfg = AgentConfig()
+        ctx = FakeAgentContext(llm, cfg)
+        controller = SubagentController(ctx, FakePromptBuilder(), tool_runtime)
+
+        explore_config = cfg.get_subagent_config("explore")
+        runtime = controller._create_subagent_runtime(
+            agent_type="explore",
+            allowed_tools=frozenset(explore_config.allowed_tools),
+            max_turns=explore_config.max_turns,
+        )
+
+        # Subagent policies have max_tokens=300/1200/1800 vs default 500/2000/3000
+        policies = runtime.budget_manager.tier_policies
+        assert policies[OutputTier.minimal].max_tokens < 500
+        assert policies[OutputTier.standard].max_tokens < 2000
+        assert policies[OutputTier.verbose].max_tokens < 3000
+
+
+# ===================================================================
+#  Test: max turns enforcement
+# ===================================================================
+
+
+class TestSubagentMaxTurns:
+    """Subagent must stop after ``max_turns`` even if LLM keeps calling tools."""
+
+    @pytest.mark.asyncio
+    async def test_stops_after_max_turns(self):
+        """With max_turns=2, subagent exits after 2 LLM turns."""
+        # Every response requests a tool call -> subagent never finishes naturally
+        tc = make_tool_call("inspect_data", {"aspect": "shape"})
+        llm = build_fake_llm([
+            make_chat_response(tool_calls=[tc]),  # turn 1
+            make_chat_response(tool_calls=[tc]),  # turn 2
+            # turn 3 would happen, but max_turns=2 stops it
+            make_chat_response(content="Should never reach here."),
+        ])
+
+        tool_runtime = FakeSubagentToolRuntime(
+            handlers={"inspect_data": lambda tc, ad, req: "shape: (100, 5)"},
+            registry_tools={"inspect_data": {"output_tier": OutputTier.standard}},
+        )
+        schemas = [_make_tool_schema("inspect_data"), _make_tool_schema("finish")]
+
+        # Override explore to have max_turns=2
+        cfg = AgentConfig(subagent_overrides={
+            "explore": {"max_turns": 2},
+        })
+        ctx = FakeAgentContext(llm, cfg, tool_schemas=schemas)
+        controller = SubagentController(ctx, FakePromptBuilder(), tool_runtime)
+
+        result = await controller.run_subagent(
+            agent_type="explore", task="keep inspecting", adata=None,
+        )
+
+        # Result should contain the timeout message
+        assert "max turns" in result["result"].lower() or "reached max turns" in result["result"].lower()
+
+        # LLM should have been called exactly 2 times (max_turns=2)
+        assert len(llm.chat_calls) == 2
+
+    @pytest.mark.asyncio
+    async def test_finishes_early_when_no_tool_calls(self):
+        """Subagent returns before max_turns if LLM produces no tool calls."""
+        llm = build_fake_llm([
+            make_chat_response(content="All done, no tools needed."),
+        ])
+
+        tool_runtime = FakeSubagentToolRuntime()
+        schemas = [_make_tool_schema("inspect_data"), _make_tool_schema("finish")]
+        cfg = AgentConfig(subagent_overrides={"explore": {"max_turns": 10}})
+        ctx = FakeAgentContext(llm, cfg, tool_schemas=schemas)
+        controller = SubagentController(ctx, FakePromptBuilder(), tool_runtime)
+
+        result = await controller.run_subagent(
+            agent_type="explore", task="quick check", adata=None,
+        )
+
+        assert result["result"] == "All done, no tools needed."
+        assert len(llm.chat_calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_finish_tool_exits_early(self):
+        """The ``finish`` tool causes immediate return before max_turns."""
+        tc_finish = make_tool_call("finish", {"summary": "Exploration complete."})
+        llm = build_fake_llm([
+            make_chat_response(tool_calls=[tc_finish]),
+            # This should never be consumed
+            make_chat_response(content="Unreachable."),
+        ])
+
+        def _finish_handler(tool_call, adata, request):
+            return {"summary": tool_call.arguments.get("summary", "")}
+
+        tool_runtime = FakeSubagentToolRuntime(
+            handlers={"finish": _finish_handler},
+            registry_tools={"finish": {"output_tier": OutputTier.minimal}},
+        )
+        schemas = [_make_tool_schema("inspect_data"), _make_tool_schema("finish")]
+        controller = _build_controller(llm, tool_runtime, tool_schemas=schemas)
+
+        result = await controller.run_subagent(
+            agent_type="explore", task="explore", adata=None,
+        )
+
+        assert result["result"] == "Exploration complete."
+        # Only 1 LLM call consumed (finish exits the loop)
+        assert len(llm.chat_calls) == 1
+        # Second response is still unconsumed
+        assert llm.remaining_responses == 1

--- a/tests/utils/test_ovagent_auth.py
+++ b/tests/utils/test_ovagent_auth.py
@@ -184,6 +184,38 @@ class TestTemporaryApiKeys:
 
         assert os.environ["__OV_TEST_KEY__"] == "original"
 
+    def test_cleanup_on_exception_during_yield(self, monkeypatch):
+        """Keys are cleaned up even when the with-block raises."""
+        monkeypatch.delenv("__OV_TEST_KEY__", raising=False)
+        mapping = {"__OV_TEST_KEY__": "secret-value"}
+
+        with pytest.raises(RuntimeError):
+            with temporary_api_keys(mapping):
+                assert os.environ["__OV_TEST_KEY__"] == "secret-value"
+                raise RuntimeError("inner error")
+
+        assert "__OV_TEST_KEY__" not in os.environ
+
+    def test_exposure_window_bounded_by_context(self, monkeypatch):
+        """Keys are only visible inside the with-block, not after."""
+        monkeypatch.delenv("__OV_TEST_KEY__", raising=False)
+        mapping = {"__OV_TEST_KEY__": "visible-during-context"}
+
+        visible_inside = None
+        with temporary_api_keys(mapping):
+            visible_inside = os.environ.get("__OV_TEST_KEY__")
+        visible_after = os.environ.get("__OV_TEST_KEY__")
+
+        assert visible_inside == "visible-during-context"
+        assert visible_after is None
+
+    def test_docstring_documents_exposure_tradeoff(self):
+        """The docstring explicitly documents the environment-exposure tradeoff."""
+        doc = temporary_api_keys.__doc__ or ""
+        assert "exposure" in doc.lower()
+        assert "tradeoff" in doc.lower() or "trade-off" in doc.lower()
+        assert "finally" in doc.lower()
+
 
 # ===================================================================
 # Moved helper functions
@@ -510,6 +542,6 @@ class TestAgentFactory:
         import inspect
         Agent = smart_agent_module.Agent
         sig = inspect.signature(Agent)
-        # The thin wrapper uses *args, **kwargs
         params = list(sig.parameters.keys())
-        assert "args" in params or "kwargs" in params
+        # After task-033, Agent() mirrors the explicit OmicVerseAgent.__init__ signature
+        assert "model" in params

--- a/tests/utils/test_ovagent_auth.py
+++ b/tests/utils/test_ovagent_auth.py
@@ -66,6 +66,7 @@ from omicverse.utils.ovagent.auth import (
     _normalize_model_for_routing,
     _is_custom_openai_endpoint,
     _looks_like_openai_endpoint,
+    _endpoint_has_hostname,
     _extract_openai_codex_account_id,
     _resolve_saved_provider_api_key,
     OPENAI_CODEX_DEFAULT_MODEL,
@@ -269,6 +270,96 @@ class TestEndpointHelpers:
         assert _looks_like_openai_endpoint("https://api.openai.com/v1") is True
         assert _looks_like_openai_endpoint(None) is False
         assert _looks_like_openai_endpoint("https://my-proxy.com/v1") is False
+
+
+# ===================================================================
+# Hostname validation hardening (CodeQL spoofed-host regression)
+# ===================================================================
+
+class TestEndpointHostnameValidation:
+    """Regression tests for parsed hostname validation.
+
+    Ensures that endpoint trust checks use parsed hostname comparison
+    instead of substring containment, so spoofed hosts like
+    ``api.openai.com.attacker.com`` are rejected.
+    """
+
+    # --- _endpoint_has_hostname helper ---
+
+    def test_endpoint_has_hostname_exact_match(self):
+        assert _endpoint_has_hostname("https://api.openai.com/v1", "api.openai.com") is True
+
+    def test_endpoint_has_hostname_rejects_subdomain_spoof(self):
+        assert _endpoint_has_hostname("https://api.openai.com.attacker.com/v1", "api.openai.com") is False
+
+    def test_endpoint_has_hostname_none_input(self):
+        assert _endpoint_has_hostname(None, "api.openai.com") is False
+
+    def test_endpoint_has_hostname_empty_string(self):
+        assert _endpoint_has_hostname("", "api.openai.com") is False
+
+    # --- _looks_like_openai_endpoint: trusted hosts ---
+
+    def test_openai_trusted_api_endpoint(self):
+        assert _looks_like_openai_endpoint("https://api.openai.com/v1") is True
+
+    def test_openai_trusted_api_endpoint_subpath(self):
+        assert _looks_like_openai_endpoint("https://api.openai.com/v2/chat") is True
+
+    def test_openai_trusted_chatgpt_backend(self):
+        assert _looks_like_openai_endpoint("https://chatgpt.com/backend-api") is True
+
+    def test_openai_trusted_chatgpt_backend_subpath(self):
+        assert _looks_like_openai_endpoint("https://chatgpt.com/backend-api/v1/completions") is True
+
+    def test_openai_legacy_codex_endpoint(self):
+        assert _looks_like_openai_endpoint(_LEGACY_OPENAI_CODEX_BASE_URL) is True
+
+    # --- _looks_like_openai_endpoint: spoofed hosts MUST be rejected ---
+
+    def test_openai_rejects_attacker_subdomain_spoof(self):
+        assert _looks_like_openai_endpoint("https://api.openai.com.attacker.com/v1") is False
+
+    def test_openai_rejects_chatgpt_subdomain_spoof(self):
+        assert _looks_like_openai_endpoint("https://chatgpt.com.attacker.com/backend-api") is False
+
+    def test_openai_rejects_path_injection(self):
+        assert _looks_like_openai_endpoint("https://evil.com/api.openai.com") is False
+
+    def test_openai_rejects_chatgpt_wrong_path(self):
+        """chatgpt.com host but without /backend-api path is not an OpenAI endpoint."""
+        assert _looks_like_openai_endpoint("https://chatgpt.com/other-path") is False
+
+    # --- Gemini hostname validation in _resolve_gemini_cli_oauth ---
+
+    @patch("omicverse.utils.ovagent.auth.GeminiCliOAuthManager")
+    def test_gemini_oauth_rewrites_standard_gemini_endpoint(self, mock_mgr_cls):
+        """Standard generativelanguage.googleapis.com endpoint is rewritten."""
+        mock_mgr = MagicMock()
+        mock_mgr.build_api_key_payload.return_value = "token"
+        mock_mgr_cls.return_value = mock_mgr
+
+        _, _, endpoint, _ = _resolve_gemini_cli_oauth(
+            "gemini-2.5-pro",
+            "https://generativelanguage.googleapis.com/v1beta",
+            None,
+        )
+        assert endpoint != "https://generativelanguage.googleapis.com/v1beta"
+
+    @patch("omicverse.utils.ovagent.auth.GeminiCliOAuthManager")
+    def test_gemini_oauth_rejects_spoofed_gemini_host(self, mock_mgr_cls):
+        """Spoofed generativelanguage.googleapis.com.attacker.com must NOT be rewritten."""
+        mock_mgr = MagicMock()
+        mock_mgr.build_api_key_payload.return_value = "token"
+        mock_mgr_cls.return_value = mock_mgr
+
+        spoofed = "https://generativelanguage.googleapis.com.attacker.com/v1beta"
+        _, _, endpoint, _ = _resolve_gemini_cli_oauth(
+            "gemini-2.5-pro", spoofed, None,
+        )
+        # The spoofed URL must be preserved (not rewritten), since it doesn't
+        # match any trusted hostname.
+        assert endpoint == spoofed
 
 
 # ===================================================================

--- a/tests/utils/test_ovagent_auth.py
+++ b/tests/utils/test_ovagent_auth.py
@@ -56,7 +56,22 @@ from omicverse.utils.ovagent.auth import (
     collect_api_key_env,
     temporary_api_keys,
     display_backend_info,
+    resolve_credentials,
+    _resolve_gemini_cli_oauth,
+    _resolve_openai_oauth,
+    _resolve_saved_openai_key,
+    _normalize_auth_mode,
+    _is_openai_oauth_supported_model,
+    _is_explicit_openai_oauth_model,
+    _normalize_model_for_routing,
+    _is_custom_openai_endpoint,
+    _looks_like_openai_endpoint,
+    _extract_openai_codex_account_id,
+    _resolve_saved_provider_api_key,
+    OPENAI_CODEX_DEFAULT_MODEL,
+    _LEGACY_OPENAI_CODEX_BASE_URL,
 )
+from unittest.mock import patch, MagicMock
 
 for name, module in _ORIGINAL_MODULES.items():
     if module is None:
@@ -168,3 +183,333 @@ class TestTemporaryApiKeys:
             assert os.environ["__OV_TEST_KEY__"] == "temporary"
 
         assert os.environ["__OV_TEST_KEY__"] == "original"
+
+
+# ===================================================================
+# Moved helper functions
+# ===================================================================
+
+class TestNormalizeAuthMode:
+
+    def test_environment_default(self):
+        assert _normalize_auth_mode(None) == "environment"
+        assert _normalize_auth_mode("environment") == "environment"
+
+    def test_openai_api_key_alias(self):
+        assert _normalize_auth_mode("openai_api_key") == "saved_api_key"
+
+    def test_openai_codex_alias(self):
+        assert _normalize_auth_mode("openai_codex") == "openai_oauth"
+
+    def test_google_oauth_passthrough(self):
+        assert _normalize_auth_mode("google_oauth") == "google_oauth"
+        assert _normalize_auth_mode("gemini_cli_oauth") == "gemini_cli_oauth"
+
+
+class TestOpenAIOAuthModelHelpers:
+
+    def test_supported_model_recognized(self):
+        assert _is_openai_oauth_supported_model("gpt-5.3-codex") is True
+        assert _is_openai_oauth_supported_model("gpt-5.2") is True
+
+    def test_unsupported_model_rejected(self):
+        assert _is_openai_oauth_supported_model("claude-3-opus") is False
+
+    def test_explicit_oauth_model_codex_only(self):
+        assert _is_explicit_openai_oauth_model("gpt-5.3-codex") is True
+        assert _is_explicit_openai_oauth_model("gpt-5.2") is False
+
+    def test_case_insensitive(self):
+        assert _is_openai_oauth_supported_model("GPT-5.3-CODEX") is True
+        assert _is_explicit_openai_oauth_model("GPT-5.3-CODEX") is True
+
+
+class TestEndpointHelpers:
+
+    def test_custom_endpoint_detected(self):
+        assert _is_custom_openai_endpoint("https://my-proxy.com/v1") is True
+
+    def test_standard_endpoints_not_custom(self):
+        assert _is_custom_openai_endpoint(_LEGACY_OPENAI_CODEX_BASE_URL) is False
+        assert _is_custom_openai_endpoint(None) is False
+
+    def test_looks_like_openai_endpoint(self):
+        assert _looks_like_openai_endpoint("https://api.openai.com/v1") is True
+        assert _looks_like_openai_endpoint(None) is False
+        assert _looks_like_openai_endpoint("https://my-proxy.com/v1") is False
+
+
+# ===================================================================
+# _resolve_gemini_cli_oauth
+# ===================================================================
+
+class TestResolveGeminiCliOAuth:
+
+    @patch("omicverse.utils.ovagent.auth.GeminiCliOAuthManager")
+    def test_success_returns_credential_tuple(self, mock_mgr_cls):
+        mock_mgr = MagicMock()
+        mock_mgr.build_api_key_payload.return_value = "gemini-token-123"
+        mock_mgr_cls.return_value = mock_mgr
+
+        model, api_key, endpoint, auth_mode = _resolve_gemini_cli_oauth(
+            "gemini-2.5-pro", None, None
+        )
+        assert model == "gemini-2.5-pro"
+        assert api_key == "gemini-token-123"
+        assert auth_mode == "gemini_cli_oauth"
+        # Endpoint should be set to the Google Code Assist endpoint
+        assert endpoint is not None
+
+    @patch("omicverse.utils.ovagent.auth.GeminiCliOAuthManager")
+    def test_empty_payload_raises(self, mock_mgr_cls):
+        mock_mgr = MagicMock()
+        mock_mgr.build_api_key_payload.return_value = None
+        mock_mgr_cls.return_value = mock_mgr
+
+        with pytest.raises(ValueError, match="No saved Gemini CLI OAuth"):
+            _resolve_gemini_cli_oauth("gemini-2.5-pro", None, None)
+
+    @patch("omicverse.utils.ovagent.auth.GeminiCliOAuthManager")
+    def test_oauth_error_raises_valueerror(self, mock_mgr_cls):
+        from omicverse.jarvis.gemini_cli_oauth import GeminiCliOAuthError
+
+        mock_mgr = MagicMock()
+        mock_mgr.build_api_key_payload.side_effect = GeminiCliOAuthError("fail")
+        mock_mgr_cls.return_value = mock_mgr
+
+        with pytest.raises(ValueError, match="Failed to load saved Gemini CLI OAuth"):
+            _resolve_gemini_cli_oauth("gemini-2.5-pro", None, None)
+
+    @patch("omicverse.utils.ovagent.auth.GeminiCliOAuthManager")
+    def test_preserves_custom_endpoint(self, mock_mgr_cls):
+        mock_mgr = MagicMock()
+        mock_mgr.build_api_key_payload.return_value = "token"
+        mock_mgr_cls.return_value = mock_mgr
+
+        _, _, endpoint, _ = _resolve_gemini_cli_oauth(
+            "gemini-2.5-pro", "https://custom.google.endpoint/v1", None
+        )
+        assert endpoint == "https://custom.google.endpoint/v1"
+
+
+# ===================================================================
+# _resolve_openai_oauth
+# ===================================================================
+
+class TestResolveOpenAIOAuth:
+
+    @patch("omicverse.utils.ovagent.auth._extract_openai_codex_account_id")
+    def test_valid_token_returns_immediately(self, mock_extract):
+        mock_extract.return_value = "acct-123"
+        model, api_key, endpoint, auth_mode = _resolve_openai_oauth(
+            "gpt-5.3-codex",
+            "valid-token",
+            None,
+            "gpt-5.3-codex",
+            "explicit",
+            None,
+        )
+        assert api_key == "valid-token"
+        assert auth_mode == "openai_oauth"
+
+    @patch("omicverse.utils.ovagent.auth._extract_openai_codex_account_id")
+    def test_explicit_key_without_account_id_raises(self, mock_extract):
+        mock_extract.return_value = ""
+        with pytest.raises(ValueError, match="chatgpt_account_id"):
+            _resolve_openai_oauth(
+                "gpt-5.3-codex",
+                "bad-token",
+                None,
+                "gpt-5.3-codex",
+                "explicit",
+                None,
+            )
+
+    @patch("omicverse.utils.ovagent.auth.OpenAIOAuthManager")
+    @patch("omicverse.utils.ovagent.auth._extract_openai_codex_account_id")
+    def test_falls_back_to_oauth_manager(self, mock_extract, mock_mgr_cls):
+        # Only one call to _extract happens: after OAuth manager returns a token
+        mock_extract.return_value = "acct-456"
+        mock_mgr = MagicMock()
+        mock_mgr.ensure_access_token_with_codex_fallback.return_value = "oauth-token"
+        mock_mgr_cls.return_value = mock_mgr
+
+        model, api_key, endpoint, auth_mode = _resolve_openai_oauth(
+            "gpt-5.3-codex",
+            None,
+            None,
+            "gpt-5.3-codex",
+            None,
+            None,
+        )
+        assert api_key == "oauth-token"
+        assert auth_mode == "openai_oauth"
+
+    @patch("omicverse.utils.ovagent.auth.OpenAIOAuthManager")
+    @patch("omicverse.utils.ovagent.auth._extract_openai_codex_account_id")
+    def test_no_saved_login_raises(self, mock_extract, mock_mgr_cls):
+        mock_extract.return_value = ""
+        mock_mgr = MagicMock()
+        mock_mgr.ensure_access_token_with_codex_fallback.return_value = None
+        mock_mgr_cls.return_value = mock_mgr
+
+        with pytest.raises(ValueError, match="No saved OpenAI Codex login"):
+            _resolve_openai_oauth(
+                "gpt-5.3-codex", None, None, "gpt-5.3-codex", None, None,
+            )
+
+    @patch("omicverse.utils.ovagent.auth.OpenAIOAuthManager")
+    @patch("omicverse.utils.ovagent.auth._extract_openai_codex_account_id")
+    def test_unsupported_model_gets_default(self, mock_extract, mock_mgr_cls):
+        mock_extract.return_value = "acct-789"
+        mock_mgr = MagicMock()
+        mock_mgr.ensure_access_token_with_codex_fallback.return_value = "token"
+        mock_mgr_cls.return_value = mock_mgr
+
+        model, _, _, _ = _resolve_openai_oauth(
+            "unknown-model", None, None, "unknown-model", None, None,
+        )
+        assert model == OPENAI_CODEX_DEFAULT_MODEL
+
+
+# ===================================================================
+# _resolve_saved_openai_key
+# ===================================================================
+
+class TestResolveSavedOpenaiKey:
+
+    @patch("omicverse.utils.ovagent.auth.load_auth")
+    def test_returns_key_from_auth_file(self, mock_load):
+        mock_load.return_value = {"OPENAI_API_KEY": "sk-saved-key"}
+        result = _resolve_saved_openai_key(None)
+        assert result == "sk-saved-key"
+
+    @patch("omicverse.utils.ovagent.auth.load_auth")
+    def test_returns_none_when_missing(self, mock_load):
+        mock_load.return_value = {}
+        result = _resolve_saved_openai_key(None)
+        assert result is None
+
+
+# ===================================================================
+# resolve_credentials (main dispatcher)
+# ===================================================================
+
+class TestResolveCredentials:
+
+    @patch("omicverse.utils.ovagent.auth.ModelConfig")
+    def test_explicit_key_passthrough(self, mock_mc):
+        """Explicit API key + environment mode returns a passthrough tuple."""
+        mock_mc.get_provider_from_model.return_value = "openai"
+        mock_mc.normalize_model_id.return_value = "gpt-5.2"
+
+        result = resolve_credentials(
+            model="gpt-5.2",
+            api_key="sk-explicit",
+            endpoint=None,
+            auth_mode="environment",
+            auth_provider=None,
+            auth_file=None,
+        )
+        model, api_key, endpoint, auth_mode = result
+        assert model == "gpt-5.2"
+        assert api_key == "sk-explicit"
+        assert auth_mode == "environment"
+
+    @patch("omicverse.utils.ovagent.auth._resolve_gemini_cli_oauth")
+    @patch("omicverse.utils.ovagent.auth.ModelConfig")
+    def test_gemini_oauth_dispatches(self, mock_mc, mock_gemini):
+        """google_oauth mode with Google provider dispatches to Gemini resolver."""
+        mock_mc.get_provider_from_model.return_value = "google"
+        mock_mc.normalize_model_id.return_value = "gemini-2.5-pro"
+        mock_gemini.return_value = ("gemini-2.5-pro", "token", "endpoint", "gemini_cli_oauth")
+
+        result = resolve_credentials(
+            model="gemini-2.5-pro",
+            api_key=None,
+            endpoint=None,
+            auth_mode="google_oauth",
+            auth_provider=None,
+            auth_file=None,
+        )
+        assert result == ("gemini-2.5-pro", "token", "endpoint", "gemini_cli_oauth")
+        mock_gemini.assert_called_once()
+
+    @patch("omicverse.utils.ovagent.auth._resolve_openai_oauth")
+    @patch("omicverse.utils.ovagent.auth.ModelConfig")
+    def test_openai_oauth_dispatches(self, mock_mc, mock_oai):
+        """openai_oauth mode with OpenAI provider dispatches to OpenAI resolver."""
+        mock_mc.get_provider_from_model.return_value = "openai"
+        mock_mc.normalize_model_id.return_value = "gpt-5.3-codex"
+        mock_oai.return_value = ("gpt-5.3-codex", "oauth-tok", "ep", "openai_oauth")
+
+        result = resolve_credentials(
+            model="gpt-5.3-codex",
+            api_key=None,
+            endpoint=None,
+            auth_mode="openai_oauth",
+            auth_provider=None,
+            auth_file=None,
+        )
+        assert result == ("gpt-5.3-codex", "oauth-tok", "ep", "openai_oauth")
+        mock_oai.assert_called_once()
+
+    @patch("omicverse.utils.ovagent.auth._resolve_saved_openai_key")
+    @patch("omicverse.utils.ovagent.auth.ModelConfig")
+    def test_saved_api_key_dispatches(self, mock_mc, mock_saved):
+        """saved_api_key mode looks up the saved key then returns passthrough."""
+        mock_mc.get_provider_from_model.return_value = "openai"
+        mock_mc.normalize_model_id.return_value = "gpt-5.2"
+        mock_saved.return_value = "sk-from-file"
+
+        model, api_key, endpoint, auth_mode = resolve_credentials(
+            model="gpt-5.2",
+            api_key=None,
+            endpoint=None,
+            auth_mode="saved_api_key",
+            auth_provider=None,
+            auth_file=None,
+        )
+        assert api_key == "sk-from-file"
+        assert auth_mode == "saved_api_key"
+        mock_saved.assert_called_once()
+
+    @patch("omicverse.utils.ovagent.auth.ModelConfig")
+    def test_returns_four_element_tuple(self, mock_mc):
+        """Return value is always a 4-element tuple (the contract)."""
+        mock_mc.get_provider_from_model.return_value = "anthropic"
+        mock_mc.normalize_model_id.return_value = "claude-opus-4-6"
+
+        result = resolve_credentials(
+            model="claude-opus-4-6",
+            api_key="key",
+            endpoint=None,
+            auth_mode=None,
+            auth_provider=None,
+            auth_file=None,
+        )
+        assert isinstance(result, tuple)
+        assert len(result) == 4
+
+
+# ===================================================================
+# Agent() thin wrapper
+# ===================================================================
+
+class TestAgentFactory:
+
+    def test_agent_is_callable(self):
+        """Agent is importable and callable."""
+        Agent = smart_agent_module.Agent
+        assert callable(Agent)
+
+    def test_agent_returns_omicverse_agent_type(self):
+        """Agent() must return an OmicVerseAgent instance (when construction
+        succeeds). We verify the function signature rather than constructing,
+        since full construction requires API credentials."""
+        import inspect
+        Agent = smart_agent_module.Agent
+        sig = inspect.signature(Agent)
+        # The thin wrapper uses *args, **kwargs
+        params = list(sig.parameters.keys())
+        assert "args" in params or "kwargs" in params

--- a/tests/utils/test_ovagent_tool_runtime.py
+++ b/tests/utils/test_ovagent_tool_runtime.py
@@ -1,5 +1,7 @@
 import asyncio
 import json
+import os
+import subprocess
 from contextlib import contextmanager
 from types import SimpleNamespace
 from unittest.mock import MagicMock
@@ -742,3 +744,484 @@ class TestExtractedExecHandlers:
         from omicverse.utils.ovagent.tool_runtime_exec import handle_agent
         import inspect
         assert inspect.iscoroutinefunction(handle_agent)
+
+
+# -----------------------------------------------------------------------
+# Task-035: Bash runtime hardening tests
+# -----------------------------------------------------------------------
+
+
+class _BashTestCtx(_DummyCtx):
+    """_DummyCtx with no-op approval/server-tool gates for direct handle_bash calls."""
+
+    def _request_tool_approval(self, tool_name: str, *, reason: str, payload):
+        pass  # no-op for testing
+
+
+class TestBashHardeningNonLoginShell:
+    """AC-001 criterion 1: Bash execution uses non-login shells."""
+
+    def test_foreground_bash_uses_non_login_shell(self, monkeypatch):
+        """handle_bash must invoke ['bash', '-c', ...], not ['bash', '-lc', ...]."""
+        from omicverse.utils.ovagent import tool_runtime_exec
+
+        captured_args = {}
+
+        class FakePopen:
+            returncode = 0
+            pid = 99999
+
+            def __init__(self, cmd, **kwargs):
+                captured_args["cmd"] = cmd
+                captured_args["kwargs"] = kwargs
+
+            def communicate(self, **kw):
+                return ("out", "err")
+
+            def wait(self, **kw):
+                return 0
+
+        ctx = _BashTestCtx()
+        monkeypatch.setattr(subprocess, "Popen", FakePopen)
+
+        tool_runtime_exec.handle_bash(
+            ctx,
+            tool_blocked_fn=lambda _: False,
+            command="echo hello",
+            description="test",
+        )
+
+        assert captured_args["cmd"] == ["bash", "-c", "echo hello"]
+        assert "-lc" not in " ".join(captured_args["cmd"])
+
+    def test_background_bash_uses_non_login_shell(self, monkeypatch):
+        """Background inline path must invoke ['bash', '-c', ...]."""
+        from omicverse.utils.ovagent import tool_runtime_exec
+
+        captured_args = {}
+
+        class FakePopen:
+            returncode = 0
+            pid = 99999
+            task_id = "bg-1"
+
+            def __init__(self, cmd, **kwargs):
+                captured_args["cmd"] = cmd
+                captured_args["kwargs"] = kwargs
+                self.stdout = iter([])
+                self.stderr = iter([])
+
+            def communicate(self, **kw):
+                return ("", "")
+
+            def wait(self, **kw):
+                return 0
+
+        ctx = _BashTestCtx()
+        monkeypatch.setattr(subprocess, "Popen", FakePopen)
+
+        result_json = tool_runtime_exec.handle_bash(
+            ctx,
+            tool_blocked_fn=lambda _: False,
+            command="sleep 1",
+            description="bg test",
+            run_in_background=True,
+        )
+
+        assert captured_args["cmd"] == ["bash", "-c", "sleep 1"]
+
+    def test_background_worker_uses_non_login_shell(self, monkeypatch):
+        """background_bash_worker must invoke ['bash', '-c', ...]."""
+        from omicverse.utils.ovagent import tool_runtime_exec
+
+        captured_args = {}
+
+        class FakePopen:
+            returncode = 0
+            pid = 99999
+
+            def __init__(self, cmd, **kwargs):
+                captured_args["cmd"] = cmd
+                captured_args["kwargs"] = kwargs
+                self.stdout = iter(["line1\n"])
+
+            def wait(self, **kw):
+                return 0
+
+        ctx = _DummyCtx()
+        monkeypatch.setattr(subprocess, "Popen", FakePopen)
+        monkeypatch.setattr(runtime_state, "attach_background_process", lambda *a, **kw: None)
+        monkeypatch.setattr(runtime_state, "append_task_output", lambda *a, **kw: None)
+        monkeypatch.setattr(runtime_state, "update_task", lambda *a, **kw: None)
+
+        tool_runtime_exec.background_bash_worker(
+            ctx, "task-1", command="echo hi", cwd=".", timeout_ms=60000,
+        )
+
+        assert captured_args["cmd"] == ["bash", "-c", "echo hi"]
+
+
+class TestBashCwdValidation:
+    """AC-001 criterion 2: cwd validation against workspace roots."""
+
+    def test_cwd_under_workspace_root_accepted(self):
+        """A cwd inside the workspace root passes validation."""
+        import tempfile
+        from omicverse.utils.ovagent.tool_runtime_exec import _validate_bash_cwd
+
+        ctx = _DummyCtx()
+        with tempfile.TemporaryDirectory() as td:
+            ctx._filesystem_context = SimpleNamespace(workspace_dir=td)
+            subdir = os.path.join(td, "sub")
+            os.makedirs(subdir)
+            result = _validate_bash_cwd(ctx, subdir)
+            assert result == os.path.realpath(subdir)
+
+    def test_cwd_at_workspace_root_accepted(self):
+        """A cwd exactly equal to the workspace root passes."""
+        import tempfile
+        from omicverse.utils.ovagent.tool_runtime_exec import _validate_bash_cwd
+
+        ctx = _DummyCtx()
+        with tempfile.TemporaryDirectory() as td:
+            ctx._filesystem_context = SimpleNamespace(workspace_dir=td)
+            result = _validate_bash_cwd(ctx, td)
+            assert result == os.path.realpath(td)
+
+    def test_cwd_outside_all_roots_rejected(self, monkeypatch):
+        """A cwd outside every allowed root raises ValueError."""
+        import tempfile
+        from omicverse.utils.ovagent.tool_runtime_exec import _validate_bash_cwd
+
+        ctx = _DummyCtx()
+        with tempfile.TemporaryDirectory() as ws, tempfile.TemporaryDirectory() as outside:
+            ctx._filesystem_context = SimpleNamespace(workspace_dir=ws)
+            # Monkeypatch cwd and tempdir so the escaping path has no fallback
+            monkeypatch.setattr(os, "getcwd", lambda: ws)
+            monkeypatch.setattr(tempfile, "gettempdir", lambda: ws)
+            with pytest.raises(ValueError, match="outside allowed workspace roots"):
+                _validate_bash_cwd(ctx, outside)
+
+    def test_cwd_traversal_attempt_rejected(self, monkeypatch):
+        """A path containing '..' that escapes roots is rejected."""
+        import tempfile
+        from omicverse.utils.ovagent.tool_runtime_exec import _validate_bash_cwd
+
+        ctx = _DummyCtx()
+        with tempfile.TemporaryDirectory() as ws:
+            ctx._filesystem_context = SimpleNamespace(workspace_dir=ws)
+            monkeypatch.setattr(os, "getcwd", lambda: ws)
+            monkeypatch.setattr(tempfile, "gettempdir", lambda: ws)
+            escaping = os.path.join(ws, "..", "..", "etc")
+            with pytest.raises(ValueError, match="outside allowed workspace roots"):
+                _validate_bash_cwd(ctx, escaping)
+
+    def test_cwd_resolves_symlinks(self):
+        """Symlink-based cwd is resolved to realpath before validation."""
+        import tempfile
+        from omicverse.utils.ovagent.tool_runtime_exec import _validate_bash_cwd
+
+        ctx = _DummyCtx()
+        with tempfile.TemporaryDirectory() as ws:
+            ctx._filesystem_context = SimpleNamespace(workspace_dir=ws)
+            subdir = os.path.join(ws, "real")
+            os.makedirs(subdir)
+            link = os.path.join(ws, "link")
+            os.symlink(subdir, link)
+            result = _validate_bash_cwd(ctx, link)
+            assert result == os.path.realpath(subdir)
+
+    def test_no_roots_degrades_gracefully(self):
+        """When no roots can be determined, validation passes (graceful degradation)."""
+        from omicverse.utils.ovagent.tool_runtime_exec import _validate_bash_cwd
+
+        ctx = _DummyCtx()
+        ctx._filesystem_context = None
+        # Even with no filesystem context, the cwd and tempdir roots still apply.
+        # To truly test graceful degradation, we need a custom helper test.
+        # This just confirms no crash with minimal context.
+        result = _validate_bash_cwd(ctx, ".")
+        assert isinstance(result, str)
+
+    def test_handle_bash_rejects_invalid_cwd(self, monkeypatch):
+        """handle_bash fails fast when cwd is outside allowed roots."""
+        import tempfile
+        from omicverse.utils.ovagent import tool_runtime_exec
+
+        ctx = _BashTestCtx()
+        with tempfile.TemporaryDirectory() as ws, tempfile.TemporaryDirectory() as outside:
+            ctx._filesystem_context = SimpleNamespace(workspace_dir=ws)
+            monkeypatch.setattr(os, "getcwd", lambda: ws)
+            monkeypatch.setattr(tempfile, "gettempdir", lambda: ws)
+            ctx._refresh_runtime_working_directory = lambda: outside
+
+            with pytest.raises(ValueError, match="outside allowed workspace roots"):
+                tool_runtime_exec.handle_bash(
+                    ctx,
+                    tool_blocked_fn=lambda _: False,
+                    command="echo pwned",
+                )
+
+
+class TestBashProcessGroupIsolation:
+    """AC-001 criterion 3: bounded execution via process group isolation."""
+
+    def test_foreground_uses_start_new_session(self, monkeypatch):
+        """Foreground Popen must pass start_new_session=True."""
+        from omicverse.utils.ovagent import tool_runtime_exec
+
+        captured_kwargs = {}
+
+        class FakePopen:
+            returncode = 0
+            pid = 99999
+
+            def __init__(self, cmd, **kwargs):
+                captured_kwargs.update(kwargs)
+
+            def communicate(self, **kw):
+                return ("", "")
+
+            def wait(self, **kw):
+                return 0
+
+        ctx = _BashTestCtx()
+        monkeypatch.setattr(subprocess, "Popen", FakePopen)
+
+        tool_runtime_exec.handle_bash(
+            ctx,
+            tool_blocked_fn=lambda _: False,
+            command="true",
+        )
+
+        assert captured_kwargs.get("start_new_session") is True
+
+    def test_background_uses_start_new_session(self, monkeypatch):
+        """Background Popen must pass start_new_session=True."""
+        from omicverse.utils.ovagent import tool_runtime_exec
+
+        captured_kwargs = {}
+
+        class FakePopen:
+            returncode = 0
+            pid = 99999
+
+            def __init__(self, cmd, **kwargs):
+                captured_kwargs.update(kwargs)
+                self.stdout = iter([])
+                self.stderr = iter([])
+
+            def communicate(self, **kw):
+                return ("", "")
+
+            def wait(self, **kw):
+                return 0
+
+        ctx = _BashTestCtx()
+        monkeypatch.setattr(subprocess, "Popen", FakePopen)
+
+        tool_runtime_exec.handle_bash(
+            ctx,
+            tool_blocked_fn=lambda _: False,
+            command="sleep 1",
+            run_in_background=True,
+        )
+
+        assert captured_kwargs.get("start_new_session") is True
+
+    def test_foreground_timeout_triggers_process_group_kill(self, monkeypatch):
+        """On timeout, foreground path must call _kill_process_tree."""
+        from omicverse.utils.ovagent import tool_runtime_exec
+
+        kill_called = []
+
+        class FakePopen:
+            returncode = None
+            pid = 99999
+
+            def __init__(self, cmd, **kwargs):
+                pass
+
+            def communicate(self, **kw):
+                raise subprocess.TimeoutExpired("bash", kw.get("timeout", 1))
+
+            def wait(self, **kw):
+                return -9
+
+            def kill(self):
+                pass
+
+        ctx = _BashTestCtx()
+        monkeypatch.setattr(subprocess, "Popen", FakePopen)
+        original_kill = tool_runtime_exec._kill_process_tree
+        def tracking_kill(proc):
+            kill_called.append(proc)
+            # Don't call original — it would fail on fake proc
+        monkeypatch.setattr(tool_runtime_exec, "_kill_process_tree", tracking_kill)
+
+        result_json = tool_runtime_exec.handle_bash(
+            ctx,
+            tool_blocked_fn=lambda _: False,
+            command="sleep 999",
+            timeout=1,
+        )
+
+        assert len(kill_called) == 1
+        result = json.loads(result_json)
+        assert result["returncode"] < 0  # negative = killed by signal
+
+    def test_background_worker_timeout_triggers_process_group_kill(self, monkeypatch):
+        """background_bash_worker must call _kill_process_tree on timeout."""
+        import time as _time
+        from omicverse.utils.ovagent import tool_runtime_exec
+
+        kill_called = []
+        call_count = [0]
+
+        class FakePopen:
+            returncode = None
+            pid = 99999
+
+            def __init__(self, cmd, **kwargs):
+                # Yield lines indefinitely; the timeout check should break out
+                self.stdout = iter(["line\n"] * 100)
+
+            def wait(self, **kw):
+                return -9
+
+            def kill(self):
+                pass
+
+        ctx = _DummyCtx()
+        monkeypatch.setattr(subprocess, "Popen", FakePopen)
+        monkeypatch.setattr(runtime_state, "attach_background_process", lambda *a, **kw: None)
+        monkeypatch.setattr(runtime_state, "append_task_output", lambda *a, **kw: None)
+
+        update_calls = []
+        monkeypatch.setattr(
+            runtime_state, "update_task",
+            lambda *a, **kw: update_calls.append(kw),
+        )
+        monkeypatch.setattr(
+            tool_runtime_exec, "_kill_process_tree",
+            lambda proc: kill_called.append(proc),
+        )
+
+        # Use a timeout of 0ms so it fires immediately
+        tool_runtime_exec.background_bash_worker(
+            ctx, "task-bg", command="yes", cwd=".", timeout_ms=0,
+        )
+
+        assert len(kill_called) == 1
+        assert any(c.get("status") == "failed" for c in update_calls)
+
+
+class TestBashPayloadBackwardsCompat:
+    """AC-001 criterion 4: payload schema remains backwards compatible."""
+
+    def test_foreground_payload_has_expected_keys(self, monkeypatch):
+        """Foreground result JSON must contain cwd, command, returncode, stdout, stderr, output."""
+        from omicverse.utils.ovagent import tool_runtime_exec
+
+        class FakePopen:
+            returncode = 0
+            pid = 99999
+
+            def __init__(self, cmd, **kwargs):
+                pass
+
+            def communicate(self, **kw):
+                return ("hello\n", "")
+
+            def wait(self, **kw):
+                return 0
+
+        ctx = _BashTestCtx()
+        monkeypatch.setattr(subprocess, "Popen", FakePopen)
+
+        result_json = tool_runtime_exec.handle_bash(
+            ctx,
+            tool_blocked_fn=lambda _: False,
+            command="echo hello",
+        )
+        result = json.loads(result_json)
+
+        assert set(result.keys()) == {"cwd", "command", "returncode", "stdout", "stderr", "output"}
+        assert result["command"] == "echo hello"
+        assert result["returncode"] == 0
+        assert result["stdout"] == "hello\n"
+
+    def test_background_payload_has_expected_keys(self, monkeypatch):
+        """Background result JSON must contain task_id, status, cwd, command."""
+        from omicverse.utils.ovagent import tool_runtime_exec
+
+        class FakePopen:
+            returncode = 0
+            pid = 99999
+
+            def __init__(self, cmd, **kwargs):
+                self.stdout = iter([])
+                self.stderr = iter([])
+
+            def communicate(self, **kw):
+                return ("", "")
+
+            def wait(self, **kw):
+                return 0
+
+        ctx = _BashTestCtx()
+        monkeypatch.setattr(subprocess, "Popen", FakePopen)
+
+        result_json = tool_runtime_exec.handle_bash(
+            ctx,
+            tool_blocked_fn=lambda _: False,
+            command="sleep 1",
+            run_in_background=True,
+        )
+        result = json.loads(result_json)
+
+        assert "task_id" in result
+        assert result["status"] == "in_progress"
+        assert result["command"] == "sleep 1"
+        assert "cwd" in result
+
+    def test_timeout_payload_has_expected_keys(self, monkeypatch):
+        """Timeout result must still have the standard foreground payload keys."""
+        from omicverse.utils.ovagent import tool_runtime_exec
+
+        class FakePopen:
+            returncode = None
+            pid = 99999
+
+            def __init__(self, cmd, **kwargs):
+                pass
+
+            def communicate(self, **kw):
+                raise subprocess.TimeoutExpired("bash", kw.get("timeout", 1))
+
+            def wait(self, **kw):
+                return -9
+
+            def kill(self):
+                pass
+
+        ctx = _BashTestCtx()
+        monkeypatch.setattr(subprocess, "Popen", FakePopen)
+        monkeypatch.setattr(tool_runtime_exec, "_kill_process_tree", lambda p: None)
+
+        result_json = tool_runtime_exec.handle_bash(
+            ctx,
+            tool_blocked_fn=lambda _: False,
+            command="sleep 999",
+            timeout=1,
+        )
+        result = json.loads(result_json)
+
+        assert set(result.keys()) == {"cwd", "command", "returncode", "stdout", "stderr", "output"}
+
+    def test_hardening_helpers_are_exported(self):
+        """The new helpers exist as module-level functions."""
+        from omicverse.utils.ovagent import tool_runtime_exec
+        assert callable(tool_runtime_exec._resolve_bash_allowed_roots)
+        assert callable(tool_runtime_exec._validate_bash_cwd)
+        assert callable(tool_runtime_exec._kill_process_tree)

--- a/tests/utils/test_ovagent_tool_runtime.py
+++ b/tests/utils/test_ovagent_tool_runtime.py
@@ -1225,3 +1225,261 @@ class TestBashPayloadBackwardsCompat:
         assert callable(tool_runtime_exec._resolve_bash_allowed_roots)
         assert callable(tool_runtime_exec._validate_bash_cwd)
         assert callable(tool_runtime_exec._kill_process_tree)
+
+
+# -----------------------------------------------------------------------
+# Task-044: Sync bridge recovery + preserved bash/stdout fixes
+# -----------------------------------------------------------------------
+
+
+class TestSyncBridgeRecovery:
+    """AC-001 criterion 1: running-event-loop bridge has bounded return/error."""
+
+    def test_bridge_uses_bounded_future_not_context_manager(self):
+        """The sync bridge must not wrap ThreadPoolExecutor in a context manager.
+
+        A ``with ThreadPoolExecutor(...) as pool:`` block calls
+        ``pool.shutdown(wait=True)`` on exit, which waits for the worker
+        thread even after a ``Future.result(timeout=...)`` raises
+        ``TimeoutError``.  The fixed implementation creates the pool
+        directly and calls ``shutdown(wait=False)`` so the caller always
+        returns or raises promptly.
+        """
+        import ast
+        import inspect
+        from omicverse.utils.ovagent import tool_runtime_exec
+
+        source = inspect.getsource(tool_runtime_exec.handle_execute_code)
+        tree = ast.parse(source)
+
+        # Walk the AST — there should be no ``with`` statement whose
+        # context expression mentions ThreadPoolExecutor.
+        for node in ast.walk(tree):
+            if isinstance(node, ast.With):
+                for item in node.items:
+                    src_fragment = ast.dump(item.context_expr)
+                    assert "ThreadPoolExecutor" not in src_fragment, (
+                        "handle_execute_code must not use ThreadPoolExecutor "
+                        "as a context manager — shutdown(wait=True) blocks "
+                        "after timeout"
+                    )
+
+    def test_bridge_calls_shutdown_wait_false(self):
+        """The sync bridge must call pool.shutdown(wait=False)."""
+        import inspect
+        from omicverse.utils.ovagent import tool_runtime_exec
+
+        source = inspect.getsource(tool_runtime_exec.handle_execute_code)
+        assert "shutdown(wait=False)" in source, (
+            "handle_execute_code must call pool.shutdown(wait=False) "
+            "to avoid blocking on executor teardown"
+        )
+
+    def test_bridge_future_result_has_timeout(self):
+        """Future.result() must be called with a timeout argument."""
+        import inspect
+        from omicverse.utils.ovagent import tool_runtime_exec
+
+        source = inspect.getsource(tool_runtime_exec.handle_execute_code)
+        assert ".result(timeout=" in source, (
+            "handle_execute_code must call future.result(timeout=...) "
+            "to bound the sync bridge wait"
+        )
+
+    def test_bridge_raises_on_timeout(self, monkeypatch):
+        """When the bridge future times out, RuntimeError is raised — not a hang."""
+        import concurrent.futures
+        from unittest.mock import patch, MagicMock
+        from omicverse.utils.ovagent import tool_runtime_exec
+
+        class _Ctx:
+            _code_only_mode = False
+
+            @staticmethod
+            def _extract_python_code(text):
+                return text
+
+        class _Executor:
+            _notebook_fallback_error = None
+            _ctx = _Ctx()
+
+            def check_code_prerequisites(self, code, adata):
+                return ""
+
+        # Make get_running_loop return a running loop so the bridge path
+        # is triggered.
+        fake_loop = MagicMock()
+        fake_loop.is_running.return_value = True
+        monkeypatch.setattr(
+            "omicverse.utils.ovagent.tool_runtime_exec.asyncio.get_running_loop",
+            lambda: fake_loop,
+        )
+
+        # Patch ThreadPoolExecutor so submit().result() raises TimeoutError
+        mock_future = MagicMock()
+        mock_future.result.side_effect = concurrent.futures.TimeoutError()
+        mock_future.cancel.return_value = True
+
+        mock_pool = MagicMock()
+        mock_pool.submit.return_value = mock_future
+
+        monkeypatch.setattr(
+            concurrent.futures, "ThreadPoolExecutor",
+            lambda **kw: mock_pool,
+        )
+
+        with pytest.raises(RuntimeError, match="sync bridge timed out"):
+            tool_runtime_exec.handle_execute_code(
+                _Ctx(), _Executor(), "print(1)", "test", None,
+            )
+
+        mock_future.cancel.assert_called_once()
+        mock_pool.shutdown.assert_called_once_with(wait=False)
+
+    def test_bridge_normal_return_also_shuts_down_without_wait(self, monkeypatch):
+        """On normal completion the bridge still calls shutdown(wait=False)."""
+        import concurrent.futures
+        from unittest.mock import MagicMock
+        from omicverse.utils.ovagent import tool_runtime_exec
+        from omicverse.utils.ovagent.repair_loop import RepairResult
+
+        class _Ctx:
+            _code_only_mode = False
+
+            @staticmethod
+            def _extract_python_code(text):
+                return text
+
+        class _Executor:
+            _notebook_fallback_error = None
+            _ctx = _Ctx()
+
+            def check_code_prerequisites(self, code, adata):
+                return ""
+
+        fake_loop = MagicMock()
+        fake_loop.is_running.return_value = True
+        monkeypatch.setattr(
+            "omicverse.utils.ovagent.tool_runtime_exec.asyncio.get_running_loop",
+            lambda: fake_loop,
+        )
+
+        # Build a successful RepairResult
+        ok_result = RepairResult(
+            success=True,
+            final_code="print(1)",
+            exec_result={"adata": None, "stdout": "1"},
+            attempts=[],
+        )
+        mock_future = MagicMock()
+        mock_future.result.return_value = ok_result
+
+        mock_pool = MagicMock()
+        mock_pool.submit.return_value = mock_future
+
+        monkeypatch.setattr(
+            concurrent.futures, "ThreadPoolExecutor",
+            lambda **kw: mock_pool,
+        )
+
+        result = tool_runtime_exec.handle_execute_code(
+            _Ctx(), _Executor(), "print(1)", "test", None,
+        )
+
+        assert "output" in result
+        mock_pool.shutdown.assert_called_once_with(wait=False)
+
+
+class TestBashEmptyRootsFailsClosed:
+    """AC-001 criterion 2: empty roots must reject, not allow."""
+
+    def test_empty_roots_raises_valueerror(self, monkeypatch):
+        """When no workspace roots can be determined, cwd is rejected."""
+        import tempfile
+        from omicverse.utils.ovagent.tool_runtime_exec import (
+            _validate_bash_cwd,
+            _resolve_bash_allowed_roots,
+        )
+
+        ctx = _DummyCtx()
+        ctx._filesystem_context = None
+        # Force _resolve_bash_allowed_roots to return [] by making
+        # getcwd and gettempdir both raise.
+        monkeypatch.setattr(os, "getcwd", _raise_os_error)
+        monkeypatch.setattr(tempfile, "gettempdir", _raise_os_error)
+
+        with pytest.raises(ValueError, match="no allowed workspace roots"):
+            _validate_bash_cwd(ctx, "/tmp")
+
+    def test_empty_roots_even_with_valid_path(self, monkeypatch):
+        """Even a seemingly innocent path is rejected when roots are empty."""
+        import tempfile
+        from omicverse.utils.ovagent.tool_runtime_exec import _validate_bash_cwd
+
+        ctx = _DummyCtx()
+        ctx._filesystem_context = None
+        monkeypatch.setattr(os, "getcwd", _raise_os_error)
+        monkeypatch.setattr(tempfile, "gettempdir", _raise_os_error)
+
+        with pytest.raises(ValueError, match="no allowed workspace roots"):
+            _validate_bash_cwd(ctx, "/tmp")
+
+
+class TestStdoutPipeGuard:
+    """AC-001 criterion 3: stdout pipe uses explicit check, not assert."""
+
+    def test_no_assert_on_proc_stdout(self):
+        """background_bash_worker must not use assert for stdout pipe check."""
+        import inspect
+        from omicverse.utils.ovagent import tool_runtime_exec
+
+        source = inspect.getsource(tool_runtime_exec.background_bash_worker)
+        assert "assert proc.stdout" not in source, (
+            "background_bash_worker must use an explicit runtime check "
+            "instead of assert for stdout pipe validation"
+        )
+
+    def test_explicit_runtime_error_on_missing_stdout(self):
+        """The explicit guard raises RuntimeError, not AssertionError."""
+        import inspect
+        from omicverse.utils.ovagent import tool_runtime_exec
+
+        source = inspect.getsource(tool_runtime_exec.background_bash_worker)
+        assert "RuntimeError" in source
+        assert "stdout pipe" in source.lower() or "stdout" in source
+
+    def test_missing_stdout_raises_runtime_error(self, monkeypatch):
+        """If Popen somehow produces stdout=None, RuntimeError is raised."""
+        from omicverse.utils.ovagent import tool_runtime_exec
+
+        class FakePopen:
+            pid = 99999
+            stdout = None
+            stderr = None
+
+            def __init__(self, *a, **kw):
+                pass
+
+        ctx = _BashTestCtx()
+        monkeypatch.setattr(subprocess, "Popen", FakePopen)
+        # Bypass cwd validation and runtime_state registration
+        monkeypatch.setattr(
+            tool_runtime_exec, "_validate_bash_cwd",
+            lambda ctx, cwd: cwd,
+        )
+        monkeypatch.setattr(
+            runtime_state, "attach_background_process",
+            lambda sid, tid, proc: None,
+        )
+
+        with pytest.raises(RuntimeError, match="stdout pipe"):
+            tool_runtime_exec.background_bash_worker(
+                ctx, "test-task-id",
+                command="echo hi",
+                cwd=os.getcwd(),
+                timeout_ms=5000,
+            )
+
+
+def _raise_os_error():
+    raise OSError("forced")

--- a/tests/utils/test_repair_loop.py
+++ b/tests/utils/test_repair_loop.py
@@ -68,6 +68,7 @@ sys.modules["omicverse.utils"] = _utils_pkg
 _ov_pkg.utils = _utils_pkg
 
 from omicverse.utils.ovagent.repair_loop import (
+    DEFAULT_LLM_TIMEOUT,
     DEFAULT_MAX_RETRIES,
     ExecutionRepairLoop,
     FailureEnvelope,
@@ -365,7 +366,7 @@ class TestExecutionRepairLoopBounded:
         assert result.attempts[0].strategy == "llm"
 
     def test_max_retries_respected(self):
-        """Loop stops after max_retries even if failures continue."""
+        """Loop runs exactly max_retries execution attempts."""
         executor = _FakeExecutor(
             exec_side_effects=[
                 ValueError("err1"),
@@ -377,20 +378,20 @@ class TestExecutionRepairLoopBounded:
         )
         # Need the guardrail to actually produce different code each time
         call_count = [0]
-        original_fix = executor.apply_execution_error_fix
 
         def varying_fix(code, error_msg):
             call_count[0] += 1
             return f"fixed_v{call_count[0]}"
 
         executor.apply_execution_error_fix = varying_fix
-        loop = ExecutionRepairLoop(executor, max_retries=2)
+        loop = ExecutionRepairLoop(executor, max_retries=3)
         result = _run(loop.run("code", None))
 
         assert result.success is False
         assert result.final_envelope is not None
-        # 1 initial + max_retries = 3 total exec attempts
-        assert len(result.attempts) <= 3
+        # max_retries=3 means exactly 3 execution attempts
+        assert len(result.attempts) == 3
+        assert executor._exec_call_count == 3
 
     def test_no_repair_strategy_exits_early(self):
         """When neither guardrail nor LLM produce new code, loop exits."""
@@ -592,3 +593,198 @@ class TestCustomExecFn:
 
         assert result.success is True
         assert call_log == ["code"]
+
+
+# ===================================================================
+# 9. Retry-count exactness (task-036)
+# ===================================================================
+
+
+class TestRetryBoundExact:
+    """max_retries bounds total execution attempts exactly."""
+
+    def test_max_retries_equals_execution_count(self):
+        """max_retries=N means exactly N execution attempts."""
+        for n in (1, 2, 3, 5):
+            executor = _FakeExecutor(
+                exec_side_effects=[ValueError(f"e{i}") for i in range(n + 5)],
+            )
+            count = [0]
+
+            def varying_fix(code, error_msg, _c=count):
+                _c[0] += 1
+                return f"fixed_{_c[0]}"
+
+            executor.apply_execution_error_fix = varying_fix
+            loop = ExecutionRepairLoop(executor, max_retries=n)
+            result = _run(loop.run("code", None))
+
+            assert result.success is False, f"max_retries={n}"
+            assert executor._exec_call_count == n, (
+                f"max_retries={n}: expected {n} executions, "
+                f"got {executor._exec_call_count}"
+            )
+
+    def test_max_retries_zero_clamped_to_one(self):
+        """max_retries=0 is clamped to 1 so at least one execution occurs."""
+        executor = _FakeExecutor(
+            exec_side_effects=[ValueError("single")],
+        )
+        loop = ExecutionRepairLoop(executor, max_retries=0)
+        assert loop.max_retries == 1
+        result = _run(loop.run("code", None))
+        assert result.success is False
+        assert executor._exec_call_count == 1
+
+    def test_max_retries_one_no_repair(self):
+        """max_retries=1 executes once and returns exhausted without repair."""
+        executor = _FakeExecutor(
+            exec_side_effects=[ValueError("only try")],
+            guardrail_return="should_not_be_used",
+        )
+        loop = ExecutionRepairLoop(executor, max_retries=1)
+        result = _run(loop.run("code", None))
+
+        assert result.success is False
+        assert len(result.attempts) == 1
+        assert result.attempts[0].strategy == "exhausted"
+        assert executor._exec_call_count == 1
+
+    def test_last_attempt_strategy_is_exhausted(self):
+        """The final failing attempt always has strategy='exhausted'."""
+        count = [0]
+
+        def varying_fix(code, error_msg):
+            count[0] += 1
+            return f"v{count[0]}"
+
+        executor = _FakeExecutor(
+            exec_side_effects=[ValueError(f"e{i}") for i in range(10)],
+        )
+        executor.apply_execution_error_fix = varying_fix
+        loop = ExecutionRepairLoop(executor, max_retries=4)
+        result = _run(loop.run("code", None))
+
+        assert result.success is False
+        assert result.attempts[-1].strategy == "exhausted"
+
+
+# ===================================================================
+# 10. LLM timeout handling (task-036)
+# ===================================================================
+
+
+class _HangingExecutor(_FakeExecutor):
+    """Executor whose LLM diagnosis hangs until cancelled."""
+
+    async def diagnose_error_with_llm(self, code, error_msg, traceback_str, adata):
+        await asyncio.sleep(100)
+        return self._llm_return  # pragma: no cover
+
+
+class TestLLMTimeout:
+    """LLM-guided repair is bounded by a configurable timeout."""
+
+    def test_default_llm_timeout(self):
+        assert DEFAULT_LLM_TIMEOUT == 30.0
+
+    def test_llm_timeout_property(self):
+        executor = _FakeExecutor()
+        loop = ExecutionRepairLoop(executor, llm_timeout=10.0)
+        assert loop.llm_timeout == 10.0
+
+    def test_llm_timeout_none_disables(self):
+        executor = _FakeExecutor()
+        loop = ExecutionRepairLoop(executor, llm_timeout=None)
+        assert loop.llm_timeout is None
+
+    def test_timeout_triggers_on_slow_llm(self):
+        """A hanging LLM call is aborted after llm_timeout seconds."""
+        executor = _HangingExecutor(
+            exec_side_effects=[
+                ValueError("err1"),
+                ValueError("err2"),
+            ],
+            guardrail_return=None,
+        )
+        # Very short timeout to keep the test fast
+        loop = ExecutionRepairLoop(executor, max_retries=2, llm_timeout=0.01)
+        result = _run(loop.run("code", None))
+
+        assert result.success is False
+        # First attempt fails, LLM times out → no repair → exits early
+        assert result.final_envelope is not None
+        # The timeout hint should be recorded
+        hints = result.final_envelope.repair_hints
+        timeout_hints = [h for h in hints if "timed out" in h]
+        assert len(timeout_hints) >= 1, (
+            f"Expected timeout hint in {hints}"
+        )
+
+    def test_timeout_hint_includes_duration(self):
+        """Timeout hint includes the configured timeout value."""
+        executor = _HangingExecutor(
+            exec_side_effects=[ValueError("err1")],
+            guardrail_return=None,
+        )
+        loop = ExecutionRepairLoop(executor, max_retries=2, llm_timeout=0.01)
+        result = _run(loop.run("code", None))
+
+        hints = result.final_envelope.repair_hints
+        timeout_hints = [h for h in hints if "timed out" in h]
+        assert any("0.01" in h for h in timeout_hints), (
+            f"Timeout hint should include duration: {timeout_hints}"
+        )
+
+    def test_timeout_distinguishable_from_exhaustion(self):
+        """Timeout and exhaustion produce different repair hint patterns."""
+        # --- Timeout case ---
+        executor_timeout = _HangingExecutor(
+            exec_side_effects=[ValueError("err")],
+            guardrail_return=None,
+        )
+        loop_timeout = ExecutionRepairLoop(
+            executor_timeout, max_retries=2, llm_timeout=0.01,
+        )
+        result_timeout = _run(loop_timeout.run("code", None))
+
+        # --- Exhaustion case ---
+        count = [0]
+
+        def varying_fix(code, error_msg):
+            count[0] += 1
+            return f"v{count[0]}"
+
+        executor_exhaust = _FakeExecutor(
+            exec_side_effects=[ValueError(f"e{i}") for i in range(10)],
+        )
+        executor_exhaust.apply_execution_error_fix = varying_fix
+        loop_exhaust = ExecutionRepairLoop(executor_exhaust, max_retries=2)
+        result_exhaust = _run(loop_exhaust.run("code", None))
+
+        # Both fail but for different reasons
+        assert result_timeout.success is False
+        assert result_exhaust.success is False
+
+        # Timeout produces "timed out" hint; exhaustion does not
+        timeout_hints = result_timeout.final_envelope.repair_hints
+        exhaust_hints = result_exhaust.final_envelope.repair_hints
+        assert any("timed out" in h for h in timeout_hints)
+        assert not any("timed out" in h for h in exhaust_hints)
+
+        # Exhaustion produces "exhausted" strategy on last attempt
+        assert result_exhaust.attempts[-1].strategy == "exhausted"
+
+    def test_timeout_with_none_disables_timeout(self):
+        """llm_timeout=None allows the LLM call to complete without timeout."""
+        executor = _FakeExecutor(
+            exec_side_effects=[
+                ValueError("err"),
+                {"stdout": "ok", "adata": None},
+            ],
+            guardrail_return=None,
+            llm_return="fixed_code",
+        )
+        loop = ExecutionRepairLoop(executor, max_retries=3, llm_timeout=None)
+        result = _run(loop.run("code", None))
+        assert result.success is True

--- a/tests/utils/test_session_facade.py
+++ b/tests/utils/test_session_facade.py
@@ -1,0 +1,250 @@
+"""Tests for SessionContextFacadeMixin extraction (task-012).
+
+Validates that session/history, filesystem-context, tracing, and
+service-wiring delegation methods have been moved out of OmicVerseAgent
+into the mixin while preserving the public API.
+"""
+
+import importlib.machinery
+import importlib.util
+import os
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Module bootstrap (same pattern as test_smart_agent.py)
+# ---------------------------------------------------------------------------
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+PACKAGE_ROOT = PROJECT_ROOT / "omicverse"
+
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+_ORIGINAL_MODULES = {
+    name: sys.modules.get(name)
+    for name in ["omicverse", "omicverse.utils", "omicverse.utils.smart_agent"]
+}
+for name in ["omicverse", "omicverse.utils", "omicverse.utils.smart_agent"]:
+    sys.modules.pop(name, None)
+
+omicverse_pkg = types.ModuleType("omicverse")
+omicverse_pkg.__path__ = [str(PACKAGE_ROOT)]
+omicverse_pkg.__spec__ = importlib.machinery.ModuleSpec(
+    "omicverse", loader=None, is_package=True
+)
+sys.modules["omicverse"] = omicverse_pkg
+
+utils_pkg = types.ModuleType("omicverse.utils")
+utils_pkg.__path__ = [str(PACKAGE_ROOT / "utils")]
+utils_pkg.__spec__ = importlib.machinery.ModuleSpec(
+    "omicverse.utils", loader=None, is_package=True
+)
+sys.modules["omicverse.utils"] = utils_pkg
+omicverse_pkg.utils = utils_pkg
+
+smart_agent_spec = importlib.util.spec_from_file_location(
+    "omicverse.utils.smart_agent", PACKAGE_ROOT / "utils" / "smart_agent.py"
+)
+smart_agent_module = importlib.util.module_from_spec(smart_agent_spec)
+sys.modules["omicverse.utils.smart_agent"] = smart_agent_module
+assert smart_agent_spec.loader is not None
+smart_agent_spec.loader.exec_module(smart_agent_module)
+
+OmicVerseAgent = smart_agent_module.OmicVerseAgent
+
+for name, module in _ORIGINAL_MODULES.items():
+    if module is None:
+        sys.modules.pop(name, None)
+    else:
+        sys.modules[name] = module
+
+from omicverse.utils.ovagent.session_facade import SessionContextFacadeMixin
+
+
+_RUN_HARNESS_TESTS = os.environ.get("OV_AGENT_RUN_HARNESS_TESTS", "").lower() in {
+    "1", "true", "yes", "on",
+}
+
+
+# -----------------------------------------------------------------------
+# AC-001.1: Methods are owned by the mixin, not the agent class body
+# -----------------------------------------------------------------------
+
+
+def test_agent_inherits_from_mixin():
+    """OmicVerseAgent must be a subclass of SessionContextFacadeMixin."""
+    assert issubclass(OmicVerseAgent, SessionContextFacadeMixin)
+
+
+MIXIN_METHODS = [
+    "_get_session_service",
+    "_get_context_service",
+    "_get_harness_session_id",
+    "_get_runtime_session_id",
+    "_refresh_runtime_working_directory",
+    "_detect_repo_root",
+    "_initialize_session_context_tracing",
+    "_wire_session_context_services",
+    "get_current_session_info",
+    "restart_session",
+    "get_session_history",
+    "write_note",
+    "search_context",
+    "get_relevant_context",
+    "save_plan",
+    "update_plan_step",
+    "get_workspace_summary",
+    "get_context_stats",
+]
+
+
+@pytest.mark.parametrize("method_name", MIXIN_METHODS)
+def test_method_defined_on_mixin(method_name):
+    """Session/context/tracing methods must be defined on the mixin."""
+    assert hasattr(SessionContextFacadeMixin, method_name)
+
+
+def test_filesystem_context_property_on_mixin():
+    """filesystem_context property must live on the mixin."""
+    assert isinstance(
+        SessionContextFacadeMixin.__dict__.get("filesystem_context"),
+        property,
+    )
+
+
+DELEGATION_METHODS = [
+    "_get_session_service",
+    "_get_context_service",
+    "_get_harness_session_id",
+    "_get_runtime_session_id",
+    "_refresh_runtime_working_directory",
+    "_detect_repo_root",
+    "get_current_session_info",
+    "restart_session",
+    "get_session_history",
+    "write_note",
+    "search_context",
+    "get_relevant_context",
+    "save_plan",
+    "update_plan_step",
+    "get_workspace_summary",
+    "get_context_stats",
+]
+
+
+@pytest.mark.parametrize("method_name", DELEGATION_METHODS)
+def test_method_not_redefined_on_agent(method_name):
+    """Extracted methods must be inherited, not re-declared on OmicVerseAgent."""
+    assert method_name not in OmicVerseAgent.__dict__, (
+        f"{method_name} is still defined directly on OmicVerseAgent"
+    )
+    assert hasattr(OmicVerseAgent, method_name)
+
+
+# -----------------------------------------------------------------------
+# AC-001.2: Public methods and call signatures remain unchanged
+# -----------------------------------------------------------------------
+
+
+PUBLIC_API = [
+    "get_current_session_info",
+    "restart_session",
+    "get_session_history",
+    "write_note",
+    "search_context",
+    "get_relevant_context",
+    "save_plan",
+    "update_plan_step",
+    "get_workspace_summary",
+    "get_context_stats",
+    "run",
+    "run_async",
+    "stream_async",
+    "generate_code",
+    "generate_code_async",
+    "help_short",
+]
+
+
+@pytest.mark.parametrize("method_name", PUBLIC_API)
+def test_public_api_accessible(method_name):
+    """All public methods must still be accessible on OmicVerseAgent."""
+    assert hasattr(OmicVerseAgent, method_name)
+
+
+def test_filesystem_context_property_accessible():
+    """filesystem_context property must be accessible on OmicVerseAgent."""
+    assert isinstance(
+        OmicVerseAgent.__dict__.get("filesystem_context", None)
+        or getattr(type, "__dict__", {}).get("filesystem_context", None)
+        or next(
+            (
+                cls.__dict__["filesystem_context"]
+                for cls in OmicVerseAgent.__mro__
+                if "filesystem_context" in cls.__dict__
+            ),
+            None,
+        ),
+        property,
+    )
+
+
+# -----------------------------------------------------------------------
+# AC-001.3: Lazy service construction works correctly
+# -----------------------------------------------------------------------
+
+
+def test_lazy_session_service_creation():
+    """SessionService is lazily created on __new__-based instances."""
+    from omicverse.utils.ovagent.session_context import SessionService
+
+    agent = OmicVerseAgent.__new__(OmicVerseAgent)
+    svc = agent._get_session_service()
+    assert isinstance(svc, SessionService)
+    # Idempotent
+    assert agent._get_session_service() is svc
+
+
+def test_lazy_context_service_creation():
+    """ContextService is lazily created on __new__-based instances."""
+    from omicverse.utils.ovagent.session_context import ContextService
+
+    agent = OmicVerseAgent.__new__(OmicVerseAgent)
+    svc = agent._get_context_service()
+    assert isinstance(svc, ContextService)
+    assert agent._get_context_service() is svc
+
+
+# -----------------------------------------------------------------------
+# AC-001.5: No new runtime dependencies
+# -----------------------------------------------------------------------
+
+
+def test_no_new_external_dependencies():
+    """The mixin module must only use stdlib and internal imports."""
+    import omicverse.utils.ovagent.session_facade as sf_mod
+
+    source = Path(sf_mod.__file__).read_text()
+    allowed_prefixes = (
+        "from __future__",
+        "import logging",
+        "from contextlib",
+        "from pathlib",
+        "from typing",
+        "from ..",
+        "from .",
+    )
+    for line in source.splitlines():
+        stripped = line.strip()
+        if not (stripped.startswith("import ") or stripped.startswith("from ")):
+            continue
+        # Skip TYPE_CHECKING-guarded imports
+        if "TYPE_CHECKING" in stripped:
+            continue
+        assert any(stripped.startswith(p) for p in allowed_prefixes), (
+            f"Unexpected import in session_facade.py: {stripped}"
+        )

--- a/tests/utils/test_session_facade.py
+++ b/tests/utils/test_session_facade.py
@@ -220,6 +220,62 @@ def test_lazy_context_service_creation():
 
 
 # -----------------------------------------------------------------------
+# AC: Thread-safe lazy initialization — concurrent access atomicity
+# -----------------------------------------------------------------------
+
+def test_concurrent_session_service_same_instance():
+    """Concurrent _get_session_service calls must all return the same instance."""
+    import threading
+    from concurrent.futures import ThreadPoolExecutor, as_completed
+
+    from omicverse.utils.ovagent.session_context import SessionService
+
+    agent = OmicVerseAgent.__new__(OmicVerseAgent)
+    barrier = threading.Barrier(4)
+
+    def get_service():
+        barrier.wait()
+        return agent._get_session_service()
+
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        futures = [pool.submit(get_service) for _ in range(4)]
+        results = [f.result() for f in as_completed(futures)]
+
+    assert all(r is results[0] for r in results)
+    assert isinstance(results[0], SessionService)
+
+
+def test_concurrent_context_service_same_instance():
+    """Concurrent _get_context_service calls must all return the same instance."""
+    import threading
+    from concurrent.futures import ThreadPoolExecutor, as_completed
+
+    from omicverse.utils.ovagent.session_context import ContextService
+
+    agent = OmicVerseAgent.__new__(OmicVerseAgent)
+    barrier = threading.Barrier(4)
+
+    def get_service():
+        barrier.wait()
+        return agent._get_context_service()
+
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        futures = [pool.submit(get_service) for _ in range(4)]
+        results = [f.result() for f in as_completed(futures)]
+
+    assert all(r is results[0] for r in results)
+    assert isinstance(results[0], ContextService)
+
+
+def test_service_init_lock_exists_on_mixin():
+    """The mixin must expose a threading.Lock for service initialization."""
+    import threading
+
+    assert hasattr(SessionContextFacadeMixin, "_service_init_lock")
+    assert isinstance(SessionContextFacadeMixin._service_init_lock, threading.Lock)
+
+
+# -----------------------------------------------------------------------
 # AC-001.5: No new runtime dependencies
 # -----------------------------------------------------------------------
 
@@ -232,6 +288,7 @@ def test_no_new_external_dependencies():
     allowed_prefixes = (
         "from __future__",
         "import logging",
+        "import threading",
         "from contextlib",
         "from pathlib",
         "from typing",

--- a/tests/utils/test_session_facade.py
+++ b/tests/utils/test_session_facade.py
@@ -268,11 +268,14 @@ def test_concurrent_context_service_same_instance():
 
 
 def test_service_init_lock_exists_on_mixin():
-    """The mixin must expose a threading.Lock for service initialization."""
-    import threading
-
+    """The mixin must expose a threading lock for service initialization."""
     assert hasattr(SessionContextFacadeMixin, "_service_init_lock")
-    assert isinstance(SessionContextFacadeMixin._service_init_lock, threading.Lock)
+    lock = SessionContextFacadeMixin._service_init_lock
+    # Verify lock semantics without isinstance(lock, threading.Lock),
+    # which is not portable because threading.Lock is a factory function
+    # rather than a type on some Python builds.
+    assert callable(getattr(lock, "acquire", None))
+    assert callable(getattr(lock, "release", None))
 
 
 # -----------------------------------------------------------------------

--- a/tests/utils/test_smart_agent.py
+++ b/tests/utils/test_smart_agent.py
@@ -923,3 +923,108 @@ def test_mixin_methods_not_duplicated_on_agent_class():
     assert not overlap, (
         f"These methods are duplicated on both OmicVerseAgent and the mixin: {overlap}"
     )
+
+
+# -----------------------------------------------------------------------
+# Task-028: Function-registry prompt footprint optimization
+# -----------------------------------------------------------------------
+
+
+def test_compact_registry_summary_returns_category_lines():
+    """AC-028.1: _get_compact_registry_summary produces category-level lines, not full JSON."""
+    agent = OmicVerseAgent.__new__(OmicVerseAgent)
+    summary = agent._get_compact_registry_summary()
+    # Must be a non-empty string
+    assert isinstance(summary, str)
+    assert len(summary) > 0
+    # Must NOT contain the full JSON dump pattern
+    assert '"signature"' not in summary, "Compact summary should not contain full function signatures"
+    assert '"examples"' not in summary, "Compact summary should not contain example lists"
+    assert '"aliases"' not in summary, "Compact summary should not contain alias lists"
+    # Must contain category markers
+    assert "**" in summary or "functions)" in summary, (
+        "Summary should contain category headings with function counts"
+    )
+
+
+def test_compact_registry_summary_is_much_smaller_than_full_dump():
+    """AC-028.1: The compact summary is significantly smaller than the old full JSON dump."""
+    agent = OmicVerseAgent.__new__(OmicVerseAgent)
+    compact = agent._get_compact_registry_summary()
+    # The compact summary should be well under 5 KB
+    assert len(compact) < 5000, (
+        f"Compact summary is {len(compact)} chars — expected under 5000"
+    )
+
+
+def test_setup_agent_instructions_do_not_contain_full_registry():
+    """AC-028.1: _setup_agent system prompt uses compact summary, not full registry."""
+    import inspect
+    source = inspect.getsource(OmicVerseAgent._setup_agent)
+    # The old code called _get_available_functions_info which returned full JSON
+    assert "_get_available_functions_info" not in source, (
+        "_setup_agent should no longer call _get_available_functions_info"
+    )
+    # The new code should reference the compact summary
+    assert "_get_compact_registry_summary" in source, (
+        "_setup_agent should use _get_compact_registry_summary"
+    )
+    # The old "Here are all the currently registered functions" dump header is gone
+    assert "Here are all the currently registered functions" not in source, (
+        "System prompt should not dump all functions"
+    )
+
+
+def test_search_functions_tool_still_works():
+    """AC-028.2: search_functions tool remains functional for on-demand lookup."""
+    from omicverse.utils.ovagent.tool_runtime_exec import handle_search_functions
+    agent = OmicVerseAgent.__new__(OmicVerseAgent)
+    # search_functions must return results for a known domain keyword
+    result = handle_search_functions(agent, "qc")
+    assert isinstance(result, str)
+    # Should either find matches or return a "no functions" message
+    assert "qc" in result.lower() or "No functions found" in result
+
+
+def test_search_functions_tool_description_mentions_signatures():
+    """AC-028.2: search_functions tool description is informative."""
+    from omicverse.utils.ovagent.tool_runtime import LEGACY_AGENT_TOOLS
+    sf_tool = next(
+        (t for t in LEGACY_AGENT_TOOLS if t["name"] == "search_functions"),
+        None,
+    )
+    assert sf_tool is not None, "search_functions tool must exist"
+    desc = sf_tool["description"]
+    assert "signature" in desc.lower() or "parameter" in desc.lower(), (
+        "search_functions description should mention it returns signatures/parameters"
+    )
+
+
+def test_codegen_flows_still_discover_tools_via_scanner():
+    """AC-028.3: Codegen flows still discover tools through the registry scanner."""
+    agent = OmicVerseAgent.__new__(OmicVerseAgent)
+    # _collect_relevant_registry_entries is the primary codegen discovery path
+    entries = agent._collect_relevant_registry_entries("quality control", max_entries=5)
+    assert isinstance(entries, list)
+    # The scanner should still find QC-related entries
+    if entries:
+        names = [e.get("full_name", "") for e in entries]
+        assert any("qc" in n.lower() for n in names), (
+            f"Expected QC-related entries, got: {names}"
+        )
+
+
+def test_no_new_runtime_dependencies():
+    """AC-028.4: No new runtime dependencies introduced."""
+    import importlib
+    # The compact summary only uses stdlib (json removed, uses string formatting)
+    # and existing internal modules. Verify no new third-party imports.
+    source_path = Path(__file__).resolve().parents[2] / "omicverse" / "utils" / "smart_agent.py"
+    source = source_path.read_text(encoding="utf-8")
+    # Check that no new third-party imports were added beyond what existed
+    # (the file already imports json, os, re, sys, etc.)
+    new_suspects = ["yaml", "toml", "rich", "click", "pydantic"]
+    for suspect in new_suspects:
+        assert f"import {suspect}" not in source, (
+            f"New runtime dependency '{suspect}' found in smart_agent.py"
+        )

--- a/tests/utils/test_smart_agent.py
+++ b/tests/utils/test_smart_agent.py
@@ -49,6 +49,7 @@ assert smart_agent_spec.loader is not None
 smart_agent_spec.loader.exec_module(smart_agent_module)
 
 OmicVerseAgent = smart_agent_module.OmicVerseAgent
+_run_coroutine_sync = smart_agent_module._run_coroutine_sync
 from omicverse.utils.harness import build_stream_event
 from omicverse.utils.ovagent.tool_runtime import ToolRuntime
 
@@ -499,3 +500,226 @@ def test_del_fallback_logs_debug_on_exception(caplog):
     assert len(debug_msgs) == 1, (
         f"Expected exactly 1 debug log about notebook executor, got {len(debug_msgs)}"
     )
+
+
+# -----------------------------------------------------------------------
+# Task-014: Sync/async entrypoint stabilization
+# -----------------------------------------------------------------------
+
+import traceback
+
+
+def _build_agent_that_raises(exc):
+    """Build a minimal agent whose run_async raises *exc*."""
+    agent = OmicVerseAgent.__new__(OmicVerseAgent)
+
+    async def _fake_run_async(self, request, adata):
+        raise exc
+
+    agent.run_async = MethodType(_fake_run_async, agent)
+    return agent
+
+
+# --- AC-001.1: Traceback preservation ---------------------------------
+
+def test_run_preserves_traceback_outside_event_loop():
+    """run() outside a loop preserves the async traceback chain."""
+    agent = _build_agent_that_raises(ValueError("outside-loop-error"))
+
+    with pytest.raises(ValueError, match="outside-loop-error") as exc_info:
+        agent.run("fail", None)
+
+    tb_text = "".join(traceback.format_exception(
+        type(exc_info.value), exc_info.value, exc_info.value.__traceback__,
+    ))
+    assert "_fake_run_async" in tb_text, (
+        f"Traceback should contain the original async function name:\n{tb_text}"
+    )
+
+
+def test_run_preserves_traceback_inside_running_loop():
+    """run() inside a running loop preserves the async traceback chain."""
+    agent = _build_agent_that_raises(ValueError("inside-loop-error"))
+
+    async def _caller():
+        with pytest.raises(ValueError, match="inside-loop-error") as exc_info:
+            agent.run("fail", None)
+
+        tb_text = "".join(traceback.format_exception(
+            type(exc_info.value), exc_info.value, exc_info.value.__traceback__,
+        ))
+        assert "_fake_run_async" in tb_text, (
+            f"Traceback should contain the original async function:\n{tb_text}"
+        )
+
+    asyncio.run(_caller())
+
+
+def test_run_preserves_exception_type_and_message():
+    """Exception type and message survive the sync bridge unchanged."""
+
+    class CustomAgentError(RuntimeError):
+        pass
+
+    agent = _build_agent_that_raises(CustomAgentError("custom-payload"))
+
+    with pytest.raises(CustomAgentError, match="custom-payload"):
+        agent.run("fail", None)
+
+
+def test_run_preserves_traceback_inside_loop_chained():
+    """The traceback chain inside a running loop includes intermediate frames."""
+    agent = OmicVerseAgent.__new__(OmicVerseAgent)
+
+    async def _inner_helper():
+        raise RuntimeError("deep-origin")
+
+    async def _fake_run_async(self, request, adata):
+        await _inner_helper()
+
+    agent.run_async = MethodType(_fake_run_async, agent)
+
+    async def _caller():
+        with pytest.raises(RuntimeError, match="deep-origin") as exc_info:
+            agent.run("fail", None)
+
+        tb_text = "".join(traceback.format_exception(
+            type(exc_info.value), exc_info.value, exc_info.value.__traceback__,
+        ))
+        assert "_inner_helper" in tb_text, (
+            f"Traceback should include the inner helper frame:\n{tb_text}"
+        )
+
+    asyncio.run(_caller())
+
+
+# --- AC-001.2: Event-loop-present regression tests --------------------
+
+def test_event_loop_present_uses_worker_thread():
+    """When a loop is already running, _run_coroutine_sync delegates to a thread."""
+    worker_thread_names = []
+    main_thread_name = threading.current_thread().name
+
+    async def _track_thread():
+        worker_thread_names.append(threading.current_thread().name)
+        return "threaded-result"
+
+    async def _caller():
+        result = _run_coroutine_sync(_track_thread())
+        assert result == "threaded-result"
+        assert len(worker_thread_names) == 1
+        assert worker_thread_names[0] != main_thread_name
+
+    asyncio.run(_caller())
+
+
+def test_no_event_loop_uses_main_thread():
+    """Without a running loop, _run_coroutine_sync uses asyncio.run on the current thread."""
+    worker_thread_names = []
+
+    async def _track_thread():
+        worker_thread_names.append(threading.current_thread().name)
+        return "direct-result"
+
+    result = _run_coroutine_sync(_track_thread())
+    assert result == "direct-result"
+    assert len(worker_thread_names) == 1
+    assert worker_thread_names[0] == threading.current_thread().name
+
+
+# --- AC-001.3: No silent nest_asyncio patching ------------------------
+
+def test_no_nest_asyncio_import_after_run():
+    """run() must not import or patch nest_asyncio as a side effect."""
+    agent = _build_agent(return_value="clean")
+    agent.run("test", None)
+    assert "nest_asyncio" not in sys.modules, (
+        "nest_asyncio was imported as a side effect of run()"
+    )
+
+
+def test_no_nest_asyncio_import_inside_running_loop():
+    """run() inside a running loop must not import nest_asyncio."""
+    agent = _build_agent(return_value="clean-nested")
+
+    async def _caller():
+        agent.run("test", None)
+        assert "nest_asyncio" not in sys.modules, (
+            "nest_asyncio was imported inside a running loop"
+        )
+
+    asyncio.run(_caller())
+
+
+# --- AC-001.4: Public signature unchanged -----------------------------
+
+def test_run_signature_unchanged():
+    """run() accepts (request: str, adata: Any) and returns Any."""
+    import inspect
+    sig = inspect.signature(OmicVerseAgent.run)
+    param_names = list(sig.parameters.keys())
+    assert param_names == ["self", "request", "adata"]
+
+
+def test_generate_code_signature_unchanged():
+    """generate_code() signature is preserved."""
+    import inspect
+    sig = inspect.signature(OmicVerseAgent.generate_code)
+    param_names = list(sig.parameters.keys())
+    assert param_names == ["self", "request", "adata", "max_functions", "progress_callback"]
+
+
+def test_run_async_signature_unchanged():
+    """run_async() signature is preserved."""
+    import inspect
+    sig = inspect.signature(OmicVerseAgent.run_async)
+    param_names = list(sig.parameters.keys())
+    assert param_names == ["self", "request", "adata"]
+
+
+def test_generate_code_async_signature_unchanged():
+    """generate_code_async() signature is preserved."""
+    import inspect
+    sig = inspect.signature(OmicVerseAgent.generate_code_async)
+    param_names = list(sig.parameters.keys())
+    assert param_names == ["self", "request", "adata", "max_functions", "progress_callback"]
+
+
+# --- AC-001.5: Backward compatibility ---------------------------------
+
+def test_run_returns_value_outside_loop():
+    """run() returns the coroutine result when no loop is running."""
+    sentinel = object()
+    agent = _build_agent(return_value=sentinel)
+    result = agent.run("request", None)
+    assert result["value"] is sentinel
+
+
+def test_run_returns_value_inside_loop():
+    """run() returns the coroutine result when called inside a running loop."""
+    sentinel = object()
+    agent = _build_agent(return_value=sentinel)
+
+    async def _caller():
+        result = agent.run("request", None)
+        assert result["value"] is sentinel
+
+    asyncio.run(_caller())
+
+
+def test_generate_code_sync_delegates_to_async():
+    """generate_code() calls generate_code_async through the sync bridge."""
+    agent = OmicVerseAgent.__new__(OmicVerseAgent)
+    calls = []
+
+    async def _fake_generate_code_async(self, request, adata=None, *, max_functions=8, progress_callback=None):
+        calls.append({"request": request, "adata": adata, "max_functions": max_functions})
+        return "generated-code"
+
+    agent.generate_code_async = MethodType(_fake_generate_code_async, agent)
+
+    result = agent.generate_code("build a plot", None, max_functions=5)
+    assert result == "generated-code"
+    assert len(calls) == 1
+    assert calls[0]["request"] == "build a plot"
+    assert calls[0]["max_functions"] == 5

--- a/tests/utils/test_smart_agent.py
+++ b/tests/utils/test_smart_agent.py
@@ -425,3 +425,77 @@ def test_agentic_loop_retries_after_text_only_promise_until_tool_call():
 
     assert [call["tool_choice"] for call in chat_calls[:2]] == ["required", "required"]
     assert "WebFetch" in dispatch_log
+
+
+# -----------------------------------------------------------------------
+# Task-008: Runtime observability tests
+# -----------------------------------------------------------------------
+
+from omicverse.utils.agent_reporter import (
+    AgentEvent,
+    EventLevel,
+    SilentReporter,
+)
+
+
+def test_run_async_silent_reporter_no_stdout():
+    """AC-001.2: SilentReporter mode produces no stdout leakage for runtime paths."""
+    import io
+    from contextlib import redirect_stdout
+
+    agent = OmicVerseAgent.__new__(OmicVerseAgent)
+
+    # Wire up SilentReporter exactly as __init__ would
+    agent._reporter = SilentReporter()
+
+    def _emit(level, message, category=""):
+        agent._reporter.emit(AgentEvent(level=level, message=message, category=category))
+
+    agent._emit = _emit
+    agent.provider = "python"
+    agent.last_usage = None
+    agent.last_usage_breakdown = {
+        "generation": None,
+        "reflection": [],
+        "review": [],
+        "total": None,
+    }
+
+    # Stub the direct-python path so run_async never touches the LLM
+    agent._detect_direct_python_request = lambda request: "x = 1"
+    agent._execute_generated_code = lambda code, adata: adata
+
+    captured = io.StringIO()
+    with redirect_stdout(captured):
+        result = asyncio.run(agent.run_async("x = 1", None))
+
+    stdout_text = captured.getvalue()
+    assert stdout_text == "", (
+        f"SilentReporter leaked to stdout: {stdout_text!r}"
+    )
+
+
+def test_del_fallback_logs_debug_on_exception(caplog):
+    """AC-001.3/4: __del__ fallback sites emit debug diagnostics."""
+    import logging as _logging
+
+    agent = OmicVerseAgent.__new__(OmicVerseAgent)
+
+    class _FailingExecutor:
+        def shutdown(self):
+            raise RuntimeError("test shutdown boom")
+
+    agent._notebook_executor = _FailingExecutor()
+    agent._filesystem_context = None  # only notebook path triggers
+
+    with caplog.at_level(_logging.DEBUG, logger="omicverse.utils.smart_agent"):
+        agent.__del__()
+
+    debug_msgs = [
+        rec
+        for rec in caplog.records
+        if rec.levelno == _logging.DEBUG and "notebook executor shutdown failed" in rec.message
+    ]
+    assert len(debug_msgs) == 1, (
+        f"Expected exactly 1 debug log about notebook executor, got {len(debug_msgs)}"
+    )

--- a/tests/utils/test_smart_agent.py
+++ b/tests/utils/test_smart_agent.py
@@ -723,3 +723,203 @@ def test_generate_code_sync_delegates_to_async():
     assert len(calls) == 1
     assert calls[0]["request"] == "build a plot"
     assert calls[0]["max_functions"] == 5
+
+
+# -----------------------------------------------------------------------
+# Task-027 (reconciled task-013): Codegen / tool-dispatch facade extraction
+# -----------------------------------------------------------------------
+
+from omicverse.utils.ovagent.codegen_tool_facade import CodegenToolDispatchFacadeMixin
+
+
+def test_codegen_tool_facade_mixin_is_base_of_agent():
+    """AC-001.1: OmicVerseAgent inherits from CodegenToolDispatchFacadeMixin."""
+    assert issubclass(OmicVerseAgent, CodegenToolDispatchFacadeMixin)
+
+
+def test_codegen_delegates_available_on_agent_via_mixin():
+    """AC-001.1: Codegen delegate methods resolve via mixin, not on OmicVerseAgent body."""
+    agent = OmicVerseAgent.__new__(OmicVerseAgent)
+    # These methods should be inherited from the mixin
+    codegen_methods = [
+        "_extract_python_code",
+        "_normalize_registry_entry_for_codegen",
+        "_capture_code_only_snippet",
+        "_select_codegen_skill_matches",
+        "_format_registry_context_for_codegen",
+        "_format_prerequisites_for_codegen_entry",
+        "_build_code_generation_system_prompt",
+        "_build_code_generation_user_prompt",
+        "_contains_forbidden_scanpy_usage",
+        "_rewrite_scanpy_calls_with_registry",
+        "_rewrite_code_without_scanpy",
+        "_review_generated_code_lightweight",
+        "_build_code_only_agentic_request",
+        "_generate_code_via_agentic_loop",
+        "_gather_code_candidates",
+        "_looks_like_python",
+        "_extract_inline_python",
+        "_normalize_code_candidate",
+        "_extract_python_code_strict",
+        "_review_result",
+        "_reflect_on_code",
+        "_detect_direct_python_request",
+        "_merge_usage_stats",
+    ]
+    for name in codegen_methods:
+        assert hasattr(agent, name), f"Missing codegen delegate: {name}"
+        # Verify the method is defined on the mixin, not directly on OmicVerseAgent
+        assert name in CodegenToolDispatchFacadeMixin.__dict__, (
+            f"{name} should be defined on CodegenToolDispatchFacadeMixin, not OmicVerseAgent"
+        )
+
+
+def test_tool_dispatch_delegates_available_on_agent_via_mixin():
+    """AC-001.1: Tool dispatch delegate methods resolve via mixin."""
+    agent = OmicVerseAgent.__new__(OmicVerseAgent)
+    tool_methods = [
+        "_get_visible_agent_tools",
+        "_get_loaded_tool_names",
+        "_tool_blocked_in_plan_mode",
+        "_dispatch_tool",
+    ]
+    for name in tool_methods:
+        assert hasattr(agent, name), f"Missing tool delegate: {name}"
+        assert name in CodegenToolDispatchFacadeMixin.__dict__, (
+            f"{name} should be defined on CodegenToolDispatchFacadeMixin"
+        )
+
+
+def test_analysis_executor_delegates_available_on_agent_via_mixin():
+    """AC-001.1: Analysis executor delegate methods resolve via mixin."""
+    agent = OmicVerseAgent.__new__(OmicVerseAgent)
+    executor_methods = [
+        "_check_code_prerequisites",
+        "_apply_execution_error_fix",
+        "_extract_package_name",
+        "_auto_install_package",
+        "_diagnose_error_with_llm",
+        "_validate_outputs",
+        "_generate_completion_code",
+        "_request_approval",
+        "_execute_generated_code",
+        "_normalize_doublet_obs",
+        "_process_context_directives",
+        "_build_sandbox_globals",
+    ]
+    for name in executor_methods:
+        assert hasattr(agent, name), f"Missing executor delegate: {name}"
+        assert name in CodegenToolDispatchFacadeMixin.__dict__, (
+            f"{name} should be defined on CodegenToolDispatchFacadeMixin"
+        )
+
+
+def test_followup_gate_delegates_available_on_agent_via_mixin():
+    """AC-001.1: FollowUp gate delegate methods resolve via mixin."""
+    agent = OmicVerseAgent.__new__(OmicVerseAgent)
+    gate_methods = [
+        "_request_requires_tool_action",
+        "_response_is_promissory",
+        "_select_agent_tool_choice",
+    ]
+    for name in gate_methods:
+        assert hasattr(agent, name), f"Missing gate delegate: {name}"
+        assert name in CodegenToolDispatchFacadeMixin.__dict__, (
+            f"{name} should be defined on CodegenToolDispatchFacadeMixin"
+        )
+
+
+def test_registry_scanner_delegates_available_on_agent_via_mixin():
+    """AC-001.1: Registry scanner delegate methods resolve via mixin."""
+    agent = OmicVerseAgent.__new__(OmicVerseAgent)
+    scanner_methods = [
+        "_load_static_registry_entries",
+        "_collect_relevant_registry_entries",
+        "_collect_static_registry_entries",
+        "_score_registry_entry_for_codegen",
+    ]
+    for name in scanner_methods:
+        assert hasattr(agent, name), f"Missing scanner delegate: {name}"
+        assert name in CodegenToolDispatchFacadeMixin.__dict__, (
+            f"{name} should be defined on CodegenToolDispatchFacadeMixin"
+        )
+
+
+def test_extract_python_code_behavioral_equivalence():
+    """AC-001.2: _extract_python_code still works identically through mixin path."""
+    agent = OmicVerseAgent.__new__(OmicVerseAgent)
+    response = """Here is the code:
+```python
+import omicverse as ov
+ov.pp.qc(adata)
+```
+"""
+    code = agent._extract_python_code(response)
+    assert "ov.pp.qc" in code
+    # Verify AST-valid
+    ast.parse(code)
+
+
+def test_codegen_lazy_property_via_mixin():
+    """AC-001.2: _codegen lazy property works through mixin for __new__ instances."""
+    agent = OmicVerseAgent.__new__(OmicVerseAgent)
+    # The _codegen property should lazily create a CodegenPipeline
+    pipeline = agent._codegen
+    from omicverse.utils.ovagent.codegen_pipeline import CodegenPipeline
+    assert isinstance(pipeline, CodegenPipeline)
+    # Second access should return same instance
+    assert agent._codegen is pipeline
+
+
+def test_scanner_lazy_property_via_mixin():
+    """AC-001.2: _scanner lazy property works through mixin for __new__ instances."""
+    agent = OmicVerseAgent.__new__(OmicVerseAgent)
+    scanner = agent._scanner
+    from omicverse.utils.ovagent.registry_scanner import RegistryScanner
+    assert isinstance(scanner, RegistryScanner)
+    assert agent._scanner is scanner
+
+
+def test_followup_gate_behavioral_equivalence():
+    """AC-001.2: Follow-up gate methods produce identical results through mixin."""
+    agent = OmicVerseAgent.__new__(OmicVerseAgent)
+    # These methods are stateless -- verify they work through the mixin path
+    assert agent._request_requires_tool_action(
+        "https://example.com\nanalyze this", None
+    ) is True
+    assert agent._response_is_promissory(
+        "Let me first fetch the page to understand."
+    ) is True
+    assert agent._select_agent_tool_choice(
+        request="https://example.com\nanalyze",
+        adata=None,
+        turn_index=0,
+        had_meaningful_tool_call=False,
+        forced_retry=False,
+    ) == "required"
+
+
+def test_no_provider_logic_in_facade_mixin():
+    """AC-001.5: Mixin does not import or reference provider-specific modules."""
+    import inspect
+    source = inspect.getsource(CodegenToolDispatchFacadeMixin)
+    # Should not contain provider-specific references
+    for provider_term in ["openai", "anthropic", "google", "bedrock", "groq"]:
+        assert provider_term not in source.lower(), (
+            f"Provider logic '{provider_term}' found in CodegenToolDispatchFacadeMixin"
+        )
+
+
+def test_mixin_methods_not_duplicated_on_agent_class():
+    """AC-001.1: Extracted methods should NOT be redefined on OmicVerseAgent itself."""
+    # Get methods defined directly on OmicVerseAgent (not inherited),
+    # excluding standard Python dunder attributes that every class has.
+    dunder_ignore = {"__module__", "__doc__", "__dict__", "__weakref__",
+                     "__firstlineno__", "__static_attributes__", "__qualname__"}
+    agent_own_methods = set(OmicVerseAgent.__dict__.keys()) - dunder_ignore
+    mixin_methods = set(CodegenToolDispatchFacadeMixin.__dict__.keys()) - dunder_ignore
+    # No overlap means no duplication
+    overlap = agent_own_methods & mixin_methods
+    assert not overlap, (
+        f"These methods are duplicated on both OmicVerseAgent and the mixin: {overlap}"
+    )

--- a/tests/utils/test_subagent_override_plumbing.py
+++ b/tests/utils/test_subagent_override_plumbing.py
@@ -1,0 +1,620 @@
+"""Tests for subagent override plumbing through runtime bootstrap (task-016).
+
+Covers:
+  - SubagentController.run_subagent uses AgentConfig.get_subagent_config
+    (not raw SUBAGENT_CONFIGS) so overrides actually reach the runtime.
+  - Default explore/plan/execute behavior is unchanged when no overrides.
+  - Permission policy and SubagentRuntime honor overridden allowed_tools,
+    max_turns, and can_mutate_adata.
+  - Tool restriction regressions are caught for both default and override paths.
+"""
+
+import importlib
+import importlib.machinery
+import os
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Guard: require harness env-var
+# ---------------------------------------------------------------------------
+
+_RUN_HARNESS = os.environ.get("OV_AGENT_RUN_HARNESS_TESTS", "").lower() in {
+    "1", "true", "yes", "on",
+}
+pytestmark = pytest.mark.skipif(
+    not _RUN_HARNESS,
+    reason="Subagent override plumbing tests require OV_AGENT_RUN_HARNESS_TESTS=1.",
+)
+
+# ---------------------------------------------------------------------------
+# Bootstrap: lightweight package stubs
+# ---------------------------------------------------------------------------
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+PACKAGE_ROOT = PROJECT_ROOT / "omicverse"
+
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+_SAVED = {
+    name: sys.modules.get(name)
+    for name in ["omicverse", "omicverse.utils"]
+}
+for name in ["omicverse", "omicverse.utils"]:
+    sys.modules.pop(name, None)
+
+_ov_pkg = types.ModuleType("omicverse")
+_ov_pkg.__path__ = [str(PACKAGE_ROOT)]
+_ov_pkg.__spec__ = importlib.machinery.ModuleSpec(
+    "omicverse", loader=None, is_package=True
+)
+sys.modules["omicverse"] = _ov_pkg
+
+_utils_pkg = types.ModuleType("omicverse.utils")
+_utils_pkg.__path__ = [str(PACKAGE_ROOT / "utils")]
+_utils_pkg.__spec__ = importlib.machinery.ModuleSpec(
+    "omicverse.utils", loader=None, is_package=True
+)
+sys.modules["omicverse.utils"] = _utils_pkg
+_ov_pkg.utils = _utils_pkg
+
+from omicverse.utils.agent_config import (
+    AgentConfig,
+    SUBAGENT_CONFIGS,
+    SubagentConfig,
+)
+from omicverse.utils.ovagent import (
+    SubagentController,
+    SubagentRuntime,
+    ToolRuntime,
+    create_subagent_policy,
+)
+from omicverse.utils.ovagent.prompt_builder import PromptBuilder
+from omicverse.utils.ovagent.tool_runtime import LEGACY_AGENT_TOOLS
+from omicverse.utils.ovagent.context_budget import create_subagent_budget_manager
+
+for name, mod in _SAVED.items():
+    if mod is None:
+        sys.modules.pop(name, None)
+    else:
+        sys.modules[name] = mod
+
+
+# ---------------------------------------------------------------------------
+# Minimal test doubles
+# ---------------------------------------------------------------------------
+
+class _DummyCtx:
+    """Minimal AgentContext stub with configurable AgentConfig."""
+
+    LEGACY_AGENT_TOOLS = LEGACY_AGENT_TOOLS
+
+    def __init__(self, agent_config=None):
+        self.model = "test-model"
+        self.provider = "openai"
+        self.endpoint = "https://api.example.com"
+        self.api_key = None
+        self._llm = None
+        self._config = agent_config or AgentConfig()
+        self._security_config = SimpleNamespace()
+        self._security_scanner = SimpleNamespace()
+        self._filesystem_context = None
+        self.skill_registry = None
+        self._notebook_executor = None
+        self._ov_runtime = None
+        self._trace_store = None
+        self._session_history = None
+        self._context_compactor = None
+        self._approval_handler = None
+        self._reporter = MagicMock()
+        self.last_usage = None
+        self.last_usage_breakdown = {}
+        self._last_run_trace = None
+        self._active_run_id = ""
+        self._web_session_id = "test-session"
+        self._managed_api_env = {}
+        self._code_only_mode = False
+        self._code_only_captured_code = ""
+        self._code_only_captured_history = []
+        self.use_notebook_execution = False
+        self.enable_filesystem_context = False
+
+    def _get_runtime_session_id(self):
+        return self._web_session_id
+
+    def _emit(self, level, message, category=""):
+        pass
+
+    def _get_harness_session_id(self):
+        return self._web_session_id
+
+    def _get_visible_agent_tools(self, *, allowed_names=None):
+        return []
+
+    def _get_loaded_tool_names(self):
+        return []
+
+    def _refresh_runtime_working_directory(self):
+        return "."
+
+    def _tool_blocked_in_plan_mode(self, tool_name):
+        return False
+
+    def _detect_repo_root(self, cwd=None):
+        return None
+
+    def _resolve_local_path(self, file_path, *, allow_relative=False):
+        raise NotImplementedError
+
+    def _ensure_server_tool_mode(self, tool_name):
+        pass
+
+    def _request_interaction(self, payload):
+        raise NotImplementedError
+
+    def _request_tool_approval(self, tool_name, *, reason, payload):
+        raise NotImplementedError
+
+    def _load_skill_guidance(self, slug):
+        return ""
+
+    def _extract_python_code(self, text):
+        return text
+
+    def _normalize_registry_entry_for_codegen(self, entry):
+        return entry
+
+    def _build_agentic_system_prompt(self):
+        return "test"
+
+    async def _run_agentic_loop(self, request, adata, **kwargs):
+        return adata
+
+    from contextlib import contextmanager
+
+    @contextmanager
+    def _temporary_api_keys(self):
+        yield
+
+
+class _DummyExecutor:
+    pass
+
+
+def _make_controller(agent_config=None):
+    """Build a SubagentController with a given AgentConfig."""
+    ctx = _DummyCtx(agent_config=agent_config)
+    pb = PromptBuilder(ctx)
+    rt = ToolRuntime(ctx, _DummyExecutor())
+    sc = SubagentController(ctx, pb, rt)
+    return sc, ctx
+
+
+# ===================================================================
+# 1. Default behaviour unchanged when no overrides
+# ===================================================================
+
+class TestDefaultBehaviourUnchanged:
+
+    def test_default_explore_runtime_matches_subagent_configs(self):
+        sc, _ = _make_controller()
+        rt = sc._create_subagent_runtime(
+            agent_type="explore",
+            allowed_tools=frozenset(SUBAGENT_CONFIGS["explore"].allowed_tools),
+            max_turns=SUBAGENT_CONFIGS["explore"].max_turns,
+            can_mutate_adata=SUBAGENT_CONFIGS["explore"].can_mutate_adata,
+        )
+        assert rt.agent_type == "explore"
+        assert rt.max_turns == 5
+        assert rt.can_mutate_adata is False
+
+    def test_default_plan_runtime_matches_subagent_configs(self):
+        sc, _ = _make_controller()
+        rt = sc._create_subagent_runtime(
+            agent_type="plan",
+            allowed_tools=frozenset(SUBAGENT_CONFIGS["plan"].allowed_tools),
+            max_turns=SUBAGENT_CONFIGS["plan"].max_turns,
+            can_mutate_adata=SUBAGENT_CONFIGS["plan"].can_mutate_adata,
+        )
+        assert rt.max_turns == 8
+        assert rt.can_mutate_adata is False
+
+    def test_default_execute_runtime_matches_subagent_configs(self):
+        sc, _ = _make_controller()
+        rt = sc._create_subagent_runtime(
+            agent_type="execute",
+            allowed_tools=frozenset(SUBAGENT_CONFIGS["execute"].allowed_tools),
+            max_turns=SUBAGENT_CONFIGS["execute"].max_turns,
+            can_mutate_adata=SUBAGENT_CONFIGS["execute"].can_mutate_adata,
+        )
+        assert rt.max_turns == 10
+        assert rt.can_mutate_adata is True
+
+    def test_no_override_config_resolves_to_defaults_for_all_types(self):
+        cfg = AgentConfig()
+        for agent_type, default in SUBAGENT_CONFIGS.items():
+            resolved = cfg.get_subagent_config(agent_type)
+            assert resolved.max_turns == default.max_turns
+            assert resolved.allowed_tools == default.allowed_tools
+            assert resolved.can_mutate_adata == default.can_mutate_adata
+            assert resolved.temperature == default.temperature
+
+
+# ===================================================================
+# 2. Override plumbing reaches SubagentController._create_subagent_runtime
+# ===================================================================
+
+class TestOverridePlumbing:
+
+    def test_overridden_max_turns_reaches_runtime(self):
+        cfg = AgentConfig(subagent_overrides={"explore": {"max_turns": 20}})
+        sc, _ = _make_controller(agent_config=cfg)
+        resolved = cfg.get_subagent_config("explore")
+        rt = sc._create_subagent_runtime(
+            agent_type="explore",
+            allowed_tools=frozenset(resolved.allowed_tools),
+            max_turns=resolved.max_turns,
+            can_mutate_adata=resolved.can_mutate_adata,
+        )
+        assert rt.max_turns == 20
+
+    def test_overridden_can_mutate_adata_reaches_runtime(self):
+        cfg = AgentConfig(subagent_overrides={
+            "explore": {"can_mutate_adata": True}
+        })
+        sc, _ = _make_controller(agent_config=cfg)
+        resolved = cfg.get_subagent_config("explore")
+        rt = sc._create_subagent_runtime(
+            agent_type="explore",
+            allowed_tools=frozenset(resolved.allowed_tools),
+            max_turns=resolved.max_turns,
+            can_mutate_adata=resolved.can_mutate_adata,
+        )
+        assert rt.can_mutate_adata is True
+
+    def test_overridden_allowed_tools_restrict_permission_policy(self):
+        """When allowed_tools is overridden, the permission policy reflects it."""
+        custom_tools = ["inspect_data", "finish"]
+        cfg = AgentConfig(subagent_overrides={
+            "execute": {"allowed_tools": custom_tools}
+        })
+        sc, _ = _make_controller(agent_config=cfg)
+        resolved = cfg.get_subagent_config("execute")
+        rt = sc._create_subagent_runtime(
+            agent_type="execute",
+            allowed_tools=frozenset(resolved.allowed_tools),
+            max_turns=resolved.max_turns,
+            can_mutate_adata=resolved.can_mutate_adata,
+        )
+        # Allowed tools should pass
+        assert not rt.check_tool_permission("inspect_data").is_denied
+        assert not rt.check_tool_permission("finish").is_denied
+        # Tools NOT in the override list should be denied
+        assert rt.check_tool_permission("execute_code").is_denied
+        assert rt.check_tool_permission("web_fetch").is_denied
+
+
+# ===================================================================
+# 3. run_subagent uses get_subagent_config (not raw SUBAGENT_CONFIGS)
+# ===================================================================
+
+class TestRunSubagentResolvesConfig:
+    """Verify run_subagent reads the effective profile, not the global default.
+
+    We can't easily run the full async loop without an LLM, so we
+    monkeypatch _create_subagent_runtime to capture the arguments it
+    receives from run_subagent and verify they match the overridden config.
+    """
+
+    def test_run_subagent_passes_overridden_values_to_runtime_factory(self):
+        cfg = AgentConfig(subagent_overrides={
+            "explore": {"max_turns": 42, "can_mutate_adata": True}
+        })
+        sc, ctx = _make_controller(agent_config=cfg)
+
+        captured = {}
+        original_create = sc._create_subagent_runtime
+
+        def spy_create(*, agent_type, allowed_tools, max_turns, can_mutate_adata=False):
+            captured["agent_type"] = agent_type
+            captured["allowed_tools"] = allowed_tools
+            captured["max_turns"] = max_turns
+            captured["can_mutate_adata"] = can_mutate_adata
+            return original_create(
+                agent_type=agent_type,
+                allowed_tools=allowed_tools,
+                max_turns=max_turns,
+                can_mutate_adata=can_mutate_adata,
+            )
+
+        sc._create_subagent_runtime = spy_create
+
+        # We need a mock LLM that returns a response with no tool_calls
+        mock_response = SimpleNamespace(
+            content="done",
+            tool_calls=None,
+            raw_message=None,
+            usage=None,
+        )
+        mock_llm = MagicMock()
+        mock_llm.chat = MagicMock(return_value=mock_response)
+        # Make chat a coroutine
+        import asyncio
+
+        async def mock_chat(*args, **kwargs):
+            return mock_response
+
+        mock_llm.chat = mock_chat
+        ctx._llm = mock_llm
+
+        result = asyncio.run(sc.run_subagent("explore", "test task", None))
+
+        assert captured["max_turns"] == 42
+        assert captured["can_mutate_adata"] is True
+        assert captured["agent_type"] == "explore"
+
+    def test_run_subagent_default_config_passes_default_values(self):
+        """With no overrides, run_subagent passes the SUBAGENT_CONFIGS defaults."""
+        cfg = AgentConfig()  # no overrides
+        sc, ctx = _make_controller(agent_config=cfg)
+
+        captured = {}
+        original_create = sc._create_subagent_runtime
+
+        def spy_create(*, agent_type, allowed_tools, max_turns, can_mutate_adata=False):
+            captured["agent_type"] = agent_type
+            captured["allowed_tools"] = allowed_tools
+            captured["max_turns"] = max_turns
+            captured["can_mutate_adata"] = can_mutate_adata
+            return original_create(
+                agent_type=agent_type,
+                allowed_tools=allowed_tools,
+                max_turns=max_turns,
+                can_mutate_adata=can_mutate_adata,
+            )
+
+        sc._create_subagent_runtime = spy_create
+
+        mock_response = SimpleNamespace(
+            content="done", tool_calls=None, raw_message=None, usage=None,
+        )
+
+        import asyncio
+
+        async def mock_chat(*args, **kwargs):
+            return mock_response
+
+        mock_llm = MagicMock()
+        mock_llm.chat = mock_chat
+        ctx._llm = mock_llm
+
+        asyncio.run(sc.run_subagent("plan", "test task", None))
+
+        default = SUBAGENT_CONFIGS["plan"]
+        assert captured["max_turns"] == default.max_turns
+        assert captured["can_mutate_adata"] == default.can_mutate_adata
+        assert captured["allowed_tools"] == frozenset(default.allowed_tools)
+
+    def test_run_subagent_overridden_allowed_tools_flow_to_runtime(self):
+        """Overridden allowed_tools reach the runtime factory."""
+        custom = ["inspect_data", "finish"]
+        cfg = AgentConfig(subagent_overrides={
+            "execute": {"allowed_tools": custom}
+        })
+        sc, ctx = _make_controller(agent_config=cfg)
+
+        captured = {}
+        original_create = sc._create_subagent_runtime
+
+        def spy_create(*, agent_type, allowed_tools, max_turns, can_mutate_adata=False):
+            captured["allowed_tools"] = allowed_tools
+            return original_create(
+                agent_type=agent_type,
+                allowed_tools=allowed_tools,
+                max_turns=max_turns,
+                can_mutate_adata=can_mutate_adata,
+            )
+
+        sc._create_subagent_runtime = spy_create
+
+        mock_response = SimpleNamespace(
+            content="done", tool_calls=None, raw_message=None, usage=None,
+        )
+
+        import asyncio
+
+        async def mock_chat(*args, **kwargs):
+            return mock_response
+
+        mock_llm = MagicMock()
+        mock_llm.chat = mock_chat
+        ctx._llm = mock_llm
+
+        asyncio.run(sc.run_subagent("execute", "test task", None))
+
+        assert captured["allowed_tools"] == frozenset(custom)
+
+
+# ===================================================================
+# 4. Permission policy covers both default and override paths
+# ===================================================================
+
+class TestPermissionPolicyDefaultVsOverride:
+
+    def test_default_explore_denies_execute_code(self):
+        """Default explore subagent does NOT have execute_code."""
+        cfg = AgentConfig()
+        sc, _ = _make_controller(agent_config=cfg)
+        resolved = cfg.get_subagent_config("explore")
+        rt = sc._create_subagent_runtime(
+            agent_type="explore",
+            allowed_tools=frozenset(resolved.allowed_tools),
+            max_turns=resolved.max_turns,
+            can_mutate_adata=resolved.can_mutate_adata,
+        )
+        assert rt.check_tool_permission("execute_code").is_denied
+
+    def test_default_execute_allows_execute_code(self):
+        """Default execute subagent DOES have execute_code."""
+        cfg = AgentConfig()
+        sc, _ = _make_controller(agent_config=cfg)
+        resolved = cfg.get_subagent_config("execute")
+        rt = sc._create_subagent_runtime(
+            agent_type="execute",
+            allowed_tools=frozenset(resolved.allowed_tools),
+            max_turns=resolved.max_turns,
+            can_mutate_adata=resolved.can_mutate_adata,
+        )
+        assert not rt.check_tool_permission("execute_code").is_denied
+
+    def test_overriding_explore_to_add_execute_code(self):
+        """If explore overrides gain execute_code, policy allows it."""
+        explore_tools = list(SUBAGENT_CONFIGS["explore"].allowed_tools) + ["execute_code"]
+        cfg = AgentConfig(subagent_overrides={
+            "explore": {"allowed_tools": explore_tools}
+        })
+        sc, _ = _make_controller(agent_config=cfg)
+        resolved = cfg.get_subagent_config("explore")
+        rt = sc._create_subagent_runtime(
+            agent_type="explore",
+            allowed_tools=frozenset(resolved.allowed_tools),
+            max_turns=resolved.max_turns,
+            can_mutate_adata=resolved.can_mutate_adata,
+        )
+        assert not rt.check_tool_permission("execute_code").is_denied
+
+    def test_overriding_execute_to_remove_execute_code(self):
+        """If execute overrides drop execute_code, policy denies it."""
+        restricted_tools = ["inspect_data", "run_snippet", "finish"]
+        cfg = AgentConfig(subagent_overrides={
+            "execute": {"allowed_tools": restricted_tools}
+        })
+        sc, _ = _make_controller(agent_config=cfg)
+        resolved = cfg.get_subagent_config("execute")
+        rt = sc._create_subagent_runtime(
+            agent_type="execute",
+            allowed_tools=frozenset(resolved.allowed_tools),
+            max_turns=resolved.max_turns,
+            can_mutate_adata=resolved.can_mutate_adata,
+        )
+        assert rt.check_tool_permission("execute_code").is_denied
+        assert not rt.check_tool_permission("inspect_data").is_denied
+
+
+# ===================================================================
+# 5. Runtime isolation properties preserved under overrides
+# ===================================================================
+
+class TestRuntimeIsolationWithOverrides:
+
+    def test_overridden_runtime_does_not_share_parent_usage(self):
+        cfg = AgentConfig(subagent_overrides={"explore": {"max_turns": 30}})
+        ctx = _DummyCtx(agent_config=cfg)
+        ctx.last_usage = {"prompt_tokens": 999}
+
+        resolved = cfg.get_subagent_config("explore")
+        policy = create_subagent_policy(
+            ToolRuntime(ctx, _DummyExecutor()).registry,
+            allowed_tools=frozenset(resolved.allowed_tools),
+        )
+        rt = SubagentRuntime(
+            agent_type="explore",
+            max_turns=resolved.max_turns,
+            permission_policy=policy,
+            budget_manager=create_subagent_budget_manager(model="test"),
+        )
+        rt.record_usage({"prompt_tokens": 42})
+
+        assert ctx.last_usage == {"prompt_tokens": 999}
+        assert rt.last_usage == {"prompt_tokens": 42}
+        assert rt.max_turns == 30
+
+    def test_overridden_runtime_tool_schemas_are_snapshot(self):
+        cfg = AgentConfig(subagent_overrides={"plan": {"max_turns": 15}})
+        sc, _ = _make_controller(agent_config=cfg)
+        resolved = cfg.get_subagent_config("plan")
+        rt = sc._create_subagent_runtime(
+            agent_type="plan",
+            allowed_tools=frozenset(resolved.allowed_tools),
+            max_turns=resolved.max_turns,
+            can_mutate_adata=resolved.can_mutate_adata,
+        )
+        original_len = len(rt.tool_schemas)
+        rt.tool_schemas.append({"name": "injected"})
+        # A new runtime gets a fresh list
+        rt2 = sc._create_subagent_runtime(
+            agent_type="plan",
+            allowed_tools=frozenset(resolved.allowed_tools),
+            max_turns=resolved.max_turns,
+            can_mutate_adata=resolved.can_mutate_adata,
+        )
+        assert len(rt2.tool_schemas) == original_len
+
+
+# ===================================================================
+# 6. No public regression in subagent tool restrictions
+# ===================================================================
+
+class TestToolRestrictionRegression:
+    """Ensure default tool sets are exactly as specified in SUBAGENT_CONFIGS."""
+
+    def test_explore_default_tool_set(self):
+        cfg = AgentConfig()
+        resolved = cfg.get_subagent_config("explore")
+        expected = {
+            "inspect_data", "run_snippet", "search_functions",
+            "web_fetch", "web_search", "finish",
+        }
+        assert set(resolved.allowed_tools) == expected
+
+    def test_plan_default_tool_set(self):
+        cfg = AgentConfig()
+        resolved = cfg.get_subagent_config("plan")
+        expected = {
+            "inspect_data", "run_snippet", "search_functions",
+            "search_skills", "web_fetch", "web_search", "finish",
+        }
+        assert set(resolved.allowed_tools) == expected
+
+    def test_execute_default_tool_set(self):
+        cfg = AgentConfig()
+        resolved = cfg.get_subagent_config("execute")
+        expected = {
+            "inspect_data", "execute_code", "run_snippet",
+            "search_functions", "web_fetch", "web_search",
+            "web_download", "finish",
+        }
+        assert set(resolved.allowed_tools) == expected
+
+    def test_explore_default_cannot_mutate(self):
+        cfg = AgentConfig()
+        assert cfg.get_subagent_config("explore").can_mutate_adata is False
+
+    def test_plan_default_cannot_mutate(self):
+        cfg = AgentConfig()
+        assert cfg.get_subagent_config("plan").can_mutate_adata is False
+
+    def test_execute_default_can_mutate(self):
+        cfg = AgentConfig()
+        assert cfg.get_subagent_config("execute").can_mutate_adata is True
+
+    def test_global_defaults_not_mutated_after_override_resolution(self):
+        """Resolving overrides must not contaminate module-level SUBAGENT_CONFIGS."""
+        cfg = AgentConfig(subagent_overrides={
+            "explore": {"max_turns": 999, "can_mutate_adata": True},
+            "plan": {"allowed_tools": ["finish"]},
+            "execute": {"temperature": 0.99},
+        })
+        for agent_type in SUBAGENT_CONFIGS:
+            cfg.get_subagent_config(agent_type)
+
+        assert SUBAGENT_CONFIGS["explore"].max_turns == 5
+        assert SUBAGENT_CONFIGS["explore"].can_mutate_adata is False
+        assert len(SUBAGENT_CONFIGS["plan"].allowed_tools) > 1
+        assert SUBAGENT_CONFIGS["execute"].temperature == 0.1

--- a/tests/utils/test_subagent_profile_schema.py
+++ b/tests/utils/test_subagent_profile_schema.py
@@ -1,0 +1,268 @@
+"""Tests for configurable subagent profile overrides in AgentConfig (task-015).
+
+Covers:
+  - AgentConfig.subagent_overrides is an optional schema field
+  - SUBAGENT_CONFIGS remain the default when no overrides are provided
+  - Partial overrides merge cleanly with defaults
+  - Flat kwargs compatibility is preserved
+  - Invalid overrides are rejected
+  - Overrides do not mutate the global SUBAGENT_CONFIGS defaults
+"""
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Guard: require harness env-var
+# ---------------------------------------------------------------------------
+
+_RUN_HARNESS = os.environ.get("OV_AGENT_RUN_HARNESS_TESTS", "").lower() in {
+    "1", "true", "yes", "on",
+}
+pytestmark = pytest.mark.skipif(
+    not _RUN_HARNESS,
+    reason="Subagent profile tests require OV_AGENT_RUN_HARNESS_TESTS=1.",
+)
+
+# ---------------------------------------------------------------------------
+# Bootstrap: ensure project root is importable
+# ---------------------------------------------------------------------------
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from omicverse.utils.agent_config import (
+    AgentConfig,
+    SUBAGENT_CONFIGS,
+    SubagentConfig,
+)
+
+
+# ===================================================================
+# 1. Schema field existence and defaults
+# ===================================================================
+
+class TestSubagentOverridesField:
+
+    def test_field_exists_on_agent_config(self):
+        cfg = AgentConfig()
+        assert hasattr(cfg, "subagent_overrides")
+
+    def test_default_is_empty_dict(self):
+        cfg = AgentConfig()
+        assert cfg.subagent_overrides == {}
+
+    def test_field_accepts_dict(self):
+        cfg = AgentConfig(subagent_overrides={"explore": {"max_turns": 10}})
+        assert cfg.subagent_overrides == {"explore": {"max_turns": 10}}
+
+
+# ===================================================================
+# 2. Defaults preserved when no overrides
+# ===================================================================
+
+class TestDefaultsPreserved:
+
+    def test_get_subagent_config_returns_defaults(self):
+        cfg = AgentConfig()
+        for name, expected in SUBAGENT_CONFIGS.items():
+            result = cfg.get_subagent_config(name)
+            assert result.agent_type == expected.agent_type
+            assert result.allowed_tools == expected.allowed_tools
+            assert result.max_turns == expected.max_turns
+            assert result.can_mutate_adata == expected.can_mutate_adata
+            assert result.temperature == expected.temperature
+
+    def test_all_known_profiles_accessible(self):
+        cfg = AgentConfig()
+        for name in ["explore", "plan", "execute"]:
+            result = cfg.get_subagent_config(name)
+            assert isinstance(result, SubagentConfig)
+            assert result.agent_type == name
+
+
+# ===================================================================
+# 3. Partial overrides merge cleanly
+# ===================================================================
+
+class TestPartialOverrideMerge:
+
+    def test_single_field_override(self):
+        cfg = AgentConfig(subagent_overrides={
+            "explore": {"max_turns": 20},
+        })
+        result = cfg.get_subagent_config("explore")
+        # Overridden field
+        assert result.max_turns == 20
+        # Non-overridden fields match defaults
+        default = SUBAGENT_CONFIGS["explore"]
+        assert result.allowed_tools == default.allowed_tools
+        assert result.can_mutate_adata == default.can_mutate_adata
+        assert result.temperature == default.temperature
+
+    def test_multiple_field_override(self):
+        cfg = AgentConfig(subagent_overrides={
+            "plan": {"max_turns": 15, "temperature": 0.5},
+        })
+        result = cfg.get_subagent_config("plan")
+        assert result.max_turns == 15
+        assert result.temperature == 0.5
+        # Remaining fields unchanged
+        default = SUBAGENT_CONFIGS["plan"]
+        assert result.allowed_tools == default.allowed_tools
+        assert result.can_mutate_adata == default.can_mutate_adata
+
+    def test_override_allowed_tools(self):
+        custom_tools = ["inspect_data", "finish"]
+        cfg = AgentConfig(subagent_overrides={
+            "execute": {"allowed_tools": custom_tools},
+        })
+        result = cfg.get_subagent_config("execute")
+        assert result.allowed_tools == custom_tools
+        # Other fields unchanged
+        default = SUBAGENT_CONFIGS["execute"]
+        assert result.max_turns == default.max_turns
+        assert result.can_mutate_adata == default.can_mutate_adata
+
+    def test_override_can_mutate_adata(self):
+        cfg = AgentConfig(subagent_overrides={
+            "explore": {"can_mutate_adata": True},
+        })
+        result = cfg.get_subagent_config("explore")
+        assert result.can_mutate_adata is True
+
+    def test_multiple_profiles_overridden(self):
+        cfg = AgentConfig(subagent_overrides={
+            "explore": {"max_turns": 3},
+            "execute": {"temperature": 0.9},
+        })
+        explore = cfg.get_subagent_config("explore")
+        execute = cfg.get_subagent_config("execute")
+        plan = cfg.get_subagent_config("plan")
+
+        assert explore.max_turns == 3
+        assert execute.temperature == 0.9
+        # Plan unaffected
+        assert plan.max_turns == SUBAGENT_CONFIGS["plan"].max_turns
+
+    def test_non_overridden_profile_returns_defaults(self):
+        cfg = AgentConfig(subagent_overrides={
+            "explore": {"max_turns": 99},
+        })
+        plan = cfg.get_subagent_config("plan")
+        default = SUBAGENT_CONFIGS["plan"]
+        assert plan.max_turns == default.max_turns
+        assert plan.temperature == default.temperature
+
+
+# ===================================================================
+# 4. Global SUBAGENT_CONFIGS not mutated
+# ===================================================================
+
+class TestNoGlobalMutation:
+
+    def test_override_does_not_mutate_global(self):
+        original_max_turns = SUBAGENT_CONFIGS["explore"].max_turns
+        cfg = AgentConfig(subagent_overrides={
+            "explore": {"max_turns": 999},
+        })
+        result = cfg.get_subagent_config("explore")
+        assert result.max_turns == 999
+        # Global default must be unchanged
+        assert SUBAGENT_CONFIGS["explore"].max_turns == original_max_turns
+
+    def test_repeated_calls_do_not_accumulate(self):
+        cfg = AgentConfig(subagent_overrides={
+            "plan": {"max_turns": 50},
+        })
+        r1 = cfg.get_subagent_config("plan")
+        r2 = cfg.get_subagent_config("plan")
+        assert r1.max_turns == 50
+        assert r2.max_turns == 50
+        # Each call returns a fresh copy
+        assert r1 is not r2
+
+
+# ===================================================================
+# 5. Error handling
+# ===================================================================
+
+class TestOverrideErrors:
+
+    def test_unknown_agent_type_raises_key_error(self):
+        cfg = AgentConfig()
+        with pytest.raises(KeyError, match="nonexistent"):
+            cfg.get_subagent_config("nonexistent")
+
+    def test_invalid_field_name_raises_value_error(self):
+        cfg = AgentConfig(subagent_overrides={
+            "explore": {"bogus_field": 42},
+        })
+        with pytest.raises(ValueError, match="bogus_field"):
+            cfg.get_subagent_config("explore")
+
+    def test_valid_error_message_lists_valid_fields(self):
+        cfg = AgentConfig(subagent_overrides={
+            "explore": {"nope": 1},
+        })
+        with pytest.raises(ValueError, match="max_turns"):
+            cfg.get_subagent_config("explore")
+
+
+# ===================================================================
+# 6. Flat kwargs compatibility
+# ===================================================================
+
+class TestFlatKwargsCompatibility:
+
+    def test_from_flat_kwargs_without_overrides(self):
+        cfg = AgentConfig.from_flat_kwargs(model="gpt-4")
+        assert cfg.subagent_overrides == {}
+        # All default profiles still accessible
+        for name in SUBAGENT_CONFIGS:
+            result = cfg.get_subagent_config(name)
+            assert isinstance(result, SubagentConfig)
+
+    def test_from_flat_kwargs_with_overrides(self):
+        overrides = {"explore": {"max_turns": 12, "temperature": 0.7}}
+        cfg = AgentConfig.from_flat_kwargs(
+            model="gpt-4",
+            subagent_overrides=overrides,
+        )
+        assert cfg.subagent_overrides == overrides
+        result = cfg.get_subagent_config("explore")
+        assert result.max_turns == 12
+        assert result.temperature == 0.7
+
+    def test_from_flat_kwargs_preserves_other_fields(self):
+        cfg = AgentConfig.from_flat_kwargs(
+            model="claude-3-opus",
+            subagent_overrides={"plan": {"max_turns": 4}},
+        )
+        assert cfg.llm.model == "claude-3-opus"
+        assert cfg.subagent_overrides == {"plan": {"max_turns": 4}}
+
+
+# ===================================================================
+# 7. Return type contract
+# ===================================================================
+
+class TestReturnTypeContract:
+
+    def test_get_subagent_config_returns_subagent_config(self):
+        cfg = AgentConfig()
+        for name in SUBAGENT_CONFIGS:
+            result = cfg.get_subagent_config(name)
+            assert isinstance(result, SubagentConfig)
+
+    def test_overridden_result_is_subagent_config(self):
+        cfg = AgentConfig(subagent_overrides={
+            "execute": {"max_turns": 25},
+        })
+        result = cfg.get_subagent_config("execute")
+        assert isinstance(result, SubagentConfig)
+        assert result.agent_type == "execute"


### PR DESCRIPTION
## Summary

This PR updates the OmicVerse agent and Jarvis runtime in four areas:
- hardens backend execution, credential handling, and local Python sandbox behavior
- decomposes `smart_agent` into clearer session/context and codegen/tool-dispatch ownership, stabilizes sync/async entrypoints, and reduces function-registry prompt footprint
- adds configurable subagent override support and optional-adata inspector compatibility
- unifies shared Jarvis channel abstractions, migrates channel implementations onto them, and adds behavior-level integration coverage for agent loop, provider switching, sandboxing, and subagent isolation

## Validation

- `OV_AGENT_RUN_HARNESS_TESTS=1 python -m pytest tests/utils/test_session_facade.py tests/utils/test_smart_agent.py tests/utils/test_agent_config_subagent_overrides.py tests/utils/test_subagent_override_plumbing.py tests/utils/inspector/test_optional_adata.py tests/utils/test_e2e_agentic_loop.py tests/utils/test_integration_provider_switching.py tests/utils/test_integration_security_sandbox.py tests/utils/test_integration_subagent_isolation.py -q`
  - `315 passed`
- `OV_AGENT_RUN_HARNESS_TESTS=1 python -m pytest tests/jarvis/test_channel_core.py tests/jarvis/test_command_abstractions.py tests/jarvis/test_discord_migration.py tests/jarvis/test_session_shared_adata.py tests/jarvis/test_telegram_presenter.py tests/jarvis/test_telegram_thread_polling.py -q`
  - `130 passed`
- `OV_AGENT_RUN_HARNESS_TESTS=1 python -m pytest tests/mcp -m "not real_runtime and not integration and not fm_real and not fm_gpu" -q`
  - `436 passed, 37 deselected`

Total: `881 passed`, `37 deselected`.
