### PR TITLE
fix: CellCharter AutoK, Banksy Jupyter compat, pickle loading

### DIFF
--- a/omicverse/external/cellcharter/__init__.py
+++ b/omicverse/external/cellcharter/__init__.py
@@ -1,7 +1,14 @@
 """Minimal CellCharter backend used by omicverse spatial clustering."""
 
 from ._aggr import aggregate_neighbors
+from ._autok import ClusterAutoK, plot_autok_stability
 from ._gmm import Cluster
 from ._graph import remove_long_links
 
-__all__ = ["aggregate_neighbors", "Cluster", "remove_long_links"]
+__all__ = [
+    "aggregate_neighbors",
+    "Cluster",
+    "ClusterAutoK",
+    "plot_autok_stability",
+    "remove_long_links",
+]

--- a/omicverse/external/cellcharter/_autok.py
+++ b/omicverse/external/cellcharter/_autok.py
@@ -1,0 +1,232 @@
+"""Automatic K selection for CellCharter via clustering stability.
+
+Implements the ClusterAutoK algorithm from the CellCharter package:
+for each candidate K, runs clustering multiple times and measures
+pairwise stability (Fowlkes-Mallows score) between adjacent K values.
+The K with highest stability is selected.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Callable
+
+import anndata as ad
+import numpy as np
+import pandas as pd
+from sklearn.metrics import fowlkes_mallows_score
+
+from ._gmm import Cluster
+from ._utils import AnyRandom
+
+logger = logging.getLogger(__name__)
+
+
+class ClusterAutoK:
+    """Automatic selection of cluster number K via stability analysis.
+
+    For each K in ``n_clusters``, the clustering is repeated ``max_runs``
+    times. Stability is measured as the Fowlkes-Mallows score between
+    labels at K vs K-1 and K vs K+1. The K with the highest mean
+    stability is selected as ``best_k``.
+
+    Parameters
+    ----------
+    n_clusters
+        Range of K values to test. Either a tuple ``(min, max)``
+        (inclusive) or a list of specific K values.
+    max_runs
+        Maximum number of clustering repetitions per K.
+    convergence_tol
+        Early stopping: if the MAPE of the stability curve between
+        consecutive iterations is below this threshold, stop.
+    model_params
+        Keyword arguments passed to :class:`Cluster`.
+    similarity_function
+        Pairwise label comparison metric. Default: Fowlkes-Mallows score.
+    """
+
+    def __init__(
+        self,
+        n_clusters: tuple[int, int] | list[int] = (2, 10),
+        max_runs: int = 10,
+        convergence_tol: float = 0.01,
+        model_params: dict | None = None,
+        similarity_function: Callable = fowlkes_mallows_score,
+    ):
+        if isinstance(n_clusters, tuple):
+            # Expand range by 1 on each side for boundary comparisons
+            self._k_range = list(range(n_clusters[0] - 1, n_clusters[1] + 2))
+        else:
+            k_sorted = sorted(n_clusters)
+            self._k_range = list(range(k_sorted[0] - 1, k_sorted[-1] + 2))
+
+        self._inner_range = self._k_range[1:-1]  # reported K values
+        self.max_runs = max_runs
+        self.convergence_tol = convergence_tol
+        self.model_params = model_params or {}
+        self.similarity_function = similarity_function
+
+        # Filled after fit
+        self._labels: dict[int, list[np.ndarray]] = {k: [] for k in self._k_range}
+        self._stability: np.ndarray | None = None
+        self._models: dict[int, Cluster] = {}
+
+    @property
+    def best_k(self) -> int:
+        """K with highest mean stability."""
+        if self._stability is None:
+            raise RuntimeError("Call `fit` first.")
+        idx = int(np.argmax(self._stability.mean(axis=0)))
+        return self._inner_range[idx]
+
+    @property
+    def peaks(self) -> np.ndarray:
+        """All K values at local stability peaks."""
+        if self._stability is None:
+            raise RuntimeError("Call `fit` first.")
+        from scipy.signal import find_peaks
+        mean_stab = self._stability.mean(axis=0)
+        peak_idx, _ = find_peaks(mean_stab)
+        return np.array([self._inner_range[i] for i in peak_idx])
+
+    def fit(self, adata: ad.AnnData, use_rep: str = "X_cellcharter"):
+        """Run repeated clustering for each K and compute stability."""
+        prev_stability = None
+
+        for run in range(self.max_runs):
+            # Cluster for each K
+            for k in self._k_range:
+                seed = self.model_params.get("random_state", 0)
+                model = Cluster(
+                    n_clusters=k,
+                    random_state=seed + run * 1000 + k,
+                    **{k_: v for k_, v in self.model_params.items() if k_ != "random_state"},
+                )
+                model.fit(adata, use_rep=use_rep)
+                labels = model.predict(adata, use_rep=use_rep)
+                self._labels[k].append(np.asarray(labels))
+                self._models[k] = model
+
+            # Compute stability (need at least 2 runs)
+            if run < 1:
+                continue
+
+            stability = self._compute_stability()
+            self._stability = stability
+
+            # Early stopping via MAPE
+            if prev_stability is not None and stability.shape[0] >= 2:
+                mean_curr = stability.mean(axis=0)
+                mean_prev = prev_stability.mean(axis=0)
+                denom = np.clip(np.abs(mean_prev), 1e-10, None)
+                mape = np.mean(np.abs(mean_curr - mean_prev) / denom)
+                if mape < self.convergence_tol:
+                    logger.info(f"ClusterAutoK converged after {run + 1} runs (MAPE={mape:.4f})")
+                    break
+
+            prev_stability = stability
+
+        return self
+
+    def _compute_stability(self) -> np.ndarray:
+        """Compute mirrored stability matrix (runs x inner_K)."""
+        n_inner = len(self._inner_range)
+        n_runs = min(len(self._labels[k]) for k in self._k_range)
+
+        # For each pair of runs, compute similarity between K and K±1
+        stab_down = np.zeros((n_runs, n_inner))  # K vs K-1
+        stab_up = np.zeros((n_runs, n_inner))    # K vs K+1
+
+        for r in range(n_runs):
+            for j, k in enumerate(self._inner_range):
+                k_prev = self._k_range[j]      # K-1
+                k_next = self._k_range[j + 2]   # K+1
+                stab_down[r, j] = self.similarity_function(
+                    self._labels[k][r], self._labels[k_prev][r]
+                )
+                stab_up[r, j] = self.similarity_function(
+                    self._labels[k][r], self._labels[k_next][r]
+                )
+
+        # Mirror: stability[j] = stab_down[j] + stab_up[j-1] (when applicable)
+        stability = np.zeros((n_runs, n_inner))
+        for j in range(n_inner):
+            stability[:, j] = stab_down[:, j]
+            if j > 0:
+                stability[:, j] += stab_up[:, j - 1]
+
+        return stability
+
+    def predict(
+        self, adata: ad.AnnData, use_rep: str = "X_cellcharter", k: int | None = None
+    ) -> pd.Categorical:
+        """Predict labels using the model at ``k`` (default: ``best_k``)."""
+        if k is None:
+            k = self.best_k
+        if k not in self._models:
+            raise ValueError(f"K={k} not in fitted range {self._inner_range}")
+        return self._models[k].predict(adata, use_rep=use_rep)
+
+
+def plot_autok_stability(
+    autok: ClusterAutoK,
+    ax=None,
+    figsize: tuple[float, float] = (6, 4),
+    color: str = "#2176AE",
+    save: str | None = None,
+):
+    """Plot the stability curve from ClusterAutoK.
+
+    Parameters
+    ----------
+    autok
+        Fitted ClusterAutoK instance.
+    ax
+        Matplotlib axes. If None, a new figure is created.
+    figsize
+        Figure size when creating a new axes.
+    color
+        Line color.
+    save
+        If provided, save figure to this path.
+
+    Returns
+    -------
+    matplotlib.axes.Axes
+    """
+    import matplotlib.pyplot as plt
+
+    if autok._stability is None:
+        raise RuntimeError("ClusterAutoK has not been fitted yet.")
+
+    k_vals = autok._inner_range
+    mean_stab = autok._stability.mean(axis=0)
+    std_stab = autok._stability.std(axis=0)
+
+    if ax is None:
+        fig, ax = plt.subplots(figsize=figsize)
+
+    ax.plot(k_vals, mean_stab, "o-", color=color, linewidth=2, markersize=5)
+    ax.fill_between(k_vals, mean_stab - std_stab, mean_stab + std_stab,
+                    alpha=0.2, color=color)
+
+    best = autok.best_k
+    best_idx = k_vals.index(best)
+    ax.axvline(best, color="#E63946", linestyle="--", linewidth=1.5,
+               label=f"Best K = {best}")
+    ax.scatter([best], [mean_stab[best_idx]], color="#E63946", s=80,
+               zorder=5, edgecolors="white", linewidth=2)
+
+    ax.set_xlabel("N. clusters", fontsize=12)
+    ax.set_ylabel("Stability", fontsize=12)
+    ax.set_title("CellCharter Auto-K Stability", fontsize=13)
+    ax.set_xticks(k_vals)
+    ax.spines["top"].set_visible(False)
+    ax.spines["right"].set_visible(False)
+    ax.legend(fontsize=11)
+
+    if save:
+        ax.get_figure().savefig(save, dpi=150, bbox_inches="tight")
+
+    return ax

--- a/omicverse/external/cellcharter/_autok.py
+++ b/omicverse/external/cellcharter/_autok.py
@@ -33,10 +33,8 @@ class ClusterAutoK:
     ----------
     n_clusters
         Range of K values to test. Either a tuple ``(min, max)``
-        (inclusive) or a list of specific K values.  When a list is
-        given, only those exact K values are tested (the list must be
-        contiguous — for non-contiguous values, use a tuple range
-        instead).
+        (inclusive) or a contiguous list of K values (e.g. ``[3, 4, 5, 6]``).
+        Non-contiguous lists raise ``ValueError``.
     max_runs
         Maximum number of clustering repetitions per K.
     convergence_tol
@@ -99,11 +97,6 @@ class ClusterAutoK:
         peak_idx, _ = find_peaks(mean_stab)
         return np.array([self._inner_range[i] for i in peak_idx])
 
-    # Keep backward compat for code that accessed _stability directly
-    @property
-    def _stability(self) -> np.ndarray | None:
-        return self.stability_
-
     def fit(self, adata: ad.AnnData, use_rep: str = "X_cellcharter"):
         """Run repeated clustering for each K and compute stability."""
         prev_stability = None
@@ -164,18 +157,8 @@ class ClusterAutoK:
                     self._labels[k][r], self._labels[k_next][r]
                 )
 
-        # Average similarity to both neighbours, normalised by number of terms
-        stability = np.zeros((n_runs, n_inner))
-        count = np.ones(n_inner)
-        for j in range(n_inner):
-            stability[:, j] = stab_down[:, j]
-            if j > 0:
-                stability[:, j] += stab_up[:, j - 1]
-                count[j] += 1
-            if j < n_inner - 1:
-                stability[:, j] += stab_up[:, j]
-                count[j] += 1
-        stability /= count
+        # Average similarity to both neighbours (K-1 and K+1)
+        stability = (stab_down + stab_up) / 2
 
         return stability
 
@@ -218,12 +201,13 @@ def plot_autok_stability(
     """
     import matplotlib.pyplot as plt
 
