### PR TITLE
feat(report): track ov.single.batch_correction + Annotation + AnnotationRef

### DIFF
--- a/omicverse/report/_provenance.py
+++ b/omicverse/report/_provenance.py
@@ -173,14 +173,15 @@ def note(**fields) -> None:
     entry.update(fields)
 
 
-def tracked(name: str, function: str):
+def tracked(name: str, function: str, *, adata_attr: Optional[str] = None):
     """Decorator for dispatchers that should appear in the pipeline report.
 
     Responsibilities covered here so the body doesn't have to:
 
     - Wall-clock timing (``duration_s``).
-    - kwargs capture into ``params`` (positional args beyond ``adata``
-      are bound via :func:`inspect.signature` so they show up by name).
+    - kwargs capture into ``params`` (positional args beyond ``adata`` /
+      ``self`` are bound via :func:`inspect.signature` so they show up
+      by name).
     - A thread-local stack that makes nested ``@tracked`` calls silent —
       only the outermost invocation writes a provenance entry. This is
       how e.g. ``ov.pp.qc`` internally invoking ``ov.pp.scrublet`` still
@@ -189,11 +190,18 @@ def tracked(name: str, function: str):
       staging entry is discarded.
 
     The body uses :func:`note` to populate ``backend`` / ``viz`` (and
-    anything else branch-dependent). Static defaults can be given via
-    this decorator if you prefer::
+    anything else branch-dependent).
+
+    Free functions::
 
         @tracked('scale', 'ov.pp.scale')
         def scale(adata, ...): ...
+
+    Class methods — pull adata from ``self.<adata_attr>``::
+
+        @tracked('Annotation.annotate', 'ov.single.Annotation.annotate',
+                 adata_attr='adata')
+        def annotate(self, method='celltypist', ...): ...
     """
 
     def decorator(fn):
@@ -212,9 +220,14 @@ def tracked(name: str, function: str):
                 n: v for n, v in zip(param_names, args[1:])
             }
             captured = {**positional, **kwargs}
