### PR TITLE
fix(docs): widen lazy __getattr__ + pin scipy<1.16

### DIFF
--- a/omicverse/__init__.py
+++ b/omicverse/__init__.py
@@ -220,7 +220,14 @@ def __getattr__(name):
                 module = importlib.import_module(f'.{name}', package='omicverse')
                 _lazy_modules[name] = module
                 return module
-            except ImportError as e:
+            except Exception as e:
+                # Catch Exception (not just ImportError) because transitive
+                # imports can fail with TypeError, OSError, ValueError, etc.
+                # The scipy 1.17.x _new_distributions module, for instance,
+                # runs doc-generation at import time and raises TypeError
+                # when torch isn't installed — that fires when sklearn pulls
+                # scipy.stats in during the docs build, and was masking this
+                # helper's sphinx stub.
                 _lazy_modules.pop(name, None)
                 # Under Sphinx builds, return an empty stub module instead of
                 # raising, so autosummary/autodoc can still introspect the
@@ -231,12 +238,13 @@ def __getattr__(name):
                     stub = types.ModuleType(f"omicverse.{name}")
                     stub.__doc__ = (
                         f"omicverse.{name} could not be imported in the docs "
-                        f"environment: {e}."
+                        f"environment: {type(e).__name__}: {e}."
                     )
                     _lazy_modules[name] = stub
                     return stub
                 raise AttributeError(
-                    f"Failed to import omicverse.{name}: {e}. "
+                    f"Failed to import omicverse.{name}: "
+                    f"{type(e).__name__}: {e}. "
                     f"A required dependency may not be installed."
                 ) from e
 


### PR DESCRIPTION
## The real root cause

After PR #643 pinned sphinx to 7.x, deploy-docs produced a readable traceback for the first time:

```
  File "scipy/stats/_new_distributions.py", line 540, in <module>
    _module[dist_name].__doc__ = _combine_docs(_module[dist_name])
  ...
  File "scipy/_lib/array_api_compat/common/_helpers.py", line 69, in _issubclass_fast
    return issubclass(cls, parent_cls)
TypeError: issubclass() arg 2 must be a class, a tuple of classes, or a union
```

**Not sphinx. Not omicverse. scipy.** scipy 1.16 introduced an experimental `_new_distributions` module that runs docstring generation **at import time**. `_combine_docs → _generate_example → _draw → xp_promote → is_torch_array → _issubclass_fast` ends in `issubclass(cls, "torch.Tensor stub")` when torch isn't installed on the runner.

Any autodoc pass over `omicverse.bulk` triggers the sklearn → `scipy.stats` import chain, so scipy's TypeError hit our `__getattr__` lazy loader, which only caught `ImportError`, letting the TypeError escape and crash autosummary.

## Fixes (defense in depth)

1. **`omicverse/__init__.py`** — widen the lazy-module fallback `except ImportError` to `except Exception`. The stub-module escape hatch was always meant to catch *any* import-time failure under sphinx; the narrow clause just missed non-ImportError exceptions raised from transitive imports.

2. **`omicverse_guide/requirements.txt`** — pin `scipy>=1.11,<1.16` so the docs environment never imports the broken `_new_distributions` module in the first place. Paired with the above, this is belt-and-suspenders.

Submodule bumped to the matching scipy pin.

## Why this wasn't caught earlier

- scipy 1.17 was only released recently; prior docs builds resolved to scipy 1.15 which is fine.
- The `__getattr__` sphinx-stub branch was written with `ImportError` as the only expected failure mode; a transitive `TypeError` was unanticipated.

## Test plan

- [ ] deploy-docs workflow on merge — verifies the build goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
