### PR TITLE
feat(metabol): MTBLS1 smoke-test fixes — cv_filter(across='all'), mass_db= for MSEA, ~100x MSEA warm speedup

### DIFF
--- a/omicverse/metabol/__init__.py
+++ b/omicverse/metabol/__init__.py
@@ -127,6 +127,10 @@ _LAZY_ATTRS: dict[str, tuple[str, str]] = {
     "vip_bar":                (".plotting", "vip_bar"),
     "pathway_bar":            (".plotting", "pathway_bar"),
     "pathway_dot":            (".plotting", "pathway_dot"),
+    "sample_qc_plot":         (".plotting", "sample_qc_plot"),
+    "dgca_class_bar":         (".plotting", "dgca_class_bar"),
+    "corr_network_plot":      (".plotting", "corr_network_plot"),
+    "asca_variance_bar":      (".plotting", "asca_variance_bar"),
     # Lifecycle class
     "pyMetabo":               (".pymetabo", "pyMetabo"),
 }
@@ -267,4 +271,8 @@ __all__ = [
     "vip_bar",
     "pathway_bar",
     "pathway_dot",
+    "sample_qc_plot",
+    "dgca_class_bar",
+    "corr_network_plot",
+    "asca_variance_bar",
 ]

--- a/omicverse/metabol/_fetchers.py
+++ b/omicverse/metabol/_fetchers.py
@@ -479,6 +479,17 @@ def fetch_hmdb_from_name(
         warnings.warn(f"PubChem CID lookup failed for {name!r}: "
                       f"{type(exc).__name__}: {exc}",
                       UserWarning, stacklevel=2)
+        # Cache the empty result on 404 / timeout too, so the next
+        # caller skips this name instead of re-hitting PubChem. That
+        # used to cost 20+ s on re-runs for datasets with many
+        # chemical-shift placeholder names (MTBLS1's NMR data has
+        # ~50 `unknown_m_<ppm>` names that PubChem 404s on).
+        if cache:
+            cache_data[key] = out
+            try:
+                cache_path.write_text(json.dumps(cache_data, indent=1))
+            except Exception:
+                pass
         return out
 
     try:

--- a/omicverse/metabol/_id_mapping.py
+++ b/omicverse/metabol/_id_mapping.py
@@ -88,14 +88,37 @@ def map_ids(
             normalize_name(n): i for i, n in enumerate(mass_db["name"])
         }
 
+    # Column-name aliases for the ChEBI DataFrame shipped by
+    # `fetch_chebi_compounds`: its ChEBI identifier column is named
+    # ``chebi_id``, but users ask for target ``"chebi"``. Without this
+    # alias every row is declared "missing chebi" -> we fall through
+    # to PubChem for every single name, which is a 30-second penalty
+    # on a typical MSEA background list of 200 metabolites.
+    _COLUMN_ALIAS = {
+        "chebi": ("chebi", "chebi_id"),
+        "pubchem": ("pubchem", "pubchem_cid"),
+        "lipidmaps": ("lipidmaps", "lipid_maps_id", "lipidmaps_id"),
+    }
+    mass_cols = set(mass_db.columns) if mass_db is not None else set()
+
+    def _column_for(target):
+        candidates = _COLUMN_ALIAS.get(target, (target,))
+        for c in candidates:
+            if c in mass_cols:
+                return c
+        return None
+
+    col_for_target = {t: _column_for(t) for t in targets}
+
     for name in names:
         row = {t: "" for t in targets}
         if idx_of_name is not None:
             hit = idx_of_name.get(normalize_name(name))
             if hit is not None:
                 for t in targets:
-                    if t in mass_db.columns:
-                        v = mass_db.iloc[hit][t]
+                    col = col_for_target[t]
+                    if col is not None:
+                        v = mass_db.iloc[hit][col]
                         if isinstance(v, str) and v:
                             row[t] = v
         # Fall back to PubChem per-name for anything still empty

--- a/omicverse/metabol/_msea.py
+++ b/omicverse/metabol/_msea.py
@@ -102,6 +102,7 @@ def msea_ora(
     *,
     pathways: Optional[dict[str, list[str]]] = None,
     min_size: int = 3,
+    mass_db: Optional[pd.DataFrame] = None,
 ) -> pd.DataFrame:
     """Over-representation analysis via Fisher's exact test.
 
@@ -118,6 +119,14 @@ def msea_ora(
     min_size
         Skip pathways with fewer than this many overlapping background
         compounds.
+    mass_db
+        Optional pre-fetched ChEBI DataFrame from
+        :func:`fetch_chebi_compounds`. When supplied, ``map_ids`` uses
+        it as an in-memory lookup for the ~54 k ChEBI names and only
+        falls back to PubChem for names not resolved there. On a cold
+        session this turns the ``map_ids`` cost from
+        ``O(n_features)`` HTTP round-trips into a single dict probe
+        per feature — often a 30–100x speedup on the first call.
 
     Returns
     -------
@@ -127,9 +136,28 @@ def msea_ora(
     """
     if pathways is None:
         pathways = load_pathways()
-    # Map names → KEGG IDs
-    hit_kegg = set(map_ids(list(hits))["kegg"].dropna().tolist()) - {""}
-    bg_kegg = set(map_ids(list(background))["kegg"].dropna().tolist()) - {""}
+    # Map names → KEGG IDs (forward mass_db so we avoid PubChem per-name).
+    # Only request the kegg target since that's the only ID MSEA uses —
+    # requesting extra targets triggers a PubChem fallback for every
+    # name that has a kegg hit in mass_db but no hmdb/chebi hit.
+    #
+    # Perf: map the **union** (background ∪ hits) in a single call so
+    # cached PubChem lookups and the ChEBI index are reused. A naïve
+    # "map hits, then map background" doubles the cost for hits (they
+    # sit inside background) and forces us to pay the same network
+    # round-trips twice.
+    hits_list = list(hits)
+    bg_list = list(background)
+    all_names = list(dict.fromkeys(bg_list + hits_list))  # preserve order
+    id_map = map_ids(all_names, targets=("kegg",), mass_db=mass_db)
+    name_to_kegg = id_map["kegg"].to_dict()
+
+    hit_kegg = set(
+        name_to_kegg.get(n, "") for n in hits_list
+    ) - {""}
+    bg_kegg = set(
+        name_to_kegg.get(n, "") for n in bg_list
+    ) - {""}
     if not hit_kegg:
         raise ValueError(
             "None of the hit metabolite names resolve to KEGG compound IDs — "
@@ -196,6 +224,7 @@ def msea_gsea(
     min_size: int = 3,
     max_size: int = 500,
     seed: int = 0,
+    mass_db: Optional[pd.DataFrame] = None,
 ) -> pd.DataFrame:
     """GSEA-style ranked enrichment via ``gseapy.prerank``.
 
@@ -212,6 +241,11 @@ def msea_gsea(
     n_perm
         Permutation count for the empirical null. 1000 is fine for
         tutorials; bump to ≥10000 for publication.
+    mass_db
+        Optional pre-fetched ChEBI DataFrame from
+        :func:`fetch_chebi_compounds` — same role as in
+        :func:`msea_ora`. Recommended for cold-cache runs to avoid
+        per-name PubChem REST round-trips.
 
     Returns
     -------
@@ -236,8 +270,11 @@ def msea_gsea(
     rank_df = deg[[stat_col]].copy()
     rank_df["name"] = rank_df.index
     rank_df = rank_df.reset_index(drop=True)
-    # Resolve names → KEGG
-    id_map = map_ids(rank_df["name"].tolist())
+    # Resolve names → KEGG (forward mass_db so we avoid PubChem per-name).
+    # Request only the kegg target — see msea_ora docstring for the
+    # rationale.
+    id_map = map_ids(rank_df["name"].tolist(), targets=("kegg",),
+                     mass_db=mass_db)
     rank_df["kegg"] = id_map["kegg"].values
     rank_df = rank_df[rank_df["kegg"] != ""].drop_duplicates("kegg")
     if rank_df.empty:

--- a/omicverse/metabol/_qc.py
+++ b/omicverse/metabol/_qc.py
@@ -38,9 +38,10 @@ from .._registry import register_function
         'qc_cv_filter',
     ],
     category='metabolomics',
-    description='Drop metabolite features with coefficient-of-variation above a threshold across pooled QC samples (metabolomics-specific QC).',
+    description='Drop metabolite features with coefficient-of-variation above a threshold. Default computes CV across pooled QC samples (metabolomics-specific); pass `across="all"` to compute across every sample (for NMR / non-QC-pool studies).',
     examples=[
         "ov.metabol.cv_filter(adata, qc_mask='is_qc', cv_threshold=0.30)",
+        "ov.metabol.cv_filter(adata, across='all', cv_threshold=1.5)",
     ],
     related=[
         'metabol.drift_correct',
@@ -50,35 +51,66 @@ from .._registry import register_function
 def cv_filter(
     adata: AnnData,
     *,
-    qc_mask: str | np.ndarray,
+    qc_mask: "str | np.ndarray | None" = None,
     cv_threshold: float = 0.30,
+    across: str = "qc",
 ) -> AnnData:
-    """Drop features with coefficient-of-variation above ``cv_threshold`` in QC samples.
+    """Drop features with coefficient-of-variation above ``cv_threshold``.
 
     Parameters
     ----------
     qc_mask
         Either the name of a boolean column in ``adata.obs`` (True = QC
         pool sample), or a boolean array of length ``adata.n_obs``.
+        Required when ``across='qc'`` (the default). Ignored when
+        ``across='all'``.
     cv_threshold
-        Features with ``std/mean > cv_threshold`` across QC samples are
-        dropped. Default 0.30 is the community standard for untargeted
-        LC-MS; lower values (0.20) for targeted / high-stringency.
+        Features with ``std/mean > cv_threshold`` are dropped. Default
+        0.30 is the community standard for untargeted LC-MS with QC
+        pools; for ``across='all'`` on biological samples a much
+        higher threshold (1–2) is typical because biology itself
+        adds variance.
+    across
+        - ``"qc"`` (default) — compute CV across QC-pool samples only
+          (the MetaboAnalyst convention for LC-MS); requires
+          ``qc_mask``.
+        - ``"all"`` — compute CV across every sample. Use for NMR
+          datasets or any workflow without pooled QC injections.
+          MTBLS1-style studies fall in this bucket.
 
     Returns
     -------
     AnnData
-        Subset to the features that passed. Features dropped:
-        ``adata.n_vars - out.n_vars``.
+        Subset to features that passed. ``adata.var['qc_cv']`` carries
+        the CV values on the kept features.
     """
-    mask = _resolve_sample_mask(adata, qc_mask)
-    qc_X = adata.X[mask]
-    if qc_X.shape[0] < 3:
+    if across == "qc":
+        if qc_mask is None:
+            raise ValueError(
+                "cv_filter(across='qc') requires a qc_mask (bool column or "
+                "array marking QC-pool samples). For studies without QC "
+                "pools pass `across='all'`."
+            )
+        mask = _resolve_sample_mask(adata, qc_mask)
+        X_sub = adata.X[mask]
+        if X_sub.shape[0] < 3:
+            raise ValueError(
+                f"Need ≥3 QC samples for a meaningful CV filter, got "
+                f"{X_sub.shape[0]}"
+            )
+    elif across == "all":
+        X_sub = np.asarray(adata.X)
+        if X_sub.shape[0] < 3:
+            raise ValueError(
+                f"Need ≥3 samples for a meaningful CV filter, got "
+                f"{X_sub.shape[0]}"
+            )
+    else:
         raise ValueError(
-            f"Need ≥3 QC samples for a meaningful CV filter, got {qc_X.shape[0]}"
+            f"across must be 'qc' or 'all', got {across!r}"
         )
-    mu = np.nanmean(qc_X, axis=0)
-    sd = np.nanstd(qc_X, axis=0, ddof=1)
+    mu = np.nanmean(X_sub, axis=0)
+    sd = np.nanstd(X_sub, axis=0, ddof=1)
     # Avoid divide-by-zero on all-zero features
     with np.errstate(divide="ignore", invalid="ignore"):
         cv = np.where(mu > 0, sd / mu, np.inf)

--- a/omicverse/metabol/plotting.py
+++ b/omicverse/metabol/plotting.py
@@ -363,3 +363,215 @@ def vip_bar(
     ax.set_xlabel("VIP score")
     ax.set_ylabel("")
     return fig, ax
+
+
+# ---------------------------------------------------------------------------
+# sample-QC scatter — Hotelling T² vs DModX
+# ---------------------------------------------------------------------------
+@register_function(
+    aliases=['sample_qc_plot', 'plot_sample_qc',
+             'hotelling_dmodx_scatter'],
+    category='metabolomics',
+    description='Scatter of Hotelling T² vs DModX with the alpha-level '
+                'critical boundaries, highlighting flagged outlier samples. '
+                'Pair with metabol.sample_qc.',
+    examples=[
+        "qc = ov.metabol.sample_qc(adata); "
+        "ov.metabol.sample_qc_plot(qc)",
+    ],
+    related=['metabol.sample_qc'],
+)
+def sample_qc_plot(
+    qc_df,
+    *,
+    ax: Optional[plt.Axes] = None,
+    figsize: tuple[float, float] = (5.0, 4.0),
+    normal_color: str = "#2980b9",
+    outlier_color: str = "#c0392b",
+):
+    """Scatter of Hotelling T² vs DModX with critical-value lines."""
+    if ax is None:
+        fig, ax = plt.subplots(figsize=figsize)
+    else:
+        fig = ax.figure
+    flag = qc_df["is_outlier"].to_numpy()
+    ax.scatter(qc_df["T2"][~flag], qc_df["DModX"][~flag],
+               c=normal_color, s=28, edgecolor="k", alpha=0.7,
+               label="normal")
+    ax.scatter(qc_df["T2"][flag], qc_df["DModX"][flag],
+               c=outlier_color, s=55, edgecolor="k", label="outlier")
+    ax.axvline(qc_df["T2_crit"].iloc[0], color="grey", ls="--", lw=1)
+    ax.axhline(qc_df["DModX_crit"].iloc[0], color="grey", ls="--", lw=1)
+    ax.set_xlabel("Hotelling T²")
+    ax.set_ylabel("DModX")
+    ax.legend(loc="best", frameon=False)
+    return fig, ax
+
+
+# ---------------------------------------------------------------------------
+# DGCA class counts
+# ---------------------------------------------------------------------------
+@register_function(
+    aliases=['dgca_class_bar', 'plot_dgca_classes', 'dc_class_counts'],
+    category='metabolomics',
+    description='Bar chart of the DGCA class distribution '
+                '(counts of +/+, +/0, +/-, -/+, ...) returned by '
+                'metabol.dgca.',
+    examples=[
+        "dc = ov.metabol.dgca(adata, group_col='group'); "
+        "ov.metabol.dgca_class_bar(dc)",
+    ],
+    related=['metabol.dgca', 'metabol.corr_network_plot'],
+)
+def dgca_class_bar(
+    dc_df,
+    *,
+    ax: Optional[plt.Axes] = None,
+    figsize: tuple[float, float] = (6.0, 3.5),
+    log: bool = True,
+):
+    """Bar chart of DC-class counts (+/+, +/0, +/-, -/+, ...)."""
+    if ax is None:
+        fig, ax = plt.subplots(figsize=figsize)
+    else:
+        fig = ax.figure
+    counts = dc_df["dc_class"].value_counts()
+    order = [c for c in counts.index if c != "0/0"] + (
+        ["0/0"] if "0/0" in counts.index else [])
+    counts = counts.reindex(order)
+    palette = {
+        "+/+": "#27ae60", "-/-": "#8e44ad",
+        "+/-": "#c0392b", "-/+": "#c0392b",
+        "+/0": "#2980b9", "0/+": "#3498db",
+        "-/0": "#e67e22", "0/-": "#f39c12",
+        "0/0": "#bdc3c7",
+    }
+    colors = [palette.get(c, "#7f8c8d") for c in counts.index]
+    ax.bar(counts.index, counts.values, color=colors, edgecolor="k")
+    if log:
+        ax.set_yscale("log")
+    ax.set_ylabel("number of pairs")
+    ax.set_xlabel("DC class (A=group_a / B=group_b)")
+    for lbl in ax.get_xticklabels():
+        lbl.set_rotation(0)
+    return fig, ax
+
+
+# ---------------------------------------------------------------------------
+# Correlation network plot
+# ---------------------------------------------------------------------------
+@register_function(
+    aliases=['corr_network_plot', 'plot_correlation_network',
+             '相关网络图'],
+    category='metabolomics',
+    description='Draw a metabolite-correlation edge DataFrame (from '
+                'metabol.corr_network or a filtered metabol.dgca) as a '
+                'NetworkX spring-layout plot. Edge color encodes sign of '
+                'r; width scales with |r|.',
+    examples=[
+        "edges = ov.metabol.corr_network(adata, group_col='group', "
+        "group='case'); ov.metabol.corr_network_plot(edges)",
+    ],
+    related=['metabol.corr_network', 'metabol.dgca'],
+)
+def corr_network_plot(
+    edges_df,
+    *,
+    ax: Optional[plt.Axes] = None,
+    figsize: tuple[float, float] = (6.5, 5.5),
+    layout: str = "spring",
+    node_size: int = 70,
+    node_color: str = "white",
+    node_edge_color: str = "#34495e",
+    edge_width_scale: float = 2.5,
+    r_column: str = "r",
+    seed: int = 0,
+    with_labels: bool = True,
+    label_font_size: int = 7,
+):
+    """Draw an edge DataFrame as a NetworkX spring-layout plot."""
+    import networkx as nx
+
+    if ax is None:
+        fig, ax = plt.subplots(figsize=figsize)
+    else:
+        fig = ax.figure
+    if edges_df.empty:
+        ax.text(0.5, 0.5, "no edges above the threshold",
+                ha="center", va="center", transform=ax.transAxes)
+        ax.set_axis_off()
+        return fig, ax
+    G = nx.from_pandas_edgelist(
+        edges_df, source="feature_a", target="feature_b",
+        edge_attr=True,
+    )
+    if layout == "spring":
+        pos = nx.spring_layout(G, seed=seed, k=0.7)
+    elif layout == "circular":
+        pos = nx.circular_layout(G)
+    else:
+        pos = nx.kamada_kawai_layout(G)
+
+    edge_colors = []
+    edge_widths = []
+    for u, v, data in G.edges(data=True):
+        r = float(data.get(r_column, 0.0))
+        edge_colors.append("#c0392b" if r > 0 else "#2980b9")
+        edge_widths.append(max(abs(r), 0.1) * edge_width_scale)
+    nx.draw_networkx_edges(G, pos, edge_color=edge_colors,
+                           width=edge_widths, alpha=0.75, ax=ax)
+    nx.draw_networkx_nodes(G, pos, node_size=node_size,
+                           node_color=node_color,
+                           edgecolors=node_edge_color, ax=ax)
+    if with_labels:
+        nx.draw_networkx_labels(G, pos, font_size=label_font_size, ax=ax)
+    ax.set_axis_off()
+    return fig, ax
+
+
+# ---------------------------------------------------------------------------
+# ASCA variance-explained bar
+# ---------------------------------------------------------------------------
+@register_function(
+    aliases=['asca_variance_bar', 'plot_asca_effects', 'ASCA方差'],
+    category='metabolomics',
+    description='Horizontal bar chart of per-effect variance-explained '
+                'fractions from an ASCAResult, plus the residual.',
+    examples=[
+        "res = ov.metabol.asca(adata, factors=['treatment', 'time']); "
+        "ov.metabol.asca_variance_bar(res)",
+    ],
+    related=['metabol.asca'],
+)
+def asca_variance_bar(
+    asca_result,
+    *,
+    ax: Optional[plt.Axes] = None,
+    figsize: tuple[float, float] = (5.5, 3.0),
+):
+    """Horizontal bars of per-effect variance-explained fractions."""
+    import numpy as np
+
+    if ax is None:
+        fig, ax = plt.subplots(figsize=figsize)
+    else:
+        fig = ax.figure
+    names = list(asca_result.effects.keys())
+    fracs = [asca_result.effects[n].variance_explained for n in names]
+    residual_frac = (
+        asca_result.residual_ss / asca_result.total_ss
+        if asca_result.total_ss > 0 else 0.0
+    )
+    names.append("residual")
+    fracs.append(residual_frac)
+    colors = ["#2980b9"] * (len(names) - 1) + ["#bdc3c7"]
+    y = np.arange(len(names))
+    ax.barh(y, fracs, color=colors, edgecolor="k")
+    ax.set_yticks(y)
+    ax.set_yticklabels(names)
+    ax.invert_yaxis()
+    ax.set_xlabel("variance explained (fraction of total SS)")
+    for i, f in enumerate(fracs):
+        ax.text(f + 0.005, i, f"{f*100:.1f}%",
+                va="center", ha="left", fontsize=8)
+    return fig, ax

--- a/omicverse/utils/__init__.py
+++ b/omicverse/utils/__init__.py
@@ -113,6 +113,7 @@ from ._venn import venny4py
 from ._lsi import Array, lsi, tfidf
 from ._neighboors import neighbors,calc_kBET,calc_kSIM
 from ._gene_id_conversion import _infer_species_and_release, convert2gene_symbol, convert2symbol, id2symbol, convert2gene_id, symbol2id
+from ._metabolights import load_metabolights
 from ._ovagent_lookup import (
     RegistryScanner,
     initialize_skill_registry,
@@ -190,6 +191,8 @@ verifier = _verifier_module
 
 # Explicit public exports for stable, non-wildcard imports
 __all__ = [
+    # @ _metabolights
+    "load_metabolights",
     # @ _data
     "read",
     "read_csv",

--- a/omicverse/utils/_metabolights.py
+++ b/omicverse/utils/_metabolights.py
@@ -1,0 +1,263 @@
+r"""Metabolights public-study loader.
+
+Turn a Metabolights accession (e.g. ``"MTBLS1"``) into a
+``samples × metabolites`` AnnData in one call, without having to
+hand-merge the sample sheet with the MAF (Metabolite Assignment File)
+every time.
+
+The EBI-hosted ISA-Tab layout per study is:
+
+- ``s_<ID>.txt`` — sample sheet (samples × factor-value columns)
+- ``a_<ID>_*.txt`` — assay sheet (samples × instrument metadata)
+- ``m_<ID>_*_maf.tsv`` — MAF: rows = metabolites, columns = sample
+  intensities + annotation columns (``metabolite_identification``,
+  ``chemical_formula``, ``smiles``, ``chemical_shift``, ``taxid``, ...)
+
+``load_metabolights`` fetches ``s_*.txt`` and ``m_*.tsv`` from the
+public FTP, caches them under a user-chosen directory, and returns
+the transposed AnnData with obs merged from the sample sheet.
+"""
+from __future__ import annotations
+
+import re
+import urllib.request
+from html.parser import HTMLParser
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+import pandas as pd
+from anndata import AnnData
+
+from .._registry import register_function
+
+
+_BASE = "https://ftp.ebi.ac.uk/pub/databases/metabolights/studies/public"
+
+
+class _FileLinks(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.files: list[str] = []
+
+    def handle_starttag(self, tag, attrs):
+        if tag == "a":
+            for k, v in attrs:
+                if k == "href":
+                    self.files.append(v)
+
+
+def _list_study_files(study_id: str, timeout: float = 20.0) -> list[str]:
+    """Parse the FTP directory index to list every file in the study."""
+    url = f"{_BASE}/{study_id}/"
+    with urllib.request.urlopen(url, timeout=timeout) as resp:
+        html = resp.read().decode("utf-8", errors="replace")
+    parser = _FileLinks()
+    parser.feed(html)
+    return parser.files
+
+
+def _pick_maf(files: list[str]) -> str:
+    """Pick the MAF filename from a study directory listing.
+
+    Most studies ship exactly one ``m_<ID>_*_maf.tsv``; if there are
+    multiple (rare) we take the first one to preserve determinism and
+    leave the choice to the caller via ``maf_name=``.
+    """
+    mafs = [f for f in files if f.startswith("m_") and f.endswith("_maf.tsv")]
+    if not mafs:
+        raise FileNotFoundError(
+            "No MAF (m_*_maf.tsv) found in the study directory."
+        )
+    return sorted(mafs)[0]
+
+
+def _pick_sample_sheet(files: list[str], study_id: str) -> str:
+    """Pick the sample-sheet filename (``s_<ID>.txt``)."""
+    # Case-insensitive match: Metabolights studies are inconsistent
+    # (MTBLS1 uses `s_MTBLS1.txt` but some use lowercase).
+    target = f"s_{study_id}.txt"
+    for f in files:
+        if f.lower() == target.lower():
+            return f
+    # Fall back to any `s_*.txt` if the study has a non-standard name.
+    candidates = [f for f in files if f.lower().startswith("s_")
+                  and f.lower().endswith(".txt")]
+    if not candidates:
+        raise FileNotFoundError("No sample sheet (s_*.txt) found.")
+    return candidates[0]
+
+
+def _download(url: str, path: Path, timeout: float = 60.0) -> None:
+    req = urllib.request.Request(
+        url, headers={"User-Agent": "omicverse/utils.load_metabolights"}
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        data = resp.read()
+    path.write_bytes(data)
+
+
+@register_function(
+    aliases=[
+        "load_metabolights",
+        "metabolights_loader",
+        "读取metabolights",
+    ],
+    category="utils",
+    description=(
+        "Download a public Metabolights study (sample sheet + MAF) from "
+        "ftp.ebi.ac.uk and return a samples × metabolites AnnData ready "
+        "for ov.metabol. Handles the ISA-Tab layout, NaN metabolite "
+        "names (falls back on chemical_shift), and optional factor "
+        "column renaming to 'group'."
+    ),
+    examples=[
+        "adata = ov.utils.load_metabolights('MTBLS1', "
+        "group_col='Factor Value[Metabolic syndrome]')",
+    ],
+    related=[
+        "metabol.read_metaboanalyst",
+        "datasets.download_data",
+    ],
+)
+def load_metabolights(
+    study_id: str,
+    *,
+    group_col: Optional[str] = None,
+    cache_dir: str | Path = "metabolights_cache",
+    maf_name: Optional[str] = None,
+    sample_name_col: str = "Sample Name",
+    refresh: bool = False,
+) -> AnnData:
+    """Load a Metabolights study into a samples × metabolites AnnData.
+
+    Parameters
+    ----------
+    study_id
+        Metabolights accession, e.g. ``"MTBLS1"``. The study must be
+        under the public mirror at ``ftp.ebi.ac.uk/pub/databases/
+        metabolights/studies/public``.
+    group_col
+        Column in the sample sheet to use as the primary phenotype
+        label. When given, the column is renamed to ``"group"`` in
+        ``adata.obs`` to match the convention the rest of
+        ``ov.metabol`` expects (``differential(group_col="group")``,
+        ``roc_feature(group_col="group")``, ...). Common choices:
+        ``"Factor Value[<name>]"``.
+    cache_dir
+        Directory to cache downloaded files. Default
+        ``./metabolights_cache/``. Re-runs reuse cached files unless
+        ``refresh=True``.
+    maf_name
+        Explicit MAF filename. Default: first alphabetical
+        ``m_*_maf.tsv`` in the directory listing. Override when a
+        study ships multiple MAFs (e.g. positive vs. negative mode).
+    sample_name_col
+        Column in the sample sheet carrying the assay-side sample
+        identifiers. Default ``"Sample Name"`` — works for every
+        study that follows the ISA-Tab standard.
+    refresh
+        Force re-download even if the cached file exists. Use when
+        Metabolights updates a study version in place.
+
+    Returns
+    -------
+    AnnData
+        ``obs`` carries every column of the sample sheet plus a
+        derived ``group`` column (if ``group_col`` was supplied).
+        ``var`` carries ``metabolite_identification`` (filled with
+        ``unknown_shift_<ppm>`` for NMR rows that lack a named
+        identification) plus ``chemical_formula`` and ``smiles`` when
+        available.
+        ``uns['metabolights'] = {'study_id', 'maf_name',
+        'sample_sheet'}`` records provenance.
+    """
+    cache = Path(cache_dir).expanduser()
+    cache.mkdir(parents=True, exist_ok=True)
+
+    listing: Optional[list[str]] = None
+    if maf_name is None:
+        listing = _list_study_files(study_id)
+        maf_name = _pick_maf(listing)
+    sample_sheet_name = _pick_sample_sheet(
+        listing if listing is not None else _list_study_files(study_id),
+        study_id,
+    )
+
+    for fname in (sample_sheet_name, maf_name):
+        dest = cache / fname
+        if dest.exists() and not refresh:
+            continue
+        _download(f"{_BASE}/{study_id}/{fname}", dest)
+
+    sample_path = cache / sample_sheet_name
+    maf_path = cache / maf_name
+    s_df = pd.read_csv(sample_path, sep="\t")
+    m_df = pd.read_csv(maf_path, sep="\t")
+
+    if sample_name_col not in s_df.columns:
+        raise KeyError(
+            f"{sample_name_col!r} not in sample sheet. "
+            f"Available: {list(s_df.columns)[:10]}..."
+        )
+    # The MAF carries one column per sample. Sample column names are
+    # exactly the values in ``s_df[sample_name_col]`` — intersect the
+    # two to filter out annotation columns (like "database_identifier").
+    sample_id_set = set(s_df[sample_name_col].astype(str))
+    sample_cols = [c for c in m_df.columns
+                   if isinstance(c, str) and c in sample_id_set]
+    if not sample_cols:
+        raise ValueError(
+            f"No columns in the MAF matched sample IDs from the sample "
+            f"sheet. First 5 MAF columns: {list(m_df.columns)[:5]}; "
+            f"first 5 sample IDs: {list(s_df[sample_name_col])[:5]}."
+        )
+
+    # Metabolite names: prefer metabolite_identification, fall back on
+    # chemical_shift (NMR), then on the row index.
+    mid = m_df.get(
+        "metabolite_identification", pd.Series(index=m_df.index, dtype=object)
+    )
+    shift = m_df.get(
+        "chemical_shift", pd.Series(index=m_df.index, dtype=object)
+    )
+    var_names = []
+    for i, (name, sh) in enumerate(zip(mid.fillna(""), shift.fillna(""))):
+        if isinstance(name, str) and name:
+            var_names.append(name)
+        elif sh != "":
+            var_names.append(f"unknown_shift_{sh}")
+        else:
+            var_names.append(f"feature_{i}")
+
+    # obs: sample-sheet rows indexed by sample ID
+    obs = s_df.set_index(sample_name_col).loc[sample_cols].copy()
+    if group_col is not None:
+        if group_col not in obs.columns:
+            raise KeyError(
+                f"group_col={group_col!r} not in sample sheet. "
+                f"Available Factor Value columns: "
+                f"{[c for c in obs.columns if 'Factor' in c]}"
+            )
+        obs = obs.rename(columns={group_col: "group"})
+        obs["group"] = obs["group"].astype(str)
+
+    var = pd.DataFrame(
+        {
+            "metabolite_identification": var_names,
+        },
+        index=[f"m{i}" for i in range(len(m_df))],
+    )
+    for col in ("chemical_formula", "smiles"):
+        if col in m_df.columns:
+            var[col] = m_df[col].values
+
+    X = m_df[sample_cols].T.astype(float).values
+    adata = AnnData(X=X, obs=obs, var=var)
+    adata.uns["metabolights"] = {
+        "study_id": str(study_id),
+        "maf_name": str(maf_name),
+        "sample_sheet": str(sample_sheet_name),
+        "cache_dir": str(cache),
+    }
+    return adata

--- a/tests/test_metabol_qc.py
+++ b/tests/test_metabol_qc.py
@@ -75,6 +75,41 @@ class TestCvFilter:
         with pytest.raises(KeyError, match="no column"):
             cv_filter(adata, qc_mask="nonexistent", cv_threshold=0.30)
 
+    def test_across_all_no_qc_needed(self):
+        """cv_filter(across='all') works on studies without QC pools."""
+        from omicverse.metabol import cv_filter
+
+        # Feature 0 is stable (CV≈1%), feature 1 is wildly variable
+        # (CV well above 1). Threshold 0.5 keeps only the stable one.
+        rng = np.random.default_rng(0)
+        X = np.column_stack([
+            np.full(30, 100.0) + rng.normal(0, 1, 30),                # CV≈1%
+            np.concatenate([rng.uniform(1, 10, 15),
+                            rng.uniform(500, 1000, 15)]),             # CV≫1
+        ])
+        adata = _adata(X, obs_cols={"group": ["a", "b"] * 15},
+                       var_names=["stable", "noisy"])
+
+        out = cv_filter(adata, across="all", cv_threshold=0.5)
+        assert "stable" in out.var_names
+        assert "noisy" not in out.var_names
+        assert out.n_obs == adata.n_obs
+
+    def test_across_qc_without_mask_raises(self):
+        """Default across='qc' still requires qc_mask."""
+        from omicverse.metabol import cv_filter
+
+        adata = _adata(np.ones((5, 2)))
+        with pytest.raises(ValueError, match="requires a qc_mask"):
+            cv_filter(adata, cv_threshold=0.30)
+
+    def test_across_unknown_raises(self):
+        from omicverse.metabol import cv_filter
+
+        adata = _adata(np.ones((5, 2)))
+        with pytest.raises(ValueError, match="across must be"):
+            cv_filter(adata, across="samples", cv_threshold=0.5)
+
 
 # --------------------------------------------------------------------------- #
 # drift_correct

--- a/tests/test_metabol_v02.py
+++ b/tests/test_metabol_v02.py
@@ -50,6 +50,47 @@ def test_id_mapping_uses_mass_db_for_local_hits():
 
 
 @needs_network
+def test_id_mapping_chebi_column_alias():
+    """``map_ids(..., targets=('chebi',), mass_db=chebi_df)`` must resolve
+    the ChEBI identifier without falling through to PubChem. The ChEBI
+    DataFrame stores the ID as ``chebi_id``, not ``chebi``; a column
+    alias in map_ids bridges the gap. Without the alias every row
+    looked "missing chebi" and the fallback hit PubChem for every
+    name — the smoke test on MTBLS1 took ~30 s per MSEA call because
+    of this."""
+    import omicverse as ov
+
+    ch = ov.metabol.fetch_chebi_compounds()
+    sample = ch[ch["chebi_id"].astype(str).str.startswith("CHEBI:")].head(1).iloc[0]
+    result = ov.metabol.map_ids(
+        [sample["name"]], targets=("chebi",), mass_db=ch,
+    )
+    assert result.iloc[0]["chebi"] == sample["chebi_id"], (
+        f"Expected {sample['chebi_id']!r}, got {result.iloc[0]['chebi']!r}"
+    )
+
+
+@needs_network
+def test_msea_ora_accepts_mass_db(cachexia_adata):
+    """``msea_ora(..., mass_db=chebi_df)`` must produce the same
+    pathway set as the network-fallback path but without per-name
+    PubChem traffic — covers the MTBLS1 perf regression fix."""
+    import omicverse as ov
+    from omicverse.metabol import differential, msea_ora, normalize, transform
+
+    a = normalize(cachexia_adata, method="pqn")
+    a = transform(a, method="log")
+    deg = differential(a, method="welch_t", log_transformed=True)
+    hits = deg[deg["padj"] < 0.30].index.tolist()
+    background = deg.index.tolist()
+    ch = ov.metabol.fetch_chebi_compounds()
+    out = msea_ora(hits, background, min_size=3, mass_db=ch)
+    assert not out.empty
+    for col in ("pathway", "overlap", "set_size", "padj"):
+        assert col in out.columns
+
+
+@needs_network
 def test_msea_ora_finds_relevant_pathways_on_cachexia(cachexia_adata):
     """Cachexia urinary metabolites should be enriched for amino-acid /
     TCA pathways. Uses the full fetched KEGG database."""


### PR DESCRIPTION
## Summary

Ran the full `ov.metabol` pipeline on **MTBLS1** (Metabolights public dataset, Salek et al., *Physiol. Genomics* 2007 — 132 urine NMR samples, Type 2 Diabetes vs control) end-to-end. Logged every step's outcome. Four issues only visible on real-world data:

| # | Fix | Before | After |
|---|---|---|---|
| 1 | `cv_filter(across='all')` for studies without QC pools | raised `TypeError` on MTBLS1 | works on any AnnData |
| 2 | `msea_ora` / `msea_gsea` accept `mass_db=` | 30 s cold, every call | fast path via ChEBI lookup |
| 3 | `map_ids` column alias (`chebi` → `chebi_id`) | ChEBI match silently no-op | resolves correctly |
| 4 | `fetch_hmdb_from_name` caches 404 / timeout | re-queries every run | **100× warm-cache speedup** |

Combined effect on the MTBLS1 MSEA step: **~26 s cold → 0.18 s warm** after the first run populates the cache.

## What's in this PR

**Code fixes** (`omicverse/metabol/`):

- `_qc.py` — `cv_filter` adds `across: {'qc', 'all'}` parameter. Default still `'qc'` (unchanged). New `'all'` computes CV across every sample; designed for NMR / targeted LC-MS that don't ship pooled QC.
- `_id_mapping.py` — column-alias table so the `chebi`/`pubchem`/`lipidmaps` targets map to the columns `fetch_chebi_compounds` actually ships (`chebi_id` / `pubchem_cid`). Previously these targets silently fell through to PubChem for every name.
- `_msea.py` — `msea_ora` and `msea_gsea` accept `mass_db=`, narrow targets to `('kegg',)`, and merge hits + background into a single `map_ids` call.
- `_fetchers.py` — `fetch_hmdb_from_name` caches the empty-result dict on PubChem 404 / network timeout, matching the already-present success-path caching.

**Tests** (+5 cases, regression run: 74 pass / 11 skip):

- `tests/test_metabol_qc.py` — `test_across_all_no_qc_needed`, `test_across_qc_without_mask_raises`, `test_across_unknown_raises`.
- `tests/test_metabol_v02.py` — `test_id_mapping_chebi_column_alias`, `test_msea_ora_accepts_mass_db` (both network-gated).

**Submodule bump** → carries the new tutorial notebook `t_metabol_11_real_data_mtbls1.ipynb` (14 code cells, 100 outputs) that demonstrates the whole pipeline on MTBLS1 including the tools that don't apply (`drift_correct`, `serrf`, `mixed_model`, `meba`, `run_mofa`) and the reasons.

## Smoke-test summary (all 21 steps pass after fixes)

```
  ✓ load_sample_sheet              0.00s
  ✓ load_maf                       0.00s
  ✓ build_anndata                  0.00s
  ✓ cv_filter                      0.42s    # across='all' path
  ✓ sample_qc                      1.90s
  ✓ drift_correct_skip             0.00s    # no QC pool on MTBLS1
  ✓ impute_qrilc                   0.02s
  ✓ normalize_pqn                  0.00s
  ✓ transform_log_pareto           0.00s
  ✓ differential_welch_t           0.01s
  ✓ plsda                          0.09s
  ✓ opls_da                        0.02s
  ✓ msea_ora                       0.18s    # warm cache
  ✓ asca                           0.43s
  ✓ mixed_model_skip               0.00s    # cross-sectional
  ✓ meba_skip                      0.00s    # no time column
  ✓ roc_feature                    0.15s
  ✓ biomarker_panel                0.36s
  ✓ dgca                           0.04s
  ✓ corr_network                   0.01s
  ✓ run_mofa_skip                  0.00s    # mono-omic
```

## Test plan

- [x] `pytest tests/test_metabol*.py` — 74 pass / 11 skip
- [x] Notebook 11 executed cleanly against this branch's code (14/14 cells, 100 outputs)
- [ ] CI run (this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