-    if autok.stability_ is None:
+    stab = autok.stability_
+    if stab is None:
         raise RuntimeError("ClusterAutoK has not been fitted yet.")
 
     k_vals = autok._inner_range
-    mean_stab = autok.stability_.mean(axis=0)
-    std_stab = autok.stability_.std(axis=0)
+    mean_stab = stab.mean(axis=0)
+    std_stab = stab.std(axis=0)
 
     if ax is None:
         fig, ax = plt.subplots(figsize=figsize)

--- a/omicverse/external/cellcharter/_autok.py
+++ b/omicverse/external/cellcharter/_autok.py
@@ -17,7 +17,6 @@ import pandas as pd
 from sklearn.metrics import fowlkes_mallows_score
 
 from ._gmm import Cluster
-from ._utils import AnyRandom
 
 logger = logging.getLogger(__name__)
 
@@ -34,7 +33,10 @@ class ClusterAutoK:
     ----------
     n_clusters
         Range of K values to test. Either a tuple ``(min, max)``
-        (inclusive) or a list of specific K values.
+        (inclusive) or a list of specific K values.  When a list is
+        given, only those exact K values are tested (the list must be
+        contiguous — for non-contiguous values, use a tuple range
+        instead).
     max_runs
         Maximum number of clustering repetitions per K.
     convergence_tol
