### PR TITLE
fix(oom): spatial viz + drop snapatac2 dep + clear error for unsorted CSR

### DIFF
--- a/omicverse/io/single/_read.py
+++ b/omicverse/io/single/_read.py
@@ -127,7 +127,11 @@ def read(path, backend='python', **kwargs):
     path : str or pathlib.Path
         Input file path.
     backend : {'python', 'rust'}, default='python'
-        Backend used for ``.h5ad`` reading.
+        Backend used for ``.h5ad`` reading. ``'rust'`` loads out-of-memory
+        via ``anndataoom`` / ``anndata-rs``. When the file's sparse X has
+        unsorted minor indices the call is aborted with a clear
+        ``ValueError`` (rather than an anndata-rs panic) pointing at
+        :func:`ov.utils.convert_adata_for_rust` for recovery.
     **kwargs
         Additional keyword arguments forwarded to backend readers.
 
@@ -139,9 +143,10 @@ def read(path, backend='python', **kwargs):
     Raises
     ------
     ImportError
-        If ``backend='rust'`` is requested but ``snapatac2`` is unavailable.
+        If ``backend='rust'`` is requested but ``anndataoom`` is not installed.
     ValueError
-        If ``backend`` is invalid for ``.h5ad`` reading or the file suffix is unsupported.
+        If ``backend`` is invalid for ``.h5ad`` reading, the file suffix is
+        unsupported, or the ``.h5ad`` has an unsorted sparse ``X``.
     """
     ext = Path(path).suffix.lower()
 

--- a/omicverse/io/single/_read.py
+++ b/omicverse/io/single/_read.py
@@ -23,6 +23,50 @@ def _log_rust_read(path: str, size_mb: float | None, elapsed: float) -> None:
     )
 
 
+def _h5ad_csr_sorted(path, n_sample_lanes: int = 256) -> bool:
+    r"""Quick probe: if ``X`` is a CSR/CSC matrix, are its minor indices sorted
+    within each lane? anndata-rs panics on unsorted minor indices with a cryptic
+    Rust stack trace, so we pre-flight using ``h5py`` and up to ``n_sample_lanes``
+    evenly-spaced lanes. Returns ``True`` when sorted / not sparse / can't be
+    checked, ``False`` only when an actual violation is found.
+    """
+    try:
+        import h5py
+        import numpy as np
+    except ImportError:
+        return True
+    try:
+        with h5py.File(str(path), "r") as f:
+            if "X" not in f:
+                return True
+            X = f["X"]
+            if not isinstance(X, h5py.Group):
+                return True
+            enc = X.attrs.get("encoding-type", b"")
+            if isinstance(enc, bytes):
+                enc = enc.decode(errors="ignore")
+            if "csr" not in enc and "csc" not in enc:
+                return True
+            if "indptr" not in X or "indices" not in X:
+                return True
+            indptr = np.asarray(X["indptr"][:], dtype=np.int64)
+            indices_d = X["indices"]
+            n_lanes = indptr.shape[0] - 1
+            if n_lanes <= 0:
+                return True
+            step = max(1, n_lanes // n_sample_lanes)
+            for i in range(0, n_lanes, step):
+                s, e = int(indptr[i]), int(indptr[i + 1])
+                if e - s <= 1:
+                    continue
+                lane = np.asarray(indices_d[s:e])
+                if np.any(np.diff(lane) < 0):
+                    return False
+        return True
+    except Exception:
+        return True
+
+
 def _read_h5ad_rust(path, **kwargs):
     try:
         import anndataoom
@@ -31,6 +75,18 @@ def _read_h5ad_rust(path, **kwargs):
             "Rust backend requires the 'anndataoom' package. "
             "Install with:  pip install omicverse[rust]   (or  pip install anndataoom)"
         ) from None
+
+    if not _h5ad_csr_sorted(path):
+        raise ValueError(
+            f"Cannot read {path} with backend='rust': its sparse X matrix has "
+            "unsorted minor indices, which anndata-rs rejects.\n"
+            "Rewrite with sorted indices, e.g.:\n"
+            "    import anndata as ad\n"
+            f"    a = ad.read_h5ad('{path}')\n"
+            "    a.X.sort_indices()\n"
+            "    a.write_h5ad('<fixed>.h5ad')\n"
+            "Or use ov.utils.convert_adata_for_rust(a, output_file='<fixed>.h5ad')."
+        )
 
     kwargs.setdefault("backed", "r")
     try:

--- a/omicverse/io/single/_rust.py
+++ b/omicverse/io/single/_rust.py
@@ -184,7 +184,7 @@ def wrap_dataframe(df_obj):
 @register_function(
     aliases=["AnnData兼容转换", "convert_adata_for_rust", "fix_adata_compatibility", "修复兼容性", "rust_compatibility"],
     category="utils",
-    description="Convert old Python-backend h5ad AnnData to be compatible with Rust backend requirements using snapatac2.AnnData",
+    description="Rewrite an AnnData as an h5ad that ov.read(backend='rust') can open (sort CSR indices, strip NaN/Inf, preserve obsm/varm/uns/obsp/varp/layers)",
     examples=[
         "adata_rust = ov.utils.convert_adata_for_rust(adata, output_file='fixed_data.h5ad')",
         "adata = ov.read('fixed_data.h5ad', backend='rust')",
@@ -192,7 +192,10 @@ def wrap_dataframe(df_obj):
     related=["utils.read", "utils.convert_to_pandas", "pp.preprocess"]
 )
 def convert_adata_for_rust(adata, output_file=None, verbose=True, close_file=True):
-    """Convert an AnnData object into a Rust-backend compatible ``.h5ad`` file.
+    """Rewrite an AnnData object as an ``.h5ad`` file that ``ov.read(..., backend='rust')`` can open.
+
+    Sorts CSR/CSC minor indices, strips NaN/Inf, coerces problematic obs/var dtypes,
+    and preserves ``obsm``, ``varm``, ``uns``, ``obsp``, ``varp`` and ``layers``.
 
     Parameters
     ----------
@@ -203,34 +206,23 @@ def convert_adata_for_rust(adata, output_file=None, verbose=True, close_file=Tru
     verbose : bool, default=True
         Whether to print conversion progress and diagnostics.
     close_file : bool, default=True
-        Whether to close the created ``snapatac2.AnnData`` handle before returning.
+        Retained for backward compatibility; ignored (there is no persistent handle).
 
     Returns
     -------
     str
         Path to the converted Rust-compatible ``.h5ad`` file.
-
-    Raises
-    ------
-    ImportError
-        If ``snapatac2`` is not installed.
-    Exception
-        Re-raises backend conversion exceptions after cleanup.
     """
