### PR TITLE
feat(micro): cross-cohort 16S meta-analysis (combine_studies + meta_da) + tutorial

### DIFF
--- a/omicverse/micro/__init__.py
+++ b/omicverse/micro/__init__.py
@@ -59,6 +59,9 @@ _LAZY_ATTRS: dict[str, tuple[str, str]] = {
     "ilr":                  ("._pp", "ilr"),
     # phylogeny
     "attach_tree":          ("._phylo", "attach_tree"),
+    # meta-analysis
+    "combine_studies":      ("._meta", "combine_studies"),
+    "meta_da":              ("._meta", "meta_da"),
 }
 
 __all__ = sorted(_LAZY_ATTRS)

--- a/omicverse/micro/_meta.py
+++ b/omicverse/micro/_meta.py
@@ -1,0 +1,382 @@
+"""Multi-cohort 16S meta-analysis utilities.
+
+Two APIs:
+
+- :func:`combine_studies` — stitch a list of AnnDatas (one per study) into a
+  single AnnData with a shared feature axis, an ``obs['study']`` label, and
+  zero-filled cells for taxa absent from a given study. This is the
+  "mega-analysis" input — run regular DA on it with ``study`` as a batch
+  covariate.
+
+- :func:`meta_da` — run per-study DA (``wilcoxon`` / ``deseq2`` / ``ancombc``)
+  first, then combine the per-study effect estimates by inverse-variance
+  weighted random-effects meta-analysis (DerSimonian-Laird). Produces a
+  single-table verdict with combined log-fold-change, z-statistic, p,
+  Benjamini-Hochberg FDR, plus Cochran's Q / I² heterogeneity diagnostics.
+
+Why both? Nearing *et al.* 2022 (*Nat. Commun.* 13, 342) showed that
+*single-cohort* 16S DA methods disagree noticeably across datasets;
+pooling effect sizes from ≥3 independent cohorts is the pragmatic cure
+and is the standard operating procedure for published 16S meta-analyses
+(Thomas *et al.* 2019, Wirbel *et al.* 2019).
+"""
+from __future__ import annotations
+
+from typing import Dict, List, Optional, Sequence, Union
+
+import numpy as np
+import pandas as pd
+from scipy import sparse
+
+try:
+    import anndata as ad
+except ImportError as exc:  # pragma: no cover
+    raise ImportError("anndata is required for ov.micro._meta") from exc
+
+from .._registry import register_function
+from ._da import DA, _bh_fdr
+from ._pp import collapse_taxa
+
+
+# ---------------------------------------------------------------------------
+# combine_studies
+# ---------------------------------------------------------------------------
+
+
+@register_function(
+    aliases=["combine_studies", "concat_studies", "meta_combine"],
+    category="microbiome",
+    description="Concatenate a list of 16S AnnDatas into one cross-cohort table with a shared feature axis (union of taxa), an obs['study'] label, and zero-fill for absent taxa.",
+    examples=[
+        "adata_all = ov.micro.combine_studies([adata_A, adata_B, adata_C], study_names=['A','B','C'], rank='genus')",
+    ],
+    related=["micro.meta_da", "micro.collapse_taxa"],
+)
+def combine_studies(
+    studies: Sequence["ad.AnnData"],
+    study_names: Optional[Sequence[str]] = None,
+    rank: Optional[str] = "genus",
+    study_key: str = "study",
+    min_prevalence: float = 0.0,
+) -> "ad.AnnData":
+    """Stitch a list of per-study AnnDatas into a single cross-cohort table.
+
+    Parameters
+    ----------
+    studies
+        List of per-study AnnData objects (samples × ASVs or pre-collapsed
+        genera). Each must already carry taxonomy columns in ``var`` if a
+        ``rank`` other than None is requested.
+    study_names
+        Optional list aligned with ``studies`` to label each cohort. Default:
+        ``['study_0', 'study_1', …]``.
+    rank
+        Collapse each study to this taxonomic rank before concatenating
+        (so feature labels align across studies). Pass ``None`` to skip
+        collapsing — only sensible when all studies already share the
+        same ASV ids.
+    study_key
+        Column name to write the per-sample study label into.
+    min_prevalence
+        Optional per-study prevalence filter applied *before* union. A
+        taxon has to appear in >= this fraction of samples in at least
+        one study to survive.
+
+    Returns
+    -------
+    AnnData
+        Shape ``(Σn_samples, n_union_features)``. The ``obs`` carries the
+        original per-study metadata (inner join on columns shared by all
+        studies) plus ``obs[study_key]``. ``var`` carries the union of
+        feature names (no taxonomy column — the rank collapse already
+        flattened that). ``X`` is a sparse CSR of ``int64`` counts;
+        features absent from a given study are zero.
+    """
+    if not studies:
+        raise ValueError("`studies` is empty.")
+
+    if study_names is None:
+        study_names = [f"study_{i}" for i in range(len(studies))]
+    if len(study_names) != len(studies):
+        raise ValueError(
+            f"study_names length {len(study_names)} != "
+            f"studies length {len(studies)}."
+        )
+
+    # Per-study collapse to shared rank.
+    per_study: List["ad.AnnData"] = []
+    for a, name in zip(studies, study_names):
+        if rank is not None:
+            a_c = collapse_taxa(a, rank=rank)
+        else:
+            a_c = a.copy()
+        if min_prevalence > 0:
+            X = _dense(a_c.X)
+            prev = (X > 0).sum(axis=0) / X.shape[0]
+            keep = prev >= min_prevalence
+            a_c = a_c[:, keep].copy()
+        a_c.obs = a_c.obs.copy()
+        a_c.obs[study_key] = str(name)
+        per_study.append(a_c)
+
+    # Union of feature names (preserve first-seen order for stable layout).
+    seen: Dict[str, int] = {}
+    for a in per_study:
+        for f in a.var_names:
+            if f not in seen:
+                seen[f] = len(seen)
+    features = np.asarray(list(seen.keys()))
+    n_feat = len(features)
+
+    # Build the concatenated count matrix by re-indexing each study onto the
+    # union feature axis.
+    blocks: List[sparse.csr_matrix] = []
+    obs_blocks: List[pd.DataFrame] = []
+    for a in per_study:
+        X = _dense(a.X).astype(np.int64)
+        idx = np.array([seen[f] for f in a.var_names], dtype=np.int64)
+        # Scatter the original columns into the union grid.
+        aligned = np.zeros((X.shape[0], n_feat), dtype=np.int64)
+        aligned[:, idx] = X
+        blocks.append(sparse.csr_matrix(aligned))
+        obs_blocks.append(a.obs.copy())
+
+    X_full = sparse.vstack(blocks, format="csr")
+    obs_full = pd.concat(obs_blocks, axis=0, join="inner")
+    obs_full.index = pd.Index([f"{s}__{i}" for s, i in zip(
+        obs_full[study_key].astype(str), obs_full.index.astype(str)
+    )], name="sample")
+
+    var_full = pd.DataFrame(index=pd.Index(features, name="feature"))
+
+    adata_all = ad.AnnData(X=X_full, obs=obs_full, var=var_full)
+    adata_all.uns["micro"] = {
+        "meta": {
+            "n_studies": len(studies),
+            "study_names": list(map(str, study_names)),
+            "rank": rank,
+            "min_prevalence": min_prevalence,
+        }
+    }
+    return adata_all
+
+
+def _dense(X) -> np.ndarray:
+    if sparse.issparse(X):
+        return np.asarray(X.toarray())
+    return np.asarray(X)
+
+
+# ---------------------------------------------------------------------------
+# meta_da — per-study DA + random-effects combine
+# ---------------------------------------------------------------------------
+
+
+_METHOD_EFFECT_COL = {
+    # DA method → (effect column, SE column). Missing SE forces wilcoxon's
+    # "normalise by the observed variance among studies" fallback.
+    "wilcoxon": ("log2FC", None),
+    "deseq2":   ("log2FC", "log2FC_se"),
+    "ancombc":  ("lfc",    "se"),
+}
+
+
+@register_function(
+    aliases=["meta_da", "meta_analysis_da", "meta_differential_abundance"],
+    category="microbiome",
+    description="Cross-cohort random-effects meta-analysis of differential abundance — run DA on each study, then combine per-feature effect sizes by inverse-variance weighting (DerSimonian-Laird) with Cochran's Q / I² heterogeneity.",
+    examples=[
+        "ov.micro.meta_da([adata_A, adata_B, adata_C], group_key='disease', method='deseq2')",
+    ],
+    related=["micro.DA", "micro.combine_studies"],
+)
+def meta_da(
+    studies: Sequence["ad.AnnData"],
+    group_key: str,
+    group_a: Optional[str] = None,
+    group_b: Optional[str] = None,
+    method: str = "deseq2",
+    rank: Optional[str] = "genus",
+    min_prevalence: float = 0.1,
+    combine: str = "random_effects",
+    study_names: Optional[Sequence[str]] = None,
+    **method_kwargs,
+) -> pd.DataFrame:
+    """Per-study DA + inverse-variance meta-analysis.
+
+    Parameters
+    ----------
+    studies
+        List of per-study AnnData objects.
+    group_key, group_a, group_b
+        Same semantics as :meth:`ov.micro.DA.wilcoxon` /
+        :meth:`DA.deseq2` / :meth:`DA.ancombc`. If ``group_a`` / ``group_b``
+        are omitted, the two sorted unique values of ``group_key`` in the
+        *first* study are used (and re-used for every study).
+    method
+        ``'wilcoxon'``, ``'deseq2'``, or ``'ancombc'``. The per-study
+        effect sizes must be on a log-fold-change scale; Wilcoxon is
+        supported but its reported log2FC has no standard-error, so
+        Wilcoxon meta-DA uses the *empirical* between-study SE to weight
+        (i.e. every study gets unit weight pre-τ² — still useful as a
+        sanity check).
+    rank
+        Collapse to this taxonomic rank in every study before DA, so
+        features align across cohorts. ``None`` assumes the studies
+        already share the same feature ids.
+    min_prevalence
+        Passed through to each per-study DA call.
+    combine
+        ``'random_effects'`` (default; DerSimonian-Laird τ²) or
+        ``'fixed_effects'``.
+    study_names
+        Labels for the per-study result columns; defaults to
+        ``['study_0', 'study_1', …]``.
+    **method_kwargs
+        Extra kwargs forwarded to the underlying DA call (e.g.
+        ``pseudocount=0.5`` for ancombc).
+
+    Returns
+    -------
+    DataFrame indexed by feature with columns:
+
+    - ``combined_lfc`` — meta-analytic log2 fold-change estimate
+    - ``combined_se`` — standard error of the combined estimate
+    - ``z`` — Wald z-score (``combined_lfc / combined_se``)
+    - ``p_value`` / ``fdr_bh`` — two-sided p + BH-FDR
+    - ``n_studies`` — number of cohorts in which the feature was tested
+    - ``Q`` — Cochran's Q statistic of between-study heterogeneity
+    - ``I2`` — I² heterogeneity (0 → homogeneous, > 75% → high)
+    - ``tau2`` — between-study variance (random-effects only)
+    - per-study columns ``lfc_<study>`` and ``se_<study>`` for traceability
+    """
+    if not studies:
+        raise ValueError("`studies` is empty.")
+    if method not in _METHOD_EFFECT_COL:
+        raise ValueError(
+            f"method={method!r} not one of {sorted(_METHOD_EFFECT_COL)}"
+        )
+    if combine not in ("random_effects", "fixed_effects"):
+        raise ValueError(
+            f"combine={combine!r} must be 'random_effects' or 'fixed_effects'"
+        )
+
+    if study_names is None:
+        study_names = [f"study_{i}" for i in range(len(studies))]
+
+    # Resolve group_a / group_b from the first study if unspecified.
+    if group_a is None or group_b is None:
+        vals = sorted(studies[0].obs[group_key].dropna().unique().tolist())
+        group_a = group_a or vals[0]
+        group_b = group_b or vals[1]
+
+    effect_col, se_col_name = _METHOD_EFFECT_COL[method]
+
+    # Per-study DA — collect (study_name, lfc Series, se Series).
+    per_study_lfc: Dict[str, pd.Series] = {}
+    per_study_se:  Dict[str, pd.Series] = {}
+    for study, name in zip(studies, study_names):
+        a = collapse_taxa(study, rank=rank) if rank is not None else study
+        da = DA(a)
+        if method == "wilcoxon":
+            res = da.wilcoxon(
+                group_key=group_key, group_a=group_a, group_b=group_b,
+                min_prevalence=min_prevalence, **method_kwargs,
+            )
+            lfc_col = f"log2FC({group_b}/{group_a})"
+            lfc = res.set_index("feature")[lfc_col]
+            # No SE — use a flat unit SE; random-effects τ² will dominate.
+            se = pd.Series(1.0, index=lfc.index)
+        elif method == "deseq2":
+            res = da.deseq2(
+                group_key=group_key, group_a=group_a, group_b=group_b,
+                min_prevalence=min_prevalence, **method_kwargs,
+            )
+            lfc_col = f"log2FC({group_b}/{group_a})"
+            lfc = res.set_index("feature")[lfc_col]
+            se = res.set_index("feature")["log2FC_se"]
+        elif method == "ancombc":
+            res = da.ancombc(
+                group_key=group_key,
+                min_prevalence=min_prevalence, **method_kwargs,
+            )
+            lfc = res.set_index("feature")["lfc"]
+            se = res.set_index("feature")["se"]
+        per_study_lfc[name] = lfc
+        per_study_se[name]  = se
+
+    # Align on feature union.
+    feats: List[str] = []
+    seen: set = set()
+    for s in per_study_lfc.values():
+        for f in s.index:
+            if f not in seen:
+                seen.add(f)
+                feats.append(f)
+
+    lfc_mat = pd.DataFrame(
+        {name: per_study_lfc[name].reindex(feats) for name in study_names},
+        index=feats,
+    )
+    se_mat = pd.DataFrame(
+        {name: per_study_se[name].reindex(feats) for name in study_names},
+        index=feats,
+    )
+
+    # Meta-analytic combine — per-row.
+    out_rows: List[dict] = []
+    for f in feats:
+        theta = lfc_mat.loc[f].values.astype(float)
+        se    = se_mat.loc[f].values.astype(float)
+        mask = np.isfinite(theta) & np.isfinite(se) & (se > 0)
+        k = int(mask.sum())
+        if k < 2:
+            combined_lfc = float(theta[mask].mean()) if k == 1 else np.nan
+            combined_se  = float(se[mask].mean())    if k == 1 else np.nan
+            Q, I2, tau2 = np.nan, np.nan, np.nan
+        else:
+            t = theta[mask]
+            s = se[mask]
+            w_fe = 1.0 / (s ** 2)
+            theta_fe = (w_fe * t).sum() / w_fe.sum()
+            Q = float(((t - theta_fe) ** 2 * w_fe).sum())
+            df = k - 1
+            c = w_fe.sum() - (w_fe ** 2).sum() / w_fe.sum()
+            tau2 = max(0.0, (Q - df) / c) if c > 0 else 0.0
+            I2 = max(0.0, (Q - df) / Q) if Q > 0 else 0.0
+
+            if combine == "fixed_effects" or tau2 == 0.0:
+                w = w_fe
+            else:
+                w = 1.0 / (s ** 2 + tau2)
+            combined_lfc = float((w * t).sum() / w.sum())
+            combined_se  = float(np.sqrt(1.0 / w.sum()))
+        row = {
+            "feature": f,
+            "combined_lfc": combined_lfc,
+            "combined_se":  combined_se,
+            "n_studies":    k,
+            "Q":            Q,
+            "I2":           I2,
+            "tau2":         tau2,
+        }
+        # Copy per-study columns for traceability.
+        for name in study_names:
+            row[f"lfc_{name}"] = lfc_mat.at[f, name]
+            row[f"se_{name}"]  = se_mat.at[f, name]
+        out_rows.append(row)
+
+    out = pd.DataFrame(out_rows)
+    # Wald z + two-sided p + BH.
+    from scipy.stats import norm
+    valid = np.isfinite(out["combined_se"]) & (out["combined_se"] > 0)
+    z = np.full(len(out), np.nan)
+    z[valid] = out.loc[valid, "combined_lfc"] / out.loc[valid, "combined_se"]
+    out["z"] = z
+    p = np.full(len(out), np.nan)
+    p[valid] = 2.0 * (1.0 - norm.cdf(np.abs(z[valid])))
+    out["p_value"] = p
+    out["fdr_bh"]  = np.nan
+    if valid.any():
+        out.loc[valid, "fdr_bh"] = _bh_fdr(out.loc[valid, "p_value"].values)
+    return out.sort_values("p_value").reset_index(drop=True)