@@ -59,6 +61,13 @@ class ClusterAutoK:
             self._k_range = list(range(n_clusters[0] - 1, n_clusters[1] + 2))
         else:
             k_sorted = sorted(n_clusters)
+            # Validate contiguity
+            expected = list(range(k_sorted[0], k_sorted[-1] + 1))
+            if k_sorted != expected:
+                raise ValueError(
+                    f"n_clusters list must be contiguous (got {n_clusters}). "
+                    f"Use a tuple (min, max) for range-based selection."
+                )
             self._k_range = list(range(k_sorted[0] - 1, k_sorted[-1] + 2))
 
         self._inner_range = self._k_range[1:-1]  # reported K values
@@ -69,39 +78,45 @@ class ClusterAutoK:
 
         # Filled after fit
         self._labels: dict[int, list[np.ndarray]] = {k: [] for k in self._k_range}
-        self._stability: np.ndarray | None = None
+        self.stability_: np.ndarray | None = None
         self._models: dict[int, Cluster] = {}
 
     @property
     def best_k(self) -> int:
         """K with highest mean stability."""
-        if self._stability is None:
+        if self.stability_ is None:
             raise RuntimeError("Call `fit` first.")
-        idx = int(np.argmax(self._stability.mean(axis=0)))
+        idx = int(np.argmax(self.stability_.mean(axis=0)))
         return self._inner_range[idx]
 
     @property
     def peaks(self) -> np.ndarray:
         """All K values at local stability peaks."""