-            adata_in = args[0] if args else kwargs.get("adata")
-            # Cell count BEFORE the step runs — lets the report summarise
-            # "cells X → Y" for filtering / QC steps.
+            # Resolve the AnnData to attach the entry to:
+            # - free function: args[0] (or `adata=` kwarg)
+            # - class method: getattr(self, adata_attr)
+            if adata_attr is None:
+                adata_in = args[0] if args else kwargs.get("adata")
+            else:
+                self_obj = args[0] if args else None
+                adata_in = getattr(self_obj, adata_attr, None)
             n_obs_before = getattr(adata_in, "n_obs", None)
             stack = _stack()
             stack.append({
@@ -234,9 +247,13 @@ def tracked(name: str, function: str):
             if stack:
                 # Nested call — the outermost @tracked owns the record.
                 return result
-            # Prefer the returned AnnData if the dispatcher uses copy-semantics.
-            target = (result if (result is not None and hasattr(result, "uns"))
-                      else adata_in)
+            # For free functions with copy-semantics, prefer the returned
+            # AnnData. For methods, the target is always the bound adata
+            # (returns are typically the model object, not the adata).
+            if adata_attr is None and result is not None and hasattr(result, "uns"):
+                target = result
+            else:
+                target = adata_in
             record_step(
                 target, entry["name"],
                 function=entry["function"],

--- a/omicverse/single/_annotation.py
+++ b/omicverse/single/_annotation.py
@@ -14,6 +14,7 @@ import scanpy as sc
 
 from ..datasets import download_data
 from .._registry import register_function
+from ..report._provenance import tracked, note
 
 
 _PROMPT_DESCRIPTION_LIMIT = 400
@@ -373,6 +374,8 @@ class Annotation(object):
         self.last_reference_llm_raw: Optional[str] = None
         self.last_reference_prompt: Optional[str] = None
 
+    @tracked("Annotation.annotate", "ov.single.Annotation.annotate",
+             adata_attr="adata")
     def annotate(
         self,
         method='celltypist',
@@ -402,6 +405,17 @@ class Annotation(object):
         >>> anno.annotate(method='celltypist')
         >>> anno.annotate(method='gpt4celltype', cluster_key='leiden')
         """
+        # Predictions land deterministically at obs['<method>_prediction'].
+        # Declare the report's viz/backend up front; @tracked discards the
+        # entry on exception so failed calls never leak.
+        _pred_col = f"{method}_prediction"
+        note(backend=f"omicverse · method={method}",
+             viz=([{"function": "ov.pl.embedding",
+                     "kwargs": {"basis": "X_umap",
+                                "color": _pred_col,
+                                "frameon": "small"}}]
+                   if "X_umap" in self.adata.obsm else []))
+
         if method=='celltypist':
             import celltypist
             predictions = celltypist.annotate(

--- a/omicverse/single/_annotation_ref.py
+++ b/omicverse/single/_annotation_ref.py
@@ -4,6 +4,7 @@ import anndata as ad
 from anndata import AnnData
 import scanpy as sc
 from .._registry import register_function
+from ..report._provenance import tracked, note
 
 
 @register_function(
@@ -117,6 +118,8 @@ class AnnotationRef(object):
         scale(self.adata_new)
         pca(self.adata_new,layer='scaled',n_pcs=50)
 
+    @tracked("AnnotationRef.train", "ov.single.AnnotationRef.train",
+             adata_attr="adata_query")
     def train(
         self,method='harmony',
         **kwargs
@@ -140,6 +143,21 @@ class AnnotationRef(object):
         --------
         >>> ar.train(method='harmony')
         """
+        # train() builds an integrated embedding under a fixed obsm key
+        # (X_<method>_anno on the query). Declare viz/backend up front;
+        # nested batch_correction() is silenced by the @tracked stack.
+        _basis_for_train = {
+            "harmony":   "X_pca_harmony_anno",
+            "scVI":      "X_scVI_anno",
+            "scanorama": "X_scanorama_anno",
+        }.get(method)
+        if _basis_for_train is not None:
+            note(backend=f"AnnotationRef · {method}",
+                 viz=[{"function": "ov.pl.embedding",
+                        "kwargs": {"basis": _basis_for_train,
+                                    "color": "integrate_batch",
+                                    "frameon": "small"}}])
+
         from ._batch import batch_correction
         if method=='harmony':
             batch_correction(self.adata_new,batch_key='integrate_batch',methods='harmony',**kwargs)
@@ -160,6 +178,8 @@ class AnnotationRef(object):
             raise ValueError(f"Unsupported method: {method}")
         return self.adata_query
 
+    @tracked("AnnotationRef.predict", "ov.single.AnnotationRef.predict",
+             adata_attr="adata_query")
     def predict(self,method='harmony',n_neighbors=15,pred_key=None,uncert_key=None):
         """
         Transfer reference labels to query cells using weighted kNN.
@@ -184,6 +204,20 @@ class AnnotationRef(object):
         --------
         >>> adata_q = ar.predict(method='harmony', n_neighbors=15)
         """
+        # Resolve the obs columns the predict will write so the report's
+        # viz spec can be declared before the actual transfer runs.
+        _pred = pred_key or {
+            "harmony":   "harmony_prediction",
+            "scVI":      "scVI_prediction",
+            "scanorama": "scanorama_prediction",
+        }.get(method, f"{method}_prediction")
+        note(backend=f"AnnotationRef · method={method}",
+             viz=([{"function": "ov.pl.embedding",
+                     "kwargs": {"basis": "X_umap",
+                                 "color": _pred,
+                                 "frameon": "small"}}]
+                   if "X_umap" in self.adata_query.obsm else []))
+
         if method=='harmony':
             if pred_key is None:
                 pred_key='harmony_prediction'

--- a/omicverse/single/_batch.py
+++ b/omicverse/single/_batch.py
@@ -5,6 +5,20 @@ import anndata
 from .._settings import add_reference,settings
 from .._registry import register_function
 from .._monitor import monitor
+from ..report._provenance import tracked, note
+
+
+# Per-method obsm key the integrated embedding lands in. Used by the
+# tracked() viz spec so the report's diagnostic plot is colored by
+# batch_key on the embedding the user just produced.
+_BATCH_OBSM = {
+    "harmony":   "X_pca_harmony",
+    "combat":    "X_combat",
+    "scanorama": "X_scanorama",
+    "scVI":      "X_scVI",
+    "CellANOVA": "X_cellanova",
+    "Concord":   "X_concord",
+}
 
 @monitor
 @register_function(
@@ -39,6 +53,7 @@ from .._monitor import monitor
     ],
     related=["pp.preprocess", "utils.mde", "utils.embedding"]
 )
+@tracked("batch_correction", "ov.single.batch_correction")
 def batch_correction(adata:anndata.AnnData,batch_key:str,
                      use_rep='scaled|original|X_pca',
                      methods:str='harmony',n_pcs:int=50,**kwargs)->anndata.AnnData:
@@ -70,6 +85,18 @@ def batch_correction(adata:anndata.AnnData,batch_key:str,
         and Concord object for ``'Concord'``. The integrated embeddings are
         written to ``adata.obsm``.
     """
+
+    # Declare the report's viz/backend up front from the static
+    # methods → obsm-key mapping. @tracked discards the entry on
+    # exception, so a method that fails mid-way never leaks a phantom
+    # entry pointing at an obsm key that was never written.
+    _basis = _BATCH_OBSM.get(methods)
+    if _basis is not None:
+        note(backend=f"omicverse · {methods}",
+             viz=[{"function": "ov.pl.embedding",
+                    "kwargs": {"basis": _basis,
+                                "color": batch_key,
+                                "frameon": "small"}}])
 
     from ..pp._qc import _is_oom
     _oom = _is_oom(adata)

--- a/tests/report/test_provenance.py
+++ b/tests/report/test_provenance.py
@@ -215,6 +215,83 @@ def test_tracked_captures_n_obs_change():
     assert prov[0]["n_obs_after"] == 8
 
 
+# ─────────────── @tracked on class methods (adata_attr) ──────────────────────
+
+
+def test_tracked_method_pulls_adata_from_self():
+    """``@tracked(adata_attr='adata')`` records on the AnnData held by
+    ``self``, not on ``args[0]`` (which is ``self`` itself)."""
+
+    class Annotator:
+        def __init__(self, adata):
+            self.adata = adata
+
+        @tracked("Annotator.annotate", "ov.x.Annotator.annotate",
+                 adata_attr="adata")
+        def annotate(self, *, method="celltypist"):
+            note(backend=f"omicverse · method={method}")
+
+    adata = _toy_adata()
+    Annotator(adata).annotate(method="celltypist")
+    prov = get_provenance(adata)
+    assert len(prov) == 1
+    e = prov[0]
+    assert e["name"] == "Annotator.annotate"
+    assert e["function"] == "ov.x.Annotator.annotate"
+    assert e["params"] == {"method": "celltypist"}
+    assert e["backend"] == "omicverse · method=celltypist"
+    assert e["n_obs_before"] == adata.n_obs
+    assert e["n_obs_after"] == adata.n_obs
+
+
+def test_tracked_method_uses_custom_adata_attr():
+    """``adata_attr`` can name any attribute (e.g. ``adata_query`` for
+    reference-based annotators)."""
+
+    class RefAnnotator:
+        def __init__(self, adata_query, adata_ref):
+            self.adata_query = adata_query
+            self.adata_ref = adata_ref
+
+        @tracked("RefAnnotator.predict", "ov.x.RefAnnotator.predict",
+                 adata_attr="adata_query")
+        def predict(self, *, method="harmony"):
+            note(backend=f"RefAnnotator · {method}")
+
+    query = _toy_adata()
+    reference = _toy_adata()
+    RefAnnotator(query, reference).predict(method="harmony")
+    # Entry lands on the query, not the reference.
+    assert len(get_provenance(query)) == 1
+    assert get_provenance(reference) == []
+
+
+def test_tracked_method_nested_inside_tracked_function_silent():
+    """A tracked free function calling a tracked class method (or vice
+    versa) still produces exactly one entry — outermost wins regardless
+    of which kind of dispatcher is on the stack."""
+
+    class _Inner:
+        def __init__(self, adata):
+            self.adata = adata
+
+        @tracked("inner.run", "ov.x.inner.run", adata_attr="adata")
+        def run(self):
+            note(backend="inner")
+
+    @tracked("outer", "ov.x.outer")
+    def outer(adata):
+        _Inner(adata).run()  # nested tracked method
+        note(backend="outer")
+
+    adata = _toy_adata()
+    outer(adata)
+    prov = get_provenance(adata)
+    assert len(prov) == 1
+    assert prov[0]["name"] == "outer"
+    assert prov[0]["backend"] == "outer"
+
+
 # ─────────────────────────── HTML rendering ───────────────────────────────────
 
 


### PR DESCRIPTION
Follow-up to #659 (which landed the report infrastructure with `@tracked` + `note()`). Extends coverage to three downstream `ov.single` APIs that take a meaningful runtime branch via a `method=` selector.

## What's tracked now

- **`ov.single.batch_correction(methods=...)`** — 6 backends (harmony / combat / scanorama / scVI / CellANOVA / Concord). Records the integrated-embedding obsm key as a viz spec colored by `batch_key`.
- **`ov.single.Annotation.annotate(method=...)`** — ref-free annotator, 6 method branches. Predictions land deterministically at `obs['<method>_prediction']`, so the embedding viz is derivable from the `method` param.
- **`ov.single.AnnotationRef.train(method=...)` and `.predict(method=...)`** — ref-based label transfer; two separate entries since users call them separately.

## Decorator change

`@tracked` gained an optional `adata_attr=` parameter so it works on class methods (where `args[0]` is `self`, not the AnnData):

```python
@tracked('Annotation.annotate', 'ov.single.Annotation.annotate',
         adata_attr='adata')
def annotate(self, *, method='celltypist', **kwargs):
    note(backend=f'omicverse · method={method}',
         viz=[{'function': 'ov.pl.embedding',
                'kwargs': {'basis': 'X_umap',
                           'color': f'{method}_prediction'}}])
```

When `adata_attr` is given the decorator pulls the AnnData from `getattr(self, adata_attr)` for both `n_obs_before` capture and the final `record_step`. Free-function behavior is unchanged.

## Submodule bump

Picks up `omicverse-tutorials#19` — the `Developer_guild.md` subsection on class-method usage of `@tracked`.

## Test plan

- [x] `tests/report/test_provenance.py` (16/16) — adds 3 new cases:
  - `test_tracked_method_pulls_adata_from_self` — basic class-method path
  - `test_tracked_method_uses_custom_adata_attr` — verifies entry lands on `adata_query`, not `adata_ref`
  - `test_tracked_method_nested_inside_tracked_function_silent` — mixed free-function + class-method nesting still yields one entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)