### PR TITLE
[codex] Stabilize agent namespace and MCP startup boundaries

### DIFF
--- a/.github/workflows/mcp-tests.yml
+++ b/.github/workflows/mcp-tests.yml
@@ -2,7 +2,7 @@ name: MCP Tests
 
 on:
   push:
-    branches: [master]
+    branches: [master, dev]
     paths:
       - "omicverse/mcp/**"
       - "tests/mcp/**"
@@ -10,7 +10,7 @@ on:
       - "scripts/ci/mcp-report-versions.py"
       - "requirements/mcp-*.txt"
   pull_request:
-    branches: [master]
+    branches: [master, dev]
     paths:
       - "omicverse/mcp/**"
       - "tests/mcp/**"

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -5,9 +5,9 @@ name: py310|py311
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "master", "dev" ]
   pull_request:
-    branches: [ "master" ]
+    branches: [ "master", "dev" ]
 
 jobs:
   build:

--- a/docs/Agent_ARCHITECTURE.md
+++ b/docs/Agent_ARCHITECTURE.md
@@ -69,35 +69,59 @@ search_skills → execute_code → delegate → finish) → Final Response
 **Purpose:** Main orchestration layer that handles the complete user interaction lifecycle.
 
 **Key Responsibilities:**
+- Agentic tool-calling loop orchestration (inspect, search, execute, delegate, finish)
 - Skill matching via LLM or algorithmic methods
 - Code generation with progressive skill disclosure
-- Code extraction and validation
-- Code execution in isolated namespace
+- Code execution in isolated notebook namespace
 - Result review and reflection mechanisms
 - Error handling and retry logic
+- Subagent delegation for multi-step workflows
 
 **Class Signature:**
 ```python
 class OmicVerseAgent:
     def __init__(
         self,
-        model: str = "gpt-4o",
-        temperature: float = 0.1,
+        model: str = "gpt-5.2",
         api_key: Optional[str] = None,
-        base_url: Optional[str] = None,
-        api_version: Optional[str] = None,
-        **kwargs
+        endpoint: Optional[str] = None,
+        auth_mode: str = "environment",
+        auth_provider: Optional[str] = None,
+        auth_file: Optional[str] = None,
+        enable_reflection: bool = True,
+        reflection_iterations: int = 1,
+        enable_result_review: bool = True,
+        use_notebook_execution: bool = True,
+        max_prompts_per_session: int = 5,
+        notebook_storage_dir: Optional[str] = None,
+        keep_execution_notebooks: bool = True,
+        notebook_timeout: int = 600,
+        strict_kernel_validation: bool = True,
+        enable_filesystem_context: bool = True,
+        context_storage_dir: Optional[str] = None,
+        approval_mode: str = "never",
+        agent_mode: str = "agentic",   # deprecated, ignored
+        max_agent_turns: int = 15,
+        security_level: Optional[str] = None,
+        *,
+        config: Optional[AgentConfig] = None,
+        reporter: Optional[Reporter] = None,
+        verbose: bool = True,
     )
 ```
 
-**Main Methods:**
-- `query(query: str, adata: Any, **kwargs) -> Dict[str, Any]` - Synchronous query execution
-- `query_async(query: str, adata: Any, **kwargs) -> Dict[str, Any]` - Async query execution
-- `stream_async(query: str, adata: Any, **kwargs) -> AsyncIterator[Dict]` - Streaming execution
-- `_extract_python_code(response_text: str) -> str` - Code extraction with AST validation
-- `_reflect_on_code(code: str, error_msg: str) -> str` - Self-reflection for error correction
+The `agent_mode` parameter is accepted for backward compatibility but
+deprecated and ignored — the agentic tool-calling loop is now the only
+execution mode.  Passing any value other than `"agentic"` emits a
+`DeprecationWarning`.
 
-**File Location:** Lines 69-1561 in `omicverse/utils/smart_agent.py`
+**Public Methods:**
+- `run(request: str, adata: Any) -> Any` — Synchronous execution (main entry point)
+- `run_async(request: str, adata: Any) -> Any` — Async execution via the agentic tool-calling loop
+- `stream_async(request: str, adata: Any, ...) -> AsyncIterator[dict]` — Stream agentic-loop events in real time
+- `generate_code(request: str, adata: Any = None, ...) -> str` — Generate OmicVerse Python code without executing it
+
+**File Location:** `omicverse/utils/smart_agent.py`
 
 ---
 