-        if self._stability is None:
+        if self.stability_ is None:
             raise RuntimeError("Call `fit` first.")
         from scipy.signal import find_peaks
-        mean_stab = self._stability.mean(axis=0)
+        mean_stab = self.stability_.mean(axis=0)
         peak_idx, _ = find_peaks(mean_stab)
         return np.array([self._inner_range[i] for i in peak_idx])
+
+    # Keep backward compat for code that accessed _stability directly
+    @property
+    def _stability(self) -> np.ndarray | None:
+        return self.stability_
 
     def fit(self, adata: ad.AnnData, use_rep: str = "X_cellcharter"):
         """Run repeated clustering for each K and compute stability."""
         prev_stability = None
+        seed = self.model_params.get("random_state", 0)
+        non_seed_params = {k: v for k, v in self.model_params.items() if k != "random_state"}
 
         for run in range(self.max_runs):
             # Cluster for each K
             for k in self._k_range:
-                seed = self.model_params.get("random_state", 0)
                 model = Cluster(
                     n_clusters=k,
                     random_state=seed + run * 1000 + k,
-                    **{k_: v for k_, v in self.model_params.items() if k_ != "random_state"},
+                    **non_seed_params,
                 )
                 model.fit(adata, use_rep=use_rep)
                 labels = model.predict(adata, use_rep=use_rep)
@@ -113,7 +128,7 @@ class ClusterAutoK:
                 continue
 
             stability = self._compute_stability()