--- a/tests/micro/test_meta.py
+++ b/tests/micro/test_meta.py
@@ -1,0 +1,240 @@
+"""Unit tests for ov.micro.combine_studies + meta_da."""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+
+def _skbio_available() -> bool:
+    try:
+        import skbio  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+def _pydeseq2_available() -> bool:
+    try:
+        import pydeseq2  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+requires_skbio = pytest.mark.skipif(
+    not _skbio_available(),
+    reason="scikit-bio not installed (install the [tests] extra)",
+)
+requires_pydeseq2 = pytest.mark.skipif(
+    not _pydeseq2_available(),
+    reason="pydeseq2 not installed (install the [tests] extra)",
+)
+
+
+def _make_study(n_per_group=4, n_features=8, seed=0,
+                feature_prefix="A", group_label=("CTRL", "CASE"),
+                effect=None):
+    """Build a (samples × features) AnnData with group metadata.
+
+    ``effect`` optionally: dict {feature_idx: multiplier} applied to the
+    CASE group to plant a ground-truth DA signal.
+    """
+    import anndata as ad
+    from scipy import sparse
+    rng = np.random.default_rng(seed)
+    n = 2 * n_per_group
+    X = rng.integers(50, 500, size=(n, n_features)).astype(np.int32)
+    if effect:
+        for feat_idx, mult in effect.items():
+            X[n_per_group:, feat_idx] = (
+                X[n_per_group:, feat_idx] * mult
+            ).astype(np.int32)
+    obs = pd.DataFrame({
+        "group": [group_label[0]] * n_per_group + [group_label[1]] * n_per_group,
+    }, index=[f"{feature_prefix}_S{i}" for i in range(n)])
+    var = pd.DataFrame({
+        "genus":   [f"{feature_prefix}g{i}" if i < 3 else f"sharedg{i}" for i in range(n_features)],
+        "domain":  ["Bacteria"] * n_features,
+        "phylum":  [""] * n_features,
+        "class":   [""] * n_features,
+        "order":   [""] * n_features,
+        "family":  [""] * n_features,
+        "species": [""] * n_features,
+    }, index=[f"{feature_prefix}_ASV{i}" for i in range(n_features)])
+    return ad.AnnData(X=sparse.csr_matrix(X), obs=obs, var=var)
+
+
+# ---------------------------------------------------------------------------
+# combine_studies
+# ---------------------------------------------------------------------------
+
+
+def test_combine_studies_union_and_study_label():
+    from omicverse.micro import combine_studies
+    a = _make_study(feature_prefix="A", seed=1)
+    b = _make_study(feature_prefix="B", seed=2)
+    merged = combine_studies([a, b], study_names=["A", "B"], rank="genus")
+    # Each study contributes 3 unique + 5 shared genera → 11 features total.
+    assert merged.shape[0] == a.shape[0] + b.shape[0]
+    assert "study" in merged.obs.columns
+    assert set(merged.obs["study"]) == {"A", "B"}
+    # Union of genera: Ag0, Ag1, Ag2, Bg0, Bg1, Bg2, sharedg{3..7}
+    names = set(merged.var_names)
+    assert "Ag0" in names and "Bg0" in names
+    assert "sharedg3" in names
+
+
+def test_combine_studies_zero_fill_for_absent_features():
+    from omicverse.micro import combine_studies
+    a = _make_study(feature_prefix="A", seed=11)
+    b = _make_study(feature_prefix="B", seed=22)
+    merged = combine_studies([a, b], study_names=["A", "B"], rank="genus")
+    # In merged, a column that originates only from study A must be
+    # all-zero for study-B rows (and vice versa).
+    X = merged.X.toarray()
+    b_mask = merged.obs["study"].values == "B"
+    ag0 = merged.var_names.get_loc("Ag0")
+    assert X[b_mask, ag0].sum() == 0
+    a_mask = merged.obs["study"].values == "A"
+    bg0 = merged.var_names.get_loc("Bg0")
+    assert X[a_mask, bg0].sum() == 0
+
+
+def test_combine_studies_default_study_names():
+    from omicverse.micro import combine_studies
+    a = _make_study(feature_prefix="A", seed=3)
+    b = _make_study(feature_prefix="B", seed=4)
+    merged = combine_studies([a, b], rank="genus")
+    assert set(merged.obs["study"]) == {"study_0", "study_1"}
+
+
+def test_combine_studies_rejects_empty_list():
+    from omicverse.micro import combine_studies
+    with pytest.raises(ValueError, match="empty"):
+        combine_studies([])
+
+
+def test_combine_studies_rejects_mismatched_names():
+    from omicverse.micro import combine_studies
+    a = _make_study()
+    with pytest.raises(ValueError, match="length"):
+        combine_studies([a, a], study_names=["only-one"], rank="genus")
+
+
+# ---------------------------------------------------------------------------
+# meta_da
+# ---------------------------------------------------------------------------
+
+
+def test_meta_da_rejects_unknown_method():
+    from omicverse.micro import meta_da
+    a = _make_study()
+    with pytest.raises(ValueError, match="method="):
+        meta_da([a], group_key="group", method="bogus")
+
+
+def test_meta_da_rejects_unknown_combine():
+    from omicverse.micro import meta_da
+    a = _make_study()
+    with pytest.raises(ValueError, match="combine="):
+        meta_da([a], group_key="group", method="wilcoxon",
+                combine="max-likelihood-or-whatever")
+
+
+def test_meta_da_wilcoxon_returns_expected_columns():
+    """Wilcoxon has no real SE, but meta_da should still produce the schema."""
+    from omicverse.micro import meta_da
+    studies = [
+        _make_study(feature_prefix="A", seed=1,
+                    effect={0: 3.0, 1: 2.5}),
+        _make_study(feature_prefix="A", seed=2,
+                    effect={0: 3.2, 1: 2.6}),
+        _make_study(feature_prefix="A", seed=3,
+                    effect={0: 2.9, 1: 2.7}),
+    ]
+    out = meta_da(studies, group_key="group",
+                  group_a="CTRL", group_b="CASE",
+                  method="wilcoxon", rank="genus",
+                  min_prevalence=0.1)
+    for col in ("feature", "combined_lfc", "combined_se", "z",
+                "p_value", "fdr_bh", "n_studies", "Q", "I2", "tau2"):
+        assert col in out.columns, col
+    # Per-study traceability columns
+    assert "lfc_study_0" in out.columns and "se_study_2" in out.columns
+    # All three cohorts planted the same signal on features 0 and 1 → they
+    # should be ranked high (low fdr_bh). Feature labels after genus
+    # collapse are "Ag0", "Ag1".
+    top2 = set(out.head(4)["feature"])
+    assert {"Ag0", "Ag1"} & top2
+
+
+@requires_pydeseq2
+def test_meta_da_deseq2_recovers_planted_signal():
+    """DESeq2 meta-DA should rank the two planted features first."""
+    from omicverse.micro import meta_da
+    studies = [
+        _make_study(feature_prefix="A", seed=10,
+                    effect={0: 5.0, 1: 4.0}),
+        _make_study(feature_prefix="A", seed=20,
+                    effect={0: 4.5, 1: 4.5}),
+        _make_study(feature_prefix="A", seed=30,
+                    effect={0: 5.5, 1: 3.5}),
+    ]
+    out = meta_da(studies, group_key="group",
+                  group_a="CTRL", group_b="CASE",
+                  method="deseq2", rank="genus",
+                  min_prevalence=0.1)
+    # n_studies must be 3 for the planted features (each appears in all).
+    top = out[out["feature"].isin(["Ag0", "Ag1"])]
+    assert (top["n_studies"] == 3).all()
+    # Direction: CASE > CTRL → combined_lfc positive.
+    assert (top["combined_lfc"] > 0).all()
+
+
+def test_meta_da_single_study_feature_has_nan_heterogeneity():
+    """A taxon seen in only one study should produce NaN Q / I² / tau²."""
+    from omicverse.micro import meta_da
+    # Study A has feature Ag0 and Ag1 only; Study B has completely disjoint
+    # genera (Bg0/Bg1) post-collapse.
+    sa = _make_study(feature_prefix="A", seed=7)
+    sb = _make_study(feature_prefix="B", seed=8)
+    out = meta_da([sa, sb], group_key="group",
+                  group_a="CTRL", group_b="CASE",
+                  method="wilcoxon", rank="genus",
+                  min_prevalence=0.1)
+    # An A-only feature: Ag0. Only study A carries it.
+    ag0 = out[out["feature"] == "Ag0"]
+    assert not ag0.empty
+    row = ag0.iloc[0]
+    assert row["n_studies"] == 1
+    assert np.isnan(row["Q"])
+    assert np.isnan(row["I2"])
+    assert np.isnan(row["tau2"])
+
+
+@requires_pydeseq2
+def test_meta_da_random_vs_fixed_effects():
+    """Random-effects combine should widen SE (vs fixed) when studies disagree."""
+    from omicverse.micro import meta_da
+    # Plant a heterogeneous effect: study 2 has the opposite sign.
+    studies = [
+        _make_study(feature_prefix="A", seed=100, effect={0: 6.0}),
+        _make_study(feature_prefix="A", seed=200, effect={0: 6.0}),
+        # Inverse effect: make CASE lower than CTRL on feature 0.
+        _make_study(feature_prefix="A", seed=300, effect={0: 0.2}),
+    ]
+    fe = meta_da(studies, group_key="group",
+                 group_a="CTRL", group_b="CASE",
+                 method="deseq2", rank="genus",
+                 combine="fixed_effects", min_prevalence=0.1)
+    re_ = meta_da(studies, group_key="group",
+                  group_a="CTRL", group_b="CASE",
+                  method="deseq2", rank="genus",
+                  combine="random_effects", min_prevalence=0.1)
+    # For the conflicted feature, random-effects SE must be >= fixed-effects SE.
+    fe_row = fe[fe["feature"] == "Ag0"].iloc[0]
+    re_row = re_[re_["feature"] == "Ag0"].iloc[0]
+    assert re_row["combined_se"] >= fe_row["combined_se"] - 1e-9
+    # I² should be high (>>50%) because studies disagree.
+    assert re_row["I2"] > 0.5


