### PR TITLE
fix(tests): lazy ov.micro, add ete3/skbio test extras, pre-CLI validation

### DIFF
--- a/omicverse/alignment/fasttree.py
+++ b/omicverse/alignment/fasttree.py
@@ -43,6 +43,9 @@ def fasttree(
     overwrite: bool = False,
 ) -> Dict[str, str]:
     """Run FastTree to infer a phylogenetic tree."""
+    if nt and model not in ("gtr", "jc"):
+        raise ValueError(f"Unknown nt model {model!r}; use 'gtr' or 'jc'.")
+
     out_root = ensure_dir(output_dir)
     tree = Path(out_root) / output_name
     log = Path(out_root) / "fasttree.log"
@@ -61,8 +64,6 @@ def fasttree(
         cmd.append("-nt")
         if model == "gtr":
             cmd.append("-gtr")
-        elif model != "jc":
-            raise ValueError(f"Unknown nt model {model!r}; use 'gtr' or 'jc'.")
     if gamma:
         cmd.append("-gamma")
     if extra_args:

--- a/omicverse/alignment/mafft.py
+++ b/omicverse/alignment/mafft.py
@@ -70,16 +70,6 @@ def mafft(
     -------
     ``{"input": …, "aligned": …, "log": …}`` — absolute paths.
     """
-    out_root = ensure_dir(output_dir)
-    aligned = Path(out_root) / output_name
-    log = Path(out_root) / "mafft.log"
-
-    if not overwrite and aligned.exists() and aligned.stat().st_size > 0:
-        return {"input": str(input_fasta), "aligned": str(aligned), "log": str(log)}
-
-    mafft_bin = resolve_executable("mafft", mafft_path, auto_install=auto_install)
-    env = build_env(extra_paths=[str(Path(mafft_bin).parent)])
-
     mode_flags = {
         "auto":    ["--auto"],
         "fftns":   ["--retree", "2"],
@@ -92,6 +82,16 @@ def mafft(
         raise ValueError(
             f"Unknown MAFFT mode {mode!r}; use one of {sorted(mode_flags)}"
         )
+
+    out_root = ensure_dir(output_dir)
+    aligned = Path(out_root) / output_name
+    log = Path(out_root) / "mafft.log"
+
+    if not overwrite and aligned.exists() and aligned.stat().st_size > 0:
+        return {"input": str(input_fasta), "aligned": str(aligned), "log": str(log)}
+
+    mafft_bin = resolve_executable("mafft", mafft_path, auto_install=auto_install)
+    env = build_env(extra_paths=[str(Path(mafft_bin).parent)])
     cmd = [mafft_bin, "--thread", str(threads), *mode_flags[mode]]
     if extra_args:
         cmd.extend(str(a) for a in extra_args)

--- a/omicverse/micro/__init__.py
+++ b/omicverse/micro/__init__.py
@@ -19,6 +19,7 @@ rarefy                 : Subsample counts to a common depth
 filter_by_prevalence   : Drop rare taxa below a prevalence threshold
 collapse_taxa          : Collapse ASV counts to a given rank (e.g. genus)
 clr / ilr              : Centred / isometric log-ratio transforms
+attach_tree            : Attach a newick phylogenetic tree to adata.uns
 
 Examples
 --------
@@ -32,29 +33,46 @@ Examples
 >>> # differential abundance at genus level
 >>> da    = ov.micro.DA(adata).wilcoxon(group_key='group', rank='genus')
 """
+from __future__ import annotations
 
-from ._diversity import Alpha, Beta, ALPHA_METRICS, BETA_METRICS
-from ._ord import Ordinate
-from ._da import DA
-from ._pp import rarefy, filter_by_prevalence, collapse_taxa, clr, ilr
-from ._phylo import attach_tree
+import importlib
 
-__all__ = [
+# Map each public name → (relative submodule, attribute). Imports are
+# deferred until the name is first accessed, so environments missing
+# optional extras (scikit-bio, ete3, pydeseq2, …) can still
+# ``import omicverse.micro`` without failing.
+_LAZY_ATTRS: dict[str, tuple[str, str]] = {
     # diversity
-    "Alpha",
-    "Beta",
-    "ALPHA_METRICS",
-    "BETA_METRICS",
+    "Alpha":           ("._diversity", "Alpha"),
+    "Beta":            ("._diversity", "Beta"),
+    "ALPHA_METRICS":   ("._diversity", "ALPHA_METRICS"),
+    "BETA_METRICS":    ("._diversity", "BETA_METRICS"),
     # ordination
-    "Ordinate",
+    "Ordinate":        ("._ord", "Ordinate"),
     # differential abundance
-    "DA",
+    "DA":              ("._da", "DA"),
     # preprocessing
-    "rarefy",
-    "filter_by_prevalence",
-    "collapse_taxa",
-    "clr",
-    "ilr",
+    "rarefy":               ("._pp", "rarefy"),
+    "filter_by_prevalence": ("._pp", "filter_by_prevalence"),
+    "collapse_taxa":        ("._pp", "collapse_taxa"),
+    "clr":                  ("._pp", "clr"),
+    "ilr":                  ("._pp", "ilr"),
     # phylogeny
-    "attach_tree",
-]
+    "attach_tree":          ("._phylo", "attach_tree"),
+}
+
+__all__ = sorted(_LAZY_ATTRS)
+
+
+def __getattr__(name: str):
+    if name in _LAZY_ATTRS:
+        module_path, attr_name = _LAZY_ATTRS[name]
+        module = importlib.import_module(module_path, package=__name__)
+        value = getattr(module, attr_name)
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return sorted({*globals(), *_LAZY_ATTRS})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,7 +170,11 @@ tests = [
   "pillow>=9.0",
   "nbformat>=5.0",
   "httpx[socks]",
-  
+  # ov.micro test dependencies — scikit-bio powers Alpha/Beta/Ordinate,
+  # ete3 powers attach_tree, pydeseq2 is the DESeq2 backend for DA.
+  "scikit-bio>=0.6",
+  "ete3",
+  "pydeseq2>=0.4.1",
 ]
 
 mcp = [

--- a/tests/micro/test_phylo.py
+++ b/tests/micro/test_phylo.py
@@ -8,6 +8,21 @@ import pandas as pd
 import pytest
 
 
+def _ete3_available() -> bool:
+    try:
+        import ete3  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+requires_ete3 = pytest.mark.skipif(
+    not _ete3_available(),
+    reason="ete3 not installed — install the [tests] extra "
+           "(`pip install -e '.[tests]'`) to run attach_tree tests.",
+)
+
+
 def _mini_adata(var_ids):
     import anndata as ad
     from scipy import sparse
@@ -19,6 +34,7 @@ def _mini_adata(var_ids):
     )
 
 
+@requires_ete3
 def test_attach_tree_exact_tip_set():
     from omicverse.micro import attach_tree
     adata = _mini_adata(["A", "B", "C"])
@@ -28,6 +44,7 @@ def test_attach_tree_exact_tip_set():
     assert adata.uns["micro"]["tree_tips"] == 3
 
 
+@requires_ete3
 def test_attach_tree_prunes_extra_tips():
     """Tips that aren't in var_names get dropped when prune=True."""
     from omicverse.micro import attach_tree
@@ -37,6 +54,7 @@ def test_attach_tree_prunes_extra_tips():
     assert adata.uns["micro"]["tree_tips"] == 2
 
 
+@requires_ete3
 def test_attach_tree_warns_on_missing_asv():
     from omicverse.micro import attach_tree
     adata = _mini_adata(["A", "B", "C", "D"])
@@ -49,6 +67,7 @@ def test_attach_tree_warns_on_missing_asv():
     assert any("no matching tip" in m for m in msgs)
 
 
+@requires_ete3
 def test_attach_tree_strict_raises_on_missing():
     from omicverse.micro import attach_tree
     adata = _mini_adata(["A", "B", "C", "D"])
@@ -66,6 +85,7 @@ def test_attach_tree_xor_newick_tree_path():
         attach_tree(adata, newick="(A:0.1);", tree_path="whatever.nwk")
 
 
+@requires_ete3
 def test_attach_tree_rejects_disjoint_tree():
     from omicverse.micro import attach_tree
     adata = _mini_adata(["X", "Y"])


### PR DESCRIPTION
## Summary

Unblock the pytest matrix (py3.10 / 3.11 / 3.12) on master. Three independent fixes:

1. **`omicverse/micro/__init__.py` is now lazy (PEP 562 `__getattr__`).** Importing `ov.micro` no longer eagerly pulls in `_diversity.py`/`_phylo.py`/`_da.py`; each class/function is only imported when first accessed. Optional deps (scikit-bio, ete3, pydeseq2) are now only required if you actually *call* the corresponding API.
2. **`pyproject.toml` `[tests]` extra now pins `scikit-bio>=0.6`, `ete3`, `pydeseq2>=0.4.1`.** Same pattern as the telegram/discord deps already there — `uv pip install -e '.[tests,mcp]'` will install everything the ov.micro / ov.alignment.phylogeny tests need.
3. **MAFFT / FastTree mode validation moved above `resolve_executable`.** `test_mafft_mode_validation` expects `ValueError("MAFFT mode")` for a bogus mode — but the wrapper was calling `resolve_executable('mafft', …)` first, so CI without mafft installed got `FileNotFoundError` instead. Same fix for `fasttree`'s model-validation test.

Defensive: `tests/micro/test_phylo.py` now skips via `requires_ete3` when ete3 is absent (mirrors `requires_skbio` in test_micro.py) so a future missing-extra scenario degrades to *skip* rather than *fail*.

## Before → after

- Previous master: `7 failed` — 5 × `ImportError: … requires ete3`, 2 × `FileNotFoundError: 'mafft' / 'FastTree' not found on PATH`.
- Local reproduction with `pytest tests/micro/ tests/alignment/test_phylogeny.py`: `24 passed, 0 failed, 61 warnings`.

## Test plan

- [x] `pytest tests/micro/ tests/alignment/test_phylogeny.py` locally → green.
- [x] `requires_ete3` skipif still triggers when ete3 is genuinely missing (verified by uninstalling ete3 in a scratch env).
- [ ] CI `py310 | py311 | py312` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)