-            self._stability = stability
+            self.stability_ = stability
 
             # Early stopping via MAPE
             if prev_stability is not None and stability.shape[0] >= 2:
@@ -130,11 +145,11 @@ class ClusterAutoK:
         return self
 
     def _compute_stability(self) -> np.ndarray:
-        """Compute mirrored stability matrix (runs x inner_K)."""
+        """Compute normalised stability matrix (runs x inner_K)."""
         n_inner = len(self._inner_range)
         n_runs = min(len(self._labels[k]) for k in self._k_range)
 
-        # For each pair of runs, compute similarity between K and K±1
+        # For each run, compute similarity between K and K±1
         stab_down = np.zeros((n_runs, n_inner))  # K vs K-1
         stab_up = np.zeros((n_runs, n_inner))    # K vs K+1
 
@@ -149,12 +164,18 @@ class ClusterAutoK:
                     self._labels[k][r], self._labels[k_next][r]
                 )
 
-        # Mirror: stability[j] = stab_down[j] + stab_up[j-1] (when applicable)
+        # Average similarity to both neighbours, normalised by number of terms
         stability = np.zeros((n_runs, n_inner))
+        count = np.ones(n_inner)
         for j in range(n_inner):
             stability[:, j] = stab_down[:, j]
             if j > 0:
                 stability[:, j] += stab_up[:, j - 1]
+                count[j] += 1
+            if j < n_inner - 1:
+                stability[:, j] += stab_up[:, j]
+                count[j] += 1
+        stability /= count
 
         return stability
 
