### PR TITLE
fix(pl): restore ov.pl.spatial background-image scaling

### DIFF
--- a/omicverse/pl/_scanpy_compat.py
+++ b/omicverse/pl/_scanpy_compat.py
@@ -131,12 +131,42 @@ def check_colornorm(vmin=None, vmax=None, vcenter=None, norm=None):
     return None
 
 
-def circles(x, y, *, s, ax: Axes, scale_factor=None, **kwargs):
-    size = np.asarray(s)
-    if scale_factor is not None:
-        size = size * float(scale_factor) ** 2
-    marker = kwargs.pop("marker", "o")
-    return ax.scatter(x, y, s=size, marker=marker, **kwargs)
+def circles(
+    x, y, *, s, ax: Axes, marker=None, c="b", vmin=None, vmax=None,
+    scale_factor=1.0, **kwargs,
+):
+    """Scatter plot where ``s`` is a radius in data units (not points**2).
+
+    Mirrors :func:`scanpy.plotting._utils.circles` — when ``scale_factor`` is
+    supplied, both the coordinates and the radii are in the *already-scaled*
+    image-pixel space; we additionally multiply ``x`` and ``y`` by
+    ``scale_factor`` here because callers in this backend pass the raw
+    fullres obsm coords through unchanged.
+    """
+    from matplotlib.collections import PatchCollection
+    from matplotlib.patches import Circle
+
+    x = np.asarray(x)
+    y = np.asarray(y)
+    if scale_factor is not None and float(scale_factor) != 1.0:
+        x = x * float(scale_factor)
+        y = y * float(scale_factor)
+
+    # PatchCollection does not accept ``marker`` or ``plotnonfinite``.
+    kwargs.pop("plotnonfinite", None)
+
+    zipped = np.broadcast(x, y, np.asarray(s))
+    patches = [Circle((x_, y_), s_) for x_, y_, s_ in zipped]
+    collection = PatchCollection(patches, **kwargs)
+
+    if isinstance(c, np.ndarray) and np.issubdtype(c.dtype, np.number):
+        collection.set_array(np.ma.masked_invalid(c))
+        collection.set_clim(vmin, vmax)
+    else:
+        collection.set_facecolor(c)
+
+    ax.add_collection(collection)
+    return collection
 
 
 def savefig_or_show(basename: str, *, show=None, save=None) -> None:


### PR DESCRIPTION
## Summary
`ov.pl.spatial` rendered the H&E background tiny in the top-left corner
while spots scattered over a huge axis — the helper `circles()` in
`omicverse/pl/_scanpy_compat.py` only multiplied marker size by
`scale_factor²` (collapsing spots to sub-pixel radii) and left `x`/`y`
in raw fullres obsm coordinates. With `tissue_hires_scalef ≈ 0.17` the
spot range was ~6× the image extent, so matplotlib's autoscale covered
the spots and the image filled only a small corner.

Rewrite `circles()` to match `scanpy.plotting._utils.circles`:
- multiply `x`, `y` by `scale_factor` so both spots and image live in
  image-pixel space
- treat `s` as a radius in **data units** and draw
  `matplotlib.patches.Circle` via `PatchCollection` (not `ax.scatter`
  where `s` is points²)
- route numeric `c` through `set_array` / `set_clim` for colormapping
- drop `marker` / `plotnonfinite` which `PatchCollection` doesn't accept

## Visual comparison (`visium_sge('V1_Human_Lymph_Node')`, `color='CD3D'`)

| Before (ov.pl.spatial, broken) | After (ov.pl.spatial, fixed) | Reference (sc.pl.spatial) |
| --- | --- | --- |
| image tiny top-left, spots invisible | spots overlay tissue at matching scale | identical layout |

## Test plan
- [x] Visium Lymph Node — gene coloring (`CD3D`) renders spots over H&E at matching scale
- [x] Visium Lymph Node — categorical coloring (`in_tissue`) renders correctly
- [x] UMAP (`ov.pl.embedding`, `scale_factor=None` path via `ax.scatter`) still works unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)