### PR TITLE
feat: auto-detect mitochondrial gene prefix in pp.qc

### DIFF
--- a/omicverse/pp/_qc.py
+++ b/omicverse/pp/_qc.py
@@ -422,6 +422,77 @@ def mads_test(meta, cov, nmads=5, lt=None, batch_key=None):
     ],
     related=["preprocess", "filter_cells", "filter_genes", "scrublet"]
 )
+def _detect_mt_prefix(var_names) -> str:
+    """Auto-detect mitochondrial gene prefix from variable names.
+
+    Checks common prefixes across species and returns the one with the
+    most matches.  Falls back to ``'MT-'`` if nothing is found.
+
+    Supported species / prefixes:
+
+    * Human, pig, cattle and most vertebrates: ``MT-``
+    * Mouse, rat, zebrafish: ``mt-``
+    * Some mixed annotations: ``Mt-``
+    * Drosophila: ``mt:``
+    * Arabidopsis thaliana: ``ATMG``
+    * C. elegans: ``ctc-`` and ``nduo-`` (checked as a group)
+    """
+    if isinstance(var_names, list):
+        var_names = pd.Index(var_names)
+
+    # Candidates ordered roughly by prevalence.
+    # Each entry is (prefix, species_hint).
+    candidates = [
+        'MT-',    # Human / pig / cattle / most vertebrates
+        'mt-',    # Mouse / rat / zebrafish
+        'Mt-',    # Some annotations
+        'mt:',    # Drosophila (e.g. mt:CoI, mt:ND1)
+        'ATMG',   # Arabidopsis thaliana mitochondrial genes
+    ]
+
+    best_prefix = 'MT-'
+    best_count = 0
+    for prefix in candidates:
+        count = int(var_names.str.startswith(prefix).sum())
+        if count > best_count:
+            best_count = count
+            best_prefix = prefix
+
+    # C. elegans: mitochondrial genes use heterogeneous names
+    # (ctc-1, ctc-2, ctc-3, nduo-1 … nduo-6, ctb-1, etc.)
+    if best_count == 0:
+        ce_prefixes = ('ctc-', 'nduo-', 'ctb-')
+        ce_count = int(var_names.str.startswith(ce_prefixes).sum())
+        if ce_count > 0:
+            best_prefix = 'ctc-'  # representative prefix
+            best_count = ce_count
+
+    if best_count == 0:
+        # Try case-insensitive as last resort
+        count = int(var_names.str.upper().str.startswith('MT-').sum())
+        if count > 0:
+            mt_mask = var_names.str.upper().str.startswith('MT-')
+            first_mt = var_names[mt_mask][0]
+            # Extract the prefix including separator (e.g. 'mT-')
+            best_prefix = first_mt[:3]
+            best_count = count
+
+    return best_prefix
+
+
+# C. elegans mitochondrial gene prefixes (no single shared prefix)
+_CE_MT_PREFIXES = ('ctc-', 'nduo-', 'ctb-')
+
+
+def _mt_mask(var_names, mt_startswith):
+    """Return boolean mask for mitochondrial genes, handling multi-prefix species."""
+    if isinstance(var_names, list):
+        var_names = pd.Index(var_names)
+    if mt_startswith in _CE_MT_PREFIXES:
+        return var_names.str.startswith(_CE_MT_PREFIXES)
+    return var_names.str.startswith(mt_startswith)
+
+
 def qc(adata,**kwargs):
     r'''
     Perform quality control on a dictionary of AnnData objects.
@@ -442,7 +513,9 @@ def qc(adata,**kwargs):
         tresh : A dictionary of QC thresholds. The keys should be 'mito_perc',
         'nUMIs', and 'detected_genes'.
             Only used if mode is 'seurat'. Default is None.
-        mt_startswith : The prefix of mitochondrial genes. Default is 'MT-'.
+        mt_startswith : The prefix of mitochondrial genes. Default is 'auto',
+            which automatically detects the prefix (e.g. 'MT-' for human,
+            'mt-' for mouse). Set explicitly (e.g. 'MT-') to override.
         mt_genes : The list of mitochondrial genes. Default is None.
         if mt_genes is not None, mt_startswith will be ignored.
 
@@ -453,6 +526,10 @@ def qc(adata,**kwargs):
         >>> import omicverse as ov
         >>> adata = ov.pp.qc(adata, tresh={'mito_perc': 0.2, 'nUMIs': 500, 'detected_genes': 250})
         >>> adata = ov.pp.qc(adata, mode='mads', nmads=5, doublets=True)
+        >>> # Auto-detects 'mt-' for mouse data
+        >>> adata = ov.pp.qc(adata)
+        >>> # Explicit prefix
+        >>> adata = ov.pp.qc(adata, mt_startswith='mt-')
 
     '''
 