@@ -765,95 +789,95 @@ def _review_result(
 ```python
 async def stream_async(
     self,
-    query: str,
+    request: str,
     adata: Any,
-    **kwargs
-) -> AsyncIterator[Dict[str, Any]]:
+    cancel_event=None,
+    history=None,
+    approval_handler=None,
+    request_content=None,
+) -> AsyncIterator[dict]:
     """
-    Stream agent execution with real-time updates.
+    Stream agentic-loop events as the agent processes a request.
+
+    Wraps ``_run_agentic_loop`` with an event callback so callers
+    can observe tool calls, code execution, results, and completion
+    in real time.
 
     Yields:
-        Dict[str, Any]: Event objects with keys:
-            - event_type: 'skill_match' | 'llm_chunk' | 'code' |
-                         'result' | 'error' | 'usage'
-            - data: Event-specific data
+        dict: Event dictionaries with ``'type'`` and ``'content'``
+              keys, plus metadata such as ``turn_id``, ``trace_id``,
+              ``session_id``, and ``category``.
     """
 ```
 
-**File Location:** Lines 1288-1428 in `smart_agent.py`
+**File Location:** `omicverse/utils/smart_agent.py`
 
 ---
 
 ### Event Stream Format
 
-#### 1. Skill Match Event
+Events are dictionaries produced by `build_stream_event()` with at
+minimum `type` and `content` keys.  Additional metadata fields
+(`turn_id`, `trace_id`, `session_id`, `category`) are attached
+automatically.
+
+#### 1. Tool Call Event
 ```python
 {
-    "event_type": "skill_match",
-    "data": {
-        "matched_skills": ["single-cell-preprocessing", "clustering"],
-        "skill_scores": {"single-cell-preprocessing": 0.95, ...}
-    }
+    "type": "tool_call",
+    "content": "inspect_data",
+    "turn_id": "...",
+    "trace_id": "...",
+    "session_id": "...",
+    "category": "tool"
 }
 ```
 
-#### 2. LLM Chunk Event
+#### 2. Code Event
 ```python
 {
-    "event_type": "llm_chunk",
-    "data": {
-        "chunk": "import omicverse as ov\n",
-        "cumulative_text": "import omicverse as ov\n"
-    }
+    "type": "code",
+    "content": "import omicverse as ov\n\nadata = ov.pp.preprocess(...)",
+    "turn_id": "...",
+    "trace_id": "...",
+    "session_id": "...",
+    "category": "execution"
 }
 ```
 
-#### 3. Code Event
+#### 3. Result Event
 ```python
 {
-    "event_type": "code",
-    "data": {
-        "code": "import omicverse as ov\n\nadata = ov.pp.preprocess(...)",
-        "validated": True
-    }
+    "type": "result",
+    "content": "Code executed successfully.",
+    "turn_id": "...",
+    "trace_id": "...",
+    "session_id": "...",
+    "category": "execution"
 }
 ```
 
-#### 4. Result Event
+#### 4. Error Event
 ```python
 {
-    "event_type": "result",
-    "data": {
-        "success": True,
-        "result": {"adata": AnnData_object, ...},
-        "execution_time": 2.5
-    }
+    "type": "error",
+    "content": "NameError: name 'ov' is not defined",
+    "turn_id": "...",
+    "trace_id": "...",
+    "session_id": "...",
+    "category": "runtime"
 }
 ```
 
-#### 5. Error Event
+#### 5. Done Event
 ```python
 {
-    "event_type": "error",
-    "data": {
-        "error_type": "ExecutionError",
-        "message": "NameError: name 'ov' is not defined",
-        "code": "...",
-        "recoverable": True
-    }
-}
-```
-
-#### 6. Usage Event
-```python
-{
-    "event_type": "usage",
-    "data": {
-        "prompt_tokens": 1234,
-        "completion_tokens": 567,
-        "total_tokens": 1801,
-        "model": "openai/gpt-4o"
-    }
+    "type": "done",
+    "content": "Agentic loop completed.",
+    "turn_id": "...",
+    "trace_id": "...",
+    "session_id": "...",
+    "category": "lifecycle"
 }
 ```
 
@@ -1053,26 +1077,17 @@ Code Generation → Execution → Error → Reflection → Corrected Code →
 Re-execution → Success/Reflection Again (max 3 iterations)
 ```
 
-**Implementation:**
+**Implementation (agentic loop):**
+
+The reflection mechanism is now handled internally by the agentic
+tool-calling loop.  When `execute_code` fails, the loop feeds the error
+back to the LLM which autonomously decides whether to retry with
+corrected code, inspect data, or finish with an error report.
+
 ```python
-# smart_agent.py lines 282-380
-def query(self, query: str, adata: Any, **kwargs) -> Dict[str, Any]:
-    max_reflection_iterations = kwargs.get('max_reflections', 3)
-
-    for iteration in range(max_reflection_iterations):
-        # Generate code
-        code = self._generate_code(query, adata, **kwargs)
-
-        # Execute
-        try:
-            result = self._execute_code(code, adata)
-            return result
-        except Exception as e:
-            if iteration < max_reflection_iterations - 1:
-                # Reflect and try again
-                code = self._reflect_on_code(code, str(e), query)
-            else:
-                raise
+# Simplified view — the agentic loop drives this automatically:
+result = await agent._run_agentic_loop(request, adata)
+# Inside the loop: tool calls → execute_code → error → LLM reflects → retry
 ```
 
 **Reflection Prompt Template:**
@@ -1349,9 +1364,9 @@ agent_claude = OmicVerseAgent(model="claude-4-5-sonnet")
 agent_gemini = OmicVerseAgent(model="gemini-2.5-flash")
 
 # Identical API
-result_gpt = agent_gpt.query("Preprocess my data", adata)
-result_claude = agent_claude.query("Preprocess my data", adata)
-result_gemini = agent_gemini.query("Preprocess my data", adata)
+result_gpt = agent_gpt.run("Preprocess my data", adata)
+result_claude = agent_claude.run("Preprocess my data", adata)
+result_gemini = agent_gemini.run("Preprocess my data", adata)
 ```
 
 ---
@@ -1448,14 +1463,14 @@ agent = OmicVerseAgent(
     verbose=True  # Enables detailed logging
 )
 
-result = agent.query("Cluster my cells", adata)
+result = agent.run("Cluster my cells", adata)
 # Logs:
-# [SKILL MATCH] Selected: single-cell-clustering
-# [CODE GENERATION] Calling OpenAI API...
-# [CODE EXTRACTED] 15 lines of Python code
-# [EXECUTION] Running code in isolated namespace...
-# [SUCCESS] Code executed successfully
-# [TOKENS] Used 3,421 tokens (prompt: 2,154, completion: 1,267)
+# [INFO] Processing request: "Cluster my cells" | Dataset: 2638 cells × 1838 genes
+# [INFO] Mode: Agentic Loop (tool-calling)
+# [INFO] Turn 1/15 — LLM call ...
+# [INFO] Tool call: inspect_data
+# [INFO] Tool call: execute_code
+# [SUCCESS] Agentic loop completed!
 ```
 
 ---

--- a/docs/ovagent_legacy_deprecation_plan.md
+++ b/docs/ovagent_legacy_deprecation_plan.md
@@ -4,7 +4,10 @@
 > All legacy Priority 1/2 methods have been removed (~1,182 lines deleted).
 > `execute_code` enhanced with pattern-based auto-recovery.
 > `stream_async` rewritten to wrap the agentic loop.
-> `agent_mode` config removed; backward-compat deprecation warning added.
+> `agent_mode` parameter retained for backward compatibility but deprecated
+> and ignored — passing any value other than `"agentic"` emits a
+> `DeprecationWarning`.  The agentic tool-calling loop is the sole
+> execution mode.
 
 ## Scope
 
@@ -16,14 +19,14 @@ This plan deprecates and removes legacy Priority 1/2 execution paths in `omicver
 
 Primary target module: `omicverse/utils/smart_agent.py`
 
-## Current Problem
+## Original Problem (resolved)
 
-`OmicVerseAgent` currently mixes two architectures:
+`OmicVerseAgent` previously mixed two architectures:
 
-- Agentic tool loop (current default, desired long-term architecture)
+- Agentic tool loop (now the sole execution mode)
 - Legacy single-shot code generation and fallback workflows (Priority 1/2)
 
-This increases maintenance cost, creates behavior divergence (`run()` vs `stream_async()`), and leaves stale docs/tests.
+This increased maintenance cost, created behavior divergence (`run()` vs `stream_async()`), and left stale docs/tests.  All legacy paths have since been removed; `run()` and `stream_async()` both execute via the agentic tool-calling loop.
 
 ## Goals
 
@@ -36,7 +39,7 @@ This increases maintenance cost, creates behavior divergence (`run()` vs `stream
 
 1. Rewriting provider backend (`agent_backend.py`) protocol layer.
 2. Removing notebook execution or security scanner features.
-3. Changing user-facing `ov.Agent(...)` constructor in this phase.
+3. Changing user-facing `ov.Agent(...)` constructor beyond the `agent_mode` deprecation.
 
 ## Legacy Inventory and Disposition
 
@@ -94,12 +97,12 @@ Move workflow-level knowledge to skills, not runtime branches:
 
 ### Phase 0: Guardrails and Visibility
 
-1. Add structured warnings when `agent_mode='legacy'` is used.
+1. ~~Add structured warnings when `agent_mode='legacy'` is used.~~ **Done** — `DeprecationWarning` emitted when `agent_mode != "agentic"`.
 2. Add telemetry events (`category=deprecation`) for legacy entry points.
-3. Update docs to state: agentic is canonical.
+3. ~~Update docs to state: agentic is canonical.~~ **Done.**
 
 Exit criteria:
-- No hidden legacy path usage in tests or web service.
+- No hidden legacy path usage in tests or web service. **Met.**
 
 ### Phase 1: Behavior Parity in Agentic Mode
 
@@ -158,7 +161,7 @@ Exit criteria:
 
 1. Remove Priority 1/2 architecture language.
 2. Document new agentic tools and recommended invocation patterns.
-3. Update stale API docs that mention `query/query_async`.
+3. ~~Update stale API docs that mention `query/query_async`.~~ **Done** — docs now reference `run`/`run_async`/`stream_async`/`generate_code`.
 
 ## Test Plan
 
@@ -185,14 +188,14 @@ Exit criteria:
 
 ## Review Checklist (for local review)
 
-1. `smart_agent.py` has a single runtime architecture.
-2. No repo references to:
+1. [x] `smart_agent.py` has a single runtime architecture.
+2. [x] No repo references to:
    - “Priority 1”
    - “Priority 2”
    - `run_async_LEGACY`
-3. `stream_async` and `run()` produce consistent behavior.
-4. Web service agent streaming still functions.
-5. Docs reflect real APIs.
+3. [x] `stream_async` and `run()` produce consistent behavior (both use agentic loop).
+4. [x] Web service agent streaming still functions.
+5. [x] Docs reflect real APIs (`run`, `run_async`, `stream_async`, `generate_code`).
 
 ## Risk Notes
 

--- a/omicverse/mcp/__main__.py
+++ b/omicverse/mcp/__main__.py
@@ -1,5 +1,17 @@
 """Allow ``python -m omicverse.mcp`` to start the MCP server."""
 
-from .server import main
+import sys
+
+try:
+    from .server import main
+except ImportError as exc:
+    print(
+        f"Error: could not load the OmicVerse MCP server.\n"
+        f"  {exc}\n\n"
+        f"Install the MCP extras with:\n"
+        f"  pip install 'omicverse[mcp]'\n",
+        file=sys.stderr,
+    )
+    raise SystemExit(1)
 
 main()

--- a/omicverse/mcp/server.py
+++ b/omicverse/mcp/server.py
@@ -22,7 +22,6 @@ from pydantic import AnyHttpUrl
 from .manifest import build_registry_manifest
 from .session_store import SessionStore, SessionError, TraceRecord, RuntimeLimits
 from .executor import McpExecutor
-from .local_oauth import LocalOAuthProvider, LOCAL_AUTH_SCOPES
 from .adata_kernel_runtime import AdataKernelRuntime
 
 logger = logging.getLogger(__name__)
@@ -2173,6 +2172,7 @@ class RegistryMcpServer:
             from mcp.server.auth.settings import AuthSettings, ClientRegistrationOptions, RevocationOptions
             from mcp.server.fastmcp.server import StreamableHTTPASGIApp
             from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
+            from .local_oauth import LocalOAuthProvider, LOCAL_AUTH_SCOPES
         except ImportError:
             raise ImportError(
                 "Streamable HTTP transport requires: mcp, uvicorn, and starlette. "

--- a/omicverse/utils/__init__.py
+++ b/omicverse/utils/__init__.py
@@ -116,7 +116,8 @@ from ._gene_id_conversion import _infer_species_and_release, convert2gene_symbol
 
 # Import smart_agent module to make it accessible and expose key entrypoints
 # Store verifier with a private name first to ensure reference is preserved
-from . import agent_backend, biocontext, smart_agent
+from . import agent_backend, agent_backend_streaming, biocontext, smart_agent
+from . import ovagent  # ensure ovagent subpackage is a direct attribute
 from . import verifier as _verifier_module
 from .agent_backend import BackendConfig, OmicVerseLLMBackend, Usage
 from .smart_agent import Agent, OmicVerseAgent, list_supported_models
@@ -148,12 +149,29 @@ from .harness import (
 # Python 3.10 compatibility: Provide __getattr__ to dynamically return verifier
 # This ensures getattr(omicverse.utils, 'verifier') works in unittest.mock.patch
 def __getattr__(name):
-    """Dynamically return module attributes for Python 3.10 compatibility.
+    """Dynamically return module attributes for submodule and symbol resolution.
 
-    This is required because unittest.mock.patch uses getattr() to resolve
-    module paths, and in Python 3.10 submodule imports don't automatically
-    become accessible as attributes of the parent module.
+    Handles two cases that arise when sys.modules is manipulated (e.g. by test
+    isolation stubs) and Python's normal import-time attribute-setting on the
+    parent package is skipped:
+
+    1. Submodule lookup: if ``omicverse.utils.<name>`` is in ``sys.modules``
+       but was never set as an attribute on *this* module object (common when a
+       test replaces ``sys.modules['omicverse.utils']`` with a fresh stub),
+       return and cache the submodule so that ``getattr(omicverse.utils, name)``
+       and ``monkeypatch.setattr("omicverse.utils.<name>.<sym>", ...)`` work.
+    2. Legacy symbol forwarding for ``verifier`` and smart-agent entrypoints.
     """
+    import sys as _sys
+
+    # Fast-path: check if a submodule with this name is already imported
+    fqn = f"{__name__}.{name}"
+    submod = _sys.modules.get(fqn)
+    if submod is not None:
+        # Cache it on the module so future lookups are O(1)
+        globals()[name] = submod
+        return submod
+
     if name == 'verifier':
         return _verifier_module
     if name in {'Agent', 'OmicVerseAgent', 'list_supported_models'}:
@@ -293,10 +311,13 @@ __all__ = [
     "symbol2id",
     # @ agent_backend
     "agent_backend",
+    "agent_backend_streaming",
     "biocontext",
     "BackendConfig",
     "OmicVerseLLMBackend",
     "Usage",
+    # @ ovagent
+    "ovagent",
     # @ smart_agent
     "smart_agent",
     "Agent",

--- a/omicverse/utils/__init__.py
+++ b/omicverse/utils/__init__.py
@@ -339,6 +339,9 @@ __all__ = [
     "make_turn_id",
     # @ verifier
     "verifier",
+    # @ agent_config
+    "AgentConfig",
+    "SandboxFallbackPolicy",
     # @ agent_errors — public compatibility shims and error hierarchy
     "OVAgentError",
     "WorkflowNeedsFallback",
@@ -346,4 +349,17 @@ __all__ = [
     "ConfigError",
     "ExecutionError",
     "SandboxDeniedError",
+    # @ agent_reporter
+    "AgentEvent",
+    "EventLevel",
+    "Reporter",
+    "make_reporter",
+    # @ context_compactor
+    "ContextCompactor",
+    "estimate_tokens",
+    # @ session_history
+    "SessionHistory",
+    "HistoryEntry",
+    # @ _gene_id_conversion (private, re-exported for compatibility)
+    "_infer_species_and_release",
 ]

--- a/tests/mcp/test_optional_dep_boundary.py
+++ b/tests/mcp/test_optional_dep_boundary.py
@@ -1,0 +1,225 @@
+"""Tests for MCP optional-dependency startup boundary.
+
+Verifies that the MCP server module can be imported and that ``--help``
+works even when the external ``mcp`` SDK is not installed, and that
+transport methods give controlled errors when the SDK is missing.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+
+
+# ---------------------------------------------------------------------------
+# Helper: run a snippet in a subprocess with mcp blocked at the meta-path level
+# ---------------------------------------------------------------------------
+
+_MCP_BLOCKER_PREAMBLE = textwrap.dedent("""\
+    import sys
+
+    class _McpBlocker:
+        \"\"\"Meta-path finder that makes 'mcp' unimportable.\"\"\"
+        def find_module(self, name, path=None):
+            if name == "mcp" or name.startswith("mcp."):
+                return self
+        def load_module(self, name):
+            raise ImportError(f"Simulated: No module named '{name}'")
+
+    sys.meta_path.insert(0, _McpBlocker())
+""")
+
+
+def _run_with_mcp_blocked(snippet: str, *, timeout: int = 30) -> subprocess.CompletedProcess:
+    """Run *snippet* in a subprocess where ``import mcp`` always fails."""
+    code = _MCP_BLOCKER_PREAMBLE + textwrap.dedent(snippet)
+    return subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+# ---------------------------------------------------------------------------
+# No-extra scenario: mcp SDK absent
+# ---------------------------------------------------------------------------
+
+class TestNoMcpExtra:
+    """Behaviour when the ``mcp`` optional dependency is NOT installed."""
+
+    def test_server_module_importable_without_mcp(self):
+        """``from omicverse.mcp.server import main`` must not crash."""
+        result = _run_with_mcp_blocked("""\
+            from omicverse.mcp.server import main
+            assert callable(main)
+            print("OK")
+        """)
+        assert result.returncode == 0, result.stderr
+        assert "OK" in result.stdout
+
+    def test_help_flag_without_mcp(self):
+        """``python -m omicverse.mcp --help`` degrades gracefully."""
+        result = _run_with_mcp_blocked("""\
+            import sys
+            sys.argv = ["omicverse.mcp", "--help"]
+            from omicverse.mcp.server import main
+            main()
+        """)
+        # --help should succeed and print usage because argparse runs
+        # before any mcp SDK import
+        assert result.returncode == 0, result.stderr
+        assert "OmicVerse" in result.stdout
+
+    def test_version_flag_without_mcp(self):
+        """``--version`` should also work without mcp SDK."""
+        result = _run_with_mcp_blocked("""\
+            import sys
+            sys.argv = ["omicverse.mcp", "--version"]
+            from omicverse.mcp.server import main
+            main()
+        """)
+        assert result.returncode == 0, result.stderr
+        assert "omicverse" in result.stdout.lower()
+
+    def test_registry_mcp_server_importable_without_mcp(self):
+        """``RegistryMcpServer`` class can be imported without mcp SDK."""
+        result = _run_with_mcp_blocked("""\
+            from omicverse.mcp.server import RegistryMcpServer
+            assert RegistryMcpServer is not None
+            print("OK")
+        """)
+        assert result.returncode == 0, result.stderr
+        assert "OK" in result.stdout
+
+    def test_meta_tools_importable_without_mcp(self):
+        """``META_TOOLS`` dict can be imported without mcp SDK."""
+        result = _run_with_mcp_blocked("""\
+            from omicverse.mcp.server import META_TOOLS
+            assert isinstance(META_TOOLS, dict)
+            assert len(META_TOOLS) > 0
+            print("OK")
+        """)
+        assert result.returncode == 0, result.stderr
+        assert "OK" in result.stdout
+
+    def test_package_init_importable_without_mcp(self):
+        """``from omicverse.mcp import get_manifest`` must not crash."""
+        result = _run_with_mcp_blocked("""\
+            from omicverse.mcp import get_manifest, build_mcp_server, build_default_manifest
+            assert callable(get_manifest)
+            assert callable(build_mcp_server)
+            assert callable(build_default_manifest)
+            print("OK")
+        """)
+        assert result.returncode == 0, result.stderr
+        assert "OK" in result.stdout
+
+    def test_dunder_main_help_without_mcp(self):
+        """``python -m omicverse.mcp --help`` via the actual __main__ path."""
+        # Build a script that blocks mcp then runs __main__
+        result = _run_with_mcp_blocked("""\
+            import sys, runpy
+            sys.argv = ["omicverse.mcp", "--help"]
+            try:
+                runpy.run_module("omicverse.mcp", run_name="__main__")
+            except SystemExit as e:
+                # argparse --help raises SystemExit(0)
+                sys.exit(e.code)
+        """)
+        assert result.returncode == 0, result.stderr
+        assert "OmicVerse" in result.stdout
+
+    def test_dunder_main_no_args_without_mcp_gives_controlled_error(self):
+        """Running without --help and without mcp gives a controlled error, not a traceback."""
+        result = _run_with_mcp_blocked("""\
+            import sys, runpy
+            sys.argv = ["omicverse.mcp"]
+            try:
+                runpy.run_module("omicverse.mcp", run_name="__main__")
+            except SystemExit as e:
+                sys.exit(e.code)
+            except ImportError as e:
+                # The server startup will fail with ImportError from run_stdio/etc.
+                # but this should be a controlled error, not from module import
+                print(f"CONTROLLED: {e}", file=sys.stderr)
+                sys.exit(42)
+        """)
+        # Either exits via controlled ImportError or crashes at run_stdio —
+        # but NOT at module import time. returncode != 0 is fine, as long as
+        # there's no "No module named 'mcp'" from the top-level import chain.
+        assert "from .local_oauth" not in result.stderr, (
+            "local_oauth should not be imported at module level"
+        )
+
+
+# ---------------------------------------------------------------------------
+# With-extra scenario: mcp SDK present
+# ---------------------------------------------------------------------------
+
+class TestWithMcpExtra:
+    """Behaviour when the ``mcp`` optional dependency IS installed.
+
+    These tests run in the current process (mcp is available in the test env).
+    """
+
+    def test_help_flag_exits_clean(self):
+        """``python -m omicverse.mcp --help`` exits 0 with usage output."""
+        result = subprocess.run(
+            [sys.executable, "-m", "omicverse.mcp", "--help"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert result.returncode == 0
+        assert "OmicVerse" in result.stdout
+        assert "--phase" in result.stdout
+
+    def test_version_flag_exits_clean(self):
+        """``python -m omicverse.mcp --version`` exits 0."""
+        result = subprocess.run(
+            [sys.executable, "-m", "omicverse.mcp", "--version"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert result.returncode == 0
+        assert "omicverse" in result.stdout.lower()
+
+    def test_server_module_imports_fully(self):
+        """All server.py exports are importable when mcp is present."""
+        from omicverse.mcp.server import RegistryMcpServer, META_TOOLS, main
+        assert callable(main)
+        assert isinstance(META_TOOLS, dict)
+        assert RegistryMcpServer is not None
+
+    def test_entrypoint_function_is_main(self):
+        """The ``omicverse-mcp`` console_script points to server:main."""
+        from omicverse.mcp.server import main
+        assert callable(main)
+
+
+# ---------------------------------------------------------------------------
+# Entrypoint packaging policy
+# ---------------------------------------------------------------------------
+
+class TestEntrypointPolicy:
+    """Verify the omicverse-mcp entrypoint packaging contract."""
+
+    def test_entrypoint_target_exists(self):
+        """The function referenced by the console_script must exist."""
+        from omicverse.mcp.server import main
+        assert callable(main)
+
+    def test_help_documents_transport_choices(self):
+        """--help must document the available transport options."""
+        result = subprocess.run(
+            [sys.executable, "-m", "omicverse.mcp", "--help"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert result.returncode == 0
+        assert "stdio" in result.stdout
+        assert "streamable-http" in result.stdout

--- a/tests/utils/test_agent_codex_auth.py
+++ b/tests/utils/test_agent_codex_auth.py
@@ -56,7 +56,7 @@ def _load_smart_agent_module():
 
 smart_agent = _load_smart_agent_module()
 # The credential resolver and its dependencies now live in ovagent.auth
-import omicverse.utils.ovagent.auth as _auth_module
+import omicverse.utils.ovagent.auth as _auth_module  # noqa: E402
 
 
 def _make_oauth_token(account_id: str = "acct_test") -> str:

--- a/tests/utils/test_agent_config_subagent_overrides.py
+++ b/tests/utils/test_agent_config_subagent_overrides.py
@@ -63,7 +63,7 @@ _utils_pkg.__spec__ = importlib.machinery.ModuleSpec(
 sys.modules["omicverse.utils"] = _utils_pkg
 _ov_pkg.utils = _utils_pkg
 
-from omicverse.utils.agent_config import (
+from omicverse.utils.agent_config import (  # noqa: E402
     AgentConfig,
     SUBAGENT_CONFIGS,
     SubagentConfig,

--- a/tests/utils/test_agent_contract.py
+++ b/tests/utils/test_agent_contract.py
@@ -67,13 +67,8 @@ Agent = smart_agent_module.Agent
 OmicVerseAgent = smart_agent_module.OmicVerseAgent
 list_supported_models = smart_agent_module.list_supported_models
 
-from omicverse.utils.harness import build_stream_event
-from omicverse.utils.ovagent.runtime import OmicVerseRuntime
-from omicverse.utils.ovagent.workflow import (
-    WorkflowConfig,
-    WorkflowDocument,
-    load_workflow_document,
-)
+from omicverse.utils.harness import build_stream_event  # noqa: E402
+from omicverse.utils.ovagent.runtime import OmicVerseRuntime  # noqa: E402
 
 for name, module in _ORIGINAL_MODULES.items():
     if module is None:

--- a/tests/utils/test_agent_contract.py
+++ b/tests/utils/test_agent_contract.py
@@ -511,3 +511,78 @@ class TestListSupportedModels:
         default = list_supported_models(show_all=False)
         full = list_supported_models(show_all=True)
         assert len(full) >= len(default)
+
+
+# ===================================================================
+# 8. __new__-constructed agent safety (PR #603 reconciliation)
+# ===================================================================
+
+class TestNewConstructedAgentSafety:
+    """__new__-constructed agents must tolerate missing __init__ state.
+
+    These tests make the _emit no-op fallback contract explicit.
+    Previously this was only implicitly tested by tests that happened
+    to pass because _emit didn't raise.
+    """
+
+    def test_emit_fallback_is_static_method(self):
+        """The class-level _emit must be a staticmethod (no-op fallback)."""
+        assert isinstance(OmicVerseAgent.__dict__["_emit"], staticmethod)
+
+    def test_emit_noop_callable_on_bare_agent(self):
+        """_emit must be callable without raising on __new__-constructed agents."""
+        agent = _bare_agent()
+        # Import the level enum needed by _emit callers
+        from omicverse.utils.agent_reporter import EventLevel
+        # Must not raise — the static method is a no-op
+        agent._emit(EventLevel.INFO, "test message", "test")
+        agent._emit(EventLevel.ERROR, "another message")
+
+    def test_bare_agent_has_no_reporter(self):
+        """__new__-constructed agents must not have _reporter (no __init__)."""
+        agent = _bare_agent()
+        assert not hasattr(agent, "_reporter")
+
+    def test_run_async_emit_does_not_crash_on_bare_agent(self):
+        """run_async tolerates _emit being the class-level no-op."""
+        agent = _bare_agent()
+
+        async def _fake_agentic_mode(self, request, adata):
+            return adata
+
+        agent._run_agentic_mode = MethodType(_fake_agentic_mode, agent)
+        agent._detect_direct_python_request = MethodType(
+            lambda self, req: None, agent
+        )
+
+        # run_async calls self._emit(...) multiple times; must not crash
+        sentinel = object()
+        result = asyncio.run(agent.run_async("test query", sentinel))
+        assert result is sentinel
+
+
+# ===================================================================
+# 9. resolve_credentials alias contract (PR #603 reconciliation)
+# ===================================================================
+
+class TestResolveCredentialsContract:
+    """resolve_credentials must have a single, clean import in smart_agent."""
+
+    def test_resolve_credentials_accessible_via_module(self):
+        """smart_agent exposes _resolve_agent_llm_credentials."""
+        assert hasattr(smart_agent_module, "_resolve_agent_llm_credentials")
+        assert callable(smart_agent_module._resolve_agent_llm_credentials)
+
+    def test_resolve_credentials_source_has_single_alias(self):
+        """smart_agent.py must import resolve_credentials exactly once."""
+        source = inspect.getsource(smart_agent_module)
+        # Count import lines with resolve_credentials (not usages)
+        import_count = sum(
+            1 for line in source.splitlines()
+            if "resolve_credentials" in line
+            and ("import" in line or "as _resolve" in line)
+        )
+        # Exactly one import alias
+        assert import_count == 1, (
+            f"Expected exactly 1 resolve_credentials import, found {import_count}"
+        )

--- a/tests/utils/test_backend_common_hygiene.py
+++ b/tests/utils/test_backend_common_hygiene.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import concurrent.futures
 import inspect
 import threading
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -398,7 +398,7 @@ class TestNoProviderBehaviorChange:
     """Verify hygiene fixes don't alter provider dispatch or types."""
 
     def test_dispatch_tables_unchanged(self):
-        from omicverse.utils.agent_backend_common import _SYNC_DISPATCH, _STREAM_DISPATCH
+        from omicverse.utils.agent_backend_common import _SYNC_DISPATCH
         from omicverse.utils.model_config import WireAPI
 
         assert _SYNC_DISPATCH[WireAPI.CHAT_COMPLETIONS] == "_chat_via_openai_compatible"

--- a/tests/utils/test_backend_common_hygiene.py
+++ b/tests/utils/test_backend_common_hygiene.py
@@ -426,3 +426,69 @@ class TestNoProviderBehaviorChange:
             "_get_shared_executor",
         }
         assert expected == set(exports)
+
+
+# ===================================================================
+# 5. _retry_with_backoff public contract (PR #603 reconciliation)
+# ===================================================================
+
+
+class TestRetryWithBackoffPublicContract:
+    """Explicit regression tests for the _retry_with_backoff public contract.
+
+    These tests freeze the contract that PR #603 was trying to establish:
+    _retry_with_backoff accepts a zero-arg callable and explicit config
+    parameters. No silent arg-forwarding is possible.
+    """
+
+    def test_signature_has_exactly_five_params(self):
+        """_retry_with_backoff has exactly 5 parameters: func + 4 config."""
+        from omicverse.utils.agent_backend_common import _retry_with_backoff
+        sig = inspect.signature(_retry_with_backoff)
+        assert len(sig.parameters) == 5, (
+            f"Expected 5 params (func + 4 config), got {len(sig.parameters)}: "
+            f"{list(sig.parameters.keys())}"
+        )
+
+    def test_func_is_first_parameter(self):
+        """'func' must be the first positional parameter."""
+        from omicverse.utils.agent_backend_common import _retry_with_backoff
+        sig = inspect.signature(_retry_with_backoff)
+        first_param = list(sig.parameters.keys())[0]
+        assert first_param == "func"
+
+    def test_config_params_have_defaults(self):
+        """All config parameters must have defaults (backward-compat)."""
+        from omicverse.utils.agent_backend_common import _retry_with_backoff
+        sig = inspect.signature(_retry_with_backoff)
+        for name in ("max_attempts", "base_delay", "factor", "jitter"):
+            param = sig.parameters[name]
+            assert param.default is not inspect.Parameter.empty, (
+                f"{name} must have a default value"
+            )
+
+    def test_func_invoked_as_zero_arg(self):
+        """func() is called with zero args; positionals are config."""
+        from omicverse.utils.agent_backend_common import _retry_with_backoff
+
+        received_args = []
+
+        def spy(*args):
+            received_args.extend(args)
+            return "done"
+
+        result = _retry_with_backoff(spy, 1)  # 1 = max_attempts
+        assert result == "done"
+        assert received_args == [], (
+            f"func received args {received_args}; "
+            "positional config was silently forwarded"
+        )
+
+    def test_backend_retry_wraps_args_in_closure(self):
+        """_retry wraps func+args into a lambda."""
+        from omicverse.utils.agent_backend import OmicVerseLLMBackend
+        source = inspect.getsource(OmicVerseLLMBackend._retry)
+        # The implementation must use lambda or partial to bind args
+        assert "lambda" in source or "partial" in source, (
+            "OmicVerseLLMBackend._retry must wrap func+args into a closure"
+        )

--- a/tests/utils/test_import_order_regression.py
+++ b/tests/utils/test_import_order_regression.py
@@ -1,0 +1,239 @@
+"""Regression tests for import-order stability (task-060).
+
+Verifies that the agent submodule test subset passes deterministically
+regardless of whether bootstrap/scanner imports run first, and that
+dotted monkeypatch paths resolve after stub-phase module manipulation.
+
+Root cause fixed: test_ovagent_bootstrap.py executed smart_agent.py which
+loaded agent_backend* into sys.modules, then cleanup only popped three
+named entries.  When test_ovagent_registry_scanner.py installed a NEW
+stub for omicverse.utils, the leftover sys.modules entries prevented
+Python from re-setting submodule attributes on the new stub, causing
+monkeypatch.setattr("omicverse.utils.agent_backend_streaming.<sym>", ...)
+to fail with AttributeError.
+"""
+
+import sys
+import types
+
+import pytest
+
+
+# ============================================================================
+# Test 1: omicverse.utils exposes agent submodules as direct attributes
+# ============================================================================
+
+
+class TestUtilsNamespaceExports:
+    """After a normal import, omicverse.utils must expose agent submodules."""
+
+    def test_agent_backend_is_attribute(self):
+        import omicverse.utils
+        assert hasattr(omicverse.utils, "agent_backend")
+
+    def test_agent_backend_streaming_is_attribute(self):
+        import omicverse.utils
+        assert hasattr(omicverse.utils, "agent_backend_streaming")
+
+    def test_ovagent_is_attribute(self):
+        import omicverse.utils
+        assert hasattr(omicverse.utils, "ovagent")
+
+    def test_smart_agent_is_attribute(self):
+        import omicverse.utils
+        assert hasattr(omicverse.utils, "smart_agent")
+
+    def test_verifier_is_attribute(self):
+        import omicverse.utils
+        assert hasattr(omicverse.utils, "verifier")
+
+
+# ============================================================================
+# Test 2: dotted monkeypatch paths resolve for streaming module
+# ============================================================================
+
+
+class TestMonkeypatchPathResolution:
+    """monkeypatch.setattr with dotted string must resolve after imports."""
+
+    def test_streaming_function_patchable(self, monkeypatch):
+        """The dotted path used by test_agent_backend_streaming must resolve."""
+        sentinel = object()
+        monkeypatch.setattr(
+            "omicverse.utils.agent_backend_streaming._stream_openai_http_fallback",
+            sentinel,
+        )
+        from omicverse.utils import agent_backend_streaming
+
+        assert agent_backend_streaming._stream_openai_http_fallback is sentinel
+
+    def test_streaming_responses_patchable(self, monkeypatch):
+        sentinel = object()
+        monkeypatch.setattr(
+            "omicverse.utils.agent_backend_streaming._stream_openai_responses",
+            sentinel,
+        )
+        from omicverse.utils import agent_backend_streaming
+
+        assert agent_backend_streaming._stream_openai_responses is sentinel
+
+
+# ============================================================================
+# Test 3: __getattr__ fallback resolves submodules from sys.modules
+# ============================================================================
+
+
+class TestGetAttrFallback:
+    """The __getattr__ on omicverse.utils must resolve submodules that are
+    in sys.modules but not set as attributes (e.g. after stub replacement)."""
+
+    def test_getattr_resolves_known_submodule(self):
+        import omicverse.utils  # noqa: F401 — trigger import for side effect
+        utils_mod = sys.modules["omicverse.utils"]
+
+        # Only run this test if the real module (with __getattr__) is loaded
+        if not hasattr(type(utils_mod), "__getattr__") and not hasattr(utils_mod, "__getattr__"):
+            # Module-level __getattr__ is a function, not a type method
+            mod_dict = getattr(utils_mod, "__dict__", {})
+            if "__getattr__" not in mod_dict:
+                pytest.skip("omicverse.utils is a stub without __getattr__")
+
+        # Ensure agent_backend_streaming is in sys.modules
+        assert "omicverse.utils.agent_backend_streaming" in sys.modules
+
+        # Delete the attribute to simulate a stub that never set it
+        real_mod = sys.modules["omicverse.utils.agent_backend_streaming"]
+        if hasattr(utils_mod, "agent_backend_streaming"):
+            delattr(utils_mod, "agent_backend_streaming")
+
+        # __getattr__ should resolve it from sys.modules
+        resolved = getattr(utils_mod, "agent_backend_streaming")
+        assert resolved is real_mod
+
+        # Restore to avoid affecting other tests
+        utils_mod.agent_backend_streaming = real_mod
+
+
+# ============================================================================
+# Test 4: public OmicVerseAgent / ov.Agent entrypoints are not regressed
+# ============================================================================
+
+
+class TestPublicEntrypoints:
+    """ov.Agent and OmicVerseAgent must remain accessible."""
+
+    def test_ov_agent_factory_returns_omicverse_agent(self):
+        from omicverse.utils.smart_agent import Agent, OmicVerseAgent
+
+        # Agent is a factory function, not the class itself
+        assert callable(Agent)
+        assert OmicVerseAgent is not None
+
+    @pytest.mark.skipif(
+        "omicverse.utils" in sys.modules
+        and not hasattr(sys.modules["omicverse.utils"], "__all__"),
+        reason="omicverse.utils is a test stub",
+    )
+    def test_utils_exposes_agent(self):
+        import omicverse.utils
+
+        assert hasattr(omicverse.utils, "Agent")
+        assert hasattr(omicverse.utils, "OmicVerseAgent")
+
+    @pytest.mark.skipif(
+        "omicverse.utils" in sys.modules
+        and not hasattr(sys.modules["omicverse.utils"], "__all__"),
+        reason="omicverse.utils is a test stub",
+    )
+    def test_agent_in_all(self):
+        import omicverse.utils
+
+        assert "Agent" in omicverse.utils.__all__
+        assert "OmicVerseAgent" in omicverse.utils.__all__
+
+    @pytest.mark.skipif(
+        "omicverse.utils" in sys.modules
+        and not hasattr(sys.modules["omicverse.utils"], "__all__"),
+        reason="omicverse.utils is a test stub",
+    )
+    def test_ovagent_in_all(self):
+        import omicverse.utils
+
+        assert "ovagent" in omicverse.utils.__all__
+        assert "agent_backend_streaming" in omicverse.utils.__all__
+
+
+# ============================================================================
+# Test 5: bootstrap test cleanup does not leave orphan modules
+# ============================================================================
+
+
+class TestBootstrapCleanup:
+    """Simulate the bootstrap test's module-manipulation pattern and verify
+    no orphan omicverse.* entries remain in sys.modules after cleanup."""
+
+    def test_no_orphan_modules_after_stub_cycle(self):
+        from pathlib import Path
+        import importlib.machinery
+        import importlib.util
+
+        PROJECT_ROOT = Path(__file__).resolve().parents[2]
+        PACKAGE_ROOT = PROJECT_ROOT / "omicverse"
+
+        # Snapshot current state
+        pre_modules = {
+            name: mod
+            for name, mod in list(sys.modules.items())
+            if name == "omicverse" or name.startswith("omicverse.")
+        }
+
+        # Install stubs (simulate bootstrap)
+        originals = {
+            name: mod
+            for name, mod in list(sys.modules.items())
+            if name == "omicverse" or name.startswith("omicverse.")
+        }
+        for name in list(originals):
+            sys.modules.pop(name, None)
+
+        ov_stub = types.ModuleType("omicverse")
+        ov_stub.__path__ = [str(PACKAGE_ROOT)]
+        ov_stub.__spec__ = importlib.machinery.ModuleSpec(
+            "omicverse", loader=None, is_package=True
+        )
+        sys.modules["omicverse"] = ov_stub
+
+        utils_stub = types.ModuleType("omicverse.utils")
+        utils_stub.__path__ = [str(PACKAGE_ROOT / "utils")]
+        utils_stub.__spec__ = importlib.machinery.ModuleSpec(
+            "omicverse.utils", loader=None, is_package=True
+        )
+        sys.modules["omicverse.utils"] = utils_stub
+        ov_stub.utils = utils_stub
+
+        # Import something that pulls in agent_backend chain
+        sa_spec = importlib.util.spec_from_file_location(
+            "omicverse.utils.smart_agent",
+            PACKAGE_ROOT / "utils" / "smart_agent.py",
+        )
+        sa_mod = importlib.util.module_from_spec(sa_spec)
+        sys.modules["omicverse.utils.smart_agent"] = sa_mod
+        sa_spec.loader.exec_module(sa_mod)
+
+        # Cleanup: remove ALL omicverse.* then restore originals
+        for name in list(sys.modules):
+            if name == "omicverse" or name.startswith("omicverse."):
+                sys.modules.pop(name, None)
+        for name, mod in originals.items():
+            if mod is not None:
+                sys.modules[name] = mod
+
+        # Verify: should have exactly the original modules back
+        post_modules = {
+            name: mod
+            for name, mod in list(sys.modules.items())
+            if name == "omicverse" or name.startswith("omicverse.")
+        }
+        assert set(post_modules.keys()) == set(pre_modules.keys()), (
+            f"Orphan modules: {set(post_modules.keys()) - set(pre_modules.keys())}"
+        )

--- a/tests/utils/test_ovagent_bootstrap.py
+++ b/tests/utils/test_ovagent_bootstrap.py
@@ -20,11 +20,15 @@ PACKAGE_ROOT = PROJECT_ROOT / "omicverse"
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
+# Snapshot ALL omicverse.* modules so we can restore them after stub-phase
+# imports.  Only tracking 3 names left behind agent_backend* entries that
+# poisoned later test files (import-order regression).
 _ORIGINAL_MODULES = {
-    name: sys.modules.get(name)
-    for name in ["omicverse", "omicverse.utils", "omicverse.utils.smart_agent"]
+    name: mod
+    for name, mod in list(sys.modules.items())
+    if name == "omicverse" or name.startswith("omicverse.")
 }
-for name in ["omicverse", "omicverse.utils", "omicverse.utils.smart_agent"]:
+for name in list(_ORIGINAL_MODULES):
     sys.modules.pop(name, None)
 
 omicverse_pkg = types.ModuleType("omicverse")
@@ -65,10 +69,13 @@ from omicverse.utils.ovagent.bootstrap import (
 from omicverse.utils.ovagent.prompt_builder import build_filesystem_context_instructions
 from omicverse.utils.agent_config import AgentConfig
 
-for name, module in _ORIGINAL_MODULES.items():
-    if module is None:
+# Remove ALL omicverse.* entries added during the stub phase, then restore
+# the originals so subsequent test files see a clean sys.modules.
+for name in list(sys.modules):
+    if name == "omicverse" or name.startswith("omicverse."):
         sys.modules.pop(name, None)
-    else:
+for name, module in _ORIGINAL_MODULES.items():
+    if module is not None:
         sys.modules[name] = module
 
 

--- a/tests/utils/test_ovagent_bootstrap.py
+++ b/tests/utils/test_ovagent_bootstrap.py
@@ -1,14 +1,11 @@
 """Tests for ovagent.bootstrap — agent subsystem initialization."""
 
-import os
 import sys
 import types
 import importlib.machinery
 import importlib.util
 from pathlib import Path
 from types import SimpleNamespace
-
-import pytest
 
 # ---------------------------------------------------------------------------
 # Bootstrap: same isolation pattern as test_smart_agent.py
@@ -54,7 +51,7 @@ sys.modules["omicverse.utils.smart_agent"] = smart_agent_module
 assert smart_agent_spec.loader is not None
 smart_agent_spec.loader.exec_module(smart_agent_module)
 
-from omicverse.utils.ovagent.bootstrap import (
+from omicverse.utils.ovagent.bootstrap import (  # noqa: E402
     format_skill_overview,
     initialize_skill_registry,
     initialize_notebook_executor,
@@ -66,8 +63,8 @@ from omicverse.utils.ovagent.bootstrap import (
     display_reflection_config,
     _is_under_root,
 )
-from omicverse.utils.ovagent.prompt_builder import build_filesystem_context_instructions
-from omicverse.utils.agent_config import AgentConfig
+from omicverse.utils.ovagent.prompt_builder import build_filesystem_context_instructions  # noqa: E402
+from omicverse.utils.agent_config import AgentConfig  # noqa: E402
 
 # Remove ALL omicverse.* entries added during the stub phase, then restore
 # the originals so subsequent test files see a clean sys.modules.
@@ -259,7 +256,7 @@ class TestInitializeOvRuntime:
 
     def test_returns_none_on_failure(self):
         """Invalid repo_root should return None gracefully."""
-        rt = initialize_ov_runtime(None)
+        initialize_ov_runtime(None)  # should not raise
         # None repo_root triggers resolve_repo_root() which may or may not find one
         # Either way it should not raise
         # (result depends on whether we're inside a git repo)

--- a/tests/utils/test_ovagent_registry_scanner.py
+++ b/tests/utils/test_ovagent_registry_scanner.py
@@ -19,6 +19,13 @@ PACKAGE_ROOT = PROJECT_ROOT / "omicverse"
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
+# Snapshot ALL omicverse.* modules so we can restore after stub-phase imports.
+_ORIGINAL_MODULES = {
+    name: mod
+    for name, mod in list(sys.modules.items())
+    if name == "omicverse" or name.startswith("omicverse.")
+}
+
 # Ensure ovagent subpackage can resolve relative imports by
 # registering minimal parent stubs if not already present.
 _stubs_installed: dict = {}
@@ -57,6 +64,14 @@ _derive_static_signature = _scanner_mod._derive_static_signature
 _branch_subject_name = _scanner_mod._branch_subject_name
 _branch_string_values = _scanner_mod._branch_string_values
 _literal_eval_or_default = _scanner_mod._literal_eval_or_default
+
+# Restore sys.modules to pre-stub state so later test files see a clean namespace.
+for _name in list(sys.modules):
+    if _name == "omicverse" or _name.startswith("omicverse."):
+        sys.modules.pop(_name, None)
+for _name, _mod in _ORIGINAL_MODULES.items():
+    if _mod is not None:
+        sys.modules[_name] = _mod
 
 
 class TestRegistryScannerInit:


### PR DESCRIPTION
## What changed

This PR packages the non-`OvIntelligence` agent repair wave onto a clean branch based on `origin/dev`.

- stabilize `omicverse.utils` namespace exports and close the import-order regression around decomposed agent modules
- harden the MCP optional-dependency startup boundary so `python -m omicverse.mcp` no longer hard-crashes when the `mcp` extra is absent
- add reconciliation regression coverage for the current-dev PR #603 contract surface
- realign agent architecture and deprecation docs with the current `OmicVerseAgent` API

## Why it changed

The agent stack was functionally close, but several boundary issues were still making it brittle:

- dotted import / monkeypatch paths through `omicverse.utils` were order-sensitive
- MCP startup imported optional transport dependencies too eagerly
- regression coverage for the reconciled current-dev agent contracts was incomplete
- docs still described removed or outdated agent APIs

## Impact

- `ov.Agent` and related non-`OvIntelligence` agent entry points are more stable under the current decomposed package layout
- MCP help/startup behavior is controlled when extras are missing
- the repaired contracts are locked by targeted regression tests
- docs now describe the public API users actually get

## Validation

Ran on the Taiwan server in a dedicated remote venv:

- tests: `434 passed, 134 skipped, 3 deselected`
- typecheck: `compiled 101 files`
- lint: `ruff check` passed on Python files changed in this PR

## Notes

This PR intentionally excludes local orchestration state and other unrelated reviewed tasks that are still present in `ngagent` history.