### PR TITLE
Pin Pygments for docs deploy stability

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -38,6 +38,7 @@ mkapi == 4.5.0
 mkdocs-gen-files ==0.4.0
 mkdocstrings-python ==0.9.0
 mkdocs-autorefs==0.4.1
+Pygments<2.20
 python-dotplot
 metatime
 tensorboard


### PR DESCRIPTION
## Summary
- pin Pygments below 2.20 in the docs dependency set
- avoid the current pymdownx/Pygments regression that crashes MkDocs code highlighting during docs deploy

## Verification
- created a fresh Python 3.11 venv
- ran   - `pip install -r requirements.txt`
  - `python -m mkdocs build --config-file omicverse_guide/mkdocs.yml --site-dir /tmp/omicverse-docs-verify-site`
- build completed successfully on the full docs tree