@@ -197,12 +218,12 @@ def plot_autok_stability(
     """
     import matplotlib.pyplot as plt
 
-    if autok._stability is None:
+    if autok.stability_ is None:
         raise RuntimeError("ClusterAutoK has not been fitted yet.")
 
     k_vals = autok._inner_range
-    mean_stab = autok._stability.mean(axis=0)
-    std_stab = autok._stability.std(axis=0)
+    mean_stab = autok.stability_.mean(axis=0)
+    std_stab = autok.stability_.std(axis=0)
 
     if ax is None:
         fig, ax = plt.subplots(figsize=figsize)

--- a/omicverse/io/general/_serialization.py
+++ b/omicverse/io/general/_serialization.py
@@ -30,7 +30,7 @@ def _patch_categorical_setstate():
                 # Reconstruct via dict-based __setstate__ which pandas 2.x supports
                 dict_state = {
                     "_dtype": dtype,
-                    "_ndarray": np.asarray(codes),
+                    "_ndarray": np.asarray(codes, dtype=np.intp),
                 }
                 return _orig(self, dict_state)
         return _orig(self, state)

--- a/omicverse/io/general/_serialization.py
+++ b/omicverse/io/general/_serialization.py
@@ -1,6 +1,45 @@
 import os
+import contextlib
 
 from ..._registry import register_function
+
+
+@contextlib.contextmanager
+def _patch_categorical_setstate():
+    """Temporarily patch ``Categorical.__setstate__`` to tolerate old pickle formats.
+
+    Older pandas versions serialised ``Categorical`` as a ``(dtype, codes)``
+    tuple.  Newer pandas (≥ 2.x) dropped that path and raises
+    ``NotImplementedError``.  This context-manager installs a shim that
+    reconstructs the ``Categorical`` from the tuple when needed, and restores
+    the original method on exit.
+    """
+    try:
+        from pandas import Categorical, CategoricalDtype
+    except ImportError:
+        yield
+        return
+
+    _orig = Categorical.__setstate__
+
+    def _compat_setstate(self, state):
+        if isinstance(state, tuple) and len(state) == 2:
+            dtype, codes = state
+            if isinstance(dtype, CategoricalDtype):
+                import numpy as np
+                # Reconstruct via dict-based __setstate__ which pandas 2.x supports
+                dict_state = {
+                    "_dtype": dtype,
+                    "_ndarray": np.asarray(codes),
+                }
+                return _orig(self, dict_state)
+        return _orig(self, state)
+
+    Categorical.__setstate__ = _compat_setstate
+    try:
+        yield
+    finally:
+        Categorical.__setstate__ = _orig
 
 
 @register_function(
@@ -85,8 +124,28 @@ def load(path, backend=None):
     """
     print("📂 Load Operation:")
     print(f"   Source path: {path}")
-    if backend is None:
-        try:
+    with _patch_categorical_setstate():
+        if backend is None:
+            try:
+                import pickle
+                print("   Using: pickle")
+                with open(path, 'rb') as f:
+                    data = pickle.load(f)
+                print("   ✅ Successfully loaded!")
+                print(f"   Loaded object type: {type(data).__name__}")
+                print("─" * 60)
+                return data
+            except Exception:
+                import cloudpickle
+                print("   Pickle failed, switching to: cloudpickle")
+                with open(path, 'rb') as f:
+                    data = cloudpickle.load(f)
+                print("   ✅ Successfully loaded using cloudpickle!")
+                print(f"   Loaded object type: {type(data).__name__}")
+                print("─" * 60)
+                return data
+
+        if backend == 'pickle':
             import pickle
             print("   Using: pickle")
             with open(path, 'rb') as f:
@@ -95,34 +154,15 @@ def load(path, backend=None):
             print(f"   Loaded object type: {type(data).__name__}")
             print("─" * 60)
             return data
-        except Exception:
+
+        if backend == 'cloudpickle':
             import cloudpickle
-            print("   Pickle failed, switching to: cloudpickle")
+            print("   Using: cloudpickle")
             with open(path, 'rb') as f:
                 data = cloudpickle.load(f)
-            print("   ✅ Successfully loaded using cloudpickle!")
+            print("   ✅ Successfully loaded!")
             print(f"   Loaded object type: {type(data).__name__}")
             print("─" * 60)
             return data
-
-    if backend == 'pickle':
-        import pickle
-        print("   Using: pickle")
-        with open(path, 'rb') as f:
-            data = pickle.load(f)
-        print("   ✅ Successfully loaded!")
-        print(f"   Loaded object type: {type(data).__name__}")
-        print("─" * 60)
-        return data
-
-    if backend == 'cloudpickle':
-        import cloudpickle
-        print("   Using: cloudpickle")
-        with open(path, 'rb') as f:
-            data = cloudpickle.load(f)
-        print("   ✅ Successfully loaded!")
-        print(f"   Loaded object type: {type(data).__name__}")
-        print("─" * 60)
-        return data
 
     raise ValueError(f"Invalid backend: {backend}")

--- a/omicverse/space/_cluster.py
+++ b/omicverse/space/_cluster.py
@@ -594,7 +594,7 @@ def clusters(adata,
             try:
                 from banksy.labels import Label
                 _orig_repr = Label.__repr__
-                Label.__repr__ = lambda self: f'Label(n={self.num_labels})'
+                Label.__repr__ = lambda self: f'Label(n={getattr(self, "num_labels", "?")})'
             except (ImportError, AttributeError):
                 _orig_repr = None
 

--- a/omicverse/space/_cluster.py
+++ b/omicverse/space/_cluster.py
@@ -598,24 +598,25 @@ def clusters(adata,
             except (ImportError, AttributeError):
                 _orig_repr = None
 
-            results_df = run_banksy_multiparam(
-                adata,
-                banksy_dict,
-                lambda_list=methods_kwargs['Banksy']['lambda_list'],
-                resolutions=methods_kwargs['Banksy']['resolutions'],
-                color_list=palette_112,
-                annotation_key=None,
-                max_m=methods_kwargs['Banksy']['max_m'],
-                filepath=methods_kwargs['Banksy']['filepath'],
-                key=coord_keys,
-                #annotation_key='banksy_label',
-                add_nonspatial=methods_kwargs['Banksy']['add_nonspatial'],
-                variance_balance=methods_kwargs['Banksy']['variance_balance'],
-                match_labels=methods_kwargs['Banksy']['match_labels'],
-            )
-
-            if _orig_repr is not None:
-                Label.__repr__ = _orig_repr
+            try:
+                results_df = run_banksy_multiparam(
+                    adata,
+                    banksy_dict,
+                    lambda_list=methods_kwargs['Banksy']['lambda_list'],
+                    resolutions=methods_kwargs['Banksy']['resolutions'],
+                    color_list=palette_112,
+                    annotation_key=None,
+                    max_m=methods_kwargs['Banksy']['max_m'],
+                    filepath=methods_kwargs['Banksy']['filepath'],
+                    key=coord_keys,
+                    #annotation_key='banksy_label',
+                    add_nonspatial=methods_kwargs['Banksy']['add_nonspatial'],
+                    variance_balance=methods_kwargs['Banksy']['variance_balance'],
+                    match_labels=methods_kwargs['Banksy']['match_labels'],
+                )
+            finally:
+                if _orig_repr is not None:
+                    Label.__repr__ = _orig_repr
             result_keys=[i for i in results_df['adata'].keys()]
             for key in result_keys:
                 adata.obsm[f'X_banksy_{key}']=results_df['adata'][key].obsm['reduced_pc_20']

--- a/omicverse/space/_cluster.py
+++ b/omicverse/space/_cluster.py
@@ -590,6 +590,14 @@ def clusters(adata,
                 max_m=methods_kwargs['Banksy']['max_m'],
             )
 
+            # Patch leidenalg Label repr to prevent Jupyter JSON serialization errors
+            try:
+                from banksy.labels import Label
+                _orig_repr = Label.__repr__
+                Label.__repr__ = lambda self: f'Label(n={self.num_labels})'
+            except (ImportError, AttributeError):
+                _orig_repr = None
+
             results_df = run_banksy_multiparam(
                 adata,
                 banksy_dict,
@@ -605,9 +613,13 @@ def clusters(adata,
                 variance_balance=methods_kwargs['Banksy']['variance_balance'],
                 match_labels=methods_kwargs['Banksy']['match_labels'],
             )
+
+            if _orig_repr is not None:
+                Label.__repr__ = _orig_repr
             result_keys=[i for i in results_df['adata'].keys()]
             for key in result_keys:
                 adata.obsm[f'X_banksy_{key}']=results_df['adata'][key].obsm['reduced_pc_20']
+            del results_df  # Prevent leidenalg Label objects from leaking into Jupyter
 
             add_reference(adata,'Banksy','clustering with Banksy')
 


### PR DESCRIPTION
## Summary
- Export `ClusterAutoK` and `plot_autok_stability` from `omicverse.external.cellcharter` for automatic K selection via clustering stability
- Fix Banksy workflow breaking Jupyter notebooks due to leidenalg `Label.__repr__` containing numpy arrays that fail JSON serialization
- Add cross-version pandas pickle compatibility in `ov.utils.load()` for old `Categorical` tuple format

## Changes
| File | Change |
|------|--------|
| `external/cellcharter/__init__.py` | Export `ClusterAutoK`, `plot_autok_stability` |
| `external/cellcharter/_autok.py` | New: AutoK stability-based K selection + visualization |
| `io/general/_serialization.py` | `_patch_categorical_setstate()` for pandas 2.x pickle compat |
| `space/_cluster.py` | Patch Label repr + cleanup `results_df` in Banksy workflow |

## Test plan
- [x] CellCharter standalone PCA clustering
- [x] ClusterAutoK automatic K selection (stability peaks)
- [x] plot_autok_stability visualization
- [x] CellCharter on GraphST embedding
- [x] Banksy in Jupyter notebook (no JSON serialization error)
- [x] Full t_cluster_space.ipynb: 0 errors across GraphST, BINARY, STAGATE, CAST, Banksy, CellCharter

🤖 Generated with [Claude Code](https://claude.com/claude-code)