### PR TITLE
feat: Rust-powered out-of-memory backend via anndataoom

### DIFF
--- a/omicverse/_oom_compat.py
+++ b/omicverse/_oom_compat.py
@@ -1,0 +1,61 @@
+"""
+Compatibility shim for the optional ``anndataoom`` dependency.
+
+omicverse's Rust-backed out-of-memory AnnData support is provided by the
+external ``anndataoom`` package (install via ``pip install omicverse[rust]``).
+If that package is not installed, this module provides no-op fallbacks so
+omicverse's core functions keep working with regular ``anndata.AnnData``.
+
+Usage inside omicverse:
+
+    from .._oom_compat import oom_guard, is_oom
+
+    @oom_guard(materialize=True, result_keys_uns=['*'])
+    def my_function(adata, ...):
+        ...
+"""
+
+from __future__ import annotations
+
+try:
+    from anndataoom import (
+        AnnDataOOM,
+        BackedArray,
+        BackedLayers,
+        TransformedBackedArray,
+        ScaledBackedArray,
+        oom_guard,
+        is_oom,
+    )
+    HAS_OOM = True
+except ImportError:
+    HAS_OOM = False
+
+    # No-op placeholders so imports don't crash
+    AnnDataOOM = None
+    BackedArray = None
+    BackedLayers = None
+    TransformedBackedArray = None
+    ScaledBackedArray = None
+
+    def is_oom(adata) -> bool:
+        """Fallback when anndataoom is not installed — always False."""
+        return False
+
+    def oom_guard(**kwargs):
+        """Fallback decorator: identity (no-op) when anndataoom is unavailable."""
+        def decorator(func):
+            return func
+        return decorator
+
+
+__all__ = [
+    "HAS_OOM",
+    "AnnDataOOM",
+    "BackedArray",
+    "BackedLayers",
+    "TransformedBackedArray",
+    "ScaledBackedArray",
+    "oom_guard",
+    "is_oom",
+]

--- a/omicverse/_oom_compat.py
+++ b/omicverse/_oom_compat.py
@@ -31,12 +31,18 @@ try:
 except ImportError:
     HAS_OOM = False
 
-    # No-op placeholders so imports don't crash
-    AnnDataOOM = None
-    BackedArray = None
-    BackedLayers = None
-    TransformedBackedArray = None
-    ScaledBackedArray = None
+    # Stub classes — never instantiated, but usable as the second argument to
+    # ``isinstance(x, AnnDataOOM)`` without raising TypeError. Since anndataoom
+    # is missing, no real OOM object can exist, so isinstance will always be
+    # False, which is the desired behaviour.
+    class _UnavailableOOMType:
+        """Placeholder class used when anndataoom is not installed."""
+
+    class AnnDataOOM(_UnavailableOOMType): pass
+    class BackedArray(_UnavailableOOMType): pass
+    class BackedLayers(_UnavailableOOMType): pass
+    class TransformedBackedArray(_UnavailableOOMType): pass
+    class ScaledBackedArray(_UnavailableOOMType): pass
 
     def is_oom(adata) -> bool:
         """Fallback when anndataoom is not installed — always False."""

--- a/omicverse/io/single/_read.py
+++ b/omicverse/io/single/_read.py
@@ -1,3 +1,5 @@
+import os
+import time
 from pathlib import Path
 
 import pandas as pd
@@ -8,6 +10,38 @@ except ImportError:
     from anndata import read_h5ad as _anndata_read_h5ad
 
 from ..._registry import register_function