### PR DESCRIPTION
## Summary

Two new public APIs for multi-cohort 16S / ITS differential abundance — addressing the Nearing 2022 finding that single-cohort DA methods disagree across datasets and pooling across cohorts is the pragmatic cure:

1. **`ov.micro.combine_studies(studies, rank='genus')`** — stitches a `List[AnnData]` (one per cohort) onto a shared feature axis. Collapses each study to the requested rank, takes the union of taxa, zero-fills absent taxa, preserves per-study obs metadata, stamps `obs['study']`. Returns an AnnData ready for mega-analysis (e.g. `DA.deseq2` with `study` as a batch covariate).

2. **`ov.micro.meta_da(studies, group_key, method='deseq2', ...)`** — runs the chosen per-study DA (`wilcoxon` / `deseq2` / `ancombc`), then combines per-feature log-fold-changes by inverse-variance-weighted random-effects meta-analysis (DerSimonian-Laird). Returns a flat DataFrame with `combined_lfc`, `combined_se`, `z`, `p_value`, `fdr_bh`, `n_studies`, `Q`, `I²`, `tau²` plus per-study traceability columns.

Both APIs wire into the lazy loader.

Submodule bump (`omicverse_guide` 4fdae4b → 4ec781c) picks up the paired `t_16s_meta_analysis.ipynb` tutorial — 3-cohort synthetic simulation with a known planted disease signal, proving the random-effects combine recovers the planted features and suppresses per-cohort batch markers. Tutorial also shows the forest-style log2FC × I² diagnostic and a method-swap sanity check (wilcoxon ↔ deseq2 ↔ ancombc).

## Test plan

- [x] `pytest tests/micro/test_meta.py -q` → 11 passed, 25 warnings in 41s (local, scikit-bio 0.7.2, pydeseq2 0.5).
  - combine_studies: union, zero-fill, default study names, empty-list / length-mismatch errors
  - meta_da: method + combine validation, Wilcoxon schema, DESeq2 signal recovery, random-vs-fixed effects SE ordering, single-study heterogeneity NaNs
- [x] Tutorial executes cleanly (`jupyter nbconvert --execute`, 327 KB with pinned outputs, 9 sections).
- [ ] CI pytest matrix (py310/11/12) green.
- [ ] Sphinx build picks up the new notebook in all three toctrees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)