@@ -473,7 +550,7 @@ def qc_cpu_gpu_mixed(adata:anndata.AnnData, mode='seurat',
        max_cells_ratio=1,max_genes_ratio=1,
        batch_key=None,doublets=True,doublets_method='scrublet',
        filter_doublets=True,
-       path_viz=None, tresh=None,mt_startswith='MT-',mt_genes=None,
+       path_viz=None, tresh=None,mt_startswith='auto',mt_genes=None,
        ribo_startswith=("RPS", "RPL"),ribo_genes=None,
        hb_startswith="^HB[^(P)]",hb_genes=None,
        use_gpu=True,batch_wise_mad=None):
@@ -520,6 +597,10 @@ def qc_cpu_gpu_mixed(adata:anndata.AnnData, mode='seurat',
     print(f"   {Colors.CYAN}Dataset shape: {Colors.BOLD}{adata.shape[0]:,} cells × {adata.shape[1]:,} genes{Colors.ENDC}")
     print(f"   {Colors.BLUE}QC mode: {Colors.BOLD}{mode}{Colors.ENDC}")
     print(f"   {Colors.BLUE}Doublet detection: {Colors.BOLD}{doublets_method if doublets else 'disabled'}{Colors.ENDC}")
+    # Auto-detect mitochondrial gene prefix
+    if mt_startswith == 'auto' and mt_genes is None:
+        mt_startswith = _detect_mt_prefix(adata.var_names)
+        print(f"   {Colors.CYAN}Auto-detected mitochondrial prefix: {Colors.BOLD}'{mt_startswith}'{Colors.ENDC}")
     print(f"   {Colors.BLUE}Mitochondrial genes: {Colors.BOLD}{mt_startswith if mt_genes is None else 'custom list'}{Colors.ENDC}")
 
     # QC metrics
@@ -535,7 +616,7 @@ def qc_cpu_gpu_mixed(adata:anndata.AnnData, mode='seurat',
             var_names = pd.Index(adata.var_names)
         else:
             var_names = adata.var_names
-        adata.var["mt"] = var_names.str.startswith(mt_startswith)
+        adata.var["mt"] = _mt_mask(var_names, mt_startswith)
         mt_genes_found = sum(adata.var["mt"])
     # print(f"   {Colors.CYAN}Mitochondrial genes (prefix '{mt_startswith}'): {Colors.BOLD}{mt_genes_found}{Colors.ENDC}{Colors.CYAN} found{Colors.ENDC}")
 
@@ -806,12 +887,12 @@ def qc_cpu(
     filter_doublets: Optional[bool] = True,
     path_viz: Optional[str] = None, 
     tresh: Optional[dict] = None,
-    mt_startswith: Optional[str] = 'MT-',
+    mt_startswith: Optional[str] = 'auto',
     mt_genes: Optional[list] = None,
     ribo_startswith: Optional[tuple] = ("RPS", "RPL"),
-    ribo_genes: Optional[list] = None, 
+    ribo_genes: Optional[list] = None,
     hb_startswith: Optional[str] = "^HB[^(P)]",
-    hb_genes: Optional[list] = None, 
+    hb_genes: Optional[list] = None,
     **kwargs
 ):
     r"""
@@ -854,6 +935,11 @@ def qc_cpu(
     # with PdfPages(path_viz + 'original_QC_by_sample.pdf') as pdf:
     removed_cells = []
 
+    # Auto-detect mitochondrial gene prefix
+    if mt_startswith == 'auto' and mt_genes is None:
+        mt_startswith = _detect_mt_prefix(adata.var_names)
+        print(f"   {Colors.CYAN}Auto-detected mitochondrial prefix: {Colors.BOLD}'{mt_startswith}'{Colors.ENDC}")
+
     # QC metrics
     print(f"\n{Colors.HEADER}{Colors.BOLD}📊 Step 1: Calculating QC Metrics{Colors.ENDC}")
     adata.var_names_make_unique()
@@ -867,13 +953,13 @@ def qc_cpu(
             var_names = pd.Index(adata.var_names)
         else:
             var_names = adata.var_names
-        adata.var["mt"] = var_names.str.startswith(mt_startswith)
+        adata.var["mt"] = _mt_mask(var_names, mt_startswith)
         mt_genes_found = sum(adata.var["mt"])
     # print(f"   {Colors.CYAN}Mitochondrial genes (prefix '{mt_startswith}'): {Colors.BOLD}{mt_genes_found}{Colors.ENDC}{Colors.CYAN} found{Colors.ENDC}")
-    
+
     if ribo_genes is not None:
-        adata.var["ribo"] = False 
-        adata.var.loc[list(set(adata.var_names) & set(ribo_genes)),'ribo']=True 
+        adata.var["ribo"] = False
+        adata.var.loc[list(set(adata.var_names) & set(ribo_genes)),'ribo']=True
         ribo_genes_found = sum(adata.var["ribo"]) 
     # print(f"   {Colors.CYAN}Ribosomal genes: {Colors.BOLD}{ribo_genes_found}/{len(ribo_genes)}{Colors.ENDC}{Colors.CYAN} found{Colors.ENDC}")
     else:
@@ -1128,7 +1214,7 @@ def qc_gpu(adata, mode='seurat',
        max_cells_ratio=1,max_genes_ratio=1,
        batch_key=None,doublets=True,doublets_method='scrublet',
        filter_doublets=True,
-       path_viz=None, tresh=None,mt_startswith='MT-',mt_genes=None,
+       path_viz=None, tresh=None,mt_startswith='auto',mt_genes=None,
        ribo_startswith=("RPS", "RPL"),ribo_genes=None,
        hb_startswith="^HB[^(P)]",hb_genes=None):
     '''
@@ -1146,11 +1232,15 @@ def qc_gpu(adata, mode='seurat',
     print(f"   {Colors.CYAN}Dataset shape: {Colors.BOLD}{adata.shape[0]:,} cells × {adata.shape[1]:,} genes{Colors.ENDC}")
     print(f"   {Colors.BLUE}QC mode: {Colors.BOLD}{mode}{Colors.ENDC}")
     print(f"   {Colors.BLUE}Doublet detection: {Colors.BOLD}{doublets_method if doublets else 'disabled'}{Colors.ENDC}")
+    # Auto-detect mitochondrial gene prefix
+    if mt_startswith == 'auto' and mt_genes is None:
+        mt_startswith = _detect_mt_prefix(adata.var_names)
+        print(f"   {Colors.CYAN}Auto-detected mitochondrial prefix: {Colors.BOLD}'{mt_startswith}'{Colors.ENDC}")
     print(f"   {Colors.BLUE}Mitochondrial genes: {Colors.BOLD}{mt_startswith if mt_genes is None else 'custom list'}{Colors.ENDC}")
-    
+
     print(f"   {Colors.GREEN}{EMOJI['gpu']} Loading data to GPU...{Colors.ENDC}")
     rsc.get.anndata_to_GPU(adata)
-    
+
     # QC metrics
     print(f"\n{Colors.HEADER}{Colors.BOLD}📊 Step 1: Calculating QC Metrics{Colors.ENDC}")
     adata.var_names_make_unique()
@@ -1160,7 +1250,11 @@ def qc_gpu(adata, mode='seurat',
         mt_genes_found = sum(adata.var['mt'])
     # print(f"   {Colors.CYAN}Custom mitochondrial genes: {Colors.BOLD}{mt_genes_found}/{len(mt_genes)}{Colors.ENDC}{Colors.CYAN} found{Colors.ENDC}")
     else:
-        rsc.pp.flag_gene_family(adata, gene_family_name="mt", gene_family_prefix=mt_startswith)
+        if mt_startswith in _CE_MT_PREFIXES:
+            # C. elegans: multiple prefixes, flag manually
+            adata.var["mt"] = _mt_mask(adata.var_names, mt_startswith)
+        else:
+            rsc.pp.flag_gene_family(adata, gene_family_name="mt", gene_family_prefix=mt_startswith)
         mt_genes_found = sum(adata.var["mt"])
     # print(f"   {Colors.CYAN}Mitochondrial genes (prefix '{mt_startswith}'): {Colors.BOLD}{mt_genes_found}{Colors.ENDC}{Colors.CYAN} found{Colors.ENDC}")
 

--- a/omicverse/pp/_qc.py
+++ b/omicverse/pp/_qc.py
@@ -404,24 +404,10 @@ def mads_test(meta, cov, nmads=5, lt=None, batch_key=None):
             
         return result
 
-@monitor
-@register_function(
-    aliases=["质控", "qc", "quality_control", "质量控制"],
-    category="preprocessing",
-    description="Perform comprehensive quality control on single-cell data. For seurat mode, use tresh dict with keys: 'mito_perc', 'nUMIs', 'detected_genes'",
-    prerequisites={},
-    requires={},
-    produces={
-        'obs': ['n_genes', 'n_counts', 'pct_counts_mt'],
-        'var': ['mt', 'n_cells']
-    },
-    auto_fix='none',
-    examples=[
-        "ov.pp.qc(adata, tresh={'mito_perc': 0.2, 'nUMIs': 500, 'detected_genes': 250})",
-        "ov.pp.qc(adata, mode='mads', nmads=5, doublets=True)"
-    ],
-    related=["preprocess", "filter_cells", "filter_genes", "scrublet"]
-)
+# C. elegans mitochondrial gene prefixes (no single shared prefix)
+_CE_MT_PREFIXES = ('ctc-', 'nduo-', 'ctb-')
+
+
 def _detect_mt_prefix(var_names) -> str:
     """Auto-detect mitochondrial gene prefix from variable names.
 
@@ -440,8 +426,6 @@ def _detect_mt_prefix(var_names) -> str:
     if isinstance(var_names, list):
         var_names = pd.Index(var_names)
 
-    # Candidates ordered roughly by prevalence.
-    # Each entry is (prefix, species_hint).
     candidates = [
         'MT-',    # Human / pig / cattle / most vertebrates
         'mt-',    # Mouse / rat / zebrafish
@@ -460,32 +444,34 @@ def _detect_mt_prefix(var_names) -> str:
 
     # C. elegans: mitochondrial genes use heterogeneous names
     # (ctc-1, ctc-2, ctc-3, nduo-1 … nduo-6, ctb-1, etc.)
+    # Note: 'ctc-' could appear in other contexts (e.g. clone names),
+    # but this check only runs when no standard MT prefix was found.
     if best_count == 0:
-        ce_prefixes = ('ctc-', 'nduo-', 'ctb-')
-        ce_count = int(var_names.str.startswith(ce_prefixes).sum())
+        ce_count = int(var_names.str.startswith(_CE_MT_PREFIXES).sum())
         if ce_count > 0:
             best_prefix = 'ctc-'  # representative prefix
             best_count = ce_count
 
     if best_count == 0:
-        # Try case-insensitive as last resort
+        # Case-insensitive fallback as last resort.
+        # [:3] is safe because all MT- variants are exactly 3 characters.
         count = int(var_names.str.upper().str.startswith('MT-').sum())
         if count > 0:
             mt_mask = var_names.str.upper().str.startswith('MT-')
             first_mt = var_names[mt_mask][0]
-            # Extract the prefix including separator (e.g. 'mT-')
             best_prefix = first_mt[:3]
             best_count = count
 
     return best_prefix
 
 
-# C. elegans mitochondrial gene prefixes (no single shared prefix)
-_CE_MT_PREFIXES = ('ctc-', 'nduo-', 'ctb-')
-
-
 def _mt_mask(var_names, mt_startswith):
-    """Return boolean mask for mitochondrial genes, handling multi-prefix species."""
+    """Return boolean mask for mitochondrial genes, handling multi-prefix species.
+
+    When ``mt_startswith`` is any of the C. elegans prefixes (``'ctc-'``,
+    ``'nduo-'``, ``'ctb-'``), all three prefixes are matched together
+    because C. elegans mitochondrial genes do not share a single prefix.
+    """
     if isinstance(var_names, list):
         var_names = pd.Index(var_names)
     if mt_startswith in _CE_MT_PREFIXES:
@@ -493,6 +479,24 @@ def _mt_mask(var_names, mt_startswith):
     return var_names.str.startswith(mt_startswith)
 
 
+@monitor
+@register_function(
+    aliases=["质控", "qc", "quality_control", "质量控制"],
+    category="preprocessing",
+    description="Perform comprehensive quality control on single-cell data. For seurat mode, use tresh dict with keys: 'mito_perc', 'nUMIs', 'detected_genes'",
+    prerequisites={},
+    requires={},
+    produces={
+        'obs': ['n_genes', 'n_counts', 'pct_counts_mt'],
+        'var': ['mt', 'n_cells']
+    },
+    auto_fix='none',
+    examples=[
+        "ov.pp.qc(adata, tresh={'mito_perc': 0.2, 'nUMIs': 500, 'detected_genes': 250})",
+        "ov.pp.qc(adata, mode='mads', nmads=5, doublets=True)"
+    ],
+    related=["preprocess", "filter_cells", "filter_genes", "scrublet"]
+)
 def qc(adata,**kwargs):
     r'''
     Perform quality control on a dictionary of AnnData objects.

--- a/omicverse/pp/_qc.py
+++ b/omicverse/pp/_qc.py
@@ -421,7 +421,7 @@ def _detect_mt_prefix(var_names) -> str:
     * Some mixed annotations: ``Mt-``
     * Drosophila: ``mt:``
     * Arabidopsis thaliana: ``ATMG``
-    * C. elegans: ``ctc-`` and ``nduo-`` (checked as a group)
+    * C. elegans: ``ctc-``, ``nduo-`` and ``ctb-`` (checked as a group)
     """
     if isinstance(var_names, list):
         var_names = pd.Index(var_names)
@@ -472,6 +472,11 @@ def _mt_mask(var_names, mt_startswith):
     ``'nduo-'``, ``'ctb-'``), all three prefixes are matched together
     because C. elegans mitochondrial genes do not share a single prefix.
     """
+    if mt_startswith == 'auto':
+        raise ValueError(
+            "mt_startswith='auto' was not resolved before calling _mt_mask. "
+            "Call _detect_mt_prefix() first."
+        )
     if isinstance(var_names, list):
         var_names = pd.Index(var_names)
     if mt_startswith in _CE_MT_PREFIXES:

--- a/tests/test_mt_detect.py
+++ b/tests/test_mt_detect.py
@@ -1,0 +1,160 @@
+"""Tests for mitochondrial gene prefix auto-detection in pp.qc."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from omicverse.pp._qc import _detect_mt_prefix, _mt_mask
+
+
+class TestDetectMtPrefix:
+    """Test _detect_mt_prefix with various species and edge cases."""
+
+    def test_human_MT(self):
+        """Human genes use 'MT-' prefix."""
+        genes = pd.Index([
+            "GAPDH", "ACTB", "TP53", "MT-CO1", "MT-CO2", "MT-CO3",
+            "MT-ND1", "MT-ND2", "MT-ATP6", "MT-CYB", "BRCA1",
+        ])
+        assert _detect_mt_prefix(genes) == "MT-"
+
+    def test_mouse_mt(self):
+        """Mouse genes use 'mt-' prefix."""
+        genes = pd.Index([
+            "Gapdh", "Actb", "Trp53", "mt-Co1", "mt-Co2", "mt-Co3",
+            "mt-Nd1", "mt-Nd2", "mt-Atp6", "mt-Cytb", "Brca1",
+        ])
+        assert _detect_mt_prefix(genes) == "mt-"
+
+    def test_mixed_case_Mt(self):
+        """Some annotations use 'Mt-' prefix."""
+        genes = pd.Index(["Mt-Co1", "Mt-Nd1", "Gapdh", "Actb"])
+        assert _detect_mt_prefix(genes) == "Mt-"
+
+    def test_drosophila_mt_colon(self):
+        """Drosophila genes use 'mt:' prefix."""
+        genes = pd.Index([
+            "Act5C", "RpL32", "mt:CoI", "mt:CoII", "mt:CoIII",
+            "mt:ND1", "mt:Cyt-b", "Gapdh1",
+        ])
+        assert _detect_mt_prefix(genes) == "mt:"
+
+    def test_arabidopsis_ATMG(self):
+        """Arabidopsis thaliana mitochondrial genes use 'ATMG' prefix."""
+        genes = pd.Index([
+            "AT1G01010", "AT3G18780", "ATMG00010", "ATMG00020",
+            "ATMG00030", "ATMG00040", "AT5G08670",
+        ])
+        assert _detect_mt_prefix(genes) == "ATMG"
+
+    def test_c_elegans_heterogeneous(self):
+        """C. elegans has heterogeneous mt gene names (ctc-, nduo-, ctb-)."""
+        genes = pd.Index([
+            "unc-54", "dpy-7", "ctc-1", "ctc-2", "ctc-3",
+            "nduo-1", "nduo-2", "nduo-6", "ctb-1", "act-1",
+        ])
+        assert _detect_mt_prefix(genes) == "ctc-"
+
+    def test_no_mt_genes_fallback(self):
+        """When no MT genes found, fallback to 'MT-'."""
+        genes = pd.Index(["GAPDH", "ACTB", "TP53", "BRCA1"])
+        assert _detect_mt_prefix(genes) == "MT-"
+
+    def test_human_dominates_mouse(self):
+        """When both 'MT-' and 'mt-' present, the one with more matches wins."""
+        genes = pd.Index([
+            "MT-CO1", "MT-CO2", "MT-CO3", "MT-ND1", "MT-ND2",
+            "mt-Co1",  # only one mouse-style
+            "GAPDH", "ACTB",
+        ])
+        assert _detect_mt_prefix(genes) == "MT-"
+
+    def test_mouse_dominates_human(self):
+        """When 'mt-' has more matches than 'MT-', select 'mt-'."""
+        genes = pd.Index([
+            "mt-Co1", "mt-Co2", "mt-Co3", "mt-Nd1", "mt-Nd2",
+            "MT-CO1",  # only one human-style
+            "Gapdh", "Actb",
+        ])
+        assert _detect_mt_prefix(genes) == "mt-"
+
+    def test_list_input(self):
+        """Works with plain list input (not pd.Index)."""
+        genes = ["mt-Co1", "mt-Nd1", "Gapdh"]
+        assert _detect_mt_prefix(genes) == "mt-"
+
+    def test_empty_index(self):
+        """Empty gene list falls back to 'MT-'."""
+        genes = pd.Index([])
+        assert _detect_mt_prefix(genes) == "MT-"
+
+    def test_case_insensitive_fallback(self):
+        """Case-insensitive fallback detects unusual capitalisation."""
+        genes = pd.Index(["mT-CO1", "mT-ND1", "GAPDH"])
+        result = _detect_mt_prefix(genes)
+        assert result == "mT-"
+
+    def test_ensembl_ids_fallback(self):
+        """Ensembl gene IDs have no MT prefix, should fallback."""
+        genes = pd.Index([
+            "ENSG00000198888", "ENSG00000198763", "ENSG00000141510",
+        ])
+        assert _detect_mt_prefix(genes) == "MT-"
+
+
+class TestMtMask:
+    """Test _mt_mask helper for multi-prefix species."""
+
+    def test_human_single_prefix(self):
+        genes = pd.Index(["MT-CO1", "MT-ND1", "GAPDH", "ACTB"])
+        mask = _mt_mask(genes, "MT-")
+        assert list(mask) == [True, True, False, False]
+
+    def test_c_elegans_multi_prefix(self):
+        """ctc- prefix should also match nduo- and ctb-."""
+        genes = pd.Index(["ctc-1", "nduo-2", "ctb-1", "unc-54", "act-1"])
+        mask = _mt_mask(genes, "ctc-")
+        assert list(mask) == [True, True, True, False, False]
+
+    def test_drosophila(self):
+        genes = pd.Index(["mt:CoI", "mt:ND1", "Act5C"])
+        mask = _mt_mask(genes, "mt:")
+        assert list(mask) == [True, True, False]
+
+    def test_list_input(self):
+        genes = ["MT-CO1", "GAPDH"]
+        mask = _mt_mask(genes, "MT-")
+        assert list(mask) == [True, False]
+
+
+class TestQcAutoMt:
+    """Integration test: verify auto-detection works end-to-end."""
+
+    def test_qc_auto_mouse(self):
+        """Detects 'mt-' for mouse data."""
+        prefix = _detect_mt_prefix(pd.Index([
+            "Gapdh", "mt-Co1", "mt-Co2", "mt-Nd1", "Actb",
+        ]))
+        assert prefix == "mt-"
+        mask = _mt_mask(pd.Index(["mt-Co1", "Gapdh", "mt-Nd1"]), prefix)
+        assert sum(mask) == 2
+
+    def test_qc_auto_drosophila(self):
+        """Detects 'mt:' for Drosophila data."""
+        prefix = _detect_mt_prefix(pd.Index([
+            "Act5C", "mt:CoI", "mt:ND1", "RpL32",
+        ]))
+        assert prefix == "mt:"
+        mask = _mt_mask(pd.Index(["mt:CoI", "Act5C", "mt:ND1"]), prefix)
+        assert sum(mask) == 2
+
+    def test_qc_auto_c_elegans(self):
+        """Detects C. elegans mt genes across multiple prefixes."""
+        prefix = _detect_mt_prefix(pd.Index([
+            "unc-54", "ctc-1", "ctc-2", "nduo-1", "ctb-1", "act-1",
+        ]))
+        assert prefix == "ctc-"
+        mask = _mt_mask(pd.Index([
+            "ctc-1", "nduo-1", "ctb-1", "unc-54",
+        ]), prefix)
+        assert sum(mask) == 3

--- a/tests/test_mt_detect.py
+++ b/tests/test_mt_detect.py
@@ -126,6 +126,23 @@ class TestMtMask:
         mask = _mt_mask(genes, "MT-")
         assert list(mask) == [True, False]
 
+    def test_explicit_override(self):
+        """Explicit mt_startswith bypasses auto-detection."""
+        genes = pd.Index(["Gapdh", "mt-Co1", "mt-Co2", "MT-CO1"])
+        mask = _mt_mask(genes, "MT-")
+        assert list(mask) == [False, False, False, True]
+
+    def test_auto_raises(self):
+        """Unresolved 'auto' raises ValueError."""
+        with pytest.raises(ValueError, match="auto"):
+            _mt_mask(pd.Index(["MT-CO1"]), "auto")
+
+    def test_nduo_expands_to_all_ce(self):
+        """User passing 'nduo-' also matches ctc- and ctb-."""
+        genes = pd.Index(["ctc-1", "nduo-2", "ctb-1", "unc-54"])
+        mask = _mt_mask(genes, "nduo-")
+        assert list(mask) == [True, True, True, False]
+
 
 class TestQcAutoMt:
     """Integration test: verify auto-detection works end-to-end."""


### PR DESCRIPTION
## Summary
- Change `mt_startswith` default from `'MT-'` to `'auto'` in `ov.pp.qc()`
- Automatically detects the correct mitochondrial gene prefix based on gene names
- Users no longer need to manually specify `mt_startswith='mt-'` for mouse data

## Supported species

| Prefix | Species |
|--------|---------|
| `MT-` | Human, pig, cattle, most vertebrates |
| `mt-` | Mouse, rat, zebrafish |
| `Mt-` | Some annotation formats |
| `mt:` | Drosophila |
| `ATMG` | Arabidopsis thaliana |
| `ctc-`/`nduo-`/`ctb-` | C. elegans (multi-prefix) |
| Case-insensitive fallback | Other annotations |

## API

```python
# Auto-detect (new default) — works for any species
adata = ov.pp.qc(adata)

# Explicit override still works
adata = ov.pp.qc(adata, mt_startswith='MT-')
```

## Test plan
- [x] 20 unit tests covering all species, edge cases, and multi-prefix handling
- [x] `pytest tests/test_mt_detect.py` — all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)