-    try:
-        import snapatac2 as snap
-    except ImportError:
-        raise ImportError("snapatac2 is required for Rust backend conversion. Install with: pip install snapatac2")
+    import anndata as ad
 
     if output_file is None:
         fd, output_file = tempfile.mkstemp(suffix='.h5ad')
         os.close(fd)
 
     if verbose:
-        print(f"{Colors.HEADER}{Colors.BOLD}🔧 Converting AnnData for Rust Backend using anndata-rs{Colors.ENDC}")
+        print(f"{Colors.HEADER}{Colors.BOLD}🔧 Converting AnnData for Rust Backend{Colors.ENDC}")
         print(f"   {Colors.CYAN}Original shape: {adata.shape}{Colors.ENDC}")
         print(f"   {Colors.CYAN}Output file: {output_file}{Colors.ENDC}")
-        print(f"   {Colors.BLUE}📝 Ensuring unique names...{Colors.ENDC}")
 
     adata_copy = adata.copy()
     adata_copy.var_names_make_unique()
@@ -333,64 +325,47 @@ def convert_adata_for_rust(adata, output_file=None, verbose=True, close_file=Tru
     obs_clean = _clean_dataframe(adata_copy.obs)
     var_clean = _clean_dataframe(adata_copy.var)
 
-    if verbose:
-        print(f"   {Colors.BLUE}🔧 Creating anndata-rs AnnData object...{Colors.ENDC}")
+    # Restore obs/var index from the original obs_names/var_names (the
+    # cleaning helper resets the index to preserve row order under column drops).
+    obs_index = pd.Index([str(n) for n in adata_copy.obs_names],
+                         name=adata_copy.obs.index.name or 'obs_names')
+    var_index = pd.Index([str(n) for n in adata_copy.var_names],
+                         name=adata_copy.var.index.name or 'var_names')
+    if obs_clean is None or obs_clean.empty:
+        obs_clean = pd.DataFrame(index=obs_index)
+    else:
+        obs_clean = obs_clean.copy()
+        obs_clean.index = obs_index
+    if var_clean is None or var_clean.empty:
+        var_clean = pd.DataFrame(index=var_index)
+    else:
+        var_clean = var_clean.copy()
+        var_clean.index = var_index
+
+    obsp_clean = {k: _clean_matrix(v) for k, v in (adata_copy.obsp or {}).items()
+                  if v is not None}
+    varp_clean = {k: _clean_matrix(v) for k, v in (adata_copy.varp or {}).items()
+                  if v is not None}
+    layers_clean = {k: _clean_matrix(v) for k, v in (adata_copy.layers or {}).items()
+                    if v is not None}
+    obsm_clean = dict(adata_copy.obsm) if getattr(adata_copy, 'obsm', None) else {}
+    varm_clean = dict(adata_copy.varm) if getattr(adata_copy, 'varm', None) else {}
+    uns_clean = _fix_uns_for_rust(dict(adata_copy.uns)) \
+                if getattr(adata_copy, 'uns', None) else {}
 
     try:
-        if verbose:
-            print(f"   {Colors.BLUE}📋 Data summary before anndata-rs creation:{Colors.ENDC}")
-            print(f"      X: {type(X_clean)} {X_clean.shape if X_clean is not None else 'None'}")
-            print(f"      obs: {type(obs_clean)} {obs_clean.shape if obs_clean is not None else 'None'}")
-            print(f"      var: {type(var_clean)} {var_clean.shape if var_clean is not None else 'None'}")
-
-        adata_snap = snap.AnnData(filename=output_file, X=X_clean)
-
-        if obs_clean is not None and not obs_clean.empty:
-            if verbose:
-                print(f"   {Colors.BLUE}📊 Adding obs data...{Colors.ENDC}")
-            for col in obs_clean.columns:
-                if obs_clean[col].dtype == 'object' or pd.api.types.is_categorical_dtype(obs_clean[col]):
-                    obs_clean[col] = obs_clean[col].astype(str)
-            adata_snap.close()
-            adata_snap = snap.AnnData(filename=output_file, X=X_clean, obs=obs_clean)
-
-        if var_clean is not None and not var_clean.empty:
-            if verbose:
-                print(f"   {Colors.BLUE}📊 Adding var data...{Colors.ENDC}")
-            for col in var_clean.columns:
-                if var_clean[col].dtype == 'object' or pd.api.types.is_categorical_dtype(var_clean[col]):
-                    var_clean[col] = var_clean[col].astype(str)
-            adata_snap.close()
-            adata_snap = snap.AnnData(filename=output_file, X=X_clean, obs=obs_clean, var=var_clean)
-
-        if verbose:
-            print(f"   {Colors.BLUE}📝 Setting obs_names and var_names...{Colors.ENDC}")
-        adata_snap.obs_names = [str(name) for name in adata_copy.obs_names]
-        adata_snap.var_names = [str(name) for name in adata_copy.var_names]
-
-        if hasattr(adata_copy, 'obsp') and adata_copy.obsp:
-            if verbose:
-                print(f"   {Colors.BLUE}📊 Adding obsp matrices...{Colors.ENDC}")
-            for key, value in adata_copy.obsp.items():
-                if value is not None:
-                    adata_snap.obsp[key] = _clean_matrix(value)
-
-        if hasattr(adata_copy, 'varp') and adata_copy.varp:
-            if verbose:
-                print(f"   {Colors.BLUE}📊 Adding varp matrices...{Colors.ENDC}")
-            for key, value in adata_copy.varp.items():
-                if value is not None:
-                    adata_snap.varp[key] = _clean_matrix(value)
-
-        if hasattr(adata_copy, 'layers') and adata_copy.layers:
-            if verbose:
-                print(f"   {Colors.BLUE}📊 Adding layers...{Colors.ENDC}")
-            for key, value in adata_copy.layers.items():
-                if value is not None:
-                    adata_snap.layers[key] = _clean_matrix(value)
-
-        if close_file:
-            adata_snap.close()
+        out = ad.AnnData(
+            X=X_clean,
+            obs=obs_clean,
+            var=var_clean,
+            obsm=obsm_clean or None,
+            varm=varm_clean or None,
+            uns=uns_clean or None,
+            obsp=obsp_clean or None,
+            varp=varp_clean or None,
+            layers=layers_clean or None,
+        )
+        out.write_h5ad(output_file, compression=None)
 
         if verbose:
             print(f"   {Colors.GREEN}🎉 Conversion completed successfully!{Colors.ENDC}")

--- a/omicverse/pl/_nanostring.py
+++ b/omicverse/pl/_nanostring.py
@@ -497,12 +497,14 @@ def nanostring(
         if color_key in adata.obs.columns:
             color_data = adata.obs.loc[cells_in_fovs, color_key]
         else:
+            from scipy.sparse import issparse
+
             gene_idx = adata.var_names.get_loc(color_key)
             X_sub = adata[fov_mask.to_numpy(), :].X
-            if hasattr(X_sub, "toarray"):
-                vals = np.asarray(X_sub[:, gene_idx].toarray()).flatten()
-            else:
-                vals = np.asarray(X_sub[:, gene_idx]).flatten()
+            vals = X_sub[:, gene_idx]
+            if issparse(vals) or hasattr(vals, "toarray"):
+                vals = vals.toarray()
+            vals = np.asarray(vals).flatten()
             color_data = pd.Series(vals, index=cells_in_fovs, name=color_key)
 
         is_categorical = (
@@ -938,12 +940,14 @@ def nanostringseg(
         if color_key in adata.obs.columns:
             color_data = adata.obs.loc[valid_cells, color_key]
         else:
+            from scipy.sparse import issparse
+
             gene_idx = adata.var_names.get_loc(color_key)
             idx_pos = adata.obs_names.get_indexer(valid_cells)
-            if hasattr(adata.X, "toarray"):
-                gene_vals = np.asarray(adata.X[idx_pos, gene_idx].toarray()).flatten()
-            else:
-                gene_vals = np.asarray(adata.X[idx_pos, gene_idx]).flatten()
+            gene_vals = adata.X[idx_pos, gene_idx]
+            if issparse(gene_vals) or hasattr(gene_vals, "toarray"):
+                gene_vals = gene_vals.toarray()
+            gene_vals = np.asarray(gene_vals).flatten()
             color_data = pd.Series(gene_vals, index=valid_cells, name=color_key)
 
         temp_gdf = gpd.GeoDataFrame({color_key: color_data}, geometry=geom_series,

--- a/omicverse/pl/_spatialseg.py
+++ b/omicverse/pl/_spatialseg.py
@@ -472,13 +472,15 @@ def spatialseg(
             temp_gdf = gpd.GeoDataFrame({color_key: color_data}, geometry=temp_geometries, index=valid_cells)
             plot_column = color_key
         else:
+            from scipy.sparse import issparse
+
             gene_idx = adata.var_names.get_loc(color_key)
-            if hasattr(adata.X, "toarray"):
-                expression_values = adata.X[
-                    adata.obs_names.get_indexer(valid_cells), gene_idx
-                ].toarray().flatten()
-            else:
-                expression_values = adata.X[adata.obs_names.get_indexer(valid_cells), gene_idx]
+            expression_values = adata.X[
+                adata.obs_names.get_indexer(valid_cells), gene_idx
+            ]
+            if issparse(expression_values) or hasattr(expression_values, "toarray"):
+                expression_values = expression_values.toarray()
+            expression_values = np.asarray(expression_values).flatten()
 
             color_data = pd.Series(expression_values, index=valid_cells, name=color_key)
             temp_gdf = gpd.GeoDataFrame({color_key: color_data}, geometry=temp_geometries, index=valid_cells)


### PR DESCRIPTION
## Summary
Three fixes that together make `ov.read(spatial.h5ad, backend='rust')` usable on real Visium / Xenium data.

### 1. Spatial viz: `spatialseg` / `nanostring` gene path fed sparse into `pd.Series`
`_spatialseg.py:476` and the two counterparts in `_nanostring.py` gated densification on `hasattr(adata.X, 'toarray')`. For `AnnDataOOM` the top-level `BackedArray` has no `toarray`, but slicing it (`BackedArray[indices, j]`) returns a scipy CSR when the underlying matrix is sparse. The else branch then fed sparse into `pd.Series(...)` and raised `TypeError: sparse array length is ambiguous; use getnnz() or shape[0]`. Fix: check the *slice result* (`issparse` / `hasattr`) so numpy, scipy sparse, BackedArray-over-sparse, and BackedArray-over-dense all take the right path.

### 2. `ov.read(..., backend='rust')` panicked with a cryptic Rust trace on unsorted CSR
anndata-rs requires CSR/CSC minor indices to be monotonically increasing within each lane, and many spatial h5ad files in the wild don't satisfy this. Pre-flight in `_read_h5ad_rust` via `h5py`, sampling up to 256 lanes, and raise a plain `ValueError` with a copy-pasteable fix recipe (`X.sort_indices()` or `ov.utils.convert_adata_for_rust`) before the Rust call.

### 3. `ov.utils.convert_adata_for_rust` no longer requires `snapatac2`, and preserves `obsm/varm/uns`
`convert_adata_for_rust` used `snap.AnnData(filename=...)` purely to write a `.h5ad` — redundant now that the Rust backend goes through `anndataoom` / `anndata-rs`. Rewrote to use plain `anndata.AnnData` + `.write_h5ad`. Also fixed a latent bug: the old path silently dropped `obsm`, `varm` and `uns`, which for spatial data meant `obsm['spatial']` and `uns['spatial']` never survived the conversion. Those are now preserved, along with `obsp`, `varp` and `layers`.

## Changes
- `omicverse/pl/_spatialseg.py`: switch gene-path densification guard to check the slice result.
- `omicverse/pl/_nanostring.py`: same fix in `nanostring` and `nanostringseg` gene paths.
- `omicverse/io/single/_read.py`: add `_h5ad_csr_sorted` pre-flight and clear `ValueError`.
- `omicverse/io/single/_rust.py`: drop `snapatac2` import, write via `anndata.write_h5ad`, preserve `obsm/varm/uns`. `close_file` kwarg is kept as a no-op for back-compat.

## Test plan
Verified on a real Visium h5ad loaded via `ov.read(..., backend='rust')`:
- [x] `ov.pl.spatial(a, color=gene | obs_col)`
- [x] `ov.pl.embedding(a, basis='spatial', ...)`
- [x] `ov.pl.spatialseg(a, color=gene | obs_col)` — previously errored with `sparse array length is ambiguous`
- [x] Unsorted CSR h5ad → clear Python `ValueError` instead of Rust panic
- [x] Sorted CSR h5ad still passes pre-flight (sub-ms)
- [x] `convert_adata_for_rust(a, 'fixed.h5ad')` succeeds with no snapatac2 installed
- [x] `obsm['spatial']` values round-trip bit-identically through the convert → rust-read cycle
- [x] Plain in-memory `AnnData` + `spatialseg(gene)` still works (regression guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)