### PR TITLE
fix(docs): Sphinx stub for failed lazy-load imports

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -40,12 +40,14 @@ jobs:
           pip install -r omicverse_guide/requirements.txt
 
       # ── 5. Build Sphinx HTML ───────────────────────────────────────────
+      # -T: show full traceback on extension errors so failures are debuggable
+      #     without a second manual run.
       - name: Build docs
         run: |
           sphinx-build -b html \
             omicverse_guide/docs \
             omicverse_guide/docs/_build/html \
-            -q
+            -q -T
 
       # ── 6. Configure git identity for gh-deploy push ──────────────────
       - name: Configure git

--- a/omicverse/__init__.py
+++ b/omicverse/__init__.py
@@ -222,6 +222,19 @@ def __getattr__(name):
                 return module
             except ImportError as e:
                 _lazy_modules.pop(name, None)
+                # Under Sphinx builds, return an empty stub module instead of
+                # raising, so autosummary/autodoc can still introspect the
+                # name without the entire build aborting when an optional
+                # heavy dependency (marsilea, torch, tangram, …) is absent.
+                if "sphinx" in sys.modules:
+                    import types
+                    stub = types.ModuleType(f"omicverse.{name}")
+                    stub.__doc__ = (
+                        f"omicverse.{name} could not be imported in the docs "
+                        f"environment: {e}."
+                    )
+                    _lazy_modules[name] = stub
+                    return stub
                 raise AttributeError(
                     f"Failed to import omicverse.{name}: {e}. "
                     f"A required dependency may not be installed."


### PR DESCRIPTION
## Summary

- Makes `omicverse.__getattr__` return an empty `types.ModuleType` stub (instead of raising `AttributeError`) when a lazy-loaded submodule can't be imported *and* Sphinx is running — so the docs build can't be taken down by a single missing optional dep.
- Adds `-T` to the `sphinx-build` command in the deploy workflow so future failures surface a real traceback instead of the opaque `ExtensionError` summary.

## Why this broke

`ov.bulk` / `ov.bulk2single` / `ov.space` etc. are lazy-loaded in `omicverse/__init__.py`. When their deps (marsilea, tangram, …) are missing the loader was raising `AttributeError`. Sphinx's `autosummary.import_by_name` raises `ImportExceptionGroup` on top of that, then `import_ivar_by_name` is called as a fallback and re-raises — which isn't caught, so the whole `builder-inited` event aborts with the misleading `issubclass() arg 2 must be a class, a tuple of classes, or a union` error at the top level.

With the stub, autosummary just logs "failed to import omicverse.bulk.Deconvolution" for the missing name (same treatment as every other `__all__`-unresolved symbol) and the build continues. Reproduced locally with Python 3.11 + sphinx 8.1.3: red → green, 429 warnings, clean HTML output.

## Test plan

- [x] Local reproduction in a Python 3.11 env matching CI: `sphinx-build` goes from `ExtensionError` at `builder-inited` → `build succeeded` with warnings only.
- [x] Non-Sphinx callers unchanged: `python -c "import omicverse; omicverse.bulk"` still works when deps are installed, still raises the actionable `AttributeError` when they aren't.
- [ ] CI pass on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)