+
+
+def _log_rust_read(path: str, size_mb: float | None, elapsed: float) -> None:
+    size_str = f"  ({size_mb:.1f} MB)" if size_mb is not None else ""
+    print(
+        "📂 Reading with anndata-rs (Rust · out-of-memory)\n"
+        f"   {path}{size_str}\n"
+        f"   ✓ Loaded in {elapsed:.2f}s\n\n"
+        "💡 Data stays on disk. Use ov.pp.* for chunked processing.\n"
+        "   adata.close() when done · adata.to_adata() to materialise"
+    )
+
+
+def _read_h5ad_rust(path, **kwargs):
+    try:
+        import anndataoom
+    except ImportError:
+        raise ImportError(
+            "Rust backend requires the 'anndataoom' package. "
+            "Install with:  pip install omicverse[rust]   (or  pip install anndataoom)"
+        ) from None
+
+    kwargs.setdefault("backed", "r")
+    try:
+        size_mb = os.path.getsize(path) / 1024**2
+    except OSError:
+        size_mb = None
+
+    t0 = time.perf_counter()
+    adata = anndataoom.read(str(path), **kwargs)
+    _log_rust_read(str(path), size_mb, time.perf_counter() - t0)
+    return adata
 
 
 @register_function(
@@ -60,63 +94,7 @@ def read(path, backend='python', **kwargs):
             return _anndata_read_h5ad(path, **kwargs)
 
         if backend == 'rust':
-            # Try backends in order of preference:
-            #   1. anndataoom (our prebuilt package, includes the Python wrapper)
-            #   2. anndata_rs (standalone, built from source)
-            #   3. snapatac2 (bundles the same Rust AnnData implementation)
-            rs_module = None
-            try:
-                import anndataoom
-                # If anndataoom is available, use its read() directly
-                # (it already wraps the result in AnnDataOOM with full API)
-                import time, os as _os
-                from ..anndata_oom._repr import _format_read_message
-                try:
-                    size_mb = _os.path.getsize(str(path)) / 1024**2
-                except Exception:
-                    size_mb = None
-                if 'backed' not in kwargs:
-                    kwargs['backed'] = 'r'
-                t0 = time.time()
-                adata = anndataoom.read(str(path), **kwargs)
-                elapsed = time.time() - t0
-                print(_format_read_message(str(path), size_mb, elapsed))
-                return adata
-            except ImportError:
-                pass
-
-            try:
-                import anndata_rs as rs_module
-            except ImportError:
-                try:
-                    import snapatac2 as rs_module  # snapatac2 bundles anndata-rs
-                except ImportError:
-                    raise ImportError(
-                        "No Rust AnnData backend available. Install one of:\n"
-                        "  1. pip install anndataoom    (prebuilt, includes full Python wrapper)\n"
-                        "  2. pip install snapatac2     (bundles anndata-rs, ~200 MB)\n"
-                        "  3. Build anndata-rs from source"
-                    )
-
-            from ..anndata_oom import AnnDataOOM
-            from ..anndata_oom._repr import _format_read_message
-            import time
-            import os
-
-            # Default to read-only mode to avoid modifying the original file
-            if 'backed' not in kwargs:
-                kwargs['backed'] = 'r'
-            try:
-                size_mb = os.path.getsize(str(path)) / 1024**2
-            except Exception:
-                size_mb = None
-
-            t0 = time.time()
-            rs_adata = rs_module.read(str(path), **kwargs)
-            elapsed = time.time() - t0
-            adata = AnnDataOOM(rs_adata)
-            print(_format_read_message(str(path), size_mb, elapsed))
-            return adata
+            return _read_h5ad_rust(path, **kwargs)
 
         raise ValueError("backend must be 'python' or 'rust'")
 

--- a/omicverse/io/single/_read.py
+++ b/omicverse/io/single/_read.py
@@ -60,15 +60,63 @@ def read(path, backend='python', **kwargs):
             return _anndata_read_h5ad(path, **kwargs)
 
         if backend == 'rust':
+            # Try backends in order of preference:
+            #   1. anndataoom (our prebuilt package, includes the Python wrapper)
+            #   2. anndata_rs (standalone, built from source)
+            #   3. snapatac2 (bundles the same Rust AnnData implementation)
+            rs_module = None
             try:
-                import snapatac2 as snap
+                import anndataoom
+                # If anndataoom is available, use its read() directly
+                # (it already wraps the result in AnnDataOOM with full API)
+                import time, os as _os
+                from ..anndata_oom._repr import _format_read_message
+                try:
+                    size_mb = _os.path.getsize(str(path)) / 1024**2
+                except Exception:
+                    size_mb = None
+                if 'backed' not in kwargs:
+                    kwargs['backed'] = 'r'
+                t0 = time.time()
+                adata = anndataoom.read(str(path), **kwargs)
+                elapsed = time.time() - t0
+                print(_format_read_message(str(path), size_mb, elapsed))
+                return adata
             except ImportError:
-                raise ImportError('snapatac2 is not installed. `pip install snapatac2`')
+                pass
 
-            print('Using anndata-rs to read h5ad file')
-            print('You should run adata.close() after analysis')
-            print('Not all function support Rust backend')
-            return snap.read(path, **kwargs)
+            try:
+                import anndata_rs as rs_module
+            except ImportError:
+                try:
+                    import snapatac2 as rs_module  # snapatac2 bundles anndata-rs
+                except ImportError:
+                    raise ImportError(
+                        "No Rust AnnData backend available. Install one of:\n"
+                        "  1. pip install anndataoom    (prebuilt, includes full Python wrapper)\n"
+                        "  2. pip install snapatac2     (bundles anndata-rs, ~200 MB)\n"
+                        "  3. Build anndata-rs from source"
+                    )
+
+            from ..anndata_oom import AnnDataOOM
+            from ..anndata_oom._repr import _format_read_message
+            import time
+            import os
+
+            # Default to read-only mode to avoid modifying the original file
+            if 'backed' not in kwargs:
+                kwargs['backed'] = 'r'
+            try:
+                size_mb = os.path.getsize(str(path)) / 1024**2
+            except Exception:
+                size_mb = None
+
+            t0 = time.time()
+            rs_adata = rs_module.read(str(path), **kwargs)
+            elapsed = time.time() - t0
+            adata = AnnDataOOM(rs_adata)
+            print(_format_read_message(str(path), size_mb, elapsed))
+            return adata
 
         raise ValueError("backend must be 'python' or 'rust'")
 

--- a/omicverse/pl/_multi.py
+++ b/omicverse/pl/_multi.py
@@ -35,7 +35,8 @@ def embedding_multi(
     Returns:
         Plot axes or figure depending on underlying plotting function
     """
-    if isinstance(data, AnnData) or getattr(data, '_is_oom', False):
+    from .._oom_compat import is_oom as _is_oom
+    if isinstance(data, AnnData) or _is_oom(data):
         return embedding(
             data, basis=basis, color=color, use_raw=use_raw, layer=layer, **kwargs
         )

--- a/omicverse/pl/_multi.py
+++ b/omicverse/pl/_multi.py
@@ -35,7 +35,7 @@ def embedding_multi(
     Returns:
         Plot axes or figure depending on underlying plotting function
     """
-    if isinstance(data, AnnData):
+    if isinstance(data, AnnData) or getattr(data, '_is_oom', False):
         return embedding(
             data, basis=basis, color=color, use_raw=use_raw, layer=layer, **kwargs
         )

--- a/omicverse/pl/_scanpy_compat.py
+++ b/omicverse/pl/_scanpy_compat.py
@@ -111,7 +111,8 @@ def _doc_params(**kwargs):
 
 
 def sanitize_anndata(adata: AnnData) -> None:
-    if not isinstance(adata, AnnData) and not getattr(adata, '_is_oom', False):
+    from .._oom_compat import is_oom as _is_oom
+    if not isinstance(adata, AnnData) and not _is_oom(adata):
         raise TypeError("Expected an AnnData object.")
 
 

--- a/omicverse/pl/_scanpy_compat.py
+++ b/omicverse/pl/_scanpy_compat.py
@@ -111,7 +111,7 @@ def _doc_params(**kwargs):
 
 
 def sanitize_anndata(adata: AnnData) -> None:
-    if not isinstance(adata, AnnData):
+    if not isinstance(adata, AnnData) and not getattr(adata, '_is_oom', False):
         raise TypeError("Expected an AnnData object.")
 
 

--- a/omicverse/pl/_single.py
+++ b/omicverse/pl/_single.py
@@ -110,7 +110,7 @@ def pca(adata: AnnData,convert=True, **kwargs):
         adata: Annotated data matrix.
         **kwargs: Additional keyword arguments.
     """
-    if 'X_pca' not in adata.obsm.keys() or 'scaled|original|X_pca' not in adata.obsm.keys():
+    if 'X_pca' not in adata.obsm.keys() and 'scaled|original|X_pca' not in adata.obsm.keys():
         raise ValueError('X_pca not found in adata.obsm. Please run ov.pp.pca first.')
     if 'scaled|original|X_pca' in adata.obsm.keys():
         adata.obsm['X_pca'] = adata.obsm['scaled|original|X_pca']

--- a/omicverse/pl/_violin.py
+++ b/omicverse/pl/_violin.py
@@ -488,21 +488,16 @@ def _extract_data_from_adata(adata, keys, groupby, layer, use_raw):
             raise ValueError(f"groupby '{groupby}' not found in adata.obs")
 
     # Handle keys (variables)
+    _has_raw = hasattr(adata, 'raw') and adata.raw is not None
     for key in keys:
         if key in adata.obs.columns:
             # Key is in observations
             data_dict[key] = adata.obs[key]
         elif key in adata.var_names:
-            # Key is a gene/variable
-            if use_raw and hasattr(adata, 'raw') and adata.raw is not None:
-                # Check if the key exists in raw.var_names
-                if key in adata.raw.var_names:
-                    gene_idx = list(adata.raw.var_names).index(key)
-                    data_dict[key] = adata.raw.X[:, gene_idx]
-                else:
-                    # Fall back to adata.X if key not in raw
-                    gene_idx = list(adata.var_names).index(key)
-                    data_dict[key] = adata.X[:, gene_idx]
+            # Key is a gene in current var_names
+            if use_raw and _has_raw and key in adata.raw.var_names:
+                gene_idx = list(adata.raw.var_names).index(key)
+                data_dict[key] = adata.raw.X[:, gene_idx]
             elif layer is not None and layer in adata.layers:
                 gene_idx = list(adata.var_names).index(key)
                 data_dict[key] = adata.layers[layer][:, gene_idx]
@@ -510,11 +505,22 @@ def _extract_data_from_adata(adata, keys, groupby, layer, use_raw):
                 gene_idx = list(adata.var_names).index(key)
                 data_dict[key] = adata.X[:, gene_idx]
 
-            # Handle sparse matrices
+            # Handle sparse matrices and ensure 1-D
             if hasattr(data_dict[key], 'toarray'):
-                data_dict[key] = data_dict[key].toarray().flatten()
+                data_dict[key] = data_dict[key].toarray()
+            data_dict[key] = np.asarray(data_dict[key]).ravel()
+        elif use_raw and _has_raw and key in adata.raw.var_names:
+            # Key is NOT in current var_names but IS in raw (e.g. after HVG subsetting)
+            gene_idx = list(adata.raw.var_names).index(key)
+            data_dict[key] = adata.raw.X[:, gene_idx]
+            if hasattr(data_dict[key], 'toarray'):
+                data_dict[key] = data_dict[key].toarray()
+            data_dict[key] = np.asarray(data_dict[key]).ravel()
         else:
-            raise ValueError(f"Key '{key}' not found in adata.obs or adata.var_names")
+            available = "adata.obs, adata.var_names"
+            if _has_raw:
+                available += ", or adata.raw.var_names (with use_raw=True)"
+            raise ValueError(f"Key '{key}' not found in {available}")
 
     return pd.DataFrame(data_dict)
 

--- a/omicverse/pp/_pca.py
+++ b/omicverse/pp/_pca.py
@@ -840,9 +840,8 @@ def pca(  # noqa: PLR0912, PLR0913, PLR0915
                 f"(available: {list(adata_comp.layers.keys())}). "
                 "Run ov.pp.scale(adata) first, or pass an existing layer name."
             )
-        _n = n_comps if n_comps is not None else min(N_PCS, adata_comp.n_vars - 1, adata_comp.n_obs - 1)
         X_pca, components, var_ratio = _chunked_pca(
-            adata_comp, layer=_layer, n_comps=_n
+            adata_comp, layer=_layer, n_comps=n_comps
         )
         # Store results back into adata (not adata_comp, which may be a view)
         adata.obsm["X_pca"] = X_pca

--- a/omicverse/pp/_pca.py
+++ b/omicverse/pp/_pca.py
@@ -847,8 +847,10 @@ def pca(  # noqa: PLR0912, PLR0913, PLR0915
         adata.obsm["X_pca"] = X_pca
         _key = f"{_layer}|original|X_pca"
         adata.obsm[_key] = X_pca
-        # Compute variance from variance_ratio (approximate: total_var ≈ n_vars for scaled data)
-        total_var = float(adata.n_vars)  # for z-scored data, total variance ≈ n_vars
+        # Compute variance from variance_ratio. PCA ran on adata_comp (the
+        # HVG-subsetted view); for z-scored data, total variance ≈ number of
+        # *PCA-input* vars, not the original adata.n_vars.
+        total_var = float(adata_comp.n_vars)
         adata.uns["pca"] = {
             "variance_ratio": var_ratio,
             "variance": var_ratio * total_var,

--- a/omicverse/pp/_pca.py
+++ b/omicverse/pp/_pca.py
@@ -857,7 +857,16 @@ def pca(  # noqa: PLR0912, PLR0913, PLR0915
             "variance_ratio": var_ratio,
             "variance": var_ratio * total_var,
         }
-        adata.varm["PCs"] = components.T[:adata.n_vars, :]
+        # components has shape (n_comps, adata_comp.n_vars); store loadings at
+        # (adata.n_vars, n_comps). If PCA ran on an HVG subset, non-selected
+        # genes get zero loadings (mirrors the CPU path).
+        loadings = components.T  # (adata_comp.n_vars, n_comps)
+        if mask_var is not None and adata_comp.n_vars != adata.n_vars:
+            pcs = np.zeros((adata.n_vars, loadings.shape[1]), dtype=loadings.dtype)
+            pcs[mask_var] = loadings
+        else:
+            pcs = loadings
+        adata.varm["PCs"] = pcs
         return adata if copy else None
 
     X = _get_obs_rep(adata_comp, layer=layer)

--- a/omicverse/pp/_pca.py
+++ b/omicverse/pp/_pca.py
@@ -841,7 +841,10 @@ def pca(  # noqa: PLR0912, PLR0913, PLR0915
                 "Run ov.pp.scale(adata) first, or pass an existing layer name."
             )
         X_pca, components, var_ratio = _chunked_pca(
-            adata_comp, layer=_layer, n_comps=n_comps
+            adata_comp,
+            layer=_layer,
+            n_comps=n_comps,
+            random_state=random_state if isinstance(random_state, int) else 0,
         )
         # Store results back into adata (not adata_comp, which may be a view)
         adata.obsm["X_pca"] = X_pca

--- a/omicverse/pp/_pca.py
+++ b/omicverse/pp/_pca.py
@@ -822,9 +822,12 @@ def pca(  # noqa: PLR0912, PLR0913, PLR0915
     # Unify new mask argument and deprecated use_highly_varible argument
     mask_var_param, mask_var = _handle_mask_var(adata, mask_var, use_highly_variable)
     del use_highly_variable
-    from ._qc import _is_rust_backend
+    from ._qc import _is_rust_backend, _is_oom
     is_rust = _is_rust_backend(adata)
-    if not is_rust:
+    is_oom = _is_oom(adata)
+    if is_oom:
+        adata_comp = adata[:, mask_var] if mask_var is not None else adata
+    elif not is_rust:
         adata_comp = adata[:, mask_var] if mask_var is not None else adata
     else:
         adata_comp = adata.subset(var_indices=np.array(adata.var_names)[mask_var],inplace=False)
@@ -836,10 +839,31 @@ def pca(  # noqa: PLR0912, PLR0913, PLR0915
 
     logg.info(f"    with {n_comps=}")
 
+    if is_oom:
+        # For OOM, use IncrementalPCA — fully chunked, never materialises
+        from anndataoom import chunked_pca as _chunked_pca
+        _layer = layer or "scaled"
+        _n = n_comps if n_comps is not None else min(N_PCS, adata_comp.n_vars - 1, adata_comp.n_obs - 1)
+        X_pca, components, var_ratio = _chunked_pca(
+            adata_comp, layer=_layer, n_comps=_n
+        )
+        # Store results back into adata (not adata_comp, which may be a view)
+        adata.obsm["X_pca"] = X_pca
+        _key = f"{_layer}|original|X_pca" if _layer else "X_pca"
+        adata.obsm[_key] = X_pca
+        # Compute variance from variance_ratio (approximate: total_var ≈ n_vars for scaled data)
+        total_var = float(adata.n_vars)  # for z-scored data, total variance ≈ n_vars
+        adata.uns["pca"] = {
+            "variance_ratio": var_ratio,
+            "variance": var_ratio * total_var,
+        }
+        adata.varm["PCs"] = components.T[:adata.n_vars, :]
+        return adata if copy else None
+
     X = _get_obs_rep(adata_comp, layer=layer)
 
     # Handle rust backend X data
-    if is_rust:
+    if is_rust and not is_oom:
         # For rust backend, X might be a special object that needs slicing to get actual data
         if hasattr(X, '__getitem__') and not isinstance(X, (np.ndarray, sparse.spmatrix, sparse.sparray)):
             try:

--- a/omicverse/pp/_pca.py
+++ b/omicverse/pp/_pca.py
@@ -855,7 +855,7 @@ def pca(  # noqa: PLR0912, PLR0913, PLR0915
         )
         # Store results back into adata (not adata_comp, which may be a view)
         adata.obsm["X_pca"] = X_pca
-        _key = f"{_layer}|original|X_pca" if _layer else "X_pca"
+        _key = f"{_layer}|original|X_pca"
         adata.obsm[_key] = X_pca
         # Compute variance from variance_ratio (approximate: total_var ≈ n_vars for scaled data)
         total_var = float(adata.n_vars)  # for z-scored data, total variance ≈ n_vars

--- a/omicverse/pp/_pca.py
+++ b/omicverse/pp/_pca.py
@@ -800,16 +800,14 @@ def pca(  # noqa: PLR0912, PLR0913, PLR0915
             "reproducible across different computational platforms. For exact "
             "reproducibility, choose `svd_solver='arpack'`."
         )
-    from ._qc import _is_rust_backend
-    is_rust = _is_rust_backend(data)
-
+    from ._qc import _is_oom
     if isinstance(data, AnnData):
         if layer is None and not chunked and is_backed_type(data.X):
             msg = f"PCA is not implemented for matrices of type {type(data.X)} with chunked as False"
             raise NotImplementedError(msg)
         adata = data.copy() if copy else data
         return_anndata = True
-    elif is_rust:
+    elif _is_oom(data):
         adata = data
         return_anndata = True
     elif pkg_version("anndata") < Version("0.8.0rc1"):
@@ -822,16 +820,9 @@ def pca(  # noqa: PLR0912, PLR0913, PLR0915
     # Unify new mask argument and deprecated use_highly_varible argument
     mask_var_param, mask_var = _handle_mask_var(adata, mask_var, use_highly_variable)
     del use_highly_variable
-    from ._qc import _is_rust_backend, _is_oom
-    is_rust = _is_rust_backend(adata)
+    from ._qc import _is_oom
     is_oom = _is_oom(adata)
-    if is_oom:
-        adata_comp = adata[:, mask_var] if mask_var is not None else adata
-    elif not is_rust:
-        adata_comp = adata[:, mask_var] if mask_var is not None else adata
-    else:
-        adata_comp = adata.subset(var_indices=np.array(adata.var_names)[mask_var],inplace=False)
-        #print(np.array(adata.var_names)[mask_var])
+    adata_comp = adata[:, mask_var] if mask_var is not None else adata
 
     if n_comps is None:
         min_dim = min(adata_comp.n_vars, adata_comp.n_obs)
@@ -877,14 +868,9 @@ def pca(  # noqa: PLR0912, PLR0913, PLR0915
 
     X = _get_obs_rep(adata_comp, layer=layer)
 
-    # Handle rust backend X data
-    if is_rust and not is_oom:
-        # For rust backend, X might be a special object that needs slicing to get actual data
-        if hasattr(X, '__getitem__') and not isinstance(X, (np.ndarray, sparse.spmatrix, sparse.sparray)):
-            try:
-                X = X[:]
-            except Exception:
-                pass
+    # Previously this block materialised X for a standalone rust/snapatac2
+    # adata. Only AnnDataOOM is supported now, and the is_oom branch above
+    # already handles it with chunked_pca.
 
     if is_backed_type(X) and layer is not None:
         msg = f"PCA is not implemented for matrices of type {type(X)} from layers"

--- a/omicverse/pp/_pca.py
+++ b/omicverse/pp/_pca.py
@@ -843,6 +843,12 @@ def pca(  # noqa: PLR0912, PLR0913, PLR0915
         # For OOM, use IncrementalPCA — fully chunked, never materialises
         from anndataoom import chunked_pca as _chunked_pca
         _layer = layer or "scaled"
+        if _layer not in adata_comp.layers:
+            raise ValueError(
+                f"OOM PCA requires layer {_layer!r} which is not present "
+                f"(available: {list(adata_comp.layers.keys())}). "
+                "Run ov.pp.scale(adata) first, or pass an existing layer name."
+            )
         _n = n_comps if n_comps is not None else min(N_PCS, adata_comp.n_vars - 1, adata_comp.n_obs - 1)
         X_pca, components, var_ratio = _chunked_pca(
             adata_comp, layer=_layer, n_comps=_n

--- a/omicverse/pp/_preprocess.py
+++ b/omicverse/pp/_preprocess.py
@@ -655,6 +655,17 @@ def preprocess(
     # Log-normalization, HVGs identification
     from ._qc import _is_oom
     is_oom = _is_oom(adata)
+
+    # Validate unsupported combinations BEFORE mutating adata (otherwise the
+    # caller gets back a half-processed object with partial lazy transforms).
+    method_list_preview = mode.split('|')
+    if is_oom and len(method_list_preview) > 1 and method_list_preview[1] == 'seurat':
+        raise NotImplementedError(
+            "Seurat v3 HVG selection (Loess-smoothed dispersion) is not "
+            "available for the OOM backend. Use 'shiftlog|pearson' instead, "
+            "or switch to mode='cpu' to materialise the data."
+        )
+
     if is_oom:
         # OOM: save a lazy reference to raw counts (zero memory cost)
         adata.layers['counts'] = adata.X

--- a/omicverse/pp/_preprocess.py
+++ b/omicverse/pp/_preprocess.py
@@ -974,15 +974,21 @@ def scale(adata, max_value=10, layers_add='scaled', to_sparse=False, **kwargs):
     is_rust = _is_rust_backend(adata)
     is_oom = _is_oom(adata)
     if is_oom:
-        # Out-of-memory: post-HVG matrix is small enough to materialise
+        # chunked_scale hard-codes the layer name to 'scaled' and installs a
+        # lazy ScaledBackedArray. Re-wrapping/materialising it defeats the
+        # point, so we short-circuit the rest of this function.
+        if layers_add != "scaled":
+            raise ValueError(
+                "OOM scale only stores to adata.layers['scaled']; "
+                f"layers_add={layers_add!r} is not supported."
+            )
         from anndataoom import chunked_scale
         chunked_scale(adata, max_value=max_value)
-        scaled_data = adata.layers.get(layers_add, None)
-        if scaled_data is not None:
-            # Already stored by chunked_scale in layers['scaled']
-            pass
-        else:
-            scaled_data = adata.X[:]
+        if "status" not in adata.uns.keys():
+            adata.uns["status"] = {}
+        add_reference(adata, "scanpy", "scaling with scanpy")
+        adata.uns["status"]["scaled"] = True
+        return
     elif is_rust:
         from ._scale import scale_array
         x = adata.X[:]

--- a/omicverse/pp/_preprocess.py
+++ b/omicverse/pp/_preprocess.py
@@ -725,8 +725,14 @@ def preprocess(
             )
             if no_cc:
                 remove_cc_genes(adata, organism=organism, corr_threshold=0.1)
-        # Note: shiftlog|seurat is pre-rejected at the top of preprocess(), so
-        # no elif branch for it is needed here.
+        else:
+            # 'seurat' is pre-rejected at the top; any other unknown HVG
+            # method should fail loudly here rather than silently skip HVG
+            # selection and leave the user with no 'highly_variable' column.
+            raise NotImplementedError(
+                f"HVG method {method_list[1]!r} is not supported for the OOM "
+                "backend. Use 'pearson', or switch to mode='cpu'."
+            )
         data_load_end = time.time()
         print(f"{Colors.BLUE}    Time to analyze data (out-of-memory): {data_load_end - data_load_start:.2f} seconds.{Colors.ENDC}")
     elif settings.mode == 'cpu' or settings.mode == 'cpu-gpu-mixed':

--- a/omicverse/pp/_preprocess.py
+++ b/omicverse/pp/_preprocess.py
@@ -725,12 +725,8 @@ def preprocess(
             )
             if no_cc:
                 remove_cc_genes(adata, organism=organism, corr_threshold=0.1)
-        elif method_list[1] == 'seurat':
-            raise NotImplementedError(
-                "Seurat v3 HVG selection (Loess-smoothed dispersion) is not "
-                "available for the OOM backend. Use 'shiftlog|pearson' instead, "
-                "or switch to mode='cpu' to materialise the data."
-            )
+        # Note: shiftlog|seurat is pre-rejected at the top of preprocess(), so
+        # no elif branch for it is needed here.
         data_load_end = time.time()
         print(f"{Colors.BLUE}    Time to analyze data (out-of-memory): {data_load_end - data_load_start:.2f} seconds.{Colors.ENDC}")
     elif settings.mode == 'cpu' or settings.mode == 'cpu-gpu-mixed':
@@ -953,6 +949,9 @@ def scale(adata, max_value=10, layers_add='scaled', to_sparse=False, **kwargs):
         adata: Annotated data matrix with n_obs x n_vars shape.
         max_value: Maximum value after scaling. Default: 10.
         layers_add: Name of the layer to store the scaled data. Default: 'scaled'.
+            OOM backend only supports layers_add='scaled' (the underlying
+            chunked_scale writes a lazy ScaledBackedArray to that fixed key);
+            passing anything else raises ValueError.
         to_sparse: If True, convert the result to csr_matrix format. Default: False.
             Scaled data is 100% dense, so sparse storage only adds overhead.
         **kwargs: Additional arguments passed to scaling functions.

--- a/omicverse/pp/_preprocess.py
+++ b/omicverse/pp/_preprocess.py
@@ -665,6 +665,17 @@ def preprocess(
             "available for the OOM backend. Use 'shiftlog|pearson' instead, "
             "or switch to mode='cpu' to materialise the data."
         )
+    if is_oom and method_list_preview[0] == 'pearson':
+        # Pearson residual normalisation needs a materialised X. Rather than
+        # leave adata in a hybrid state (in-memory data wrapped in
+        # BackedArray, but _is_oom still True), refuse the combination and
+        # let the user opt into mode='cpu' explicitly.
+        raise NotImplementedError(
+            "Pearson residual normalisation is not available for the OOM "
+            "backend (it requires the full X in memory, which would leave "
+            "adata in a hybrid state). Use 'shiftlog|pearson' instead, or "
+            "switch to mode='cpu'."
+        )
 
     if is_oom:
         # OOM: save a lazy reference to raw counts (zero memory cost)
@@ -694,26 +705,15 @@ def preprocess(
             chunked_normalize_total, chunked_log1p,
         )
         data_load_start = time.time()
-        if method_list[0] == 'shiftlog':
-            chunked_normalize_total(
-                adata,
-                target_sum=target_sum,
-                exclude_highly_expressed=True,
-                max_fraction=0.2,
-            )
-            chunked_log1p(adata)
-        elif method_list[0] == 'pearson':
-            # Pearson residuals cannot be chunked — we materialise X here.
-            # This defeats part of the OOM benefit for this normalisation step.
-            print(f"{Colors.WARNING}    ⚠️  Pearson residuals require a materialised X; "
-                  f"{adata.n_obs:,} × {adata.n_vars:,} will be loaded into memory.{Colors.ENDC}")
-            from .experimental import normalize_pearson_residuals
-            from anndataoom import BackedArray
-            X_dense = adata.X[:]
-            if issparse(X_dense):
-                X_dense = X_dense.toarray()
-            adata.X = BackedArray(X_dense.astype(np.float32), shape=X_dense.shape)
-            normalize_pearson_residuals(adata)
+        # Only 'shiftlog' normalisation is supported for OOM; 'pearson' is
+        # pre-rejected at the top of this function.
+        chunked_normalize_total(
+            adata,
+            target_sum=target_sum,
+            exclude_highly_expressed=True,
+            max_fraction=0.2,
+        )
+        chunked_log1p(adata)
 
         if method_list[1] == 'pearson':
             from anndataoom import chunked_highly_variable_genes_pearson

--- a/omicverse/pp/_preprocess.py
+++ b/omicverse/pp/_preprocess.py
@@ -17,6 +17,7 @@ from ._qc import _is_rust_backend
 from ..utils import load_signatures_from_file,predefined_signatures
 from .._registry import register_function
 from .._settings import settings,print_gpu_usage_color,EMOJI,Colors,add_reference
+from .._oom_compat import oom_guard as _oom_guard
 
 
 from ._normalization import normalize_total,log1p
@@ -659,9 +660,13 @@ def preprocess(
     original_adata = adata
 
     # Log-normalization, HVGs identification
-    from ._qc import _is_rust_backend
+    from ._qc import _is_rust_backend, _is_oom
     is_rust = _is_rust_backend(adata)
-    if is_rust:
+    is_oom = _is_oom(adata)
+    if is_oom:
+        # OOM: save a lazy reference to raw counts (zero memory cost)
+        adata.layers['counts'] = adata.X
+    elif is_rust:
         adata.layers['counts'] = adata.X[:]
     else:
         adata.layers['counts'] = adata.X.copy()
@@ -670,15 +675,69 @@ def preprocess(
     print(f"{EMOJI['start']} [{datetime.now().strftime('%Y-%m-%d %H:%M:%S')}] Running preprocessing in '{settings.mode}' mode...")
     print(f"{Colors.CYAN}Begin robust gene identification{Colors.ENDC}")
     if identify_robust:
-        identify_robust_genes(adata, percent_cells=0.05)
-        if not is_rust:
+        if is_oom:
+            from anndataoom import chunked_identify_robust_genes
+            chunked_identify_robust_genes(adata, percent_cells=0.05)
+        else:
+            identify_robust_genes(adata, percent_cells=0.05)
+        if is_oom:
+            adata._inplace_subset_var(adata.var['robust'].values)
+        elif not is_rust:
             adata = adata[:, adata.var['robust']]
         else:
             adata.subset(var_indices=np.where(adata.var['robust']==True)[0])
         print(f"{EMOJI['done']} Robust gene identification completed successfully.")
     method_list = mode.split('|')
     print(f"{Colors.CYAN}Begin size normalization: {method_list[0]} and HVGs selection {method_list[1]}{Colors.ENDC}")
-    if settings.mode == 'cpu' or settings.mode == 'cpu-gpu-mixed':
+    if is_oom:
+        # Out-of-memory path — lazy transforms, no full materialisation
+        from anndataoom import (
+            chunked_normalize_total, chunked_log1p,
+        )
+        data_load_start = time.time()
+        if method_list[0] == 'shiftlog':
+            chunked_normalize_total(
+                adata,
+                target_sum=target_sum,
+                exclude_highly_expressed=True,
+                max_fraction=0.2,
+            )
+            chunked_log1p(adata)
+        elif method_list[0] == 'pearson':
+            # Pearson residuals need materialized data — convert lazily
+            from .experimental import normalize_pearson_residuals
+            # Materialize X for pearson (it's already filtered to robust genes)
+            from anndataoom import BackedArray
+            X_dense = adata.X[:]
+            if issparse(X_dense):
+                X_dense = X_dense.toarray()
+            adata.X = BackedArray(X_dense.astype(np.float32), shape=X_dense.shape)
+            normalize_pearson_residuals(adata)
+
+        if method_list[1] == 'pearson':
+            from anndataoom import chunked_highly_variable_genes_pearson
+            chunked_highly_variable_genes_pearson(
+                adata,
+                n_top_genes=n_HVGs,
+                layer='counts',
+                batch_key=batch_key,
+            )
+            if no_cc:
+                remove_cc_genes(adata, organism=organism, corr_threshold=0.1)
+        elif method_list[1] == 'seurat':
+            from anndataoom import chunked_highly_variable_genes_pearson
+            # seurat_v3 also uses residual variance ranking
+            chunked_highly_variable_genes_pearson(
+                adata,
+                n_top_genes=n_HVGs,
+                layer='counts',
+                batch_key=batch_key,
+            )
+            if no_cc:
+                remove_cc_genes(adata, organism=organism, corr_threshold=0.1)
+        data_load_end = time.time()
+        print(f"{Colors.BLUE}    Time to analyze data (out-of-memory): {data_load_end - data_load_start:.2f} seconds.{Colors.ENDC}")
+    elif settings.mode == 'cpu' or settings.mode == 'cpu-gpu-mixed':
         data_load_start = time.time()
         if method_list[0] == 'shiftlog': # Size normalization + scanpy batch aware HVGs selection
             normalize_total(
@@ -688,7 +747,7 @@ def preprocess(
                 max_fraction=0.2,
             )
             log1p(adata)
-            
+
         elif method_list[0] == 'pearson':
             # Perason residuals workflow
             from .experimental import normalize_pearson_residuals
@@ -914,8 +973,20 @@ def scale(adata, max_value=10, layers_add='scaled', to_sparse=False, **kwargs):
         >>> # Scale data keeping dense format
         >>> ov.pp.scale(adata, max_value=10, to_sparse=False)
     """
+    from ._qc import _is_oom
     is_rust = _is_rust_backend(adata)
-    if is_rust:
+    is_oom = _is_oom(adata)
+    if is_oom:
+        # Out-of-memory: post-HVG matrix is small enough to materialise
+        from anndataoom import chunked_scale
+        chunked_scale(adata, max_value=max_value)
+        scaled_data = adata.layers.get(layers_add, None)
+        if scaled_data is not None:
+            # Already stored by chunked_scale in layers['scaled']
+            pass
+        else:
+            scaled_data = adata.X[:]
+    elif is_rust:
         from ._scale import scale_array
         x = adata.X[:]
         scaled_data = scale_array(
@@ -1576,6 +1647,11 @@ def leiden(
         "ov.pl.embedding(adata, basis='X_umap', color='phase')"
     ],
     related=["pp.preprocess", "pl.embedding", "utils.embedding"]
+)
+@_oom_guard(
+    materialize=True,
+    result_keys_obs=['S_score', 'G2M_score', 'phase'],
+    result_keys_uns=['*'],
 )
 def score_genes_cell_cycle(adata,species='human',s_genes=None, g2m_genes=None):
     """Score cell cycle phases using predefined or custom gene sets.

--- a/omicverse/pp/_preprocess.py
+++ b/omicverse/pp/_preprocess.py
@@ -704,9 +704,11 @@ def preprocess(
             )
             chunked_log1p(adata)
         elif method_list[0] == 'pearson':
-            # Pearson residuals need materialized data — convert lazily
+            # Pearson residuals cannot be chunked — we materialise X here.
+            # This defeats part of the OOM benefit for this normalisation step.
+            print(f"{Colors.WARNING}    ⚠️  Pearson residuals require a materialised X; "
+                  f"{adata.n_obs:,} × {adata.n_vars:,} will be loaded into memory.{Colors.ENDC}")
             from .experimental import normalize_pearson_residuals
-            # Materialize X for pearson (it's already filtered to robust genes)
             from anndataoom import BackedArray
             X_dense = adata.X[:]
             if issparse(X_dense):
@@ -725,16 +727,11 @@ def preprocess(
             if no_cc:
                 remove_cc_genes(adata, organism=organism, corr_threshold=0.1)
         elif method_list[1] == 'seurat':
-            from anndataoom import chunked_highly_variable_genes_pearson
-            # seurat_v3 also uses residual variance ranking
-            chunked_highly_variable_genes_pearson(
-                adata,
-                n_top_genes=n_HVGs,
-                layer='counts',
-                batch_key=batch_key,
+            raise NotImplementedError(
+                "Seurat v3 HVG selection (Loess-smoothed dispersion) is not "
+                "available for the OOM backend. Use 'shiftlog|pearson' instead, "
+                "or switch to mode='cpu' to materialise the data."
             )
-            if no_cc:
-                remove_cc_genes(adata, organism=organism, corr_threshold=0.1)
         data_load_end = time.time()
         print(f"{Colors.BLUE}    Time to analyze data (out-of-memory): {data_load_end - data_load_start:.2f} seconds.{Colors.ENDC}")
     elif settings.mode == 'cpu' or settings.mode == 'cpu-gpu-mixed':

--- a/omicverse/pp/_preprocess.py
+++ b/omicverse/pp/_preprocess.py
@@ -676,6 +676,15 @@ def preprocess(
             "adata in a hybrid state). Use 'shiftlog|pearson' instead, or "
             "switch to mode='cpu'."
         )
+    if is_oom and no_cc:
+        # remove_cc_genes materialises cc_genes × n_obs and hvgs × n_obs
+        # slices via `.X.toarray()`, which doesn't stream on BackedArray.
+        # Refuse rather than silently defeat OOM.
+        raise NotImplementedError(
+            "no_cc=True is not available for the OOM backend "
+            "(remove_cc_genes requires a materialised X). Run preprocess "
+            "without no_cc, or switch to mode='cpu'."
+        )
 
     if is_oom:
         # OOM: save a lazy reference to raw counts (zero memory cost)

--- a/omicverse/pp/_preprocess.py
+++ b/omicverse/pp/_preprocess.py
@@ -13,7 +13,6 @@ import time
 
 from scipy.sparse import issparse, csr_matrix
 
-from ._qc import _is_rust_backend
 from ..utils import load_signatures_from_file,predefined_signatures
 from .._registry import register_function
 from .._settings import settings,print_gpu_usage_color,EMOJI,Colors,add_reference
@@ -92,17 +91,11 @@ def identify_robust_genes(data: anndata.AnnData, percent_cells: float = 0.05) ->
 
     prior_n = data.shape[1]
 
-    from ._qc import _is_rust_backend
-    is_rust = _is_rust_backend(data)
-
+    # OOM goes through chunked_identify_robust_genes in preprocess(); this
+    # function only runs for regular AnnData.
     if issparse(data.X):
         data.var["n_cells"] = data.X.getnnz(axis=0)
         data._inplace_subset_var(data.var["n_cells"] > 0)
-        data.var["percent_cells"] = (data.var["n_cells"] / data.shape[0]) * 100
-        data.var["robust"] = data.var["percent_cells"] >= percent_cells
-    elif is_rust:
-        data.var["n_cells"] =data.X[:].getnnz(axis=0)
-        data.subset(var_indices=np.where(data.var["n_cells"]>0)[0])
         data.var["percent_cells"] = (data.var["n_cells"] / data.shape[0]) * 100
         data.var["robust"] = data.var["percent_cells"] >= percent_cells
     else:
@@ -660,14 +653,11 @@ def preprocess(
     original_adata = adata
 
     # Log-normalization, HVGs identification
-    from ._qc import _is_rust_backend, _is_oom
-    is_rust = _is_rust_backend(adata)
+    from ._qc import _is_oom
     is_oom = _is_oom(adata)
     if is_oom:
         # OOM: save a lazy reference to raw counts (zero memory cost)
         adata.layers['counts'] = adata.X
-    elif is_rust:
-        adata.layers['counts'] = adata.X[:]
     else:
         adata.layers['counts'] = adata.X.copy()
     
@@ -682,10 +672,8 @@ def preprocess(
             identify_robust_genes(adata, percent_cells=0.05)
         if is_oom:
             adata._inplace_subset_var(adata.var['robust'].values)
-        elif not is_rust:
-            adata = adata[:, adata.var['robust']]
         else:
-            adata.subset(var_indices=np.where(adata.var['robust']==True)[0])
+            adata = adata[:, adata.var['robust']]
         print(f"{EMOJI['done']} Robust gene identification completed successfully.")
     method_list = mode.split('|')
     print(f"{Colors.CYAN}Begin size normalization: {method_list[0]} and HVGs selection {method_list[1]}{Colors.ENDC}")
@@ -971,9 +959,7 @@ def scale(adata, max_value=10, layers_add='scaled', to_sparse=False, **kwargs):
         >>> ov.pp.scale(adata, max_value=10, to_sparse=False)
     """
     from ._qc import _is_oom
-    is_rust = _is_rust_backend(adata)
-    is_oom = _is_oom(adata)
-    if is_oom:
+    if _is_oom(adata):
         # chunked_scale hard-codes the layer name to 'scaled' and installs a
         # lazy ScaledBackedArray. Re-wrapping/materialising it defeats the
         # point, so we short-circuit the rest of this function.
@@ -989,13 +975,7 @@ def scale(adata, max_value=10, layers_add='scaled', to_sparse=False, **kwargs):
         add_reference(adata, "scanpy", "scaling with scanpy")
         adata.uns["status"]["scaled"] = True
         return
-    elif is_rust:
-        from ._scale import scale_array
-        x = adata.X[:]
-        scaled_data = scale_array(
-            x, zero_center=True, max_value=max_value, copy=True, mask_obs=None
-        )
-    elif settings.mode == 'cpu' or settings.mode == 'cpu-gpu-mixed':
+    if settings.mode == 'cpu' or settings.mode == 'cpu-gpu-mixed':
         from ._scale import scale_anndata as scale
         adata_mock = scale(adata, copy=True, max_value=max_value, **kwargs)
         scaled_data = adata_mock.X.copy()

--- a/omicverse/pp/_qc.py
+++ b/omicverse/pp/_qc.py
@@ -95,31 +95,18 @@ def _filter_genes_impl(
         return gene_subset, n_counts
 
 
-# Helper function to detect Rust backend
-def _is_rust_backend(adata):
-    """Detect if the adata object is from Rust backend (like snapatac2)."""
-    # AnnDataOOM wraps rust backend — treat it as rust for legacy checks
-    if _is_oom(adata):
-        return True
-    # Check if it's a Rust/anndata_rs/snapatac2 backend
-    try:
-        # Check class type
-        if type(adata.obs).__name__.endswith("PyDataFrameElem"):
-            return True
-        if type(adata.X).__name__.endswith("PyArrayElem"):
-            return True
-        # Check module name
-        module = type(adata).__module__
-        if "snapatac2" in module or "pyanndata" in module or "anndata_rs" in module:
-            return True
-    except Exception:
-        pass
-    return False
-
-
 def _is_oom(adata) -> bool:
     """Detect if the adata object is an AnnDataOOM (out-of-memory) instance."""
     return getattr(adata, "_is_oom", False)
+
+
+# Deprecated alias — AnnDataOOM is the only rust-backed AnnData we support in
+# omicverse's preprocessing path. The standalone snapatac2 / anndata-rs paths
+# were never publicly exposed. Kept as an alias so call sites that still read
+# ``is_rust = _is_rust_backend(adata)`` keep working, but new code should use
+# ``_is_oom`` directly.
+def _is_rust_backend(adata) -> bool:
+    return _is_oom(adata)
 
 
 def _print_qc_metrics_table(adata):
@@ -1113,11 +1100,6 @@ def qc_cpu(
         removed_cells.extend(removed)
         total_qc_failed = len(removed)
         adata._inplace_subset_obs(passing)
-    elif is_rust:
-        removed = list(np.array(adata.obs_names)[np.where(QC_test==False)[0]])
-        removed_cells.extend(removed)
-        total_qc_failed = len(removed)
-        adata.subset(obs_indices=np.array(adata.obs_names)[np.where(QC_test==True)[0]])
     else:
         removed = QC_test.loc[lambda x : x == False]
         removed_cells.extend(list(removed.index.values))
@@ -1211,10 +1193,6 @@ def qc_cpu(
                     removed = list(adata.obs_names[~doublet_mask])
                     removed_cells.extend(removed)
                     adata._inplace_subset_obs(doublet_mask)
-                elif is_rust:
-                    removed=list(np.array(adata.obs_names)[np.where(adata.obs['predicted_doublet']==True)[0]])
-                    removed_cells.extend(removed)
-                    adata.subset(obs_indices=np.array(adata.obs_names)[np.where(adata.obs['predicted_doublet']==False)[0]])
                 else:
                     adata_remove = adata[adata.obs['predicted_doublet'], :]
                     removed_cells.extend(list(adata_remove.obs_names))
@@ -1229,15 +1207,10 @@ def qc_cpu(
                 print(f"   {Colors.CYAN}💡 Doublets retained in adata.obs['predicted_doublet'] for downstream analysis{Colors.ENDC}")
 
         elif doublets_method=='sccomposite':
-            # Pick the object sccomposite runs on:
-            # - OOM: adata_mem (materialised above), then copy labels back
-            # - plain rust: materialise in place, keep the reassignment
-            # - regular AnnData: use adata directly
+            # Pick the object sccomposite runs on: OOM uses the materialised
+            # adata_mem and copies labels back; regular AnnData uses adata.
             if is_oom:
                 sccomp_target = adata_mem
-            elif is_rust:
-                adata = adata.to_memory()
-                sccomp_target = adata
             else:
                 sccomp_target = adata
             print(f"   {Colors.WARNING}⚠️  Note: the `sccomposite` will remove more cells than `scrublet`{Colors.ENDC}")

--- a/omicverse/pp/_qc.py
+++ b/omicverse/pp/_qc.py
@@ -1164,33 +1164,26 @@ def qc_cpu(
         _filter_cells_impl(adata, max_genes=int(max_genes_ratio*adata.shape[1]))
         _filter_genes_impl(adata, max_cells=int(max_cells_ratio*adata.shape[0]))
     else:
+        # Pure rust path (OOM is handled by the `if is_oom:` branch above).
         selected_cells = True
         if min_genes: selected_cells &= adata.obs["detected_genes"] >= min_genes
         if max_genes_ratio: selected_cells &= adata.obs["detected_genes"] <= max_genes_ratio*adata.shape[1]
         selected_cells = np.flatnonzero(selected_cells)
         adata.subset(obs_indices=selected_cells)
         selected_genes = True
-        # Count non-zero cells per gene. For OOM, stream in chunks rather than
-        # materialising X[:]; for raw rust, fall back to the one-shot read.
-        if _is_oom(adata):
-            from anndataoom import chunked_qc_metrics
-            if "n_cells" not in adata.var.columns:
-                chunked_qc_metrics(adata)
-            adata.var["n_cell"] = adata.var["n_cells"].values
-        else:
-            adata.var["n_cell"] = np.array((adata.X[:] != 0).sum(axis=0)).reshape(-1)
+        adata.var["n_cell"] = np.array((adata.X[:] != 0).sum(axis=0)).reshape(-1)
         if min_cells: selected_genes &= adata.var["n_cell"] >= min_cells
         if max_cells_ratio: selected_genes &= adata.var["n_cell"] <= max_cells_ratio*adata.shape[0]
         selected_genes = np.flatnonzero(selected_genes)
         adata.subset(var_indices=selected_genes)
-    
+
     cells_final_filtered = cells_before_final - adata.shape[0]
     genes_final_filtered = genes_before_final - adata.shape[1]
-    
+
     print(f"   {Colors.GREEN}✓ Final filtering: {Colors.BOLD}{cells_final_filtered:,}{Colors.ENDC}{Colors.GREEN} cells, {Colors.BOLD}{genes_final_filtered:,}{Colors.ENDC}{Colors.GREEN} genes removed{Colors.ENDC}")
-    
+
     n_after_final_filt = adata.shape[0]
-    
+
     if doublets is True:
         print(f"\n{Colors.HEADER}{Colors.BOLD}🔍 Step 4: Doublet Detection{Colors.ENDC}")
         if is_oom:
@@ -1236,30 +1229,49 @@ def qc_cpu(
                 print(f"   {Colors.CYAN}💡 Doublets retained in adata.obs['predicted_doublet'] for downstream analysis{Colors.ENDC}")
 
         elif doublets_method=='sccomposite':
-            if is_rust:
+            # Pick the object sccomposite runs on:
+            # - OOM: adata_mem (materialised above), then copy labels back
+            # - plain rust: materialise in place, keep the reassignment
+            # - regular AnnData: use adata directly
+            if is_oom:
+                sccomp_target = adata_mem
+            elif is_rust:
                 adata = adata.to_memory()
+                sccomp_target = adata
+            else:
+                sccomp_target = adata
             print(f"   {Colors.WARNING}⚠️  Note: the `sccomposite` will remove more cells than `scrublet`{Colors.ENDC}")
             print(f"   {Colors.GREEN}{EMOJI['start']} Running sccomposite doublet detection...{Colors.ENDC}")
-            adata.obs['sccomposite_doublet']=0
-            adata.obs['sccomposite_consistency']=0
+            sccomp_target.obs['sccomposite_doublet']=0
+            sccomp_target.obs['sccomposite_consistency']=0
             if batch_key is None:
                 from ._sccomposite import composite_rna
-                multiplet_classification, consistency = composite_rna(adata)
-                adata.obs['sccomposite_doublet']=multiplet_classification
-                adata.obs['sccomposite_consistency']=consistency
+                multiplet_classification, consistency = composite_rna(sccomp_target)
+                sccomp_target.obs['sccomposite_doublet']=multiplet_classification
+                sccomp_target.obs['sccomposite_consistency']=consistency
             else:
-                for batch in adata.obs[batch_key].unique():
+                for batch in sccomp_target.obs[batch_key].unique():
                     from ._sccomposite import composite_rna
-                    adata_batch=adata[adata.obs[batch_key]==batch]
+                    adata_batch=sccomp_target[sccomp_target.obs[batch_key]==batch]
                     multiplet_classification, consistency = composite_rna(adata_batch)
-                    adata.obs.loc[adata_batch.obs.index,'sccomposite_doublet']=\
+                    sccomp_target.obs.loc[adata_batch.obs.index,'sccomposite_doublet']=\
                     multiplet_classification
-                    adata.obs.loc[adata_batch.obs.index,'sccomposite_consistency']=consistency
+                    sccomp_target.obs.loc[adata_batch.obs.index,'sccomposite_consistency']=consistency
+
+            if is_oom:
+                adata.obs['sccomposite_doublet']=sccomp_target.obs['sccomposite_doublet'].values
+                adata.obs['sccomposite_consistency']=sccomp_target.obs['sccomposite_consistency'].values
+                del adata_mem
 
             if filter_doublets:
-                adata_remove = adata[adata.obs['sccomposite_doublet']!=0, :]
-                removed_cells.extend(list(adata_remove.obs_names))
-                adata = adata[adata.obs['sccomposite_doublet']==0, :]
+                if is_oom:
+                    mask = (adata.obs['sccomposite_doublet']==0).values
+                    removed_cells.extend(list(adata.obs_names[~mask]))
+                    adata._inplace_subset_obs(mask)
+                else:
+                    adata_remove = adata[adata.obs['sccomposite_doublet']!=0, :]
+                    removed_cells.extend(list(adata_remove.obs_names))
+                    adata = adata[adata.obs['sccomposite_doublet']==0, :]
                 n1 = adata.shape[0]
                 doublets_removed = n_after_final_filt-n1
                 print(f"   {Colors.GREEN}✓ sccomposite completed: {Colors.BOLD}{doublets_removed:,}{Colors.ENDC}{Colors.GREEN} doublets removed ({doublets_removed/n_after_final_filt*100:.1f}%){Colors.ENDC}")

--- a/omicverse/pp/_qc.py
+++ b/omicverse/pp/_qc.py
@@ -788,7 +788,15 @@ def qc_cpu_gpu_mixed(adata:anndata.AnnData, mode='seurat',
         adata.subset(obs_indices=selected_cells)
 
         selected_genes = True
-        adata.var["n_cell"] = np.array(adata.X[:].sum(axis=0)).reshape(-1)
+        # Count non-zero cells per gene. For OOM, stream in chunks rather than
+        # materialising X[:]; for raw rust, fall back to the one-shot read.
+        if _is_oom(adata):
+            from anndataoom import chunked_qc_metrics
+            if "n_cells" not in adata.var.columns:
+                chunked_qc_metrics(adata)
+            adata.var["n_cell"] = adata.var["n_cells"].values
+        else:
+            adata.var["n_cell"] = np.array((adata.X[:] != 0).sum(axis=0)).reshape(-1)
         if min_cells: selected_genes &= adata.var["n_cell"] >= min_cells
         if max_cells_ratio: selected_genes &= adata.var["n_cell"] <= max_cells_ratio*adata.shape[0]
         selected_genes = np.flatnonzero(selected_genes)
@@ -1130,7 +1138,7 @@ def qc_cpu(
     genes_before_final = adata.shape[1]
 
     if is_oom:
-        # OOM path: use _inplace_subset and chunked column sums
+        # OOM path: use _inplace_subset and chunked column counts
         selected_cells = np.ones(adata.n_obs, dtype=bool)
         if min_genes:
             selected_cells &= adata.obs["detected_genes"].values >= min_genes
@@ -1138,7 +1146,11 @@ def qc_cpu(
             selected_cells &= adata.obs["detected_genes"].values <= max_genes_ratio * adata.shape[1]
         adata._inplace_subset_obs(selected_cells)
 
-        n_cell = adata.X.sum(axis=0)
+        # Recompute n_cells after cell subsetting. Uses chunked streaming —
+        # never materialises the full X.
+        from anndataoom import chunked_qc_metrics
+        chunked_qc_metrics(adata)
+        n_cell = adata.var["n_cells"].values
         adata.var["n_cell"] = n_cell
         selected_genes = np.ones(adata.n_vars, dtype=bool)
         if min_cells:
@@ -1158,7 +1170,15 @@ def qc_cpu(
         selected_cells = np.flatnonzero(selected_cells)
         adata.subset(obs_indices=selected_cells)
         selected_genes = True
-        adata.var["n_cell"] = np.array(adata.X[:].sum(axis=0)).reshape(-1)
+        # Count non-zero cells per gene. For OOM, stream in chunks rather than
+        # materialising X[:]; for raw rust, fall back to the one-shot read.
+        if _is_oom(adata):
+            from anndataoom import chunked_qc_metrics
+            if "n_cells" not in adata.var.columns:
+                chunked_qc_metrics(adata)
+            adata.var["n_cell"] = adata.var["n_cells"].values
+        else:
+            adata.var["n_cell"] = np.array((adata.X[:] != 0).sum(axis=0)).reshape(-1)
         if min_cells: selected_genes &= adata.var["n_cell"] >= min_cells
         if max_cells_ratio: selected_genes &= adata.var["n_cell"] <= max_cells_ratio*adata.shape[0]
         selected_genes = np.flatnonzero(selected_genes)

--- a/omicverse/pp/_qc.py
+++ b/omicverse/pp/_qc.py
@@ -1137,6 +1137,11 @@ def qc_cpu(
 
     if doublets is True:
         print(f"\n{Colors.HEADER}{Colors.BOLD}🔍 Step 4: Doublet Detection{Colors.ENDC}")
+        if doublets_method not in ('scrublet', 'sccomposite'):
+            raise ValueError(
+                f"Unknown doublets_method={doublets_method!r}; "
+                "expected 'scrublet' or 'sccomposite'."
+            )
         if is_oom:
             # Scrublet/sccomposite require in-memory X — convert temporarily
             print(f"   {Colors.CYAN}Converting to in-memory for doublet detection...{Colors.ENDC}")

--- a/omicverse/pp/_qc.py
+++ b/omicverse/pp/_qc.py
@@ -98,7 +98,10 @@ def _filter_genes_impl(
 # Helper function to detect Rust backend
 def _is_rust_backend(adata):
     """Detect if the adata object is from Rust backend (like snapatac2)."""
-    # Check if it's a Rust/snapatac2 backend
+    # AnnDataOOM wraps rust backend — treat it as rust for legacy checks
+    if _is_oom(adata):
+        return True
+    # Check if it's a Rust/anndata_rs/snapatac2 backend
     try:
         # Check class type
         if type(adata.obs).__name__.endswith("PyDataFrameElem"):
@@ -107,11 +110,16 @@ def _is_rust_backend(adata):
             return True
         # Check module name
         module = type(adata).__module__
-        if "snapatac2" in module or "pyanndata" in module:
+        if "snapatac2" in module or "pyanndata" in module or "anndata_rs" in module:
             return True
     except Exception:
         pass
     return False
+
+
+def _is_oom(adata) -> bool:
+    """Detect if the adata object is an AnnDataOOM (out-of-memory) instance."""
+    return getattr(adata, "_is_oom", False)
 
 
 def _print_qc_metrics_table(adata):
@@ -542,7 +550,11 @@ def qc(adata,**kwargs):
 
     '''
 
-    if settings.mode == 'gpu':
+    if _is_oom(adata):
+        # OOM path always uses CPU with chunked operations
+        print(f"{Colors.HEADER}{Colors.BOLD}{EMOJI['cpu']} Using CPU mode for QC (out-of-memory)...{Colors.ENDC}")
+        return qc_cpu(adata,**kwargs)
+    elif settings.mode == 'gpu':
         print(f"{Colors.HEADER}{Colors.BOLD}{EMOJI['gpu']} Using RAPIDS GPU to calculate QC...{Colors.ENDC}")
         return qc_gpu(adata,**kwargs)
     elif settings.mode == 'cpu-gpu-mixed':
@@ -996,8 +1008,16 @@ def qc_cpu(
     _print_gene_detection_table(mt_genes_found, ribo_genes_found, hb_genes_found, mt_genes, ribo_genes, hb_genes)
     # Check if it's a Rust backend
     is_rust = _is_rust_backend(adata)
-    
-    if issparse(adata.X):
+    is_oom = _is_oom(adata)
+
+    if is_oom:
+        # Out-of-memory path — chunked, never loads full matrix
+        from anndataoom import chunked_qc_metrics, chunked_gene_group_pct
+        chunked_qc_metrics(adata)
+        adata.obs['mito_perc'] = chunked_gene_group_pct(adata, adata.var["mt"].values)
+        adata.obs['ribo_perc'] = chunked_gene_group_pct(adata, adata.var["ribo"].values)
+        adata.obs['hb_perc'] = chunked_gene_group_pct(adata, adata.var["hb"].values)
+    elif issparse(adata.X):
         adata.obs['nUMIs'] = np.array(adata.X.sum(axis=1)).reshape(-1)
         adata.obs['mito_perc'] = np.array(adata[:, adata.var["mt"]].X.sum(axis=1)).reshape(-1) / \
         adata.obs['nUMIs'].values
@@ -1079,7 +1099,13 @@ def qc_cpu(
 
     # QC plot
     QC_test = (adata.obs['passing_mt']) & (adata.obs['passing_nUMIs']) & (adata.obs['passing_ngenes'])
-    if is_rust:
+    if is_oom:
+        passing = QC_test.values if hasattr(QC_test, 'values') else np.asarray(QC_test)
+        removed = list(adata.obs_names[~passing])
+        removed_cells.extend(removed)
+        total_qc_failed = len(removed)
+        adata._inplace_subset_obs(passing)
+    elif is_rust:
         removed = list(np.array(adata.obs_names)[np.where(QC_test==False)[0]])
         removed_cells.extend(removed)
         total_qc_failed = len(removed)
@@ -1103,7 +1129,24 @@ def qc_cpu(
     cells_before_final = adata.shape[0]
     genes_before_final = adata.shape[1]
 
-    if not is_rust:
+    if is_oom:
+        # OOM path: use _inplace_subset and chunked column sums
+        selected_cells = np.ones(adata.n_obs, dtype=bool)
+        if min_genes:
+            selected_cells &= adata.obs["detected_genes"].values >= min_genes
+        if max_genes_ratio:
+            selected_cells &= adata.obs["detected_genes"].values <= max_genes_ratio * adata.shape[1]
+        adata._inplace_subset_obs(selected_cells)
+
+        n_cell = adata.X.sum(axis=0)
+        adata.var["n_cell"] = n_cell
+        selected_genes = np.ones(adata.n_vars, dtype=bool)
+        if min_cells:
+            selected_genes &= n_cell >= min_cells
+        if max_cells_ratio:
+            selected_genes &= n_cell <= max_cells_ratio * adata.shape[0]
+        adata._inplace_subset_var(selected_genes)
+    elif not is_rust:
         _filter_cells_impl(adata, min_genes=min_genes)
         _filter_genes_impl(adata, min_cells=min_cells)
         _filter_cells_impl(adata, max_genes=int(max_genes_ratio*adata.shape[1]))
@@ -1130,16 +1173,32 @@ def qc_cpu(
     
     if doublets is True:
         print(f"\n{Colors.HEADER}{Colors.BOLD}🔍 Step 4: Doublet Detection{Colors.ENDC}")
+        if is_oom:
+            # Scrublet/sccomposite require in-memory X — convert temporarily
+            print(f"   {Colors.CYAN}Converting to in-memory for doublet detection...{Colors.ENDC}")
+            adata_mem = adata.to_adata()
         if doublets_method=='scrublet':
             from ._scrublet import scrublet
             # Post doublets removal QC plot
             print(f"   {Colors.WARNING}⚠️  Note: 'scrublet' detection is too old and may not work properly{Colors.ENDC}")
             print(f"   {Colors.CYAN}💡 Consider using 'doublets_method=sccomposite' for better results{Colors.ENDC}")
             print(f"   {Colors.GREEN}{EMOJI['start']} Running scrublet doublet detection...{Colors.ENDC}")
-            scrublet(adata, random_state=1234,batch_key=batch_key)
+            if is_oom:
+                scrublet(adata_mem, random_state=1234, batch_key=batch_key)
+                adata.obs['predicted_doublet'] = adata_mem.obs['predicted_doublet'].values
+                if 'doublet_score' in adata_mem.obs.columns:
+                    adata.obs['doublet_score'] = adata_mem.obs['doublet_score'].values
+                del adata_mem
+            else:
+                scrublet(adata, random_state=1234,batch_key=batch_key)
 
             if filter_doublets:
-                if is_rust:
+                if is_oom:
+                    doublet_mask = ~adata.obs['predicted_doublet'].values
+                    removed = list(adata.obs_names[~doublet_mask])
+                    removed_cells.extend(removed)
+                    adata._inplace_subset_obs(doublet_mask)
+                elif is_rust:
                     removed=list(np.array(adata.obs_names)[np.where(adata.obs['predicted_doublet']==True)[0]])
                     removed_cells.extend(removed)
                     adata.subset(obs_indices=np.array(adata.obs_names)[np.where(adata.obs['predicted_doublet']==False)[0]])

--- a/omicverse/pp/_qc.py
+++ b/omicverse/pp/_qc.py
@@ -95,9 +95,10 @@ def _filter_genes_impl(
         return gene_subset, n_counts
 
 
-def _is_oom(adata) -> bool:
-    """Detect if the adata object is an AnnDataOOM (out-of-memory) instance."""
-    return getattr(adata, "_is_oom", False)
+# Single source of truth for "is this adata an AnnDataOOM?" — delegates to
+# the compat shim so it stays in lockstep with the anndataoom package (or its
+# no-op fallback when anndataoom is not installed).
+from .._oom_compat import is_oom as _is_oom
 
 
 # Deprecated alias — AnnDataOOM is the only rust-backed AnnData we support in
@@ -1001,8 +1002,6 @@ def qc_cpu(
 
     # Print gene detection table
     _print_gene_detection_table(mt_genes_found, ribo_genes_found, hb_genes_found, mt_genes, ribo_genes, hb_genes)
-    # Check if it's a Rust backend
-    is_rust = _is_rust_backend(adata)
     is_oom = _is_oom(adata)
 
     if is_oom:
@@ -1021,23 +1020,6 @@ def qc_cpu(
         adata.obs['hb_perc'] = np.array(adata[:, adata.var["hb"]].X.sum(axis=1)).reshape(-1) / \
         adata.obs['nUMIs'].values
         adata.obs['detected_genes'] = adata.X.getnnz(axis=1)
-    elif is_rust:
-        # For Rust backend (snapatac2) - use adata.X[:] and subset method
-        adata.obs['nUMIs'] = np.array(adata.X[:].sum(axis=1)).reshape(-1)
-        # Use subset method for Rust backend slicing
-        mt_indices = np.where(adata.var["mt"])[0]
-        ribo_indices = np.where(adata.var["ribo"])[0]
-        hb_indices = np.where(adata.var["hb"])[0]
-        if len(mt_indices) > 0:
-            #adata.X[:,mt_indices].sum(axis=1) / adata.obs['nUMIs'].values
-            adata.obs['mito_perc'] = np.array(adata.X[:,mt_indices].sum(axis=1)).reshape(-1) / adata.obs['nUMIs']
-            adata.obs['ribo_perc'] = np.array(adata.X[:,ribo_indices].sum(axis=1)).reshape(-1) / adata.obs['nUMIs']
-            adata.obs['hb_perc'] = np.array(adata.X[:,hb_indices].sum(axis=1)).reshape(-1) / adata.obs['nUMIs']
-        else:
-            adata.obs['mito_perc'] = np.zeros(adata.n_obs)
-            adata.obs['ribo_perc'] = np.zeros(adata.n_obs)
-            adata.obs['hb_perc'] = np.zeros(adata.n_obs)
-        adata.obs['detected_genes'] = adata.X[:].getnnz(axis=1)
     else:
         # Regular pandas backend
         adata.obs['nUMIs'] = adata.X.sum(axis=1)
@@ -1140,24 +1122,11 @@ def qc_cpu(
         if max_cells_ratio:
             selected_genes &= n_cell <= max_cells_ratio * adata.shape[0]
         adata._inplace_subset_var(selected_genes)
-    elif not is_rust:
+    else:
         _filter_cells_impl(adata, min_genes=min_genes)
         _filter_genes_impl(adata, min_cells=min_cells)
         _filter_cells_impl(adata, max_genes=int(max_genes_ratio*adata.shape[1]))
         _filter_genes_impl(adata, max_cells=int(max_cells_ratio*adata.shape[0]))
-    else:
-        # Pure rust path (OOM is handled by the `if is_oom:` branch above).
-        selected_cells = True
-        if min_genes: selected_cells &= adata.obs["detected_genes"] >= min_genes
-        if max_genes_ratio: selected_cells &= adata.obs["detected_genes"] <= max_genes_ratio*adata.shape[1]
-        selected_cells = np.flatnonzero(selected_cells)
-        adata.subset(obs_indices=selected_cells)
-        selected_genes = True
-        adata.var["n_cell"] = np.array((adata.X[:] != 0).sum(axis=0)).reshape(-1)
-        if min_cells: selected_genes &= adata.var["n_cell"] >= min_cells
-        if max_cells_ratio: selected_genes &= adata.var["n_cell"] <= max_cells_ratio*adata.shape[0]
-        selected_genes = np.flatnonzero(selected_genes)
-        adata.subset(var_indices=selected_genes)
 
     cells_final_filtered = cells_before_final - adata.shape[0]
     genes_final_filtered = genes_before_final - adata.shape[1]

--- a/omicverse/single/_batch.py
+++ b/omicverse/single/_batch.py
@@ -3,7 +3,6 @@ import scanpy as sc
 import numpy as np
 import anndata
 from .._settings import add_reference,settings
-from .._oom_compat import oom_guard as _oom_guard
 from .._registry import register_function
 from .._monitor import monitor
 

--- a/omicverse/single/_batch.py
+++ b/omicverse/single/_batch.py
@@ -3,6 +3,7 @@ import scanpy as sc
 import numpy as np
 import anndata
 from .._settings import add_reference,settings
+from .._oom_compat import oom_guard as _oom_guard
 from .._registry import register_function
 from .._monitor import monitor
 
@@ -70,6 +71,30 @@ def batch_correction(adata:anndata.AnnData,batch_key:str,
         and Concord object for ``'Concord'``. The integrated embeddings are
         written to ``adata.obsm``.
     """
+
+    from ..pp._qc import _is_oom
+    _oom = _is_oom(adata)
+
+    if _oom and methods not in ('harmony',):
+        print(
+            f"[AnnDataOOM] '{methods}' requires the full expression matrix in memory.\n"
+            f"  Converting to in-memory AnnData automatically.\n"
+            f"  Tip: 'harmony' works directly on PCA embeddings without materialisation —\n"
+            f"       consider ov.single.batch_correction(adata, methods='harmony') instead."
+        )
+        adata_mem = adata.to_adata()
+        result = batch_correction(adata_mem, batch_key, use_rep=use_rep,
+                                  methods=methods, n_pcs=n_pcs, **kwargs)
+        # Copy results back to OOM
+        for k in adata_mem.obsm:
+            if k not in adata.obsm:
+                adata.obsm[k] = adata_mem.obsm[k]
+        for k in adata_mem.obs.columns:
+            if k not in adata.obs.columns:
+                adata.obs[k] = adata_mem.obs[k].values
+        adata.uns.update(adata_mem.uns)
+        del adata_mem
+        return result if result is not None else adata
 
     print(f'...Begin using {methods} to correct batch effect')
 

--- a/omicverse/single/_batch.py
+++ b/omicverse/single/_batch.py
@@ -82,9 +82,9 @@ def batch_correction(adata:anndata.AnnData,batch_key:str,
             f"       consider ov.single.batch_correction(adata, methods='harmony') instead."
         )
         adata_mem = adata.to_adata()
-        result = batch_correction(adata_mem, batch_key, use_rep=use_rep,
-                                  methods=methods, n_pcs=n_pcs, **kwargs)
-        # Copy results back to OOM
+        batch_correction(adata_mem, batch_key, use_rep=use_rep,
+                         methods=methods, n_pcs=n_pcs, **kwargs)
+        # Copy results back onto the OOM adata so we preserve the OOM contract.
         for k in adata_mem.obsm:
             if k not in adata.obsm:
                 adata.obsm[k] = adata_mem.obsm[k]
@@ -93,7 +93,7 @@ def batch_correction(adata:anndata.AnnData,batch_key:str,
                 adata.obs[k] = adata_mem.obs[k].values
         adata.uns.update(adata_mem.uns)
         del adata_mem
-        return result if result is not None else adata
+        return adata
 
     print(f'...Begin using {methods} to correct batch effect')
 

--- a/omicverse/single/_batch.py
+++ b/omicverse/single/_batch.py
@@ -91,7 +91,9 @@ def batch_correction(adata:anndata.AnnData,batch_key:str,
         for k in adata_mem.obs.columns:
             if k not in adata.obs.columns:
                 adata.obs[k] = adata_mem.obs[k].values
-        adata.uns.update(adata_mem.uns)
+        for k in adata_mem.uns:
+            if k not in adata.uns:
+                adata.uns[k] = adata_mem.uns[k]
         del adata_mem
         return adata
 

--- a/omicverse/single/_markers.py
+++ b/omicverse/single/_markers.py
@@ -13,6 +13,7 @@ from typing import Generator, Iterable, Optional, Sequence, Union
 import numpy as np
 import pandas as pd
 from anndata import AnnData
+from .._oom_compat import oom_guard as _oom_guard
 from scipy import sparse, stats
 
 from .._registry import register_function
@@ -592,6 +593,7 @@ def _cosg_add_pts(
     ],
     related=["single.get_markers", "pl.markers_dotplot", "single.cosg"],
 )
+@_oom_guard(materialize=True, result_keys_uns=['*'])
 def find_markers(
     adata: AnnData,
     groupby: str,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,12 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+# Out-of-memory backend (Rust-powered AnnData). Install via:
+#   pip install omicverse[rust]
+# Enables ov.read(path, backend='rust') with chunked preprocessing.
+rust = [
+    "anndataoom>=0.1.0",
+]
 full = [
   "dynamo-release",
   "squidpy",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ dependencies = [
 #   pip install omicverse[rust]
 # Enables ov.read(path, backend='rust') with chunked preprocessing.
 rust = [
-    "anndataoom>=0.1.0",
+    "anndataoom>=0.1.0,<1.0",
 ]
 full = [
   "dynamo-release",

--- a/tests/others/test_oom_backend.py
+++ b/tests/others/test_oom_backend.py
@@ -111,19 +111,12 @@ def test_read_rust_backend_returns_oom(tiny_h5ad):
 
 def test_read_rust_backend_raises_without_anndataoom(tiny_h5ad, monkeypatch):
     """If anndataoom is not importable, backend='rust' must fail cleanly."""
-    # Simulate missing anndataoom by blocking its import.
+    # Mark anndataoom as unavailable in sys.modules — a subsequent `import
+    # anndataoom` inside _read_h5ad_rust will raise ImportError.
     for name in list(sys.modules):
         if name == "anndataoom" or name.startswith("anndataoom."):
             monkeypatch.delitem(sys.modules, name, raising=False)
-
-    real_import = __builtins__["__import__"] if isinstance(__builtins__, dict) else __builtins__.__import__
-
-    def blocked(name, *args, **kwargs):
-        if name == "anndataoom" or name.startswith("anndataoom."):
-            raise ImportError("simulated missing anndataoom")
-        return real_import(name, *args, **kwargs)
-
-    monkeypatch.setattr("builtins.__import__", blocked)
+    monkeypatch.setitem(sys.modules, "anndataoom", None)
 
     from omicverse.io.single._read import _read_h5ad_rust
 
@@ -163,8 +156,6 @@ def test_preprocess_seurat_raises_on_oom(tiny_h5ad):
             mode="seurat",
             min_cells=0,
             min_genes=0,
-            max_cells_ratio=100,
-            max_genes_ratio=100,
             tresh={"mito_perc": 1.0, "nUMIs": 0, "detected_genes": 0},
             mt_startswith="MT-",
             doublets=False,
@@ -187,8 +178,6 @@ def test_pca_varm_shape_matches_adata_n_vars(tiny_h5ad):
             mode="seurat",
             min_cells=0,
             min_genes=0,
-            max_cells_ratio=100,  # permissive; the rust path uses count-sum here
-            max_genes_ratio=100,
             tresh={"mito_perc": 1.0, "nUMIs": 0, "detected_genes": 0},
             mt_startswith="MT-",
             doublets=False,

--- a/tests/others/test_oom_backend.py
+++ b/tests/others/test_oom_backend.py
@@ -146,8 +146,9 @@ def test_read_invalid_backend_raises(tiny_h5ad):
 # ──────────────────────────────────────────────────────────────────────
 
 def test_preprocess_seurat_raises_on_oom(tiny_h5ad):
-    """shiftlog|seurat is not implemented for OOM — it must raise, not run
-    the Pearson chunked function in silence."""
+    """shiftlog|seurat is not implemented for OOM — it must raise BEFORE any
+    mutation (no normalize, no log1p, no counts layer) so the user's adata
+    isn't left in a half-processed state."""
     import omicverse as ov
 
     adata = ov.read(tiny_h5ad, backend="rust")
@@ -161,8 +162,17 @@ def test_preprocess_seurat_raises_on_oom(tiny_h5ad):
             mt_startswith="MT-",
             doublets=False,
         )
+        layers_before = set(adata.layers.keys())
+        obs_cols_before = set(adata.obs.columns)
+
         with pytest.raises(NotImplementedError, match="[Ss]eurat"):
             ov.pp.preprocess(adata, mode="shiftlog|seurat", n_HVGs=50)
+
+        # No mutation happened — adata is still usable.
+        assert set(adata.layers.keys()) == layers_before
+        assert "_norm_factor" not in adata.obs.columns  # chunked_normalize_total side-effect
+        # New obs cols must be a subset of what was there pre-call
+        assert set(adata.obs.columns) == obs_cols_before
     finally:
         adata.close()
 
@@ -195,30 +205,22 @@ def test_pca_varm_shape_matches_adata_n_vars(tiny_h5ad):
         adata.close()
 
 
-def test_oom_compat_isinstance_is_safe():
+def test_oom_compat_isinstance_is_safe(monkeypatch):
     """AnnDataOOM in the fallback shim must be a real class so that
     `isinstance(obj, AnnDataOOM)` never raises TypeError."""
-    import sys
     import importlib
 
     for name in list(sys.modules):
         if name == "anndataoom" or name.startswith("anndataoom."):
-            sys.modules.pop(name, None)
-    sys.modules["anndataoom"] = None
+            monkeypatch.delitem(sys.modules, name, raising=False)
+    monkeypatch.setitem(sys.modules, "anndataoom", None)
+    monkeypatch.delitem(sys.modules, "omicverse._oom_compat", raising=False)
 
-    try:
-        if "omicverse._oom_compat" in sys.modules:
-            del sys.modules["omicverse._oom_compat"]
-        compat = importlib.import_module("omicverse._oom_compat")
-
-        assert compat.HAS_OOM is False
-        # Must not raise — this is the regression the stub class prevents.
-        assert isinstance("not an adata", compat.AnnDataOOM) is False
-        assert isinstance(object(), compat.BackedArray) is False
-    finally:
-        sys.modules.pop("anndataoom", None)
-        sys.modules.pop("omicverse._oom_compat", None)
-        importlib.import_module("omicverse._oom_compat")
+    compat = importlib.import_module("omicverse._oom_compat")
+    assert compat.HAS_OOM is False
+    # Must not raise — this is the regression the stub class prevents.
+    assert isinstance("not an adata", compat.AnnDataOOM) is False
+    assert isinstance(object(), compat.BackedArray) is False
 
 
 def test_qc_sccomposite_oom_copies_results_back(tiny_h5ad, monkeypatch):
@@ -255,6 +257,39 @@ def test_qc_sccomposite_oom_copies_results_back(tiny_h5ad, monkeypatch):
         assert (adata.obs["sccomposite_doublet"] != 0).sum() > 0
         # OOM contract preserved
         assert getattr(adata, "_is_oom", False) is True
+    finally:
+        adata.close()
+
+
+def test_full_pipeline_through_leiden_oom(tiny_h5ad):
+    """End-to-end smoke test: qc -> preprocess -> scale -> pca -> neighbors
+    -> leiden on an OOM adata. Guards the lazy-transform chain at the
+    integration boundaries (each step adds a new wrapping layer)."""
+    import omicverse as ov
+
+    adata = ov.read(tiny_h5ad, backend="rust")
+    try:
+        ov.pp.qc(
+            adata,
+            mode="seurat",
+            min_cells=0,
+            min_genes=0,
+            tresh={"mito_perc": 1.0, "nUMIs": 0, "detected_genes": 0},
+            mt_startswith="MT-",
+            doublets=False,
+        )
+        ov.pp.preprocess(adata, mode="shiftlog|pearson", n_HVGs=50)
+        ov.pp.scale(adata)
+        ov.pp.pca(adata, layer="scaled", n_pcs=10)
+        ov.pp.neighbors(
+            adata, n_neighbors=5, n_pcs=10,
+            use_rep="scaled|original|X_pca",
+        )
+        ov.pp.leiden(adata, resolution=1.0)
+
+        assert "leiden" in adata.obs.columns
+        assert adata.obs["leiden"].nunique() >= 1
+        assert "neighbors" in adata.uns
     finally:
         adata.close()
 

--- a/tests/others/test_oom_backend.py
+++ b/tests/others/test_oom_backend.py
@@ -1,0 +1,205 @@
+"""
+Tests for the Rust-backed out-of-memory (OOM) AnnData path.
+
+Covers the integration points that exist in omicverse itself. Deep checks of
+the backend semantics live in the `anndataoom` package's own test suite.
+"""
+
+import importlib
+import sys
+
+import numpy as np
+import pytest
+
+
+anndataoom = pytest.importorskip("anndataoom")
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Compat shim — must work whether or not anndataoom is installed
+# ──────────────────────────────────────────────────────────────────────
+
+def test_oom_compat_exports():
+    from omicverse import _oom_compat
+
+    for attr in (
+        "HAS_OOM",
+        "AnnDataOOM",
+        "BackedArray",
+        "BackedLayers",
+        "TransformedBackedArray",
+        "ScaledBackedArray",
+        "oom_guard",
+        "is_oom",
+    ):
+        assert hasattr(_oom_compat, attr), f"_oom_compat missing {attr!r}"
+
+
+def test_oom_compat_fallback_when_anndataoom_missing(monkeypatch):
+    """When anndataoom cannot be imported, the shim must provide no-op stubs."""
+    saved = {
+        k: v for k, v in sys.modules.items()
+        if k == "anndataoom" or k.startswith("anndataoom.")
+    }
+    for name in saved:
+        monkeypatch.delitem(sys.modules, name, raising=False)
+    monkeypatch.setitem(sys.modules, "anndataoom", None)
+
+    if "omicverse._oom_compat" in sys.modules:
+        monkeypatch.delitem(sys.modules, "omicverse._oom_compat")
+    compat = importlib.import_module("omicverse._oom_compat")
+
+    assert compat.HAS_OOM is False
+    assert compat.AnnDataOOM is None
+    assert compat.is_oom(object()) is False
+
+    @compat.oom_guard(materialize=True)
+    def identity(x):
+        return x
+
+    assert identity(123) == 123
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Fixtures — small h5ad written to a temp path
+# ──────────────────────────────────────────────────────────────────────
+
+@pytest.fixture(scope="module")
+def tiny_h5ad(tmp_path_factory):
+    """A dense-enough synthetic h5ad that survives default QC filtering."""
+    import anndata as ad
+    import pandas as pd
+    from scipy.sparse import csr_matrix
+
+    rng = np.random.default_rng(0)
+    n_obs, n_vars = 1000, 600
+    # Poisson-like counts, high density so genes clear min_cells/robust filters.
+    X = rng.poisson(lam=2.0, size=(n_obs, n_vars)).astype(np.float32)
+    X = csr_matrix(X)
+
+    obs = pd.DataFrame(
+        {"batch": rng.choice(["A", "B"], size=n_obs)},
+        index=[f"cell_{i}" for i in range(n_obs)],
+    )
+    mt_idx = rng.choice(n_vars, size=20, replace=False)
+    var_names = [
+        f"MT-{i}" if i in mt_idx else f"gene_{i}" for i in range(n_vars)
+    ]
+    var = pd.DataFrame(index=var_names)
+
+    adata = ad.AnnData(X=X, obs=obs, var=var)
+    path = tmp_path_factory.mktemp("oom") / "tiny.h5ad"
+    adata.write_h5ad(path)
+    return str(path)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# ov.read(backend='rust')
+# ──────────────────────────────────────────────────────────────────────
+
+def test_read_rust_backend_returns_oom(tiny_h5ad):
+    import omicverse as ov
+
+    adata = ov.read(tiny_h5ad, backend="rust")
+    try:
+        assert type(adata).__name__ == "AnnDataOOM"
+        assert getattr(adata, "_is_oom", False) is True
+        assert adata.shape == (1000, 600)
+    finally:
+        adata.close()
+
+
+def test_read_rust_backend_raises_without_anndataoom(tiny_h5ad, monkeypatch):
+    """If anndataoom is not importable, backend='rust' must fail cleanly."""
+    # Simulate missing anndataoom by blocking its import.
+    for name in list(sys.modules):
+        if name == "anndataoom" or name.startswith("anndataoom."):
+            monkeypatch.delitem(sys.modules, name, raising=False)
+
+    real_import = __builtins__["__import__"] if isinstance(__builtins__, dict) else __builtins__.__import__
+
+    def blocked(name, *args, **kwargs):
+        if name == "anndataoom" or name.startswith("anndataoom."):
+            raise ImportError("simulated missing anndataoom")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.__import__", blocked)
+
+    from omicverse.io.single._read import _read_h5ad_rust
+
+    with pytest.raises(ImportError, match="anndataoom"):
+        _read_h5ad_rust(tiny_h5ad)
+
+
+def test_read_python_backend_unaffected(tiny_h5ad):
+    """backend='python' must not touch anndataoom at all."""
+    import omicverse as ov
+
+    adata = ov.read(tiny_h5ad, backend="python")
+    assert adata.shape == (1000, 600)
+    assert getattr(adata, "_is_oom", False) is False
+
+
+def test_read_invalid_backend_raises(tiny_h5ad):
+    import omicverse as ov
+
+    with pytest.raises(ValueError, match="backend"):
+        ov.read(tiny_h5ad, backend="julia")
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Preprocess on OOM backend
+# ──────────────────────────────────────────────────────────────────────
+
+def test_preprocess_seurat_raises_on_oom(tiny_h5ad):
+    """shiftlog|seurat is not implemented for OOM — it must raise, not run
+    the Pearson chunked function in silence."""
+    import omicverse as ov
+
+    adata = ov.read(tiny_h5ad, backend="rust")
+    try:
+        ov.pp.qc(
+            adata,
+            mode="seurat",
+            min_cells=0,
+            min_genes=0,
+            max_cells_ratio=100,
+            max_genes_ratio=100,
+            tresh={"mito_perc": 1.0, "nUMIs": 0, "detected_genes": 0},
+            mt_startswith="MT-",
+            doublets=False,
+        )
+        with pytest.raises(NotImplementedError, match="[Ss]eurat"):
+            ov.pp.preprocess(adata, mode="shiftlog|seurat", n_HVGs=50)
+    finally:
+        adata.close()
+
+
+def test_pca_varm_shape_matches_adata_n_vars(tiny_h5ad):
+    """After the full OOM pipeline, adata.varm['PCs'] must have shape
+    (adata.n_vars, n_comps). Regression test for issue #7."""
+    import omicverse as ov
+
+    adata = ov.read(tiny_h5ad, backend="rust")
+    try:
+        ov.pp.qc(
+            adata,
+            mode="seurat",
+            min_cells=0,
+            min_genes=0,
+            max_cells_ratio=100,  # permissive; the rust path uses count-sum here
+            max_genes_ratio=100,
+            tresh={"mito_perc": 1.0, "nUMIs": 0, "detected_genes": 0},
+            mt_startswith="MT-",
+            doublets=False,
+        )
+        assert adata.n_obs > 0 and adata.n_vars > 0, "QC filtered everything"
+
+        ov.pp.preprocess(adata, mode="shiftlog|pearson", n_HVGs=50)
+        ov.pp.scale(adata)
+        ov.pp.pca(adata, layer="scaled", n_pcs=10)
+
+        assert adata.obsm["X_pca"].shape == (adata.n_obs, 10)
+        assert adata.varm["PCs"].shape == (adata.n_vars, 10)
+    finally:
+        adata.close()

--- a/tests/others/test_oom_backend.py
+++ b/tests/others/test_oom_backend.py
@@ -50,7 +50,8 @@ def test_oom_compat_fallback_when_anndataoom_missing(monkeypatch):
     compat = importlib.import_module("omicverse._oom_compat")
 
     assert compat.HAS_OOM is False
-    assert compat.AnnDataOOM is None
+    # Stub is a real class so isinstance never raises; no real OOM object exists.
+    assert isinstance(compat.AnnDataOOM, type)
     assert compat.is_oom(object()) is False
 
     @compat.oom_guard(materialize=True)
@@ -190,5 +191,107 @@ def test_pca_varm_shape_matches_adata_n_vars(tiny_h5ad):
 
         assert adata.obsm["X_pca"].shape == (adata.n_obs, 10)
         assert adata.varm["PCs"].shape == (adata.n_vars, 10)
+    finally:
+        adata.close()
+
+
+def test_oom_compat_isinstance_is_safe():
+    """AnnDataOOM in the fallback shim must be a real class so that
+    `isinstance(obj, AnnDataOOM)` never raises TypeError."""
+    import sys
+    import importlib
+
+    for name in list(sys.modules):
+        if name == "anndataoom" or name.startswith("anndataoom."):
+            sys.modules.pop(name, None)
+    sys.modules["anndataoom"] = None
+
+    try:
+        if "omicverse._oom_compat" in sys.modules:
+            del sys.modules["omicverse._oom_compat"]
+        compat = importlib.import_module("omicverse._oom_compat")
+
+        assert compat.HAS_OOM is False
+        # Must not raise — this is the regression the stub class prevents.
+        assert isinstance("not an adata", compat.AnnDataOOM) is False
+        assert isinstance(object(), compat.BackedArray) is False
+    finally:
+        sys.modules.pop("anndataoom", None)
+        sys.modules.pop("omicverse._oom_compat", None)
+        importlib.import_module("omicverse._oom_compat")
+
+
+def test_qc_sccomposite_oom_copies_results_back(tiny_h5ad, monkeypatch):
+    """Regression: sccomposite on an OOM adata must copy obs labels back onto
+    the original OOM object and must not leak adata_mem."""
+    import omicverse as ov
+
+    # Replace composite_rna with a deterministic fake: flag half the cells.
+    def fake_composite_rna(a):
+        n = a.n_obs
+        labels = np.zeros(n, dtype=int)
+        labels[::2] = 1  # every other cell is a "doublet"
+        consistency = np.ones(n, dtype=float)
+        return labels, consistency
+
+    import omicverse.pp._sccomposite as sc_mod
+    monkeypatch.setattr(sc_mod, "composite_rna", fake_composite_rna)
+
+    adata = ov.read(tiny_h5ad, backend="rust")
+    try:
+        ov.pp.qc(
+            adata,
+            mode="seurat",
+            min_cells=0,
+            min_genes=0,
+            tresh={"mito_perc": 1.0, "nUMIs": 0, "detected_genes": 0},
+            mt_startswith="MT-",
+            doublets=True,
+            doublets_method="sccomposite",
+            filter_doublets=False,
+        )
+        assert "sccomposite_doublet" in adata.obs.columns
+        assert "sccomposite_consistency" in adata.obs.columns
+        assert (adata.obs["sccomposite_doublet"] != 0).sum() > 0
+        # OOM contract preserved
+        assert getattr(adata, "_is_oom", False) is True
+    finally:
+        adata.close()
+
+
+def test_batch_correction_oom_preserves_uns(tiny_h5ad):
+    """Regression: the OOM copy-back pattern must not clobber pre-existing
+    uns keys with the materialised adata_mem's uns."""
+    import omicverse as ov
+
+    adata = ov.read(tiny_h5ad, backend="rust")
+    try:
+        # Pre-existing OOM-side state that must survive the copy-back
+        adata.uns["preserve_me"] = {"oom_specific": True}
+
+        # Simulate what batch_correction does under OOM: materialise, add
+        # obsm/uns on the copy (potentially clobbering the same keys), then
+        # copy only new keys back onto the OOM object.
+        adata_mem = adata.to_adata()
+        adata_mem.obsm["X_corrected"] = np.zeros((adata.n_obs, 3), dtype=np.float32)
+        adata_mem.uns["new_key_from_bc"] = {"hello": "world"}
+        adata_mem.uns["preserve_me"] = {"clobbered": True}  # adversarial
+
+        # Copy-back logic from omicverse/single/_batch.py
+        for k in adata_mem.obsm:
+            if k not in adata.obsm:
+                adata.obsm[k] = adata_mem.obsm[k]
+        for k in adata_mem.obs.columns:
+            if k not in adata.obs.columns:
+                adata.obs[k] = adata_mem.obs[k].values
+        for k in adata_mem.uns:
+            if k not in adata.uns:
+                adata.uns[k] = adata_mem.uns[k]
+
+        # OOM-side state preserved
+        assert adata.uns["preserve_me"] == {"oom_specific": True}
+        # New state copied back
+        assert "X_corrected" in adata.obsm
+        assert "new_key_from_bc" in adata.uns
     finally:
         adata.close()


### PR DESCRIPTION
## Summary

Adds support for the new [`anndataoom`](https://github.com/Starlitnightly/anndata-oom) package as an **optional** Rust-powered backend for reading and processing large h5ad files out-of-memory.

- `pip install omicverse[rust]` → opt-in to chunked/lazy processing
- `ov.read(path, backend='rust')` returns an `AnnDataOOM` (drop-in for `anndata.AnnData`)
- Full pipeline (QC → normalize → HVG → scale → PCA → neighbors → UMAP → leiden) runs as **lazy transforms** or **chunked ops** — the full matrix is never loaded.

## Motivation

Standard `anndata.AnnData` needs the full matrix in RAM. For a 1M cell × 30k gene atlas that's ~120 GB, which exceeds most workstations. The Rust-backed `anndataoom` keeps X on disk (HDF5 via [anndata-rs](https://github.com/scverse/anndata-rs)) and streams chunks through a lazy transform chain; peak RAM is independent of dataset size.

## Design

### Compat shim (\`omicverse/_oom_compat.py\`)

Provides \`oom_guard\` decorator and \`is_oom()\` helper. When anndataoom is not installed:
- \`is_oom(adata)\` always returns False
- \`oom_guard(...)\` is an identity decorator (no-op)
- Nothing else in omicverse breaks

This lets top-level \`from .._oom_compat import oom_guard\` never fail, so users without the rust extra still get a working omicverse.

### Backend resolution in \`ov.read\`

\`backend='rust'\` tries, in order:
1. \`anndataoom\` (prebuilt PyPI wheel, has the Python wrapper)
2. \`anndata_rs\` (standalone, built from source)
3. \`snapatac2\` (bundles the same Rust AnnData)

### Lazy transform chain

Each preprocessing step adds a small descriptor (vector/flag) to a lazy
computation chain. Data is computed on-the-fly during chunked reads:

\`\`\`
X (HDF5 on disk)
  → TransformedBackedArray  (normalize: ÷ per-cell factors)
    → TransformedBackedArray  (log1p)
      → _SubsetBackedArray    (HVG: 2,000 columns)
        → ScaledBackedArray   (z-score: μ,σ only)
          → Randomized SVD    (chunked matrix products)
            → X_pca (n_obs × 50)
\`\`\`

### Auto-materialisation for in-memory-only functions

\`find_markers\`, \`score_genes_cell_cycle\`, and non-Harmony \`batch_correction\`
require the full matrix. They're wrapped with \`@oom_guard\` which:
1. Prints a warning explaining why
2. Calls \`adata.to_adata()\` to materialise
3. Runs the function on the in-memory copy
4. Copies results (\`uns\`, \`obs\`, \`obsm\`) back to the OOM object

### Plotting support

\`ov.pl.embedding\`, \`ov.pl.umap\`, \`ov.pl.pca\`, \`ov.pl.dotplot\`, \`ov.pl.violin\`,
\`ov.pl.ConvexHull\`, \`ov.pl.markers_dotplot\` all work directly with
\`AnnDataOOM\`, including \`use_raw=True\` (the \`_FrozenRaw\` object exposes
\`obs_vector\` and slicing so non-HVG genes plot correctly).

## Benchmark

PBMC 8k (7,750 × 20,939), full pipeline from read → leiden:

| Backend              | Peak RSS  | Total time |
|----------------------|----------:|-----------:|
| python (in-memory)   |  1,502 MB |      397 s |
| rust (anndataoom)    |     54 MB |      407 s |

→ **27.8× memory savings** with negligible time cost.

For million-cell data the python backend OOMs; the rust backend peaks at ~700 MB.

## Test plan

- [x] \`import omicverse as ov\` succeeds without \`anndataoom\` installed (compat shim)
- [x] \`import omicverse as ov\` succeeds with \`anndataoom\` installed
- [x] \`ov.read(path, backend='rust')\` returns \`AnnDataOOM\`
- [x] Full pipeline (qc → preprocess → scale → pca → neighbors → umap → leiden) runs on PBMC 8k
- [x] \`ov.pl.embedding\` / \`dotplot\` / \`violin\` with \`use_raw=True\`
- [x] \`find_markers\` auto-materialises with warning
- [x] \`batch_correction(methods='harmony')\` works natively on OOM object
- [ ] CI passes (triggered by this PR)

## Installation

\`\`\`bash
pip install omicverse[rust]    # opt-in to Rust backend
\`\`\`

Prebuilt wheels for \`anndataoom\` are available on PyPI for Linux (x86_64, aarch64), macOS (x86_64, arm64), and Windows x86_64 on Python 3.9–3.13.