### PR TITLE
feat(ccc): unify communication adapters and stabilize ccc visualizations

### DIFF
--- a/omicverse/pl/_ccc.py
+++ b/omicverse/pl/_ccc.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import re
 import textwrap
 import warnings
+import io
+from contextlib import nullcontext, redirect_stdout
 from typing import Mapping, Sequence, Literal
 
 import anndata
@@ -12,6 +14,7 @@ import numpy as np
 import pandas as pd
 import seaborn as sns
 from matplotlib import colors as mcolors
+from matplotlib.colors import Normalize
 from matplotlib import patheffects
 from matplotlib.patches import FancyArrowPatch, PathPatch, Rectangle
 from matplotlib.path import Path
@@ -26,8 +29,12 @@ from ._heatmap_marsilea import (
     _import_marsilea,
     _render_plot,
     _style_heatmap_axes,
+    _warn_if_broken_marsilea_version,
 )
 from ._palette import palette_28, palette_56, palette_112
+
+_COMM_REQUIRED_OBS = ("sender", "receiver")
+_COMM_REQUIRED_LAYERS = ("means", "pvalues")
 
 
 def _to_dense(matrix):
@@ -51,8 +58,8 @@ def _pick_first_available(frame: pd.DataFrame, candidates: Sequence[str], fallba
 
 
 def _ensure_comm_adata(adata: anndata.AnnData) -> None:
-    missing_obs = [key for key in ("sender", "receiver") if key not in adata.obs.columns]
-    missing_layers = [key for key in ("means", "pvalues") if key not in adata.layers]
+    missing_obs = [key for key in _COMM_REQUIRED_OBS if key not in adata.obs.columns]
+    missing_layers = [key for key in _COMM_REQUIRED_LAYERS if key not in adata.layers]
 
     if missing_obs:
         raise ValueError(
@@ -64,6 +71,47 @@ def _ensure_comm_adata(adata: anndata.AnnData) -> None:
             "Communication AnnData is missing required layers: "
             f"{missing_layers}. Expected both 'means' and 'pvalues'."
         )
+
+
+def _is_comm_adata(adata: anndata.AnnData) -> bool:
+    if not isinstance(adata, anndata.AnnData):
+        return False
+    has_obs = all(key in adata.obs.columns for key in _COMM_REQUIRED_OBS)
+    has_layers = all(key in adata.layers for key in _COMM_REQUIRED_LAYERS)
+    return has_obs and has_layers
+
+
+def _resolve_comm_adata(
+    adata: anndata.AnnData,
+    *,
+    arg_name: str,
+    result_uns_key: str = "liana_res",
+    score_key: str = "specificity_rank",
+    pvalue_key: str = "specificity_rank",
+    inverse_score: bool = True,
+    inverse_pvalue: bool = False,
+    classification: str | Mapping[str, str] | None = None,
+    classification_reference: str | pd.DataFrame | None = "cellchat",
+    classification_fallback: str | None = "family",
+) -> anndata.AnnData:
+    from ..single._comm import to_comm_adata
+
+    try:
+        return to_comm_adata(
+            adata,
+            result_uns_key=result_uns_key,
+            score_key=score_key,
+            pvalue_key=pvalue_key,
+            inverse_score=inverse_score,
+            inverse_pvalue=inverse_pvalue,
+            classification=classification,
+            classification_reference=classification_reference,
+            classification_fallback=classification_fallback,
+        )
+    except (TypeError, ValueError, KeyError) as exc:
+        if _is_comm_adata(adata):
+            return adata
+        raise type(exc)(f"{exc} (while resolving `{arg_name}`)").with_traceback(exc.__traceback__)
 
 
 def _normalize_use_arg(values) -> list[str] | None:
@@ -115,6 +163,19 @@ def _require_use_argument(plot_type: str, arg_name: str, values) -> list[str]:
     if normalized is None:
         raise ValueError(f"`{arg_name}` is required when `plot_type='{plot_type}'`.")
     return normalized
+
+
+def _validate_plot_type(plot_type: str, allowed: Sequence[str], *, func_name: str) -> None:
+    if plot_type not in allowed:
+        allowed_str = ", ".join(f"'{item}'" for item in allowed)
+        raise ValueError(f"Unsupported `plot_type='{plot_type}'` for `{func_name}`. Allowed values are: {allowed_str}.")
+
+
+def _validate_display_by(display_by: str, *, func_name: str) -> None:
+    allowed = ("aggregation", "interaction")
+    if display_by not in allowed:
+        allowed_str = ", ".join(f"'{item}'" for item in allowed)
+        raise ValueError(f"Unsupported `display_by='{display_by}'` for `{func_name}`. Allowed values are: {allowed_str}.")
 
 
 def _aggregate_series(grouped, value: Literal["sum", "mean", "max", "count"], *, field: str = "score") -> pd.Series:
@@ -640,6 +701,7 @@ def _draw_flow_stage_node(
     label_mode: Literal["center", "side"] = "center",
     text_offset: float = 0.055,
     text_y_offset: float = 0.0,
+    text_align: Literal["left", "right"] = "left",
     facecolor: str = "white",
     edgecolor: str = "#6E6E6E",
 ) -> None:
@@ -666,11 +728,15 @@ def _draw_flow_stage_node(
                 zorder=3,
             )
         )
+        if text_align == "right":
+            text_x = x_coord - marker_width / 2.0 - text_offset
+        else:
+            text_x = x_coord + marker_width / 2.0 + text_offset
         ax.text(
-            x_coord + text_offset,
+            text_x,
             y_coord + text_y_offset,
             wrapped_label,
-            ha="left",
+            ha=text_align,
             va="center",
             fontsize=max(7.0, fontsize - 0.2),
             zorder=4,
@@ -730,8 +796,6 @@ def _build_flow_plot_frames(
         if plot_df.empty:
             raise ValueError("No interaction-level communication edges remain after filtering.")
 
-        # Keep the interaction-flow panels readable by pruning each ligand-receptor
-        # stage to its strongest sender/receiver branches.
         branch_limit = max(3, min(5, int(np.ceil(np.sqrt(max(int(top_n), 1))))))
         sender_keep = (
             plot_df.groupby(["interaction_label", "sender"], observed=True)["weight"]
@@ -896,6 +960,8 @@ def _plot_heatmap_matrix(
     col_wrap_width: int = 18,
     max_col_labels: int = 18,
     clip_quantile: float | None = None,
+    show_row_names: bool = False,
+    show_col_names: bool = False,
 ):
     ma, mp = _import_marsilea()
     display_matrix = matrix.copy()
@@ -953,6 +1019,8 @@ def _plot_heatmap_matrix(
         )
     if "cell" in left_annos and row_palette is not None:
         heatmap.add_left(mp.Colors(row_names, palette=row_palette), size=0.2, pad=0.04, legend=False)
+    if show_row_names:
+        heatmap.add_left(mp.Labels(row_names, fontsize=9), pad=0.08)
     if "cell" in right_annos and row_palette is not None:
         heatmap.add_right(mp.Colors(row_names, palette=row_palette), size=0.12, pad=0.03, legend=False)
     if "bar" in right_annos and row_totals is not None:
@@ -984,6 +1052,8 @@ def _plot_heatmap_matrix(
         heatmap.add_top(mp.Colors(col_names, palette=col_palette), size=0.18, pad=0.03)
     if "cell" in bottom_annos and col_palette is not None:
         heatmap.add_bottom(mp.Colors(col_names, palette=col_palette), size=0.12, pad=0.03, legend=False)
+    if show_col_names:
+        heatmap.add_bottom(mp.Labels(col_names, fontsize=9), pad=0.08)
     if "bar" in bottom_annos and col_totals is not None:
         heatmap.add_bottom(
             mp.Numbers(
@@ -1039,6 +1109,29 @@ def _largest_content_axis(fig):
     if not content_axes:
         return fig.axes[0]
     return max(content_axes, key=lambda axis: axis.get_position().width * axis.get_position().height)
+
+
+def _draw_network_column_headers(
+    ax,
+    column_titles: Sequence[tuple[float, str]],
+    *,
+    x_min: float,
+    x_max: float,
+    y_axes: float = 0.90,
+    fontsize: int = 11,
+) -> None:
+    x_span = max(float(x_max) - float(x_min), 1e-9)
+    for x_coord, label in column_titles:
+        x_frac = (float(x_coord) - float(x_min)) / x_span
+        ax.text(
+            x_frac,
+            y_axes,
+            str(label),
+            ha="center",
+            va="bottom",
+            fontsize=fontsize,
+            transform=ax.transAxes,
+        )
 
 
 def _render_plotter_figure(plotter, *, title: str | None = None, add_custom_legends: bool = False):
@@ -1133,19 +1226,22 @@ def _pathway_summary_table(
     strength_threshold: float = 0.5,
     pvalue_threshold: float = 0.05,
     min_significant_pairs: int = 1,
+    verbose: bool = True,
 ) -> pd.DataFrame:
     viz = _build_cellchatviz(adata, palette=palette)
-    pathway_comm = viz.compute_pathway_communication(
-        method=pathway_method,
-        min_lr_pairs=min_lr_pairs,
-        min_expression=min_expression,
-    )
-    _, summary = viz.get_significant_pathways_v2(
-        pathway_comm,
-        strength_threshold=strength_threshold,
-        pvalue_threshold=pvalue_threshold,
-        min_significant_pairs=min_significant_pairs,
-    )
+    stdout_context = nullcontext() if verbose else redirect_stdout(io.StringIO())
+    with stdout_context:
+        pathway_comm = viz.compute_pathway_communication(
+            method=pathway_method,
+            min_lr_pairs=min_lr_pairs,
+            min_expression=min_expression,
+        )
+        _, summary = viz.get_significant_pathways_v2(
+            pathway_comm,
+            strength_threshold=strength_threshold,
+            pvalue_threshold=pvalue_threshold,
+            min_significant_pairs=min_significant_pairs,
+        )
     if summary is None or len(summary) == 0:
         raise ValueError("No signaling pathways remain after applying the pathway summary thresholds.")
     summary = summary.copy()
@@ -1332,6 +1428,708 @@ def _communication_matrix(
     return matrix, size_matrix, label
 
 
+def _rank_and_filter_long_df(
+    long_df: pd.DataFrame,
+    *,
+    color_by: Literal["score", "pvalue"],
+    top_n: int | None,
+    interaction_use=None,
+    pair_lr_use=None,
+) -> pd.DataFrame:
+    data = long_df.copy()
+    if interaction_use is not None or pair_lr_use is not None:
+        return data
+    if top_n is not None and top_n > 0:
+        score_col = "score" if color_by == "score" else "neglog10_pvalue"
+        keep = (
+            data.groupby("interaction", observed=True)[score_col]
+            .sum()
+            .sort_values(ascending=False)
+            .head(int(top_n))
+            .index
+        )
+        data = data.loc[data["interaction"].isin(keep)].copy()
+    return data
+
+
+def _normalized_marker_sizes(values: pd.Series, *, min_size: float = 20.0, max_size: float = 160.0) -> np.ndarray:
+    numeric = pd.to_numeric(values, errors="coerce").fillna(0.0).astype(float)
+    if numeric.empty:
+        return np.array([], dtype=float)
+    min_value = float(numeric.min())
+    max_value = float(numeric.max())
+    if np.isclose(min_value, max_value):
+        return np.full(len(numeric), (min_size + max_size) / 2.0, dtype=float)
+    scaled = (numeric - min_value) / (max_value - min_value)
+    return (min_size + scaled.to_numpy(dtype=float) * (max_size - min_size)).astype(float)
+
+
+def _facet_row_spacing(*, nrows: int, spacing: float = 0.16) -> float:
+    if nrows <= 1:
+        return 0.0
+    return float(spacing)
+
+
+def _last_visible_row_per_column(n_items: int, ncols: int) -> dict[int, int]:
+    mapping: dict[int, int] = {}
+    for idx in range(max(n_items, 0)):
+        col_idx = idx % max(ncols, 1)
+        row_idx = idx // max(ncols, 1)
+        mapping[col_idx] = row_idx
+    return mapping
+
+
+def _dotplot_left_margin(interactions: Sequence[str]) -> float:
+    max_label_len = max((len(str(label)) for label in interactions), default=0)
+    return float(np.clip(0.15 + 0.0045 * max_label_len, 0.17, 0.3))
+
+
+def _measured_dotplot_left_layout(
+    fig: plt.Figure,
+    axes: Sequence[plt.Axes],
+    fallback: float,
+) -> tuple[float, float]:
+    try:
+        fig.canvas.draw()
+        renderer = fig.canvas.get_renderer()
+    except Exception:
+        return fallback, max(fallback - 0.08, 0.01)
+
+    max_width_px = 0.0
+    for ax in axes:
+        if not ax.get_visible():
+            continue
+        for label in ax.get_yticklabels():
+            if not label.get_text():
+                continue
+            bbox = label.get_window_extent(renderer=renderer)
+            max_width_px = max(max_width_px, float(bbox.width))
+
+    if max_width_px <= 0:
+        return fallback, max(fallback - 0.08, 0.01)
+
+    fig_width_px = fig.get_figwidth() * fig.dpi
+    label_width_frac = max_width_px / max(fig_width_px, 1e-6)
+    measured_margin = float(max(fallback, min(label_width_frac + 0.05, 0.38)))
+    ylabel_x = float(max(0.01, measured_margin - label_width_frac - 0.035))
+    return measured_margin, ylabel_x
+
+
+def _measured_axis_text_extent(
+    fig: plt.Figure,
+    ax: plt.Axes,
+    *,
+    side: Literal["left", "right"],
+) -> float | None:
+    try:
+        fig.canvas.draw()
+        renderer = fig.canvas.get_renderer()
+    except Exception:
+        return None
+
+    extents: list[float] = []
+    ticklabels = ax.get_yticklabels()
+    for label in ticklabels:
+        if not label.get_text():
+            continue
+        bbox = label.get_window_extent(renderer=renderer)
+        if side == "left":
+            extents.append(float(bbox.x0))
+        else:
+            extents.append(float(bbox.x1))
+
+    ylabel = ax.yaxis.label
+    if ylabel is not None and ylabel.get_text():
+        bbox = ylabel.get_window_extent(renderer=renderer)
+        if side == "left":
+            extents.append(float(bbox.x0))
+        else:
+            extents.append(float(bbox.x1))
+
+    if not extents:
+        return None
+    return min(extents) if side == "left" else max(extents)
+
+
+def _axes_text_boundary(
+    fig: plt.Figure,
+    axes: Sequence[plt.Axes],
+    *,
+    side: Literal["left", "right"],
+) -> float | None:
+    extents = [
+        extent
+        for extent in (_measured_axis_text_extent(fig, ax, side=side) for ax in axes)
+        if extent is not None
+    ]
+    if not extents:
+        return None
+    return min(extents) if side == "left" else max(extents)
+
+
+def _axes_union_tightbbox(
+    fig: plt.Figure,
+    axes: Sequence[plt.Axes],
+) -> tuple[float, float, float, float] | None:
+    try:
+        fig.canvas.draw()
+        renderer = fig.canvas.get_renderer()
+    except Exception:
+        return None
+
+    bboxes = [ax.get_tightbbox(renderer=renderer) for ax in axes if ax.get_visible()]
+    bboxes = [bbox for bbox in bboxes if bbox is not None]
+    if not bboxes:
+        return None
+
+    fig_bbox = fig.bbox
+    if fig_bbox.width <= 0 or fig_bbox.height <= 0:
+        return None
+
+    x0 = min(float(bbox.x0) for bbox in bboxes) / fig_bbox.width
+    y0 = min(float(bbox.y0) for bbox in bboxes) / fig_bbox.height
+    x1 = max(float(bbox.x1) for bbox in bboxes) / fig_bbox.width
+    y1 = max(float(bbox.y1) for bbox in bboxes) / fig_bbox.height
+    return x0, y0, x1, y1
+
+
+def _set_nonoverlapping_supylabel(
+    fig: plt.Figure,
+    axes: Sequence[plt.Axes],
+    text: str,
+    *,
+    fallback_margin: float,
+    fontsize: float = 10,
+    padding_px: float = 10.0,
+):
+    left_margin, ylabel_x = _measured_dotplot_left_layout(fig, axes, fallback=fallback_margin)
+    artist = fig.supylabel(text, x=ylabel_x, fontsize=fontsize)
+    try:
+        for _ in range(2):
+            fig.canvas.draw()
+            renderer = fig.canvas.get_renderer()
+            label_bbox = artist.get_window_extent(renderer=renderer)
+            left_boundary = _axes_text_boundary(fig, axes, side="left")
+            if left_boundary is None or label_bbox.x1 < left_boundary - padding_px:
+                break
+            fig_width_px = fig.get_figwidth() * fig.dpi
+            delta_frac = (label_bbox.x1 - (left_boundary - padding_px)) / max(fig_width_px, 1e-6)
+            artist.set_x(max(0.002, float(artist.get_position()[0]) - delta_frac))
+    except Exception:
+        pass
+    return artist, left_margin
+
+
+def _contrasting_text_color(color) -> str:
+    r, g, b = mcolors.to_rgb(color)
+    luminance = 0.2126 * r + 0.7152 * g + 0.0722 * b
+    return "#1F1F1F" if luminance > 0.62 else "#FFFFFF"
+
+
+def _text_width_in_data_units(
+    fig: plt.Figure,
+    ax: plt.Axes,
+    text: str,
+    *,
+    fontsize: float,
+) -> float | None:
+    try:
+        fig.canvas.draw()
+        renderer = fig.canvas.get_renderer()
+    except Exception:
+        return None
+
+    probe = ax.text(0.0, 0.0, text, fontsize=fontsize, alpha=0.0)
+    try:
+        fig.canvas.draw()
+        renderer = fig.canvas.get_renderer()
+        bbox = probe.get_window_extent(renderer=renderer)
+    finally:
+        probe.remove()
+
+    left_data = ax.transData.inverted().transform((bbox.x0, bbox.y0))[0]
+    right_data = ax.transData.inverted().transform((bbox.x1, bbox.y0))[0]
+    width = abs(float(right_data - left_data))
+    if not np.isfinite(width):
+        return None
+    return width
+
+
+def _draw_liana_source_target_dot(
+    long_df: pd.DataFrame,
+    *,
+    color_by: Literal["score", "pvalue"],
+    top_n: int | None,
+    interaction_use=None,
+    pair_lr_use=None,
+    ncols: int | None,
+    nrows: int | None,
+    cmap: str,
+    figsize: tuple[float, float] | None,
+    title: str | None,
+):
+    data = _rank_and_filter_long_df(
+        long_df,
+        color_by=color_by,
+        top_n=top_n,
+        interaction_use=interaction_use,
+        pair_lr_use=pair_lr_use,
+    )
+    data = data.loc[data["score"] > 0].copy()
+    if data.empty:
+        raise ValueError("No dotplot records remain after filtering.")
+
+    score_col = "score" if color_by == "score" else "neglog10_pvalue"
+    data["target"] = data["receiver"].astype(str)
+    data["source"] = data["sender"].astype(str)
+    data["interaction_label"] = data["interaction_display"].astype(str)
+    interactions = (
+        data.groupby("interaction_label", observed=True)[score_col]
+        .sum()
+        .sort_values(ascending=True)
+        .index.astype(str)
+        .tolist()
+    )
+    targets = (
+        data.groupby("target", observed=True)[score_col]
+        .sum()
+        .sort_values(ascending=False)
+        .index.astype(str)
+        .tolist()
+    )
+    sources = (
+        data.groupby("source", observed=True)[score_col]
+        .sum()
+        .sort_values(ascending=False)
+        .index.astype(str)
+        .tolist()
+    )
+    n_sources = len(sources)
+    if ncols is not None and ncols <= 0:
+        raise ValueError("`ncols` must be a positive integer when provided.")
+    if nrows is not None and nrows <= 0:
+        raise ValueError("`nrows` must be a positive integer when provided.")
+    if ncols is not None and nrows is not None and ncols * nrows < n_sources:
+        raise ValueError("`ncols * nrows` must be at least the number of source panels.")
+
+    if ncols is None and nrows is None:
+        ncols = n_sources
+        nrows = 1
+    elif ncols is None:
+        nrows = int(nrows)
+        ncols = int(np.ceil(n_sources / nrows))
+    elif nrows is None:
+        ncols = int(ncols)
+        nrows = int(np.ceil(n_sources / ncols))
+    else:
+        ncols = int(ncols)
+        nrows = int(nrows)
+
+    ncols = min(ncols, max(n_sources, 1))
+    nrows = int(np.ceil(n_sources / max(ncols, 1)))
+
+    if figsize is None:
+        panel_width = 0.5 * max(len(targets), 1) + 1.0
+        panel_height = 0.44 * max(len(interactions), 1) + 0.9
+        fig_width = panel_width * ncols + 0.8
+        fig_height = panel_height * nrows + 0.6
+    else:
+        fig_width = float(figsize[0])
+        fig_height = float(figsize[1])
+    fig, axes = plt.subplots(
+        nrows,
+        ncols,
+        figsize=(fig_width, fig_height),
+        sharey=True,
+        squeeze=False,
+    )
+    axes_flat = axes.ravel()
+    facet_hspace = _facet_row_spacing(nrows=nrows)
+    left_margin = _dotplot_left_margin(interactions)
+    norm = mcolors.Normalize(vmin=float(data[score_col].min()), vmax=float(data[score_col].max()))
+    cmap_obj = plt.get_cmap(cmap)
+    last_visible_rows = _last_visible_row_per_column(len(sources), ncols)
+
+    for idx, (ax, source) in enumerate(zip(axes_flat, sources)):
+        subset = data.loc[data["source"] == source].copy()
+        x_codes = pd.Categorical(subset["target"].astype(str), categories=targets, ordered=True).codes
+        y_codes = pd.Categorical(subset["interaction_label"].astype(str), categories=interactions, ordered=True).codes
+        sizes = _normalized_marker_sizes(subset["score"])
+        colors = cmap_obj(norm(subset[score_col].astype(float)))
+        ax.scatter(x_codes, y_codes, s=sizes, c=colors, edgecolors="#2B2B2B", linewidths=0.35, alpha=0.88)
+        ax.set_title(str(source), fontsize=11, pad=8)
+        row_idx = idx // max(ncols, 1)
+        col_idx = idx % max(ncols, 1)
+        if row_idx == last_visible_rows.get(col_idx, nrows - 1):
+            ax.set_xticks(range(len(targets)), labels=targets, rotation=90)
+            ax.set_xlabel("Target", fontsize=10)
+        else:
+            ax.set_xticks(range(len(targets)), labels=[])
+            ax.set_xlabel("")
+        ax.set_yticks(range(len(interactions)), labels=interactions)
+        ax.tick_params(axis="x", labelsize=9)
+        ax.tick_params(axis="y", labelsize=9)
+        ax.grid(True, axis="both", color="#E6E6E6", linewidth=0.6)
+        ax.set_xlim(-0.5, len(targets) - 0.5)
+        ax.set_ylim(-0.5, len(interactions) - 0.5)
+    for idx, ax in enumerate(axes_flat[: len(sources)]):
+        if idx % max(ncols, 1) != 0:
+            ax.tick_params(labelleft=False)
+    for ax in axes_flat[len(sources):]:
+        ax.axis("off")
+    if hasattr(fig, "supylabel"):
+        _, left_margin = _set_nonoverlapping_supylabel(
+            fig,
+            axes_flat[: len(sources)],
+            "Interactions (Ligand -> Receptor)",
+            fallback_margin=left_margin,
+            fontsize=10,
+        )
+    else:
+        axes_flat[0].set_ylabel("Interactions (Ligand -> Receptor)", fontsize=10)
+    sm = plt.cm.ScalarMappable(norm=norm, cmap=cmap_obj)
+    sm.set_array([])
+    fig.subplots_adjust(
+        left=left_margin,
+        right=0.84,
+        bottom=0.14 if nrows == 1 else 0.1,
+        top=0.92 if title else 0.96,
+        wspace=0.12,
+        hspace=facet_hspace,
+    )
+    cbar_height = 0.34 if nrows == 1 else 0.42
+    cbar_y = 0.31 if nrows == 1 else 0.28
+    cax = fig.add_axes([0.87, cbar_y, 0.012, cbar_height])
+    cbar = fig.colorbar(
+        sm,
+        cax=cax,
+        label="Communication score" if color_by == "score" else "-log10(p-value)",
+    )
+    cbar.ax.tick_params(labelsize=8, length=2)
+    cbar.set_label(
+        "Communication score" if color_by == "score" else "-log10(p-value)",
+        fontsize=9,
+    )
+    if title:
+        fig.suptitle(title, y=0.975, fontsize=13)
+    return fig, axes_flat[0]
+
+
+def _draw_liana_tileplot(
+    long_df: pd.DataFrame,
+    *,
+    color_by: Literal["score", "pvalue"],
+    top_n: int | None,
+    interaction_use=None,
+    pair_lr_use=None,
+    cmap: str,
+    figsize: tuple[float, float] | None,
+    title: str | None,
+):
+    data = _rank_and_filter_long_df(
+        long_df,
+        color_by=color_by,
+        top_n=top_n,
+        interaction_use=interaction_use,
+        pair_lr_use=pair_lr_use,
+    )
+    if data.empty:
+        raise ValueError("No tile plot records remain after filtering.")
+
+    score_col = "score" if color_by == "score" else "neglog10_pvalue"
+
+    def _row_side_labels(frame: pd.DataFrame, column: str, ordered_interactions: list[str]) -> list[str]:
+        labels = (
+            frame.groupby("interaction_display", observed=True)[column]
+            .agg(lambda values: ", ".join(sorted(set(map(str, values))))[:42])
+            .reindex(ordered_interactions)
+            .fillna("")
+        )
+        return labels.astype(str).tolist()
+
+    rows = []
+    for side, cell_col, gene_col in (
+        ("Source ligand", "sender", "ligand_display"),
+        ("Target receptor", "receiver", "receptor_display"),
+    ):
+        tmp = (
+            data.groupby(["interaction_display", cell_col], observed=True)
+            .agg(value=(score_col, "mean"), label=(gene_col, lambda values: ", ".join(sorted(set(map(str, values))))[:42]))
+            .reset_index()
+            .rename(columns={"interaction_display": "interaction", cell_col: "cell_type"})
+        )
+        tmp["type"] = side
+        rows.append(tmp)
+    plot_data = pd.concat(rows, ignore_index=True)
+    interactions = (
+        data.groupby("interaction_display", observed=True)[score_col]
+        .sum()
+        .sort_values(ascending=True)
+        .index.astype(str)
+        .tolist()
+    )
+    left_row_labels = _row_side_labels(data, "ligand_display", interactions)
+    right_row_labels = _row_side_labels(data, "receptor_display", interactions)
+    cell_types = (
+        pd.concat([plot_data.loc[:, "cell_type"]])
+        .astype(str)
+        .drop_duplicates()
+        .tolist()
+    )
+    sides = ["Source ligand", "Target receptor"]
+    if figsize is None:
+        fig_width = 0.52 * max(len(cell_types), 1) * len(sides) + 2.8
+        fig_height = 0.42 * max(len(interactions), 1) + 1.8
+    else:
+        fig_width = float(figsize[0])
+        fig_height = float(figsize[1])
+    fig, axes = plt.subplots(1, 2, figsize=(fig_width, fig_height), sharey=False, squeeze=False)
+    axes_flat = axes.ravel()
+    norm = mcolors.Normalize(vmin=float(plot_data["value"].min()), vmax=float(plot_data["value"].max()))
+    cmap_obj = plt.get_cmap(cmap)
+    left_label_len = max((len(label) for label in left_row_labels), default=0)
+    right_label_len = max((len(label) for label in right_row_labels), default=0)
+    left_margin = float(np.clip(0.16 + 0.004 * left_label_len, 0.18, 0.3))
+    right_text_space = float(np.clip(0.12 + 0.004 * right_label_len, 0.16, 0.24))
+    cbar_space = 0.08
+
+    for ax, side in zip(axes_flat, sides):
+        subset = plot_data.loc[plot_data["type"] == side].copy()
+        matrix = subset.pivot_table(index="interaction", columns="cell_type", values="value", aggfunc="mean")
+        matrix = matrix.reindex(index=interactions, columns=cell_types)
+        im = ax.imshow(matrix.to_numpy(dtype=float), aspect="auto", cmap=cmap_obj, norm=norm)
+        ax.set_title("", fontsize=11)
+        ax.set_xticks(range(len(cell_types)), labels=cell_types, rotation=90)
+        ax.set_yticks(range(len(interactions)), labels=interactions)
+        ax.set_xlabel("Cell type", fontsize=10)
+        ax.tick_params(axis="x", labelsize=9)
+        ax.tick_params(axis="y", labelsize=9)
+        ax.grid(False)
+        ax.set_xticks(np.arange(-0.5, len(cell_types), 1), minor=True)
+        ax.set_yticks(np.arange(-0.5, len(interactions), 1), minor=True)
+        ax.grid(which="minor", color="#E6E6E6", linewidth=0.6)
+        ax.tick_params(which="minor", bottom=False, left=False)
+
+    axes_flat[0].set_yticks(range(len(interactions)), labels=left_row_labels)
+    axes_flat[0].set_ylabel("Source ligand", fontsize=10)
+    axes_flat[0].tick_params(axis="y", labelsize=9, pad=4)
+    axes_flat[1].set_yticks(range(len(interactions)), labels=right_row_labels)
+    axes_flat[1].yaxis.tick_right()
+    axes_flat[1].tick_params(axis="y", labelright=True, labelleft=False, labelsize=9, pad=4)
+    axes_flat[1].yaxis.set_label_position("right")
+    axes_flat[1].set_ylabel("Target receptor", fontsize=10, rotation=270, labelpad=18)
+
+    plot_right = 1.0 - right_text_space - cbar_space
+    fig.subplots_adjust(
+        left=left_margin,
+        right=plot_right,
+        bottom=0.24,
+        top=0.92 if title else 0.97,
+        wspace=0.08,
+    )
+    right_text_px = _measured_axis_text_extent(fig, axes_flat[1], side="right")
+    if right_text_px is not None:
+        fig_width_px = fig.get_figwidth() * fig.dpi
+        right_text_frac = right_text_px / max(fig_width_px, 1e-6)
+        cbar_x = min(max(right_text_frac + 0.02, plot_right + 0.03), 0.96)
+    else:
+        cbar_x = plot_right + 0.04
+    heatmap_bbox = axes_flat[1].get_position()
+    cbar_height = 0.5 * heatmap_bbox.height
+    cbar_y = heatmap_bbox.y0 + 0.5 * heatmap_bbox.height - 0.5 * cbar_height
+    cax = fig.add_axes([cbar_x, cbar_y, 0.012, cbar_height])
+    cbar = fig.colorbar(
+        im,
+        cax=cax,
+        label="Communication score" if color_by == "score" else "-log10(p-value)",
+    )
+    cbar.ax.tick_params(labelsize=8, length=2)
+    cbar.set_label(
+        "Communication score" if color_by == "score" else "-log10(p-value)",
+        fontsize=9,
+    )
+    if title:
+        fig.suptitle(title, y=0.98, fontsize=13)
+    return fig, axes_flat[0]
+
+
+def _draw_liana_sample_dot(
+    long_df: pd.DataFrame,
+    *,
+    sample_key: str,
+    color_by: Literal["score", "pvalue"],
+    top_n: int | None,
+    top_n_pairs: int | None,
+    interaction_use=None,
+    pair_lr_use=None,
+    ncols: int | None,
+    nrows: int | None,
+    cmap: str,
+    figsize: tuple[float, float] | None,
+    title: str | None,
+):
+    if sample_key not in long_df.columns:
+        raise ValueError(
+            f"`sample_key='{sample_key}'` is not available. Provide LIANA results with a "
+            f"`{sample_key}` column before using `plot_type='sample_dot'`."
+        )
+    data = _rank_and_filter_long_df(
+        long_df,
+        color_by=color_by,
+        top_n=top_n,
+        interaction_use=interaction_use,
+        pair_lr_use=pair_lr_use,
+    )
+    data = data.loc[data["score"] > 0].copy()
+    if data.empty:
+        raise ValueError("No sample dotplot records remain after filtering.")
+
+    score_col = "score" if color_by == "score" else "neglog10_pvalue"
+    data["sample"] = data[sample_key].astype(str)
+    data["pair"] = data["sender"].astype(str) + " -> " + data["receiver"].astype(str)
+    interactions = (
+        data.groupby("interaction_display", observed=True)[score_col]
+        .sum()
+        .sort_values(ascending=False)
+        .index.astype(str)
+        .tolist()
+    )
+    samples = sorted(data["sample"].dropna().astype(str).unique().tolist())
+    n_panels = max(len(interactions), 1)
+    if ncols is not None and ncols <= 0:
+        raise ValueError("`ncols` must be a positive integer when provided.")
+    if nrows is not None and nrows <= 0:
+        raise ValueError("`nrows` must be a positive integer when provided.")
+    if ncols is not None and nrows is not None and ncols * nrows < n_panels:
+        raise ValueError("`ncols * nrows` must be at least the number of interaction panels.")
+
+    if ncols is None and nrows is None:
+        ncols = min(3, n_panels)
+        nrows = int(np.ceil(n_panels / ncols))
+    elif ncols is None:
+        nrows = int(nrows)
+        ncols = int(np.ceil(n_panels / nrows))
+    elif nrows is None:
+        ncols = int(ncols)
+        nrows = int(np.ceil(n_panels / ncols))
+    else:
+        ncols = int(ncols)
+        nrows = int(nrows)
+
+    ncols = min(ncols, max(n_panels, 1))
+    nrows = int(np.ceil(n_panels / max(ncols, 1)))
+
+    if figsize is None:
+        fig_width = 3.1 * ncols + 1.4
+        fig_height = 2.7 * nrows + 0.9
+    else:
+        fig_width = float(figsize[0])
+        fig_height = float(figsize[1])
+    fig, axes = plt.subplots(nrows, ncols, figsize=(fig_width, fig_height), squeeze=False, sharex=False, sharey=False)
+    axes_flat = axes.ravel()
+    norm = mcolors.Normalize(vmin=float(data[score_col].min()), vmax=float(data[score_col].max()))
+    cmap_obj = plt.get_cmap(cmap)
+    panel_height = fig_height / max(nrows, 1)
+    auto_pair_cap = max(4, int((panel_height - 0.9) / 0.32))
+    pair_cap = int(top_n_pairs) if top_n_pairs is not None and top_n_pairs > 0 else auto_pair_cap
+    last_visible_rows = _last_visible_row_per_column(len(interactions), ncols)
+
+    visible_axes = []
+    for idx, (ax, interaction) in enumerate(zip(axes_flat, interactions)):
+        subset = data.loc[data["interaction_display"].astype(str) == interaction].copy()
+        pairs = (
+            subset.groupby("pair", observed=True)[score_col]
+            .sum()
+            .sort_values(ascending=False)
+            .index.astype(str)
+            .tolist()
+        )
+        pairs = pairs[:pair_cap]
+        subset = subset.loc[subset["pair"].astype(str).isin(pairs)].copy()
+        pairs = [pair for pair in pairs if pair in set(subset["pair"].astype(str))]
+        x_codes = pd.Categorical(subset["sample"].astype(str), categories=samples, ordered=True).codes
+        y_codes = pd.Categorical(subset["pair"].astype(str), categories=pairs, ordered=True).codes
+        ax.scatter(
+            x_codes,
+            y_codes,
+            s=_normalized_marker_sizes(subset["score"]),
+            c=cmap_obj(norm(subset[score_col].astype(float))),
+            edgecolors="#2B2B2B",
+            linewidths=0.35,
+            alpha=0.88,
+            zorder=3,
+        )
+        ax.set_title(interaction, fontsize=10)
+        row_idx = idx // max(ncols, 1)
+        col_idx = idx % max(ncols, 1)
+        if row_idx == last_visible_rows.get(col_idx, nrows - 1):
+            ax.set_xticks(range(len(samples)), labels=samples, rotation=90)
+            ax.set_xlabel(str(sample_key), fontsize=10)
+        else:
+            ax.set_xticks(range(len(samples)), labels=[])
+            ax.set_xlabel("")
+        if col_idx == 0:
+            ax.set_yticks(range(len(pairs)), labels=pairs)
+        else:
+            ax.set_yticks(range(len(pairs)), labels=[])
+        ax.tick_params(axis="x", labelsize=9)
+        ax.tick_params(axis="y", labelsize=8)
+        ax.grid(True, axis="both", color="#E6E6E6", linewidth=0.6, zorder=0)
+        ax.set_xlim(-0.18, len(samples) - 1 + 0.18)
+        ax.set_ylim(len(pairs) - 1 + 0.32, -0.32)
+        for spine in ax.spines.values():
+            spine.set_linewidth(0.9)
+            spine.set_zorder(1)
+        visible_axes.append(ax)
+    for ax in axes_flat[len(interactions):]:
+        ax.axis("off")
+    sm = plt.cm.ScalarMappable(norm=norm, cmap=cmap_obj)
+    sm.set_array([])
+    fig.subplots_adjust(left=0.28, right=0.88, bottom=0.16, top=0.9 if title else 0.95, wspace=0.18, hspace=0.24)
+    left_axes = [ax for idx, ax in enumerate(visible_axes) if idx % max(ncols, 1) == 0]
+    max_pair_label_len = max((len(str(pair)) for pair in data["pair"].astype(str).unique()), default=0)
+    fallback_left_margin = float(np.clip(0.22 + 0.0048 * max_pair_label_len, 0.34, 0.56))
+    left_margin = _measured_dotplot_left_layout(fig, left_axes, fallback=fallback_left_margin)[0]
+    fig.subplots_adjust(left=left_margin, right=0.88, bottom=0.16, top=0.9 if title else 0.95, wspace=0.18, hspace=0.24)
+    if hasattr(fig, "supylabel"):
+        _set_nonoverlapping_supylabel(
+            fig,
+            left_axes,
+            "Sender -> receiver",
+            fallback_margin=left_margin,
+            fontsize=10,
+            padding_px=24,
+        )
+    else:
+        visible_axes[0].set_ylabel("Sender -> receiver", fontsize=10)
+
+    x0 = min(ax.get_position().x0 for ax in visible_axes)
+    y0 = min(ax.get_position().y0 for ax in visible_axes)
+    x1 = max(ax.get_position().x1 for ax in visible_axes)
+    y1 = max(ax.get_position().y1 for ax in visible_axes)
+    tightbbox = _axes_union_tightbbox(fig, visible_axes)
+    if tightbbox is not None:
+        _, _, tight_x1, _ = tightbbox
+        x1 = max(x1, tight_x1)
+    bbox_height = y1 - y0
+    cbar_height = 0.45 * bbox_height
+    cbar_y = y0 + 0.5 * bbox_height - 0.5 * cbar_height
+    cax = fig.add_axes([min(x1 + 0.03, 0.94), cbar_y, 0.012, cbar_height])
+    cbar = fig.colorbar(
+        sm,
+        cax=cax,
+        label="Communication score" if color_by == "score" else "-log10(p-value)",
+    )
+    cbar.ax.tick_params(labelsize=8, length=2)
+    cbar.set_label(
+        "Communication score" if color_by == "score" else "-log10(p-value)",
+        fontsize=9,
+    )
+    if title:
+        fig.suptitle(title, y=0.98, fontsize=13)
+    return fig, axes_flat[0]
+
+
 def _maybe_save_show(fig, *, show: bool, save):
     if save:
         save_path = save if isinstance(save, str) else "communication_plot.png"
@@ -1492,6 +2290,127 @@ def _style_scatter_axis(ax, *, max_marker_size: float | None = None, arrow: bool
     ax.margins(x=0.08, y=0.10)
 
 
+def _style_lr_contribution_bar_axis(ax) -> None:
+    title_fontsize = 13
+    tick_fontsize = 13
+    label_fontsize = title_fontsize - 1
+    bars = list(ax.patches)
+    texts = list(ax.texts)
+    max_width = max((float(bar.get_width()) for bar in bars), default=0.0)
+    label_padding = 0.015 * max(max_width, 1.0)
+    outside_padding = 0.012 * max(max_width, 1.0)
+    has_outside_labels = False
+    for bar, text in zip(bars, texts):
+        label = text.get_text()
+        label_width = _text_width_in_data_units(
+            ax.figure,
+            ax,
+            label,
+            fontsize=label_fontsize,
+        )
+        bar_width = float(bar.get_width())
+        fits_inside = (
+            label_width is not None
+            and bar_width >= label_width + 2.0 * label_padding
+        )
+        if fits_inside:
+            text_x = max(bar_width - label_padding, label_width + label_padding)
+            text_ha = "right"
+            text_color = _contrasting_text_color(bar.get_facecolor())
+        else:
+            text_x = bar_width + outside_padding
+            text_ha = "left"
+            text_color = "#4A4A4A"
+            has_outside_labels = True
+        text.set_x(text_x)
+        text.set_y(float(bar.get_y() + bar.get_height() / 2.0))
+        text.set_ha(text_ha)
+        text.set_va("center")
+        text.set_color(text_color)
+        text.set_fontsize(label_fontsize)
+
+    if max_width > 0:
+        outside_extent = max(
+            [
+                float(bar.get_width())
+                + outside_padding
+                + (
+                    _text_width_in_data_units(
+                        ax.figure,
+                        ax,
+                        text.get_text(),
+                        fontsize=label_fontsize,
+                    )
+                    or 0.0
+                )
+            for bar, text in zip(bars, texts)
+            ],
+            default=max_width,
+        )
+        ax.set_xlim(0, outside_extent + label_padding if has_outside_labels else max_width * 1.001)
+    ax.margins(x=0.0)
+
+    ax.tick_params(axis="x", labelsize=12)
+    ax.tick_params(axis="y", labelsize=tick_fontsize)
+    ax.set_title(ax.get_title(), fontsize=title_fontsize)
+    ax.set_xlabel(ax.get_xlabel(), fontsize=12)
+    ax.set_ylabel("")
+    ax.grid(axis="x", alpha=0.22, linewidth=0.7)
+
+
+def _style_lr_contribution_scatter_axis(ax) -> None:
+    ax.set_title(ax.get_title(), fontsize=13)
+    ax.set_xlabel(ax.get_xlabel(), fontsize=12)
+    ax.set_ylabel(ax.get_ylabel(), fontsize=12)
+    ax.tick_params(axis="both", labelsize=11)
+    if ax.collections:
+        for collection in ax.collections:
+            if not hasattr(collection, "get_sizes"):
+                continue
+            sizes = np.asarray(collection.get_sizes(), dtype=float)
+            if sizes.size == 0:
+                continue
+            if float(sizes.max()) > 260.0:
+                scaled = np.sqrt(np.clip(sizes, a_min=0.0, a_max=None))
+                if float(scaled.max()) > 0.0:
+                    scaled = 36.0 + (scaled / float(scaled.max())) * (260.0 - 36.0)
+                collection.set_sizes(np.clip(scaled, 24.0, 260.0))
+    ax.margins(x=0.16, y=0.18)
+    ax.grid(True, alpha=0.22, linewidth=0.7)
+    for collection in ax.collections:
+        if hasattr(collection, "set_alpha"):
+            collection.set_alpha(0.82)
+    for text in ax.texts:
+        text.set_clip_on(False)
+    _repel_text_labels(ax, ax.texts, arrow=True)
+    if ax.figure is not None:
+        for extra_ax in ax.figure.axes:
+            if extra_ax is ax:
+                continue
+            ylabel = extra_ax.get_ylabel()
+            if ylabel and "Contribution" in ylabel:
+                bbox = ax.get_position()
+                extra_ax.set_position([
+                    bbox.x1 + 0.018,
+                    bbox.y0 + 0.25 * bbox.height,
+                    0.014,
+                    0.5 * bbox.height,
+                ])
+                extra_ax.tick_params(labelsize=11)
+                extra_ax.yaxis.label.set_size(12)
+
+
+def _resolve_dual_cmaps(cmap) -> tuple[str, str]:
+    if isinstance(cmap, (tuple, list)):
+        if len(cmap) >= 2:
+            return str(cmap[0]), str(cmap[1])
+        if len(cmap) == 1:
+            return str(cmap[0]), str(cmap[0])
+    if cmap is None:
+        return "Blues", "viridis"
+    return str(cmap), str(cmap)
+
+
 def _draw_role_scatter_style(
     ax,
     *,
@@ -1618,6 +2537,7 @@ def _dot_matrix_plot(
     right_annos: Sequence[str] = (),
 ):
     ma, mp = _import_marsilea()
+    _warn_if_broken_marsilea_version(ma)
     display_color = matrix.copy()
     display_size = size_matrix.reindex(index=matrix.index, columns=matrix.columns, fill_value=0.0).copy()
     row_names = matrix.index.astype(str).tolist()
@@ -1783,12 +2703,12 @@ def _draw_diff_circle_network(
 @register_function(
     aliases=["ccc_heatmap", "communication_heatmap", "细胞通讯热图"],
     category="pl",
-    description="Python-native cell-cell communication heatmap and dot-matrix plots for CellPhoneDB-style communication AnnData.",
+    description="Python-native cell-cell communication heatmaps and dot-style plots that accept raw analysis AnnData or preformatted communication AnnData.",
     examples=[
-        "ov.pl.ccc_heatmap(comm_adata, plot_type='heatmap')",
-        "ov.pl.ccc_heatmap(comm_adata, plot_type='dot', display_by='interaction', top_n=20)",
-        "ov.pl.ccc_heatmap(comm_adata, plot_type='role_heatmap', pattern='incoming')",
-        "ov.pl.ccc_heatmap(comm_adata, signaling='MK', sender_use='Ductal')",
+        "ov.pl.ccc_heatmap(adata, plot_type='heatmap')",
+        "ov.pl.ccc_heatmap(adata, plot_type='dot', display_by='interaction', top_n=20)",
+        "ov.pl.ccc_heatmap(adata, plot_type='role_heatmap', pattern='incoming')",
+        "ov.pl.ccc_heatmap(adata, signaling='MK', sender_use='Ductal')",
     ],
     related=["pl.ccc_network_plot", "pl.ccc_stat_plot", "pl.CellChatViz"],
 )
@@ -1799,6 +2719,10 @@ def ccc_heatmap(
         "heatmap",
         "focused_heatmap",
         "dot",
+        "tile",
+        "source_target_dot",
+        "source_target_tile",
+        "sample_dot",
         "bubble",
         "bubble_lr",
         "pathway_bubble",
@@ -1814,6 +2738,17 @@ def ccc_heatmap(
     signaling=None,
     interaction_use=None,
     pair_lr_use=None,
+    sample_key: str = "sample",
+    ncols: int | None = None,
+    nrows: int | None = None,
+    result_uns_key: str = "liana_res",
+    score_key: str = "specificity_rank",
+    pvalue_key: str = "specificity_rank",
+    inverse_score: bool = True,
+    inverse_pvalue: bool = False,
+    classification: str | Mapping[str, str] | None = None,
+    classification_reference: str | pd.DataFrame | None = "cellchat",
+    classification_fallback: str | None = "family",
     pvalue_threshold: float = 0.05,
     pattern: Literal["outgoing", "incoming", "all"] = "all",
     color_by: Literal["score", "pvalue"] = "score",
@@ -1836,11 +2771,14 @@ def ccc_heatmap(
     min_interaction_threshold: float = 0.0,
     cluster_rows: bool = False,
     cluster_columns: bool = False,
+    show_row_names: bool = False,
+    show_col_names: bool = False,
     add_text: bool | None = None,
     border: bool = False,
     cmap: str = "Reds",
-    figsize: tuple[float, float] = (8, 6),
+    figsize: tuple[float, float] | None = None,
     title: str | None = None,
+    verbose: bool = True,
     show: bool = False,
     save: str | bool = False,
 ):
@@ -1849,13 +2787,17 @@ def ccc_heatmap(
     Parameters
     ----------
     adata : anndata.AnnData
-        Communication AnnData produced by the OmicVerse CCC workflow. The
-        object should contain aggregated pathway scores and interaction-level
-        summaries required by the selected ``plot_type``.
+        Communication AnnData produced by the OmicVerse CCC workflow, or a
+        regular AnnData containing a LIANA result table in
+        ``adata.uns[result_uns_key]``. LIANA inputs are adapted internally to
+        the communication format expected by ``ccc_*``.
     plot_type : str, default="heatmap"
-        Matrix view to render. Supported values include aggregated heatmaps,
-        focused heatmaps, dot and bubble summaries, pathway-level bubble
-        plots, signaling role maps, and differential heatmaps.
+        Matrix view to render. ``'dot'`` is the primary LIANA-style source /
+        target interaction dotplot. ``'source_target_dot'`` is kept only as a
+        backward-compatible alias of the same layout. Other supported values
+        include aggregated heatmaps, focused heatmaps, bubble summaries,
+        pathway-level bubble plots, source-target tile/sample views,
+        signaling role maps, and differential heatmaps.
     comparison_adata : anndata.AnnData or None, default=None
         Second communication AnnData used when plotting condition-to-condition
         differential heatmaps.
@@ -1873,6 +2815,41 @@ def ccc_heatmap(
         plots.
     pair_lr_use : str, sequence of str, or None, default=None
         Ligand-receptor pair identifiers used by pair-resolved bubble views.
+    sample_key : str, default="sample"
+        Observation/sample column used by ``plot_type='sample_dot'`` after
+        LIANA results are converted to communication AnnData. If this column
+        is not present but LIANA conversion stored a detected sample/context
+        key in ``adata.uns['liana_sample_key']``, that key is used
+        automatically.
+    ncols, nrows : int or None, default=None
+        Number of source facets per row/column for LIANA-style dot layouts.
+        These parameters are used by ``plot_type='dot'`` (and the
+        backward-compatible alias ``'source_target_dot'``) to avoid a
+        single excessively wide row when many source panels are shown.
+    result_uns_key : str, default="liana_res"
+        ``adata.uns`` key searched when ``adata`` is not already a
+        communication AnnData. If a compatible LIANA result table is found, it
+        is converted automatically.
+    score_key, pvalue_key : str, default="specificity_rank"
+        Columns used when auto-converting LIANA results to communication
+        scores and p-value-like support values.
+    inverse_score, inverse_pvalue : bool, default=(True, False)
+        Whether the LIANA score or p-value columns should be inverted during
+        automatic conversion.
+    classification : str, mapping, or None, default=None
+        Optional LIANA classification override used only during automatic
+        conversion.
+    classification_reference : str, pandas.DataFrame, or None, default="cellchat"
+        Reference used to backfill pathway labels during automatic LIANA
+        conversion. This mainly affects pathway/signaling summaries such as
+        ``display_by='aggregation'`` and ``plot_type='pathway_summary'``.
+        Pure interaction-level views do not depend on this label unless the
+        plotted layout groups interactions by pathway.
+    classification_fallback : str or None, default="family"
+        Fallback pathway label strategy used during automatic LIANA
+        conversion when a pair is not found in ``classification_reference``.
+        Supported values are ``'family'``, ``'unclassified'``,
+        ``'label:<name>'``, or ``None``.
     pvalue_threshold : float, default=0.05
         Maximum p-value retained as a significant communication event.
     pattern : {"outgoing", "incoming", "all"}, default="all"
@@ -1884,11 +2861,10 @@ def ccc_heatmap(
         Aggregation statistic used to summarize communication strengths before
         plotting.
     top_n : int, default=20
-        Number of top pathways or interactions retained in ranked matrix
-        views.
+        Number of top pathways or interactions retained in ranked views.
     top_n_pairs : int or None, default=None
-        Number of ligand-receptor pairs retained in interaction-level views.
-        When omitted and ``display_by='interaction'``, ``top_n`` is used.
+        Reserved for dense interaction matrix layouts. It is not used by the
+        LIANA-style ``plot_type='dot'`` view.
     top_anno : str, sequence of str, or None, default="bar"
         Annotation layer(s) displayed above the matrix, such as cell-color or
         summary-bar annotations.
@@ -1901,8 +2877,8 @@ def ccc_heatmap(
     bar_value : {"count", "sum", "mean", "max"}, default="sum"
         Summary statistic used in bar-style annotations.
     facet_by : {"sender", "receiver"} or None, default=None
-        Split the matrix into sender- or receiver-specific facets when the
-        selected plot type supports faceting.
+        Split matrix-style views into sender- or receiver-specific facets when
+        the selected plot type supports faceting.
     pathway_method : str, default="mean"
         Method used to summarize multiple ligand-receptor pairs into pathway
         level scores.
@@ -1926,6 +2902,13 @@ def ccc_heatmap(
         Whether to cluster matrix rows before plotting.
     cluster_columns : bool, default=False
         Whether to cluster matrix columns before plotting.
+    show_row_names : bool, default=False
+        Whether to display explicit row/cell-type labels in Marsilea-backed
+        ``plot_type='heatmap'`` and ``plot_type='focused_heatmap'`` views.
+    show_col_names : bool, default=False
+        Whether to display explicit column/cell-type labels in
+        Marsilea-backed ``plot_type='heatmap'`` and
+        ``plot_type='focused_heatmap'`` views.
     add_text : bool or None, default=None
         Whether to overlay text labels on matrix entries when the selected
         plot type supports annotation text.
@@ -1933,11 +2916,21 @@ def ccc_heatmap(
         Whether to draw borders around matrix cells.
     cmap : str, default="Reds"
         Colormap used for the matrix color scale.
-    figsize : tuple of float, default=(8, 6)
-        Figure size in inches.
+    figsize : tuple of float or None, default=None
+        Figure size in inches. For ``plot_type='dot'`` and
+        ``'source_target_dot'`` and ``'tile'``/``'source_target_tile'``,
+        ``None`` enables automatic sizing based on
+        the number of source panels, targets, and interactions. When an
+        explicit tuple is provided, the dot plot uses that final size directly
+        without enforcing an internal minimum. Other heatmap-style views fall
+        back to their historical default size when ``None`` is given.
     title : str or None, default=None
         Custom title for the generated figure. When omitted, a plot-specific
         default title is used.
+    verbose : bool, default=True
+        Whether pathway-ranking helper steps should print textual summaries to
+        standard output. This currently matters for views that auto-rank
+        pathways from summary statistics.
     show : bool, default=False
         Whether to immediately display the figure.
     save : str or bool, default=False
@@ -1949,6 +2942,36 @@ def ccc_heatmap(
         A ``(fig, ax)`` tuple containing the Matplotlib figure and the main
         axes used for the rendered heatmap-style view.
     """
+    _validate_display_by(display_by, func_name="ccc_heatmap")
+    dot_figsize = figsize
+    if figsize is None:
+        figsize = (8, 6)
+
+    adata = _resolve_comm_adata(
+        adata,
+        arg_name="adata",
+        result_uns_key=result_uns_key,
+        score_key=score_key,
+        pvalue_key=pvalue_key,
+        inverse_score=inverse_score,
+        inverse_pvalue=inverse_pvalue,
+        classification=classification,
+        classification_reference=classification_reference,
+        classification_fallback=classification_fallback,
+    )
+    if comparison_adata is not None:
+        comparison_adata = _resolve_comm_adata(
+            comparison_adata,
+            arg_name="comparison_adata",
+            result_uns_key=result_uns_key,
+            score_key=score_key,
+            pvalue_key=pvalue_key,
+            inverse_score=inverse_score,
+            inverse_pvalue=inverse_pvalue,
+            classification=classification,
+            classification_reference=classification_reference,
+            classification_fallback=classification_fallback,
+        )
     default_top_bar = top_anno == "bar"
     default_left_bar = left_anno == "bar"
     default_bottom_cell = bottom_anno == "cell"
@@ -1957,16 +2980,19 @@ def ccc_heatmap(
     bottom_annos = _normalize_side_annotations(bottom_anno, default=("cell",))
     left_annos = _normalize_side_annotations(left_anno, default=("bar",))
     right_annos = _normalize_side_annotations(right_anno, default=("cell",))
-    if plot_type in {"heatmap", "dot", "bubble"} and default_top_bar:
+    if plot_type in {"heatmap", "bubble"} and default_top_bar:
         top_annos = ["bar", "cell"]
-    if plot_type in {"heatmap", "dot", "bubble"} and display_by == "aggregation" and default_left_bar:
+    if plot_type in {"heatmap", "bubble"} and display_by == "aggregation" and default_left_bar:
         left_annos = ["bar", "cell"]
-    if plot_type in {"heatmap", "dot", "bubble", "pathway_bubble"} and default_bottom_cell:
+    if plot_type in {"heatmap", "bubble", "pathway_bubble"} and default_bottom_cell:
         bottom_annos = []
-    if plot_type in {"heatmap", "dot", "bubble", "pathway_bubble"} and default_right_cell:
+    if plot_type in {"heatmap", "bubble", "pathway_bubble"} and default_right_cell:
         right_annos = []
-    if display_by == "interaction" and top_n_pairs is None:
-        top_n_pairs = top_n
+    if plot_type == "matrix_dot":
+        raise ValueError(
+            "`plot_type='matrix_dot'` has been removed. Use `plot_type='dot'` "
+            "for the LIANA-style interaction dotplot."
+        )
 
     if plot_type == "heatmap" and display_by == "aggregation":
         _raise_for_unsupported_arguments(
@@ -1993,6 +3019,8 @@ def ccc_heatmap(
             add_dendrogram=cluster_rows or cluster_columns,
             add_row_sum=True,
             add_col_sum=True,
+            show_row_names=show_row_names,
+            show_col_names=show_col_names,
             title=title or "Communication heatmap",
         )
         fig, ax = _render_plotter_figure(plotter, title=None)
@@ -2024,6 +3052,8 @@ def ccc_heatmap(
             add_dendrogram=cluster_rows or cluster_columns,
             add_row_sum=True,
             add_col_sum=True,
+            show_row_names=show_row_names,
+            show_col_names=show_col_names,
             figsize=figsize,
             title=title or "Focused communication heatmap",
         )
@@ -2050,7 +3080,8 @@ def ccc_heatmap(
         viz = _build_cellchatviz(adata)
         role_pattern = "overall" if pattern == "all" else pattern
         signaling_values = _normalize_use_arg(signaling)
-        if signaling_values is None and top_n is not None and top_n > 0:
+        auto_selected_pathways = signaling_values is None and top_n is not None and top_n > 0
+        if auto_selected_pathways:
             pathway_summary = _pathway_summary_table(
                 adata,
                 signaling=None,
@@ -2058,18 +3089,26 @@ def ccc_heatmap(
                 min_lr_pairs=min_lr_pairs,
                 min_expression=min_expression,
                 pvalue_threshold=pvalue_threshold,
+                verbose=verbose,
             )
             signaling_values = pathway_summary["pathway"].astype(str).head(int(top_n)).tolist()
-        plotter, _, _ = viz.netAnalysis_signalingRole_heatmap(
-            pattern=role_pattern,
-            signaling=signaling_values,
-            row_scale=False,
-            figsize=figsize,
-            cmap=cmap,
-            show_totals=True,
-            title=title or f"Communication role heatmap ({role_pattern})",
-        )
-        fig, ax = _render_plotter_figure(plotter, title=None)
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message="Using categorical units to plot a list of strings that are all parsable as floats or dates.*",
+                category=UserWarning,
+            )
+            plotter, _, _ = viz.netAnalysis_signalingRole_heatmap(
+                pattern=role_pattern,
+                signaling=signaling_values,
+                row_scale=False,
+                figsize=figsize,
+                cmap=cmap,
+                show_totals=True,
+                min_threshold=min_expression,
+                title=title or f"Communication role heatmap ({role_pattern})",
+            )
+            fig, ax = _render_plotter_figure(plotter, title=None)
         return _maybe_save_show(fig, show=show, save=save), ax
 
     if plot_type == "role_network":
@@ -2152,32 +3191,58 @@ def ccc_heatmap(
             value=value,
             allowed_value=("sum", "mean", "count"),
         )
-        signaling_values = _require_use_argument(plot_type, "signaling", signaling)
+        signaling_values = _normalize_use_arg(signaling)
+        auto_selected_pathways = signaling_values is None and top_n is not None and top_n > 0
+        if auto_selected_pathways:
+            pathway_summary = _pathway_summary_table(
+                adata,
+                signaling=None,
+                pathway_method=pathway_method,
+                min_lr_pairs=min_lr_pairs,
+                min_expression=min_expression,
+                pvalue_threshold=pvalue_threshold,
+                verbose=verbose,
+            )
+            signaling_values = pathway_summary["pathway"].astype(str).head(int(top_n)).tolist()
+        if signaling_values is None:
+            raise ValueError("`signaling` is required when `plot_type='pathway_bubble'`, unless `top_n` is used to auto-select pathways.")
         viz = _build_cellchatviz(adata)
-        plotter = viz.netVisual_bubble_marsilea(
-            sources_use=sender_use,
-            targets_use=receiver_use,
-            signaling=signaling_values,
-            pvalue_threshold=pvalue_threshold,
-            mean_threshold=min_expression,
-            top_interactions=top_n,
-            show_pvalue=True,
-            show_mean=True,
-            show_count=(value == "count"),
-            add_violin=add_violin,
-            add_dendrogram=cluster_rows or cluster_columns,
-            group_pathways=group_pathways,
-            figsize=figsize,
-            title=title or "Pathway bubble summary",
-            remove_isolate=remove_isolate,
-            cmap=cmap,
-            transpose=transpose,
-            show_sender_colors=True,
-            show_receiver_colors=False,
-        )
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message="Using categorical units to plot a list of strings that are all parsable as floats or dates.*",
+                category=UserWarning,
+            )
+            plotter = viz.netVisual_bubble_marsilea(
+                sources_use=sender_use,
+                targets_use=receiver_use,
+                signaling=signaling_values,
+                pvalue_threshold=pvalue_threshold,
+                mean_threshold=min_expression,
+                top_interactions=None if auto_selected_pathways else top_n,
+                show_pvalue=True,
+                show_mean=True,
+                show_count=(value == "count"),
+                add_violin=add_violin,
+                add_dendrogram=cluster_rows or cluster_columns,
+                group_pathways=group_pathways,
+                figsize=figsize,
+                title=title or "Pathway bubble summary",
+                remove_isolate=remove_isolate,
+                cmap=cmap,
+                transpose=transpose,
+                show_sender_colors=True,
+                show_receiver_colors=False,
+            )
         if plotter is None:
             raise ValueError("No communication records remain after filtering.")
-        fig, ax = _render_plotter_figure(plotter, title=None)
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message="Using categorical units to plot a list of strings that are all parsable as floats or dates.*",
+                category=UserWarning,
+            )
+            fig, ax = _render_plotter_figure(plotter, title=None)
         return _maybe_save_show(fig, show=show, save=save), ax
 
     if plot_type == "bubble_lr":
@@ -2275,6 +3340,8 @@ def ccc_heatmap(
             right_annos=right_annos,
             max_col_labels=14,
             clip_quantile=0.95,
+            show_row_names=show_row_names,
+            show_col_names=show_col_names,
         )
         return _maybe_save_show(fig, show=show, save=save), ax
 
@@ -2287,6 +3354,91 @@ def ccc_heatmap(
         pair_lr_use=pair_lr_use,
         pvalue_threshold=pvalue_threshold,
     )
+    resolved_sample_key = sample_key
+    if resolved_sample_key not in adata.obs.columns:
+        detected_sample_key = adata.uns.get("liana_sample_key")
+        if (
+            isinstance(detected_sample_key, str)
+            and detected_sample_key
+            and detected_sample_key != "none"
+            and detected_sample_key in adata.obs.columns
+        ):
+            resolved_sample_key = detected_sample_key
+
+    if resolved_sample_key in adata.obs.columns:
+        long_df = long_df.merge(
+            adata.obs.loc[:, [resolved_sample_key]].astype(str),
+            left_on="pair_id",
+            right_index=True,
+            how="left",
+        )
+    if plot_type in {"dot", "source_target_dot"}:
+        if display_by != "interaction":
+            raise ValueError(
+                f"`plot_type='{plot_type}'` only supports `display_by='interaction'`."
+            )
+        if plot_type == "source_target_dot":
+            warnings.warn(
+                "`plot_type='source_target_dot'` is now a compatibility alias of "
+                "`plot_type='dot'`. Prefer `plot_type='dot'`.",
+                FutureWarning,
+                stacklevel=2,
+            )
+        _raise_for_unsupported_arguments(
+            plot_type,
+            comparison_adata=comparison_adata,
+            facet_by=facet_by,
+            top_n_pairs=top_n_pairs,
+        )
+        fig, ax = _draw_liana_source_target_dot(
+            long_df,
+            color_by=color_by,
+            top_n=top_n,
+            interaction_use=interaction_use,
+            pair_lr_use=pair_lr_use,
+            ncols=ncols,
+            nrows=nrows,
+            cmap=cmap,
+            figsize=dot_figsize,
+            title=title,
+        )
+        return _maybe_save_show(fig, show=show, save=save), ax
+    if plot_type in {"tile", "source_target_tile"}:
+        if plot_type == "source_target_tile":
+            warnings.warn(
+                "`plot_type='source_target_tile'` is now a compatibility alias of "
+                "`plot_type='tile'`. Prefer `plot_type='tile'`.",
+                FutureWarning,
+                stacklevel=2,
+            )
+        fig, ax = _draw_liana_tileplot(
+            long_df,
+            color_by=color_by,
+            top_n=top_n,
+            interaction_use=interaction_use,
+            pair_lr_use=pair_lr_use,
+            cmap=cmap,
+            figsize=figsize,
+            title=title,
+        )
+        return _maybe_save_show(fig, show=show, save=save), ax
+    if plot_type == "sample_dot":
+        fig, ax = _draw_liana_sample_dot(
+            long_df,
+            sample_key=resolved_sample_key,
+            color_by=color_by,
+            top_n=top_n,
+            top_n_pairs=top_n_pairs,
+            interaction_use=interaction_use,
+            pair_lr_use=pair_lr_use,
+            ncols=ncols,
+            nrows=nrows,
+            cmap=cmap,
+            figsize=figsize,
+            title=title,
+        )
+        return _maybe_save_show(fig, show=show, save=save), ax
+
     matrix, size_matrix, color_label = _communication_matrix(
         long_df,
         display_by=display_by,
@@ -2303,8 +3455,8 @@ def ccc_heatmap(
     if add_text is None:
         add_text = plot_type == "heatmap" and display_by == "aggregation" and matrix.size <= 49
 
-    if plot_type in {"dot", "bubble"}:
-        default_title = "Communication bubble plot" if plot_type == "bubble" else "Communication dot matrix"
+    if plot_type == "bubble":
+        default_title = "Communication bubble plot"
         resolved_title = title or f"{default_title} ({display_color_label})"
         fig, ax = _dot_matrix_plot(
             matrix,
@@ -2535,13 +3687,33 @@ def _draw_arrow_network(
                 edgecolor="white",
             )
 
-    for x_coord, label in column_titles:
-        ax.text(x_coord, 1.01, label, ha="center", va="bottom", fontsize=11, transform=ax.transAxes)
+    column_anchor_offsets = {
+        "Sender": -0.12,
+        "Ligand-Receptor": 0.10,
+        "Receiver": 0.12,
+    }
+    title_anchors = [float(x_coord) + column_anchor_offsets.get(str(label), 0.0) for x_coord, label in column_titles]
 
-    ax.set_xlim(-0.18, 1.28)
-    ax.set_ylim(-0.08, 1.06)
-    ax.set_title(title or "Communication flow", pad=24)
+    if not node_df.empty:
+        x_values = node_df["x"].astype(float).tolist() + title_anchors
+        x_min = min(x_values) - 0.20
+        x_max = max(x_values) + 0.20
+    else:
+        x_min, x_max = -0.30, 1.35
+
+    _draw_network_column_headers(
+        ax,
+        list(zip(title_anchors, [label for _, label in column_titles])),
+        x_min=x_min,
+        x_max=x_max,
+        y_axes=0.90,
+        fontsize=11,
+    )
+    ax.set_xlim(x_min, x_max)
+    ax.set_ylim(-0.03, 1.01)
+    ax.set_title(title or "Communication flow", fontsize=13, pad=8)
     ax.set_axis_off()
+    fig.subplots_adjust(top=0.88, bottom=0.08, left=0.06, right=0.94)
     return fig, ax
 
 
@@ -2651,13 +3823,33 @@ def _draw_sigmoid_network(
                 edgecolor="white",
             )
 
-    for x_coord, label in column_titles:
-        ax.text(x_coord, 1.01, label, ha="center", va="bottom", fontsize=11, transform=ax.transAxes)
+    column_anchor_offsets = {
+        "Sender": -0.12,
+        "Ligand-Receptor": 0.10,
+        "Receiver": 0.12,
+    }
+    title_anchors = [float(x_coord) + column_anchor_offsets.get(str(label), 0.0) for x_coord, label in column_titles]
 
-    ax.set_xlim(-0.18, 1.28)
-    ax.set_ylim(-0.08, 1.06)
-    ax.set_title(title or "Communication sigmoid flow", pad=24)
+    if not node_df.empty:
+        x_values = node_df["x"].astype(float).tolist() + title_anchors
+        x_min = min(x_values) - 0.20
+        x_max = max(x_values) + 0.20
+    else:
+        x_min, x_max = -0.30, 1.35
+
+    _draw_network_column_headers(
+        ax,
+        list(zip(title_anchors, [label for _, label in column_titles])),
+        x_min=x_min,
+        x_max=x_max,
+        y_axes=0.90,
+        fontsize=11,
+    )
+    ax.set_xlim(x_min, x_max)
+    ax.set_ylim(-0.03, 1.01)
+    ax.set_title(title or "Communication sigmoid flow", fontsize=13, pad=8)
     ax.set_axis_off()
+    fig.subplots_adjust(top=0.88, bottom=0.08, left=0.06, right=0.94)
     return fig, ax
 
 
@@ -2717,9 +3909,25 @@ def _draw_bipartite_network(
     receptor_totals = data.groupby("receptor", observed=True)["score"].sum().reindex(receptors).fillna(0.0)
     receiver_totals = data.groupby("receiver", observed=True)["score"].sum().reindex(receivers).fillna(0.0)
 
-    sender_pos = {label: (0.0, pos[1]) for label, pos in _weighted_positions(senders, sender_totals).items()}
+    sender_stage_pos, _, _ = _stacked_stage_positions(
+        senders,
+        sender_totals,
+        wrap_width=18,
+        top=0.86,
+        bottom=0.10,
+        gap=0.028,
+    )
+    sender_pos = {label: (0.0, y_coord) for label, y_coord in sender_stage_pos.items()}
     sender_center = np.median([value[1] for value in sender_pos.values()]) if sender_pos else 0.5
-    receiver_pos = {label: (3.0, pos[1]) for label, pos in _weighted_positions(receivers, receiver_totals).items()}
+    receiver_stage_pos, _, _ = _stacked_stage_positions(
+        receivers,
+        receiver_totals,
+        wrap_width=18,
+        top=0.86,
+        bottom=0.10,
+        gap=0.028,
+    )
+    receiver_pos = {label: (3.0, y_coord) for label, y_coord in receiver_stage_pos.items()}
     receiver_center = np.median([value[1] for value in receiver_pos.values()]) if receiver_pos else sender_center
     bridge_center = float((sender_center + receiver_center) / 2.0)
     ligand_pos = {ligand_name: (1.0, bridge_center)}
@@ -2805,7 +4013,9 @@ def _draw_bipartite_network(
             )
         )
 
-    bridge_label_offset = 0.065
+    bridge_label_offset = 0.0
+    ligand_label_x = 1.0 - 0.10
+    receptor_label_x = 2.0 + 0.10
     for sender, (x_coord, y_coord) in sender_pos.items():
         ax.scatter(x_coord, y_coord, s=280, c=cell_colors[sender], edgecolors="white", linewidths=1.0, zorder=3)
         ax.text(x_coord - 0.08, y_coord, sender, ha="right", va="center", fontsize=10)
@@ -2821,41 +4031,61 @@ def _draw_bipartite_network(
             zorder=3,
         )
         ax.text(
-            x_coord,
+            ligand_label_x,
             y_coord + bridge_label_offset,
             _wrap_plot_label(ligand_display, width=16),
-            ha="center",
-            va="bottom",
+            ha="right",
+            va="center",
             fontsize=9,
+            bbox={"facecolor": "white", "edgecolor": "none", "alpha": 0.82, "pad": 0.2},
+            zorder=4,
         )
     for receptor_label, (x_coord, y_coord) in receptor_pos.items():
         _draw_flow_stage_node(
             ax,
             x_coord=x_coord,
             y_coord=y_coord,
-            label=receptor_display.get(receptor_label, _display_gene_label(receptor_label)),
+            label="",
             weight=float(receptor_totals.get(receptor_label, 0.0)),
             node_max_weight=float(receptor_totals.max()) if not receptor_totals.empty else 1.0,
             wrap_width=18,
             compact_scale=receptor_scale,
             font_scale=receptor_font_scale,
             label_mode="side",
-            text_offset=0.08,
-            text_y_offset=bridge_label_offset,
+            text_offset=0.0,
+            text_y_offset=0.0,
+            text_align="left",
             facecolor=bridge_colors.get(str(receptor_label), "#D9D9D9"),
             edgecolor="white",
+        )
+        ax.text(
+            receptor_label_x,
+            y_coord + bridge_label_offset,
+            _wrap_plot_label(receptor_display.get(receptor_label, _display_gene_label(receptor_label)), width=16),
+            ha="left",
+            va="center",
+            fontsize=max(7.0, 8.8 * receptor_font_scale),
+            bbox={"facecolor": "white", "edgecolor": "none", "alpha": 0.82, "pad": 0.2},
+            zorder=4,
         )
     for receiver, (x_coord, y_coord) in receiver_pos.items():
         ax.scatter(x_coord, y_coord, s=280, c=cell_colors[receiver], edgecolors="white", linewidths=1.0, zorder=3)
         ax.text(x_coord + 0.08, y_coord, receiver, ha="left", va="center", fontsize=10)
 
-    for x_coord, label in ((0.0, "Sender"), (1.0, "Ligand"), (2.0, "Receptor"), (3.0, "Receiver")):
-        ax.text(x_coord, 0.98, label, ha="center", va="bottom", fontsize=11, transform=ax.transData)
-
-    ax.set_xlim(-0.4, 3.65)
-    ax.set_ylim(-0.1, 1.06)
-    ax.set_title(title or "Communication bipartite network", pad=24)
+    x_min, x_max = -0.4, 3.65
+    _draw_network_column_headers(
+        ax,
+        [(0.0, "Sender"), (1.0, "Ligand"), (2.0, "Receptor"), (3.0, "Receiver")],
+        x_min=x_min,
+        x_max=x_max,
+        y_axes=0.90,
+        fontsize=11,
+    )
+    ax.set_xlim(x_min, x_max)
+    ax.set_ylim(-0.03, 1.01)
+    ax.set_title(title or "Communication bipartite network", fontsize=13, pad=8)
     ax.set_axis_off()
+    fig.subplots_adjust(top=0.88, bottom=0.08, left=0.06, right=0.94)
     return fig, ax
 
 
@@ -2986,8 +4216,6 @@ def _draw_embedding_network(
     max_node_weight = max(node_weights.values(), default=1.0)
     edge_weights = np.array([graph.edges[edge]["weight"] for edge in graph.edges], dtype=float)
     max_edge_weight = float(edge_weights.max()) if edge_weights.size else 1.0
-    label_positions = _embedding_label_positions(coords)
-
     span_x = float(coords["x"].max() - coords["x"].min())
     span_y = float(coords["y"].max() - coords["y"].min())
     pad = max(span_x, span_y, 1.0) * 0.18
@@ -3001,9 +4229,9 @@ def _draw_embedding_network(
             ax.scatter(
                 group["x"],
                 group["y"],
-                s=10,
+                s=8,
                 c=background_colors[str(cell_type)],
-                alpha=0.9,
+                alpha=0.82,
                 linewidths=0.0,
                 zorder=0,
                 label=f"{cell_type}({len(group)})",
@@ -3012,7 +4240,7 @@ def _draw_embedding_network(
     for source, target, data in graph.edges(data=True):
         start = coords.loc[source]
         end = coords.loc[target]
-        linewidth = 0.8 + 4.8 * (float(data["weight"]) / max_edge_weight)
+        linewidth = 0.55 + 3.1 * (float(data["weight"]) / max_edge_weight)
         if source == target:
             loop_center_x = float(start["x"])
             loop_center_y = float(start["y"]) + loop_scale * 0.2
@@ -3020,10 +4248,10 @@ def _draw_embedding_network(
                 (loop_center_x - loop_scale * 0.45, loop_center_y),
                 (loop_center_x + loop_scale * 0.45, loop_center_y),
                 arrowstyle="-|>",
-                mutation_scale=12,
+                mutation_scale=10,
                 linewidth=linewidth,
                 color=colors[source],
-                alpha=0.72,
+                alpha=0.6,
                 connectionstyle="arc3,rad=1.5",
             )
         else:
@@ -3031,57 +4259,46 @@ def _draw_embedding_network(
                 (float(start["x"]), float(start["y"])),
                 (float(end["x"]), float(end["y"])),
                 arrowstyle="-|>",
-                mutation_scale=13,
+                mutation_scale=10,
                 linewidth=linewidth,
                 color=colors[source],
-                alpha=0.72,
+                alpha=0.6,
                 connectionstyle="arc3,rad=0.08",
             )
         ax.add_patch(patch)
 
     for node in nodes:
         row = coords.loc[node]
-        node_size = 180 + 1100 * (node_weights[node] / max_node_weight)
+        node_size = 110 + 820 * (node_weights[node] / max_node_weight)
         ax.scatter(
             float(row["x"]),
             float(row["y"]),
             s=node_size,
             c=colors[node],
             edgecolors="#F7F7F7",
-            linewidths=2.0,
+            linewidths=1.6,
             zorder=3,
-        )
-        label_x, label_y, ha, va = label_positions[node]
-        ax.text(
-            label_x,
-            label_y,
-            node,
-            ha=ha,
-            va=va,
-            fontsize=11,
-            color="#1F1F1F",
-            path_effects=[patheffects.withStroke(linewidth=3.0, foreground="white")],
         )
 
     ax.set_xlim(float(coords["x"].min()) - pad, float(coords["x"].max()) + pad)
     ax.set_ylim(float(coords["y"].min()) - pad, float(coords["y"].max()) + pad)
     ax.set_aspect("equal")
-    ax.set_title(title or "Communication embedding network")
+    ax.set_title(title or "Communication embedding network", fontsize=13, pad=4)
     if background is None or background.empty:
         ax.set_axis_off()
     else:
         axis_labels = adata.uns.get("embedding_axes", ("UMAP_1", "UMAP_2"))
         if len(axis_labels) >= 2:
-            ax.set_xlabel(str(axis_labels[0]))
-            ax.set_ylabel(str(axis_labels[1]))
+            ax.set_xlabel(str(axis_labels[0]), fontsize=11)
+            ax.set_ylabel(str(axis_labels[1]), fontsize=11)
+        ax.tick_params(axis="both", labelsize=9)
         ax.grid(False)
-        n_cells = int(len(background))
-        ax.text(0.0, 1.02, f"nCells:{n_cells}", transform=ax.transAxes, ha="left", va="bottom", fontsize=10)
         handles, labels = ax.get_legend_handles_labels()
         if handles:
             legend = ax.legend(handles, labels, title="CellType", loc="center left", bbox_to_anchor=(1.02, 0.5), frameon=False)
+            legend.get_title().set_fontsize(10)
             for text in legend.get_texts():
-                text.set_fontsize(9)
+                text.set_fontsize(8)
     return fig, ax
 
 
@@ -3104,6 +4321,124 @@ def _weighted_positions(labels: list[str], totals: pd.Series) -> dict[str, tuple
     return {label: (0.0, centers[idx]) for idx, label in enumerate(labels)}
 
 
+def _compute_sankey_scale(
+    stage_totals: Sequence[pd.Series],
+    *,
+    top: float,
+    bottom: float,
+    gap: float,
+) -> float:
+    scales = []
+    available_span = max(float(top) - float(bottom), 0.2)
+    for totals in stage_totals:
+        if totals is None or len(totals) == 0:
+            continue
+        total_flow = float(totals.sum())
+        if total_flow <= 0:
+            continue
+        available = available_span - gap * max(len(totals.index) - 1, 0)
+        scales.append(max(available, 0.05) / total_flow)
+    return min(scales) if scales else 0.05
+
+
+def _sankey_stage_layout(
+    labels: Sequence[str],
+    totals: pd.Series,
+    *,
+    top: float,
+    bottom: float,
+    gap: float,
+    scale: float,
+) -> dict[str, dict[str, float]]:
+    layout: dict[str, dict[str, float]] = {}
+    ordered = list(labels)
+    cursor = float(top)
+    for label in ordered:
+        height = float(totals.get(label, 0.0)) * float(scale)
+        top_y = cursor
+        bottom_y = top_y - height
+        layout[str(label)] = {
+            "top": top_y,
+            "bottom": bottom_y,
+            "center": (top_y + bottom_y) / 2.0,
+            "height": height,
+        }
+        cursor = bottom_y - float(gap)
+    return layout
+
+
+def _spread_stage_label_positions(
+    layout: Mapping[str, Mapping[str, float]],
+    *,
+    top: float,
+    bottom: float,
+    min_gap: float,
+) -> dict[str, float]:
+    if not layout:
+        return {}
+    ordered = sorted(
+        ((str(label), float(spec["center"])) for label, spec in layout.items()),
+        key=lambda item: item[1],
+        reverse=True,
+    )
+    positions: dict[str, float] = {}
+    cursor = float(top)
+    for label, preferred in ordered:
+        y_pos = min(float(preferred), cursor)
+        positions[label] = y_pos
+        cursor = y_pos - float(min_gap)
+
+    cursor = float(bottom)
+    for label, _ in reversed(ordered):
+        y_pos = max(positions[label], cursor)
+        positions[label] = y_pos
+        cursor = y_pos + float(min_gap)
+    return positions
+
+
+def _assign_sankey_slots(
+    flow_df: pd.DataFrame,
+    *,
+    left_col: str,
+    right_col: str,
+    left_layout: Mapping[str, Mapping[str, float]],
+    right_layout: Mapping[str, Mapping[str, float]],
+    scale: float,
+) -> pd.DataFrame:
+    flow_df = flow_df.copy()
+    flow_df["band_height"] = flow_df["weight"].astype(float) * float(scale)
+    flow_df["source_top"] = np.nan
+    flow_df["source_bottom"] = np.nan
+    flow_df["target_top"] = np.nan
+    flow_df["target_bottom"] = np.nan
+
+    for left_label, subset in flow_df.groupby(left_col, observed=True, sort=False):
+        ordered_idx = subset.assign(
+            _sort_key=subset[right_col].astype(str).map(lambda item: right_layout[str(item)]["center"])
+        ).sort_values("_sort_key", ascending=False).index
+        cursor = float(left_layout[str(left_label)]["top"])
+        for idx in ordered_idx:
+            band_height = float(flow_df.at[idx, "band_height"])
+            flow_df.at[idx, "source_top"] = cursor
+            flow_df.at[idx, "source_bottom"] = cursor - band_height
+            cursor -= band_height
+
+    for right_label, subset in flow_df.groupby(right_col, observed=True, sort=False):
+        ordered_idx = subset.assign(
+            _sort_key=subset[left_col].astype(str).map(lambda item: left_layout[str(item)]["center"])
+        ).sort_values("_sort_key", ascending=False).index
+        cursor = float(right_layout[str(right_label)]["top"])
+        for idx in ordered_idx:
+            band_height = float(flow_df.at[idx, "band_height"])
+            flow_df.at[idx, "target_top"] = cursor
+            flow_df.at[idx, "target_bottom"] = cursor - band_height
+            cursor -= band_height
+
+    flow_df["source_center"] = 0.5 * (flow_df["source_top"] + flow_df["source_bottom"])
+    flow_df["target_center"] = 0.5 * (flow_df["target_top"] + flow_df["target_bottom"])
+    return flow_df
+
+
 def _draw_sankey_flows(
     ax,
     flow_df: pd.DataFrame,
@@ -3116,22 +4451,40 @@ def _draw_sankey_flows(
     width_scale: float,
 ):
     for _, row in flow_df.iterrows():
-        y0 = row[f"{left_col}_y"]
-        y1 = row[f"{right_col}_y"]
+        y0_top = float(row["source_top"])
+        y0_bottom = float(row["source_bottom"])
+        y1_top = float(row["target_top"])
+        y1_bottom = float(row["target_bottom"])
         verts = [
-            (left_x, y0),
-            (left_x + (right_x - left_x) * 0.35, y0),
-            (left_x + (right_x - left_x) * 0.65, y1),
-            (right_x, y1),
+            (left_x, y0_top),
+            (left_x + (right_x - left_x) * 0.35, y0_top),
+            (left_x + (right_x - left_x) * 0.65, y1_top),
+            (right_x, y1_top),
+            (right_x, y1_bottom),
+            (left_x + (right_x - left_x) * 0.65, y1_bottom),
+            (left_x + (right_x - left_x) * 0.35, y0_bottom),
+            (left_x, y0_bottom),
+            (left_x, y0_top),
         ]
-        path = Path(verts, [Path.MOVETO, Path.CURVE4, Path.CURVE4, Path.CURVE4])
+        codes = [
+            Path.MOVETO,
+            Path.CURVE4,
+            Path.CURVE4,
+            Path.CURVE4,
+            Path.LINETO,
+            Path.CURVE4,
+            Path.CURVE4,
+            Path.CURVE4,
+            Path.CLOSEPOLY,
+        ]
+        path = Path(verts, codes)
         patch = PathPatch(
             path,
-            facecolor="none",
-            edgecolor=colors[str(row[left_col])],
-            linewidth=1.0 + width_scale * float(row["weight"]),
-            alpha=0.45,
-            capstyle="round",
+            facecolor=colors[str(row[left_col])],
+            edgecolor="none",
+            linewidth=0.0,
+            alpha=0.38,
+            joinstyle="round",
         )
         ax.add_patch(patch)
 
@@ -3142,10 +4495,12 @@ def _draw_sankey_plot(
     display_by: Literal["aggregation", "interaction"],
     value: Literal["sum", "mean", "max", "count"],
     top_n: int,
+    min_receiver_flow: float,
     palette,
     figsize: tuple[float, float],
     title: str | None,
 ):
+    _validate_display_by(display_by, func_name="_draw_sankey_plot")
     if display_by == "aggregation":
         flow_df = _aggregate_series(long_df.groupby(["sender", "receiver"], observed=True), value).rename("weight").reset_index()
         flow_df = flow_df.sort_values("weight", ascending=False).head(int(top_n))
@@ -3155,14 +4510,30 @@ def _draw_sankey_plot(
         receivers = list(dict.fromkeys(flow_df["receiver"]))
         sender_totals = flow_df.groupby("sender", observed=True)["weight"].sum().sort_values(ascending=False)
         receiver_totals = flow_df.groupby("receiver", observed=True)["weight"].sum().sort_values(ascending=False)
-        sender_pos = _bounded_weighted_positions(senders, sender_totals, top=0.84, bottom=0.08)
-        receiver_pos = _bounded_weighted_positions(receivers, receiver_totals, top=0.84, bottom=0.08)
-        flow_df["sender_y"] = flow_df["sender"].map(lambda item: sender_pos[str(item)][1])
-        flow_df["receiver_y"] = flow_df["receiver"].map(lambda item: receiver_pos[str(item)][1])
+        if min_receiver_flow > 0:
+            keep_receivers = receiver_totals.loc[receiver_totals >= float(min_receiver_flow)].index.astype(str)
+            flow_df = flow_df.loc[flow_df["receiver"].astype(str).isin(keep_receivers)].copy()
+            if flow_df.empty:
+                raise ValueError("No communication flows remain after applying `min_receiver_flow`.")
+            receivers = list(dict.fromkeys(flow_df["receiver"]))
+            sender_totals = flow_df.groupby("sender", observed=True)["weight"].sum().sort_values(ascending=False)
+            receiver_totals = flow_df.groupby("receiver", observed=True)["weight"].sum().sort_values(ascending=False)
+        scale = _compute_sankey_scale((sender_totals, receiver_totals), top=0.84, bottom=0.08, gap=0.02)
+        sender_layout = _sankey_stage_layout(senders, sender_totals, top=0.84, bottom=0.08, gap=0.02, scale=scale)
+        receiver_layout = _sankey_stage_layout(receivers, receiver_totals, top=0.84, bottom=0.08, gap=0.02, scale=scale)
+        flow_df = _assign_sankey_slots(
+            flow_df,
+            left_col="sender",
+            right_col="receiver",
+            left_layout=sender_layout,
+            right_layout=receiver_layout,
+            scale=scale,
+        )
 
         fig, ax = plt.subplots(figsize=figsize)
         node_colors = _choose_palette(sorted(set(senders) | set(receivers)), palette=palette)
-        width_scale = 10.0 / max(float(flow_df["weight"].max()), 1.0)
+        sender_label_pos = _spread_stage_label_positions(sender_layout, top=0.84, bottom=0.08, min_gap=0.04)
+        receiver_label_pos = _spread_stage_label_positions(receiver_layout, top=0.84, bottom=0.08, min_gap=0.04)
         _draw_sankey_flows(
             ax,
             flow_df,
@@ -3171,17 +4542,22 @@ def _draw_sankey_plot(
             left_x=0.15,
             right_x=0.85,
             colors=node_colors,
-            width_scale=width_scale,
+            width_scale=scale,
         )
-        for sender, (x_coord, y_coord) in sender_pos.items():
-            ax.add_patch(Rectangle((0.08, y_coord - 0.03), 0.04, 0.06, facecolor=node_colors[sender], edgecolor="white"))
-            ax.text(0.06, y_coord, sender, ha="right", va="center", fontsize=10)
-        for receiver, (_, y_coord) in receiver_pos.items():
-            ax.add_patch(Rectangle((0.88, y_coord - 0.03), 0.04, 0.06, facecolor=node_colors[receiver], edgecolor="white"))
-            ax.text(0.94, y_coord, receiver, ha="left", va="center", fontsize=10)
+        for sender, layout in sender_layout.items():
+            x_coord = 0.0
+            y_coord = float(layout["center"])
+            half_height = 0.5 * float(layout["height"])
+            ax.add_patch(Rectangle((0.08, y_coord - half_height), 0.04, 2 * half_height, facecolor=node_colors[sender], edgecolor="white"))
+            ax.text(0.06, sender_label_pos.get(sender, y_coord), sender, ha="right", va="center", fontsize=10)
+        for receiver, layout in receiver_layout.items():
+            y_coord = float(layout["center"])
+            half_height = 0.5 * float(layout["height"])
+            ax.add_patch(Rectangle((0.88, y_coord - half_height), 0.04, 2 * half_height, facecolor=node_colors[receiver], edgecolor="white"))
+            ax.text(0.94, receiver_label_pos.get(receiver, y_coord), receiver, ha="left", va="center", fontsize=10)
         ax.text(0.10, 0.90, "Sender", ha="center", va="bottom", fontsize=11, transform=ax.transAxes)
         ax.text(0.90, 0.90, "Receiver", ha="center", va="bottom", fontsize=11, transform=ax.transAxes)
-        fig.subplots_adjust(top=0.90)
+        fig.subplots_adjust(top=0.88, bottom=0.08, left=0.05, right=0.95)
         fig.suptitle(title or "Communication sankey", y=0.985)
         ax.set_xlim(0, 1)
         ax.set_ylim(0, 1)
@@ -3205,29 +4581,49 @@ def _draw_sankey_plot(
     sender_totals = flow_df.groupby("sender", observed=True)["weight"].sum().sort_values(ascending=False)
     interaction_totals = flow_df.groupby("interaction", observed=True)["weight"].sum().sort_values(ascending=False)
     receiver_totals = flow_df.groupby("receiver", observed=True)["weight"].sum().sort_values(ascending=False)
-    sender_pos = _bounded_weighted_positions(senders, sender_totals, top=0.84, bottom=0.08)
-    interaction_y, _, sankey_font_scale = _stacked_stage_positions(
-        interactions,
-        interaction_totals,
-        wrap_width=20,
-        top=0.78,
-        bottom=0.10,
-        gap=0.03,
-    )
-    interaction_pos = {label: (0.0, y_coord) for label, y_coord in interaction_y.items()}
-    receiver_pos = _bounded_weighted_positions(receivers, receiver_totals, top=0.84, bottom=0.08)
+    if min_receiver_flow > 0:
+        keep_receivers = receiver_totals.loc[receiver_totals >= float(min_receiver_flow)].index.astype(str)
+        flow_df = flow_df.loc[flow_df["receiver"].astype(str).isin(keep_receivers)].copy()
+        if flow_df.empty:
+            raise ValueError("No interaction-level communication flows remain after applying `min_receiver_flow`.")
+        receivers = list(dict.fromkeys(flow_df["receiver"]))
+        sender_totals = flow_df.groupby("sender", observed=True)["weight"].sum().sort_values(ascending=False)
+        interaction_totals = flow_df.groupby("interaction", observed=True)["weight"].sum().sort_values(ascending=False)
+        receiver_totals = flow_df.groupby("receiver", observed=True)["weight"].sum().sort_values(ascending=False)
+    scale = _compute_sankey_scale((sender_totals, interaction_totals, receiver_totals), top=0.84, bottom=0.08, gap=0.02)
+    sender_layout = _sankey_stage_layout(senders, sender_totals, top=0.84, bottom=0.08, gap=0.02, scale=scale)
+    interaction_layout = _sankey_stage_layout(interactions, interaction_totals, top=0.78, bottom=0.10, gap=0.025, scale=scale)
+    receiver_layout = _sankey_stage_layout(receivers, receiver_totals, top=0.84, bottom=0.08, gap=0.02, scale=scale)
 
     flow_left = flow_df.groupby(["sender", "interaction"], observed=True)["weight"].sum().rename("weight").reset_index()
-    flow_left["sender_y"] = flow_left["sender"].map(lambda item: sender_pos[str(item)][1])
-    flow_left["interaction_y"] = flow_left["interaction"].map(lambda item: interaction_pos[str(item)][1])
+    flow_left = _assign_sankey_slots(
+        flow_left,
+        left_col="sender",
+        right_col="interaction",
+        left_layout=sender_layout,
+        right_layout=interaction_layout,
+        scale=scale,
+    )
     flow_right = flow_df.groupby(["interaction", "receiver"], observed=True)["weight"].sum().rename("weight").reset_index()
-    flow_right["interaction_y"] = flow_right["interaction"].map(lambda item: interaction_pos[str(item)][1])
-    flow_right["receiver_y"] = flow_right["receiver"].map(lambda item: receiver_pos[str(item)][1])
+    flow_right = _assign_sankey_slots(
+        flow_right,
+        left_col="interaction",
+        right_col="receiver",
+        left_layout=interaction_layout,
+        right_layout=receiver_layout,
+        scale=scale,
+    )
 
     fig, ax = plt.subplots(figsize=figsize)
     cell_colors = _choose_palette(sorted(set(senders) | set(receivers)), palette=palette)
     interaction_colors = _choose_palette(interactions, palette="Set2")
-    width_scale = 9.0 / max(float(max(flow_left["weight"].max(), flow_right["weight"].max())), 1.0)
+    sender_label_pos = _spread_stage_label_positions(sender_layout, top=0.84, bottom=0.08, min_gap=0.04)
+    visible_receivers = {
+        receiver: layout
+        for receiver, layout in receiver_layout.items()
+        if float(layout["height"]) >= 0.016
+    }
+    receiver_label_pos = _spread_stage_label_positions(visible_receivers, top=0.84, bottom=0.08, min_gap=0.028)
     _draw_sankey_flows(
         ax,
         flow_left,
@@ -3236,7 +4632,7 @@ def _draw_sankey_plot(
         left_x=0.12,
         right_x=0.5,
         colors=cell_colors,
-        width_scale=width_scale,
+        width_scale=scale,
     )
     _draw_sankey_flows(
         ax,
@@ -3246,14 +4642,23 @@ def _draw_sankey_plot(
         left_x=0.5,
         right_x=0.88,
         colors=interaction_colors,
-        width_scale=width_scale,
+        width_scale=scale,
     )
-    for sender, (_, y_coord) in sender_pos.items():
-        ax.add_patch(Rectangle((0.06, y_coord - 0.025), 0.04, 0.05, facecolor=cell_colors[sender], edgecolor="white"))
-        ax.text(0.04, y_coord, sender, ha="right", va="center", fontsize=9)
-    for interaction, (_, y_coord) in interaction_pos.items():
+    for sender, layout in sender_layout.items():
+        y_coord = float(layout["center"])
+        half_height = 0.5 * float(layout["height"])
+        ax.add_patch(Rectangle((0.06, y_coord - half_height), 0.04, 2 * half_height, facecolor=cell_colors[sender], edgecolor="white"))
+        ax.text(0.04, sender_label_pos.get(sender, y_coord), sender, ha="right", va="center", fontsize=9)
+    sankey_font_scale = 1.0
+    if interaction_layout:
+        max_height = max(float(layout["height"]) for layout in interaction_layout.values())
+        if max_height > 0:
+            sankey_font_scale = max(0.72, min(1.0, max_height / 0.08))
+    for interaction, layout in interaction_layout.items():
+        y_coord = float(layout["center"])
+        half_height = 0.5 * float(layout["height"])
         ax.add_patch(
-            Rectangle((0.48, y_coord - 0.025), 0.04, 0.05, facecolor=interaction_colors[interaction], edgecolor="white")
+            Rectangle((0.48, y_coord - half_height), 0.04, 2 * half_height, facecolor=interaction_colors[interaction], edgecolor="white")
         )
         ax.text(
             0.535,
@@ -3264,13 +4669,17 @@ def _draw_sankey_plot(
             fontsize=max(7.0, 8.0 * sankey_font_scale),
             bbox={"facecolor": "white", "edgecolor": "none", "alpha": 0.75, "pad": 0.2},
         )
-    for receiver, (_, y_coord) in receiver_pos.items():
-        ax.add_patch(Rectangle((0.9, y_coord - 0.025), 0.04, 0.05, facecolor=cell_colors[receiver], edgecolor="white"))
-        ax.text(0.96, y_coord, receiver, ha="left", va="center", fontsize=9)
+    for receiver, layout in receiver_layout.items():
+        y_coord = float(layout["center"])
+        half_height = 0.5 * float(layout["height"])
+        ax.add_patch(Rectangle((0.9, y_coord - half_height), 0.04, 2 * half_height, facecolor=cell_colors[receiver], edgecolor="white"))
+        if receiver in receiver_label_pos:
+            ax.text(0.96, receiver_label_pos[receiver], receiver, ha="left", va="center", fontsize=9)
     ax.text(0.08, 0.90, "Sender", ha="center", va="bottom", fontsize=11, transform=ax.transAxes)
     ax.text(0.50, 0.90, "Ligand-Receptor", ha="center", va="bottom", fontsize=11, transform=ax.transAxes)
     ax.text(0.92, 0.90, "Receiver", ha="center", va="bottom", fontsize=11, transform=ax.transAxes)
     fig.subplots_adjust(top=0.90)
+    fig.subplots_adjust(top=0.88, bottom=0.08, left=0.05, right=0.95)
     fig.suptitle(title or "Interaction sankey", y=0.985)
     ax.set_xlim(0, 1)
     ax.set_ylim(0, 1)
@@ -3281,12 +4690,12 @@ def _draw_sankey_plot(
 @register_function(
     aliases=["ccc_network_plot", "communication_network_plot", "细胞通讯网络图"],
     category="pl",
-    description="Python-native communication network plots for CellPhoneDB-style communication AnnData.",
+    description="Python-native communication network plots that accept raw analysis AnnData or preformatted communication AnnData.",
     examples=[
-        "ov.pl.ccc_network_plot(comm_adata, plot_type='circle')",
-        "ov.pl.ccc_network_plot(comm_adata, plot_type='arrow', display_by='interaction', signaling='MK')",
-        "ov.pl.ccc_network_plot(comm_adata, plot_type='bipartite', ligand='TGFB1')",
-        "ov.pl.ccc_network_plot(comm_adata, plot_type='embedding_network', node_positions=coords)",
+        "ov.pl.ccc_network_plot(adata, plot_type='circle')",
+        "ov.pl.ccc_network_plot(adata, plot_type='arrow', display_by='interaction', signaling='MK')",
+        "ov.pl.ccc_network_plot(adata, plot_type='bipartite', ligand='TGFB1')",
+        "ov.pl.ccc_network_plot(adata, plot_type='embedding_network', node_positions=coords)",
     ],
     related=["pl.ccc_heatmap", "pl.ccc_stat_plot", "pl.cpdb_network"],
 )
@@ -3318,37 +4727,48 @@ def ccc_network_plot(
     signaling=None,
     interaction_use=None,
     pair_lr_use=None,
+    result_uns_key: str = "liana_res",
+    score_key: str = "specificity_rank",
+    pvalue_key: str = "specificity_rank",
+    inverse_score: bool = True,
+    inverse_pvalue: bool = False,
+    classification: str | Mapping[str, str] | None = None,
+    classification_reference: str | pd.DataFrame | None = "cellchat",
+    classification_fallback: str | None = "family",
     pvalue_threshold: float = 0.05,
     value: Literal["sum", "mean", "max", "count"] = "sum",
     top_n: int = 20,
     ligand: str | None = None,
     receptor=None,
-    layout: Literal["circle", "hierarchy"] = "circle",
     normalize_to_sender: bool = True,
     rotate_names: bool = True,
     min_interaction_threshold: float = 0.0,
     node_positions=None,
     embedding_points=None,
     palette=None,
+    ncols: int | None = None,
+    nrows: int | None = None,
     figsize: tuple[float, float] = (7, 7),
     title: str | None = None,
+    verbose: bool = True,
     show: bool = False,
     save: str | bool = False,
 ):
-    """Plot cell-cell communication networks with multiple graph layouts.
+    """Plot cell-cell communication networks with multiple graph styles.
 
     Parameters
     ----------
     adata : anndata.AnnData
-        Communication AnnData produced by the OmicVerse CCC workflow. The
-        object is expected to contain sender, receiver, ligand-receptor, and
-        pathway level communication summaries used by the selected
-        ``plot_type``.
+        Communication AnnData produced by the OmicVerse CCC workflow, or a
+        regular AnnData containing a LIANA result table in
+        ``adata.uns[result_uns_key]``. LIANA inputs are adapted internally to
+        the communication format expected by ``ccc_*``.
     plot_type : str, default="circle"
         Network style to render. Supported values include aggregated circle
-        views, pathway or interaction flow plots, bipartite ligand-receptor
-        layouts, embedding-based networks, differential comparison networks,
-        chord summaries, and diffusion-style visualizations.
+        views, pathway-filtered circle networks, interaction flow plots,
+        bipartite ligand-receptor layouts, embedding-based networks,
+        differential comparison networks, chord summaries, and diffusion-style
+        visualizations.
     comparison_adata : anndata.AnnData or None, default=None
         Second communication AnnData used by ``plot_type='diff_network'`` to
         compute differential edges between two conditions.
@@ -3368,6 +4788,23 @@ def ccc_network_plot(
     pair_lr_use : str, sequence of str, or None, default=None
         Ligand-receptor pair identifiers used to filter individual or
         interaction-focused plots.
+    result_uns_key : str, default="liana_res"
+        ``adata.uns`` key searched when ``adata`` is not already a
+        communication AnnData.
+    score_key, pvalue_key : str, default="specificity_rank"
+        Columns used when auto-converting LIANA results.
+    inverse_score, inverse_pvalue : bool, default=(True, False)
+        Whether the LIANA score or p-value columns should be inverted during
+        automatic conversion.
+    classification : str, mapping, or None, default=None
+        Optional LIANA classification override used only during automatic
+        conversion.
+    classification_reference : str, pandas.DataFrame, or None, default="cellchat"
+        Reference used to backfill pathway labels during automatic LIANA
+        conversion.
+    classification_fallback : str or None, default="family"
+        Fallback pathway label strategy used during automatic LIANA
+        conversion.
     pvalue_threshold : float, default=0.05
         Maximum p-value retained as a significant communication event.
     value : {"sum", "mean", "max", "count"}, default="sum"
@@ -3381,8 +4818,6 @@ def ccc_network_plot(
         ligand-receptor chord views.
     receptor : str, sequence of str, or None, default=None
         Receptor name or names used by receptor-specific network views.
-    layout : {"circle", "hierarchy"}, default="circle"
-        Layout passed to compatible CellChat-style network backends.
     normalize_to_sender : bool, default=True
         Whether to normalize outgoing edge contributions per sender before
         plotting chord-style networks.
@@ -3399,11 +4834,22 @@ def ccc_network_plot(
         ``embedding_network`` edges.
     palette : mapping, sequence, or None, default=None
         Color palette used for cell types, pathways, or nodes.
+    ncols : int or None, default=None
+        Number of subplot columns used by multi-panel network views such as
+        ``individual_outgoing`` and ``individual_incoming``. When omitted, a
+        plot-specific default is used.
+    nrows : int or None, default=None
+        Number of subplot rows used by multi-panel network views such as
+        ``individual_outgoing`` and ``individual_incoming``. When omitted, the
+        value is inferred from ``ncols`` and the number of selected panels.
     figsize : tuple of float, default=(7, 7)
         Figure size in inches.
     title : str or None, default=None
         Custom title for the generated figure. When omitted, a plot-specific
         default title is used.
+    verbose : bool, default=True
+        Reserved for method-specific progress output. Network views remain
+        silent by default; this parameter keeps the ``ccc_*`` API uniform.
     show : bool, default=False
         Whether to immediately display the figure.
     save : str or bool, default=False
@@ -3415,6 +4861,55 @@ def ccc_network_plot(
         A ``(fig, ax)`` tuple containing the Matplotlib figure and the main
         axes used for the rendered network.
     """
+    _validate_plot_type(
+        plot_type,
+        (
+            "circle",
+            "circle_focused",
+            "individual_outgoing",
+            "individual_incoming",
+            "individual",
+            "arrow",
+            "sigmoid",
+            "embedding_network",
+            "pathway",
+            "chord",
+            "lr_chord",
+            "gene_chord",
+            "diffusion",
+            "diff_network",
+            "individual_lr",
+            "bipartite",
+        ),
+        func_name="ccc_network_plot",
+    )
+    _validate_display_by(display_by, func_name="ccc_network_plot")
+
+    adata = _resolve_comm_adata(
+        adata,
+        arg_name="adata",
+        result_uns_key=result_uns_key,
+        score_key=score_key,
+        pvalue_key=pvalue_key,
+        inverse_score=inverse_score,
+        inverse_pvalue=inverse_pvalue,
+        classification=classification,
+        classification_reference=classification_reference,
+        classification_fallback=classification_fallback,
+    )
+    if comparison_adata is not None:
+        comparison_adata = _resolve_comm_adata(
+            comparison_adata,
+            arg_name="comparison_adata",
+            result_uns_key=result_uns_key,
+            score_key=score_key,
+            pvalue_key=pvalue_key,
+            inverse_score=inverse_score,
+            inverse_pvalue=inverse_pvalue,
+            classification=classification,
+            classification_reference=classification_reference,
+            classification_fallback=classification_fallback,
+        )
     if plot_type == "circle_focused":
         signaling_values = _normalize_use_arg(signaling)
         _raise_for_unsupported_arguments(
@@ -3459,8 +4954,6 @@ def ccc_network_plot(
         _raise_for_unsupported_arguments(
             plot_type,
             comparison_adata=comparison_adata,
-            sender_use=sender_use,
-            receiver_use=receiver_use,
             signaling=signaling,
             interaction_use=interaction_use,
             pair_lr_use=pair_lr_use,
@@ -3474,20 +4967,20 @@ def ccc_network_plot(
             edge_width_max=12,
             show_labels=True,
             figsize=figsize,
-            ncols=4,
+            ncols=ncols,
+            nrows=nrows,
+            sender_use=_normalize_use_arg(sender_use),
+            receiver_use=_normalize_use_arg(receiver_use),
             use_sender_colors=True,
+            title=title,
         )
         ax = _largest_content_axis(fig)
-        if title:
-            fig.suptitle(title)
         return _maybe_save_show(fig, show=show, save=save), ax
 
     if plot_type == "individual_incoming":
         _raise_for_unsupported_arguments(
             plot_type,
             comparison_adata=comparison_adata,
-            sender_use=sender_use,
-            receiver_use=receiver_use,
             signaling=signaling,
             interaction_use=interaction_use,
             pair_lr_use=pair_lr_use,
@@ -3501,12 +4994,14 @@ def ccc_network_plot(
             edge_width_max=12,
             show_labels=True,
             figsize=figsize,
-            ncols=4,
+            ncols=ncols,
+            nrows=nrows,
+            sender_use=_normalize_use_arg(sender_use),
+            receiver_use=_normalize_use_arg(receiver_use),
             use_sender_colors=True,
+            title=title,
         )
         ax = _largest_content_axis(fig)
-        if title:
-            fig.suptitle(title)
         return _maybe_save_show(fig, show=show, save=save), ax
 
     if plot_type == "individual":
@@ -3529,8 +5024,8 @@ def ccc_network_plot(
             pairLR_use=pair_lr,
             sources_use=_normalize_use_arg(sender_use),
             targets_use=_normalize_use_arg(receiver_use),
-            layout=layout,
-            vertex_receiver=_normalize_use_arg(receiver_use) if layout == "hierarchy" else None,
+            layout="circle",
+            vertex_receiver=None,
             pvalue_threshold=pvalue_threshold,
             figsize=figsize,
             title=title or "Individual ligand-receptor communication",
@@ -3580,6 +5075,7 @@ def ccc_network_plot(
             rotate_names=rotate_names,
             figsize=figsize,
             title_name=title or "Gene-level chord diagram",
+            show_legend=False,
             save=None,
         )
         return _maybe_save_show(fig, show=show, save=save), ax
@@ -3605,7 +5101,7 @@ def ccc_network_plot(
             sources=_normalize_use_arg(sender_use),
             targets=_normalize_use_arg(receiver_use),
             pvalue_threshold=pvalue_threshold,
-            count_min=1,
+            count_min=0,
             rotate_names=rotate_names,
             figsize=figsize,
             title_name=title or "Ligand-receptor chord diagram",
@@ -3706,12 +5202,6 @@ def ccc_network_plot(
             receptor=receptor,
         )
         pathway_signaling = _require_use_argument(plot_type, "signaling", signaling)
-        if layout != "hierarchy":
-            _raise_for_unsupported_arguments(
-                plot_type,
-                sender_use=sender_use,
-                receiver_use=receiver_use,
-            )
 
     edge_df = _aggregated_pair_frame(
         adata,
@@ -3788,9 +5278,9 @@ def ccc_network_plot(
         viz = _build_cellchatviz(adata, palette=palette)
         fig, ax = viz.netVisual_aggregate(
             signaling=pathway_signaling,
-            layout=layout,
-            vertex_receiver=_normalize_use_arg(receiver_use) if layout == "hierarchy" else None,
-            vertex_sender=_normalize_use_arg(sender_use) if layout == "hierarchy" else None,
+            layout="circle",
+            vertex_receiver=None,
+            vertex_sender=None,
             pvalue_threshold=pvalue_threshold,
             figsize=figsize,
             vertex_size_max=10,
@@ -4210,11 +5700,11 @@ def _draw_gene_expression_plot(
 @register_function(
     aliases=["ccc_stat_plot", "communication_stat_plot", "细胞通讯统计图"],
     category="pl",
-    description="Python-native summary and distribution plots for CellPhoneDB-style communication AnnData.",
+    description="Python-native communication summary plots that accept raw analysis AnnData or preformatted communication AnnData.",
     examples=[
-        "ov.pl.ccc_stat_plot(comm_adata, plot_type='bar', group_by='interaction')",
-        "ov.pl.ccc_stat_plot(comm_adata, plot_type='sankey', display_by='interaction')",
-        "ov.pl.ccc_stat_plot(comm_adata, plot_type='scatter')",
+        "ov.pl.ccc_stat_plot(adata, plot_type='bar', group_by='interaction')",
+        "ov.pl.ccc_stat_plot(adata, plot_type='sankey', display_by='interaction')",
+        "ov.pl.ccc_stat_plot(adata, plot_type='scatter')",
     ],
     related=["pl.ccc_heatmap", "pl.ccc_network_plot", "pl.CellChatViz"],
 )
@@ -4246,6 +5736,14 @@ def ccc_stat_plot(
     signaling=None,
     interaction_use=None,
     pair_lr_use=None,
+    result_uns_key: str = "liana_res",
+    score_key: str = "specificity_rank",
+    pvalue_key: str = "specificity_rank",
+    inverse_score: bool = True,
+    inverse_pvalue: bool = False,
+    classification: str | Mapping[str, str] | None = None,
+    classification_reference: str | pd.DataFrame | None = "cellchat",
+    classification_fallback: str | None = "family",
     pvalue_threshold: float = 0.05,
     group_by: Literal["interaction", "classification", "pair", "sender", "receiver"] = "interaction",
     compare_by: Literal["overall", "celltype"] = "overall",
@@ -4255,6 +5753,7 @@ def ccc_stat_plot(
     facet_by: Literal["sender", "receiver"] | None = None,
     value: Literal["sum", "mean", "max", "count"] = "sum",
     top_n: int = 20,
+    min_receiver_flow: float = 0.0,
     pathway_method: str = "mean",
     min_lr_pairs: int = 1,
     min_expression: float = 0.1,
@@ -4265,6 +5764,7 @@ def ccc_stat_plot(
     cmap: str = "RdYlBu_r",
     figsize: tuple[float, float] = (8, 5),
     title: str | None = None,
+    verbose: bool = True,
     show: bool = False,
     save: str | bool = False,
 ):
@@ -4273,9 +5773,10 @@ def ccc_stat_plot(
     Parameters
     ----------
     adata : anndata.AnnData
-        Communication AnnData produced by the OmicVerse CCC workflow. The
-        object should contain pathway-, interaction-, and cell-pair-level
-        communication summaries used by the selected ``plot_type``.
+        Communication AnnData produced by the OmicVerse CCC workflow, or a
+        regular AnnData containing a LIANA result table in
+        ``adata.uns[result_uns_key]``. LIANA inputs are adapted internally to
+        the communication format expected by ``ccc_*``.
     plot_type : str, default="bar"
         Summary view to render. Supported values include bar plots, sankey
         diagrams, score distributions, signaling role analyses, pathway
@@ -4302,6 +5803,23 @@ def ccc_stat_plot(
         Interaction names used to restrict interaction-level statistics.
     pair_lr_use : str, sequence of str, or None, default=None
         Ligand-receptor pair identifiers used by pair-specific statistics.
+    result_uns_key : str, default="liana_res"
+        ``adata.uns`` key searched when ``adata`` is not already a
+        communication AnnData.
+    score_key, pvalue_key : str, default="specificity_rank"
+        Columns used when auto-converting LIANA results.
+    inverse_score, inverse_pvalue : bool, default=(True, False)
+        Whether the LIANA score or p-value columns should be inverted during
+        automatic conversion.
+    classification : str, mapping, or None, default=None
+        Optional LIANA classification override used only during automatic
+        conversion.
+    classification_reference : str, pandas.DataFrame, or None, default="cellchat"
+        Reference used to backfill pathway labels during automatic LIANA
+        conversion.
+    classification_fallback : str or None, default="family"
+        Fallback pathway label strategy used during automatic LIANA
+        conversion.
     pvalue_threshold : float, default=0.05
         Maximum p-value retained as a significant communication event.
     group_by : {"interaction", "classification", "pair", "sender", "receiver"}, default="interaction"
@@ -4325,6 +5843,11 @@ def ccc_stat_plot(
     top_n : int, default=20
         Number of top pathways, interactions, or pairs retained in ranked
         summaries.
+    min_receiver_flow : float, default=0.0
+        Minimum total flow required for a receiver node to be retained in
+        Sankey plots. This is mainly useful for
+        ``plot_type='sankey', display_by='interaction'`` when many tiny
+        receiver nodes make the right side unreadable.
     pathway_method : str, default="mean"
         Method used to summarize multiple ligand-receptor pairs into pathway
         level scores.
@@ -4350,6 +5873,9 @@ def ccc_stat_plot(
     title : str or None, default=None
         Custom title for the generated figure. When omitted, a plot-specific
         default title is used.
+    verbose : bool, default=True
+        Whether pathway-summary style plots should print progress messages and
+        summary tables. This currently affects ``plot_type='pathway_summary'``.
     show : bool, default=False
         Whether to immediately display the figure.
     save : str or bool, default=False
@@ -4361,6 +5887,32 @@ def ccc_stat_plot(
         A ``(fig, ax)`` tuple containing the Matplotlib figure and the main
         axes used for the rendered statistical summary.
     """
+    _validate_display_by(display_by, func_name="ccc_stat_plot")
+    adata = _resolve_comm_adata(
+        adata,
+        arg_name="adata",
+        result_uns_key=result_uns_key,
+        score_key=score_key,
+        pvalue_key=pvalue_key,
+        inverse_score=inverse_score,
+        inverse_pvalue=inverse_pvalue,
+        classification=classification,
+        classification_reference=classification_reference,
+        classification_fallback=classification_fallback,
+    )
+    if comparison_adata is not None:
+        comparison_adata = _resolve_comm_adata(
+            comparison_adata,
+            arg_name="comparison_adata",
+            result_uns_key=result_uns_key,
+            score_key=score_key,
+            pvalue_key=pvalue_key,
+            inverse_score=inverse_score,
+            inverse_pvalue=inverse_pvalue,
+            classification=classification,
+            classification_reference=classification_reference,
+            classification_fallback=classification_fallback,
+        )
     if plot_type == "role_network":
         _raise_for_unsupported_arguments(
             plot_type,
@@ -4476,30 +6028,77 @@ def ccc_stat_plot(
             strength_threshold=strength_threshold,
             pvalue_threshold=pvalue_threshold,
             min_significant_pairs=min_significant_pairs,
+            verbose=verbose,
         )
         summary = summary.sort_values(["is_significant", "total_strength"], ascending=[False, False]).head(int(top_n))
-        min_height = max(figsize[1], 0.42 * len(summary.index) + 1.6)
-        if min_height > figsize[1]:
-            figsize = (figsize[0], min_height)
         fig, ax = plt.subplots(figsize=figsize)
+        summary_title_fontsize = 13
+        summary_tick_fontsize = summary_title_fontsize
+        summary_bar_label_fontsize = summary_title_fontsize - 1
         pathway_names = summary["pathway"].astype(str).tolist()
         colors = _choose_palette(pathway_names, palette=palette)
         bar_colors = [colors[name] if is_sig else "#D9D9D9" for name, is_sig in zip(pathway_names, summary["is_significant"])]
-        ax.barh(pathway_names, summary["total_strength"], color=bar_colors)
+        bars = ax.barh(pathway_names, summary["total_strength"], color=bar_colors)
         ax.invert_yaxis()
-        for y_pos, (_, row) in enumerate(summary.iterrows()):
-            ax.text(
-                float(row["total_strength"]),
-                y_pos,
-                f"  {int(row['n_significant_pairs'])}/{int(row['n_active_cell_pairs'])} sig",
-                va="center",
-                ha="left",
-                fontsize=8,
-                color="#4A4A4A",
+        max_strength = float(summary["total_strength"].max()) if not summary.empty else 0.0
+        label_padding = 0.015 * max(max_strength, 1.0)
+        outside_padding = 0.012 * max(max_strength, 1.0)
+        has_outside_labels = False
+        for bar, (_, row), bar_color in zip(bars, summary.iterrows(), bar_colors):
+            bar_width = float(row["total_strength"])
+            label = f"{int(row['n_significant_pairs'])}/{int(row['n_active_cell_pairs'])} sig"
+            label_width = _text_width_in_data_units(
+                fig,
+                ax,
+                label,
+                fontsize=summary_bar_label_fontsize,
             )
+            fits_inside = (
+                label_width is not None
+                and bar_width >= label_width + 2.0 * label_padding
+            )
+            if fits_inside:
+                text_x = max(bar_width - label_padding, label_width + label_padding)
+                text_ha = "right"
+                text_color = _contrasting_text_color(bar_color)
+            else:
+                text_x = bar_width + outside_padding
+                text_ha = "left"
+                text_color = "#4A4A4A"
+                has_outside_labels = True
+            ax.text(
+                text_x,
+                float(bar.get_y() + bar.get_height() / 2.0),
+                label,
+                va="center",
+                ha=text_ha,
+                fontsize=summary_bar_label_fontsize,
+                color=text_color,
+            )
+        if max_strength > 0:
+            outside_extent = max(
+                (
+                    float(row["total_strength"]) + outside_padding
+                    + (
+                        _text_width_in_data_units(
+                            fig,
+                            ax,
+                            f"{int(row['n_significant_pairs'])}/{int(row['n_active_cell_pairs'])} sig",
+                            fontsize=summary_bar_label_fontsize,
+                        )
+                        or 0.0
+                    )
+                )
+                for _, row in summary.iterrows()
+            )
+            x_upper = outside_extent + label_padding if has_outside_labels else max_strength * 1.001
+            ax.set_xlim(0, x_upper)
+        ax.margins(x=0.0)
+        ax.tick_params(axis="y", labelsize=summary_tick_fontsize)
         ax.set_xlabel("Total pathway communication strength")
         ax.set_ylabel("")
-        ax.set_title(title or "Significant pathway communication summary")
+        ax.set_title(title or "Significant pathway communication summary", fontsize=summary_title_fontsize)
+        ax.grid(axis="x", alpha=0.22, linewidth=0.7)
         return _maybe_save_show(fig, show=show, save=save), ax
 
     long_df = _communication_long_table(
@@ -4520,6 +6119,7 @@ def ccc_stat_plot(
             display_by=display_by,
             value=value,
             top_n=top_n,
+            min_receiver_flow=min_receiver_flow,
             palette=palette,
             figsize=figsize,
             title=title,
@@ -4581,17 +6181,48 @@ def ccc_stat_plot(
             if len(contribution_result) == 3 and hasattr(contribution_result[1], "savefig"):
                 _, fig, axes = contribution_result
                 if isinstance(axes, tuple):
-                    ax = axes[0]
+                    if len(axes) >= 2:
+                        bar_ax, contribution_ax = axes[0], axes[1]
+                    else:
+                        bar_ax = axes[0]
+                        contribution_ax = axes[0]
                 else:
-                    ax = _largest_content_axis(fig)
+                    figure_axes = list(fig.axes)
+                    bar_ax = figure_axes[0] if figure_axes else _largest_content_axis(fig)
+                    contribution_ax = figure_axes[1] if len(figure_axes) > 1 else bar_ax
+                left_cmap, right_cmap = _resolve_dual_cmaps(cmap)
+                bar_widths = np.array([float(bar.get_width()) for bar in bar_ax.patches], dtype=float)
+                if bar_widths.size:
+                    width_norm = Normalize(vmin=float(bar_widths.min()), vmax=float(bar_widths.max()) if float(bar_widths.max()) > float(bar_widths.min()) else float(bar_widths.min()) + 1.0)
+                    left_cmap_obj = plt.get_cmap(left_cmap)
+                    for bar, width in zip(bar_ax.patches, bar_widths):
+                        bar.set_facecolor(left_cmap_obj(width_norm(float(width))))
+                        bar.set_alpha(0.92)
+                        bar.set_edgecolor("#3A4FB7")
+                        bar.set_linewidth(1.0)
+                bar_ax.invert_yaxis()
+                _style_lr_contribution_bar_axis(bar_ax)
+                if contribution_ax is not bar_ax:
+                    for collection in contribution_ax.collections:
+                        if hasattr(collection, "set_cmap"):
+                            collection.set_cmap(plt.get_cmap(right_cmap))
+                    _style_lr_contribution_scatter_axis(contribution_ax)
+                if len(fig.axes) > 2:
+                    for extra_ax in fig.axes:
+                        if extra_ax in {bar_ax, contribution_ax}:
+                            continue
+                        ylabel = extra_ax.get_ylabel()
+                        if ylabel and "Contribution" in ylabel:
+                            for collection in contribution_ax.collections:
+                                if hasattr(collection, "changed"):
+                                    collection.changed()
+                fig.subplots_adjust(wspace=0.34)
+                ax = bar_ax
             else:
                 fig, _ = contribution_result
                 ax = _largest_content_axis(fig)
             if title:
                 ax.set_title(title)
-            for contribution_ax in fig.axes:
-                if "Activity vs Significance" in contribution_ax.get_title():
-                    _style_scatter_axis(contribution_ax, max_marker_size=260.0, arrow=False)
             return _maybe_save_show(fig, show=show, save=save), ax
 
         fig, ax = plt.subplots(figsize=figsize)
@@ -4818,6 +6449,8 @@ def ccc_stat_plot(
 
     if plot_type == "bar":
         summary = _group_metric_summary(long_df, group_key="plot_group", value=value).head(int(top_n))
+        summary_title_fontsize = 13
+        summary_tick_fontsize = 13
         colors = _choose_palette(summary.index.astype(str).tolist(), palette=palette)
         ax.barh(summary.index.astype(str), summary.values, color=[colors[idx] for idx in summary.index.astype(str)])
         ax.invert_yaxis()
@@ -4825,9 +6458,12 @@ def ccc_stat_plot(
             np.arange(len(summary.index), dtype=float),
             labels=[_wrap_plot_label(label, width=22) for label in summary.index.astype(str)],
         )
+        ax.tick_params(axis="y", labelsize=summary_tick_fontsize)
+        ax.tick_params(axis="x", labelsize=summary_tick_fontsize - 1)
         ax.set_xlabel("Communication score" if value != "count" else "Significant interactions")
         ax.set_ylabel("")
-        ax.set_title(title or f"Top communication groups by {group_by}")
+        ax.set_title(title or f"Top communication groups by {group_by}", fontsize=summary_title_fontsize)
+        ax.grid(axis="x", alpha=0.22, linewidth=0.7)
         return _maybe_save_show(fig, show=show, save=save), ax
 
     if plot_type in {"violin", "box"} and facet_by in {"sender", "receiver", "pair"} and group_by == "interaction":

--- a/omicverse/pl/_cpdbviz.py
+++ b/omicverse/pl/_cpdbviz.py
@@ -2,6 +2,7 @@ import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
 import seaborn as sns
+import math
 from scipy import sparse
 import networkx as nx
 from matplotlib.patches import FancyBboxPatch, ConnectionPatch
@@ -77,6 +78,93 @@ class CellChatViz(CellChatVizPlus):
         self.n_cell_types = len(self.cell_types)
         self.palette = self._validate_palette(palette)
         self._color_cache = None  # Cache for consistent colors across all methods
+
+    def _resolve_individual_panel_layout(self, panel_names, ncols=None, nrows=None):
+        n_panels = len(panel_names)
+        if n_panels == 0:
+            raise ValueError("No cell types remain after applying sender/receiver filters.")
+        if ncols is None and nrows is None:
+            ncols = min(4, n_panels)
+            nrows = math.ceil(n_panels / ncols)
+        elif ncols is None:
+            nrows = int(nrows)
+            if nrows <= 0:
+                raise ValueError("`nrows` must be a positive integer.")
+            ncols = math.ceil(n_panels / nrows)
+        elif nrows is None:
+            ncols = int(ncols)
+            if ncols <= 0:
+                raise ValueError("`ncols` must be a positive integer.")
+            nrows = math.ceil(n_panels / ncols)
+        else:
+            ncols = int(ncols)
+            nrows = int(nrows)
+            if ncols <= 0 or nrows <= 0:
+                raise ValueError("`ncols` and `nrows` must be positive integers.")
+            if ncols * nrows < n_panels:
+                raise ValueError("`ncols * nrows` must be large enough for the selected cell types.")
+        return int(ncols), int(nrows)
+
+    def _add_compact_individual_colorbar(
+        self,
+        fig,
+        axes,
+        global_max_weight,
+        use_sender_colors,
+        cmap,
+        legend_labels=None,
+    ):
+        if global_max_weight <= 0:
+            return
+        visible_axes = [ax for ax in np.ravel(axes) if ax.get_visible()]
+        if not visible_axes:
+            return
+        bboxes = [ax.get_position() for ax in visible_axes]
+        left = min(b.x0 for b in bboxes)
+        right = max(b.x1 for b in bboxes)
+        bottom = min(b.y0 for b in bboxes)
+        top = max(b.y1 for b in bboxes)
+        union_height = max(top - bottom, 0.1)
+        if use_sender_colors:
+            legend_labels = list(self.cell_types if legend_labels is None else legend_labels)
+            if not legend_labels:
+                return
+            cell_colors = self._get_cell_type_colors()
+            handles = [
+                mpatches.Patch(color=cell_colors.get(label, '#1f77b4'), label=label)
+                for label in legend_labels
+            ]
+            ncol = 1 if len(handles) <= 8 else 2
+            fig.legend(
+                handles=handles,
+                title='Sender',
+                loc='center left',
+                bbox_to_anchor=(min(right + 0.012, 0.84), bottom + 0.5 * union_height),
+                bbox_transform=fig.transFigure,
+                frameon=False,
+                fontsize=6,
+                title_fontsize=7,
+                handlelength=0.9,
+                handleheight=0.5,
+                handletextpad=0.4,
+                columnspacing=0.7,
+                borderaxespad=0.0,
+                ncol=ncol,
+            )
+            return
+        cbar_height = min(union_height * 0.24, 0.24)
+        cbar_width = 0.008
+        cbar_y = bottom + 0.5 * union_height - 0.5 * cbar_height
+        cbar_x = min(right + 0.018, 0.965 - cbar_width)
+        cbar_ax = fig.add_axes([cbar_x, cbar_y, cbar_width, cbar_height])
+        sm = plt.cm.ScalarMappable(
+            cmap=plt.cm.get_cmap(cmap),
+            norm=plt.Normalize(vmin=0, vmax=global_max_weight),
+        )
+        sm.set_array([])
+        cbar = plt.colorbar(sm, cax=cbar_ax)
+        cbar.set_label('Interaction strength', rotation=270, labelpad=10, fontsize=8)
+        cbar.ax.tick_params(labelsize=7, length=2)
         
     def _get_unique_cell_types(self):
         """Get unique cell types from sender and receiver"""
@@ -709,7 +797,7 @@ class CellChatViz(CellChatVizPlus):
             interaction_means = means[i, :]
             # Apply count_min threshold (interactions below threshold are set to 0)
             filtered_means = np.where(interaction_means >= count_min, interaction_means, 0)
-            mean_matrix[sender_idx, receiver_idx] = np.sum(filtered_means)
+            mean_matrix[sender_idx, receiver_idx] += np.sum(filtered_means)
         
         # Convert to DataFrame for easier handling
         mean_df = pd.DataFrame(mean_matrix, 
@@ -733,7 +821,8 @@ class CellChatViz(CellChatVizPlus):
             Sender-by-receiver matrix of aggregated p-values.
         """
         # Initialize matrix
-        pvalue_matrix = np.ones((self.n_cell_types, self.n_cell_types))  # Default p=1
+        pvalue_sum = np.zeros((self.n_cell_types, self.n_cell_types))
+        pvalue_count = np.zeros((self.n_cell_types, self.n_cell_types))
         
         # Get data
         pvalues = self.adata.layers['pvalues']
@@ -751,11 +840,12 @@ class CellChatViz(CellChatVizPlus):
             valid_mask = interaction_means >= count_min
             
             if np.any(valid_mask):
-                # Compute average p-value for valid interactions
-                pvalue_matrix[sender_idx, receiver_idx] = np.mean(interaction_pvals[valid_mask])
-            else:
-                # No valid interactions, keep default p=1
-                pvalue_matrix[sender_idx, receiver_idx] = 1.0
+                pvalue_sum[sender_idx, receiver_idx] += float(np.sum(interaction_pvals[valid_mask]))
+                pvalue_count[sender_idx, receiver_idx] += float(np.sum(valid_mask))
+
+        pvalue_matrix = np.ones((self.n_cell_types, self.n_cell_types))
+        valid_entries = pvalue_count > 0
+        pvalue_matrix[valid_entries] = pvalue_sum[valid_entries] / pvalue_count[valid_entries]
         
         # Convert to DataFrame for easier handling
         pvalue_df = pd.DataFrame(pvalue_matrix, 
@@ -864,6 +954,8 @@ class CellChatViz(CellChatVizPlus):
             pathway_matrix = np.zeros((self.n_cell_types, self.n_cell_types))
             pathway_pvalue_matrix = np.ones((self.n_cell_types, self.n_cell_types))
             valid_interactions_matrix = np.zeros((self.n_cell_types, self.n_cell_types))
+            pooled_means = [[[] for _ in range(self.n_cell_types)] for _ in range(self.n_cell_types)]
+            pooled_pvals = [[[] for _ in range(self.n_cell_types)] for _ in range(self.n_cell_types)]
             
             for i, (sender, receiver) in enumerate(zip(self.adata.obs['sender'], self.adata.obs['receiver'])):
                 sender_idx = self.cell_types.index(sender)
@@ -877,10 +969,17 @@ class CellChatViz(CellChatVizPlus):
                 valid_mask = pathway_means >= min_expression
                 
                 if np.any(valid_mask):
-                    valid_means = pathway_means[valid_mask]
-                    valid_pvals = pathway_pvals[valid_mask]
-                    
-                    # Calculate pathway-level communication strength
+                    pooled_means[sender_idx][receiver_idx].append(np.asarray(pathway_means[valid_mask], dtype=float))
+                    pooled_pvals[sender_idx][receiver_idx].append(np.asarray(pathway_pvals[valid_mask], dtype=float))
+
+            for sender_idx in range(self.n_cell_types):
+                for receiver_idx in range(self.n_cell_types):
+                    if not pooled_means[sender_idx][receiver_idx]:
+                        continue
+
+                    valid_means = np.concatenate(pooled_means[sender_idx][receiver_idx])
+                    valid_pvals = np.concatenate(pooled_pvals[sender_idx][receiver_idx])
+
                     if method == 'mean':
                         pathway_strength = np.mean(valid_means)
                     elif method == 'sum':
@@ -891,18 +990,10 @@ class CellChatViz(CellChatVizPlus):
                         pathway_strength = np.median(valid_means)
                     else:
                         raise ValueError(f"Unknown method: {method}")
-                    
-                    # Calculate pathway-level p-value (use minimum p-value as pathway significance)
-                    pathway_pval = np.min(valid_pvals)
-                    
+
                     pathway_matrix[sender_idx, receiver_idx] = pathway_strength
-                    pathway_pvalue_matrix[sender_idx, receiver_idx] = pathway_pval
+                    pathway_pvalue_matrix[sender_idx, receiver_idx] = np.min(valid_pvals)
                     valid_interactions_matrix[sender_idx, receiver_idx] = len(valid_means)
-                else:
-                    # No valid interactions
-                    pathway_matrix[sender_idx, receiver_idx] = 0
-                    pathway_pvalue_matrix[sender_idx, receiver_idx] = 1.0
-                    valid_interactions_matrix[sender_idx, receiver_idx] = 0
             
             # Store pathway communication results
             pathway_communication[pathway] = {
@@ -1286,7 +1377,9 @@ class CellChatViz(CellChatVizPlus):
     
     def netVisual_individual_circle(self, pvalue_threshold=0.05, vertex_size_max=50, 
                                    edge_width_max=10, show_labels=True, cmap='Blues', 
-                                   figsize=(20, 15), ncols=4, use_sender_colors=True):
+                                   figsize=(20, 15), ncols=None, nrows=None,
+                                   sender_use=None, receiver_use=None,
+                                   use_sender_colors=True, title=None):
         """
         Plot one outgoing communication circle per cell type.
 
@@ -1311,11 +1404,20 @@ class CellChatViz(CellChatVizPlus):
             ``use_sender_colors=False``.
         figsize : tuple
             Figure size in inches as ``(width, height)``.
-        ncols : int
+        ncols : int or None
             Number of columns in the subplot grid.
+        nrows : int or None
+            Number of rows in the subplot grid.
+        sender_use : sequence of str or None
+            Optional sender cell types to keep as individual panels.
+        receiver_use : sequence of str or None
+            Optional receiver cell types to keep as outgoing targets inside each
+            panel.
         use_sender_colors : bool
             If ``True``, color each edge by sender cell type (CellChat-like
             style); otherwise use the numeric colormap from ``cmap``.
+        title : str or None
+            Optional figure-level title.
         
         Returns
         -------
@@ -1330,15 +1432,18 @@ class CellChatViz(CellChatVizPlus):
         if global_max_weight == 0:
             global_max_weight = 1  # Avoid division by zero
         
-        # Calculate subplot layout
-        nrows = (self.n_cell_types + ncols - 1) // ncols
-        
+        panel_names = list(self.cell_types if sender_use is None else sender_use)
+        receiver_filter = None if receiver_use is None else set(receiver_use)
+        invalid_senders = [ct for ct in panel_names if ct not in self.cell_types]
+        if invalid_senders:
+            raise ValueError(f"Invalid sender cell types: {invalid_senders}. Available cell types: {self.cell_types}")
+        invalid_receivers = [ct for ct in receiver_filter or [] if ct not in self.cell_types]
+        if invalid_receivers:
+            raise ValueError(f"Invalid receiver cell types: {invalid_receivers}. Available cell types: {self.cell_types}")
+        ncols, nrows = self._resolve_individual_panel_layout(panel_names, ncols=ncols, nrows=nrows)
+
         # Create figure with subplots
-        fig, axes = plt.subplots(nrows, ncols, figsize=figsize)
-        if nrows == 1:
-            axes = axes.reshape(1, -1)
-        elif ncols == 1:
-            axes = axes.reshape(-1, 1)
+        fig, axes = plt.subplots(nrows, ncols, figsize=figsize, squeeze=False)
         
         # Create circular layout (same for all subplots)
         angles = np.linspace(0, 2*np.pi, self.n_cell_types, endpoint=False)
@@ -1354,15 +1459,21 @@ class CellChatViz(CellChatVizPlus):
         # Get cell type colors for consistency
         cell_colors = self._get_cell_type_colors()
         
-        for i in range(self.n_cell_types):
+        for panel_idx, panel_name in enumerate(panel_names):
             # Calculate subplot position
-            row = i // ncols
-            col = i % ncols
+            row = panel_idx // ncols
+            col = panel_idx % ncols
             ax = axes[row, col]
+            i = self.cell_types.index(panel_name)
             
             # Create individual matrix (only outgoing from cell type i)
             individual_matrix = np.zeros_like(weight_matrix)
-            individual_matrix[i, :] = weight_matrix[i, :]
+            if receiver_filter is None:
+                individual_matrix[i, :] = weight_matrix[i, :]
+            else:
+                for receiver_name in receiver_filter:
+                    receiver_idx = self.cell_types.index(receiver_name)
+                    individual_matrix[i, receiver_idx] = weight_matrix[i, receiver_idx]
             
             # Create graph for this cell type
             G = nx.DiGraph()
@@ -1415,51 +1526,35 @@ class CellChatViz(CellChatVizPlus):
                 label_pos = {j: (1.2*np.cos(angle), 1.2*np.sin(angle)) 
                            for j, angle in enumerate(angles)}
                 labels = {j: self.cell_types[j] for j in range(self.n_cell_types)}
-                nx.draw_networkx_labels(G, label_pos, labels, font_size=8, ax=ax)
+                nx.draw_networkx_labels(G, label_pos, labels, font_size=7, ax=ax)
             
             # Set title with cell type name and use sender color
             title_color = cell_colors.get(self.cell_types[i], '#000000')
-            ax.set_title(self.cell_types[i], fontsize=12, pad=10, weight='bold', color=title_color)
+            ax.set_title(self.cell_types[i], fontsize=10, pad=5, weight='bold', color=title_color)
             ax.set_xlim(-1.4, 1.4)
             ax.set_ylim(-1.4, 1.4)
             ax.axis('off')
         
         # Hide unused subplots
-        for i in range(self.n_cell_types, nrows * ncols):
+        for i in range(len(panel_names), nrows * ncols):
             row = i // ncols
             col = i % ncols
             axes[row, col].axis('off')
         
-        # Add a single colorbar for the entire figure
-        if global_max_weight > 0:
-            # Create colorbar on the right side
-            cbar_ax = fig.add_axes([0.92, 0.15, 0.02, 0.7])
-            if use_sender_colors:
-                # Use a neutral colormap for the colorbar when using sender colors
-                sm = plt.cm.ScalarMappable(cmap='viridis', 
-                                          norm=plt.Normalize(vmin=0, vmax=global_max_weight))
-                sm.set_array([])
-                cbar = plt.colorbar(sm, cax=cbar_ax)
-                cbar.set_label('Interaction Strength\n(Colors: Sender Cell Types)', rotation=270, labelpad=25)
-            else:
-                sm = plt.cm.ScalarMappable(cmap=plt.cm.get_cmap(cmap), 
-                                          norm=plt.Normalize(vmin=0, vmax=global_max_weight))
-                sm.set_array([])
-                cbar = plt.colorbar(sm, cax=cbar_ax)
-                cbar.set_label('Interaction Strength', rotation=270, labelpad=20)
-        
-        # Add main title
-        fig.suptitle('Individual Cell Type Communication Networks\n(Outgoing Signals with Sender Colors)', 
-                    fontsize=16, y=0.95)
-        
-        plt.tight_layout()
-        plt.subplots_adjust(right=0.9)
+        fig.suptitle(
+            title or 'Individual cell type communication networks (outgoing)',
+            fontsize=12,
+            y=0.955,
+        )
+        plt.tight_layout(rect=[0, 0, 0.99, 0.965])
         
         return fig
     
     def netVisual_individual_circle_incoming(self, pvalue_threshold=0.05, vertex_size_max=50, 
                                            edge_width_max=10, show_labels=True, cmap='Reds', 
-                                           figsize=(20, 15), ncols=4, use_sender_colors=True):
+                                           figsize=(20, 15), ncols=None, nrows=None,
+                                           sender_use=None, receiver_use=None,
+                                           use_sender_colors=True, title=None):
         """
         Plot one incoming communication circle per cell type.
 
@@ -1484,11 +1579,20 @@ class CellChatViz(CellChatVizPlus):
             ``use_sender_colors=False``.
         figsize : tuple
             Figure size in inches as ``(width, height)``.
-        ncols : int
+        ncols : int or None
             Number of columns in the subplot grid.
+        nrows : int or None
+            Number of rows in the subplot grid.
+        sender_use : sequence of str or None
+            Optional sender cell types to keep as incoming sources inside each
+            panel.
+        receiver_use : sequence of str or None
+            Optional receiver cell types to keep as individual panels.
         use_sender_colors : bool
             If ``True``, color edges by sender identity so incoming signal origin
             is visually explicit.
+        title : str or None
+            Optional figure-level title.
         
         Returns
         -------
@@ -1503,15 +1607,18 @@ class CellChatViz(CellChatVizPlus):
         if global_max_weight == 0:
             global_max_weight = 1  # Avoid division by zero
         
-        # Calculate subplot layout
-        nrows = (self.n_cell_types + ncols - 1) // ncols
-        
+        panel_names = list(self.cell_types if receiver_use is None else receiver_use)
+        sender_filter = None if sender_use is None else set(sender_use)
+        invalid_receivers = [ct for ct in panel_names if ct not in self.cell_types]
+        if invalid_receivers:
+            raise ValueError(f"Invalid receiver cell types: {invalid_receivers}. Available cell types: {self.cell_types}")
+        invalid_senders = [ct for ct in sender_filter or [] if ct not in self.cell_types]
+        if invalid_senders:
+            raise ValueError(f"Invalid sender cell types: {invalid_senders}. Available cell types: {self.cell_types}")
+        ncols, nrows = self._resolve_individual_panel_layout(panel_names, ncols=ncols, nrows=nrows)
+
         # Create figure with subplots
-        fig, axes = plt.subplots(nrows, ncols, figsize=figsize)
-        if nrows == 1:
-            axes = axes.reshape(1, -1)
-        elif ncols == 1:
-            axes = axes.reshape(-1, 1)
+        fig, axes = plt.subplots(nrows, ncols, figsize=figsize, squeeze=False)
         
         # Create circular layout (same for all subplots)
         angles = np.linspace(0, 2*np.pi, self.n_cell_types, endpoint=False)
@@ -1527,15 +1634,21 @@ class CellChatViz(CellChatVizPlus):
         # Get cell type colors for consistency
         cell_colors = self._get_cell_type_colors()
         
-        for i in range(self.n_cell_types):
+        for panel_idx, panel_name in enumerate(panel_names):
             # Calculate subplot position
-            row = i // ncols
-            col = i % ncols
+            row = panel_idx // ncols
+            col = panel_idx % ncols
             ax = axes[row, col]
+            i = self.cell_types.index(panel_name)
             
             # Create individual matrix (only incoming to cell type i)
             individual_matrix = np.zeros_like(weight_matrix)
-            individual_matrix[:, i] = weight_matrix[:, i]
+            if sender_filter is None:
+                individual_matrix[:, i] = weight_matrix[:, i]
+            else:
+                for sender_name in sender_filter:
+                    sender_idx = self.cell_types.index(sender_name)
+                    individual_matrix[sender_idx, i] = weight_matrix[sender_idx, i]
             
             # Create graph for this cell type
             G = nx.DiGraph()
@@ -1598,45 +1711,27 @@ class CellChatViz(CellChatVizPlus):
                 label_pos = {j: (1.2*np.cos(angle), 1.2*np.sin(angle)) 
                            for j, angle in enumerate(angles)}
                 labels = {j: self.cell_types[j] for j in range(self.n_cell_types)}
-                nx.draw_networkx_labels(G, label_pos, labels, font_size=8, ax=ax)
+                nx.draw_networkx_labels(G, label_pos, labels, font_size=7, ax=ax)
             
             # Set title with cell type name and use receiver color (target cell type)
             title_color = cell_colors.get(self.cell_types[i], '#000000')
-            ax.set_title(self.cell_types[i], fontsize=12, pad=10, weight='bold', color=title_color)
+            ax.set_title(self.cell_types[i], fontsize=10, pad=5, weight='bold', color=title_color)
             ax.set_xlim(-1.4, 1.4)
             ax.set_ylim(-1.4, 1.4)
             ax.axis('off')
         
         # Hide unused subplots
-        for i in range(self.n_cell_types, nrows * ncols):
+        for i in range(len(panel_names), nrows * ncols):
             row = i // ncols
             col = i % ncols
             axes[row, col].axis('off')
         
-        # Add a single colorbar for the entire figure
-        if global_max_weight > 0:
-            # Create colorbar on the right side
-            cbar_ax = fig.add_axes([0.92, 0.15, 0.02, 0.7])
-            if use_sender_colors:
-                # Use a neutral colormap for the colorbar when using sender colors
-                sm = plt.cm.ScalarMappable(cmap='viridis', 
-                                          norm=plt.Normalize(vmin=0, vmax=global_max_weight))
-                sm.set_array([])
-                cbar = plt.colorbar(sm, cax=cbar_ax)
-                cbar.set_label('Interaction Strength\n(Colors: Sender Cell Types)', rotation=270, labelpad=25)
-            else:
-                sm = plt.cm.ScalarMappable(cmap=plt.cm.get_cmap(cmap), 
-                                          norm=plt.Normalize(vmin=0, vmax=global_max_weight))
-                sm.set_array([])
-                cbar = plt.colorbar(sm, cax=cbar_ax)
-                cbar.set_label('Interaction Strength', rotation=270, labelpad=20)
-        
-        # Add main title
-        fig.suptitle('Individual Cell Type Communication Networks\n(Incoming Signals with Sender Colors)', 
-                    fontsize=16, y=0.95)
-        
-        plt.tight_layout()
-        plt.subplots_adjust(right=0.9)
+        fig.suptitle(
+            title or 'Individual cell type communication networks (incoming)',
+            fontsize=12,
+            y=0.955,
+        )
+        plt.tight_layout(rect=[0, 0, 0.99, 0.965])
         
         return fig
     
@@ -1683,7 +1778,8 @@ class CellChatViz(CellChatVizPlus):
     
     def netVisual_heatmap_marsilea(self, signaling=None, pvalue_threshold=0.05, 
                                 color_heatmap="Reds", add_dendrogram=True,
-                                add_row_sum=True, add_col_sum=True, 
+                                add_row_sum=True, add_col_sum=True,
+                                show_row_names=False, show_col_names=False,
                                 linewidth=0.5, figsize=(8, 6), title="Communication Heatmap"):
         """
         Draw a CellChat-style communication heatmap with Marsilea.
@@ -1706,6 +1802,10 @@ class CellChatViz(CellChatVizPlus):
             If ``True``, annotate outgoing total strength per sender cell type.
         add_col_sum : bool
             If ``True``, annotate incoming total strength per receiver cell type.
+        show_row_names : bool
+            If ``True``, place sender cell-type labels beside the heatmap rows.
+        show_col_names : bool
+            If ``True``, place receiver cell-type labels below the heatmap columns.
         linewidth : float
             Cell border width in the heatmap.
         figsize : tuple
@@ -1798,6 +1898,10 @@ class CellChatViz(CellChatVizPlus):
         # Add cell type color bars
         h.add_left(ma.plotter.Colors(self.cell_types,palette=row_colors),size=0.2,legend=False)
         h.add_top(ma.plotter.Colors(self.cell_types,palette=col_colors),size=0.2)
+        if show_row_names:
+            h.add_left(ma.plotter.Labels(self.cell_types, fontsize=9), pad=0.08)
+        if show_col_names:
+            h.add_bottom(ma.plotter.Labels(self.cell_types, fontsize=9), pad=0.08)
         
         # Add legends
         h.add_legends()
@@ -1815,6 +1919,7 @@ class CellChatViz(CellChatVizPlus):
     def netVisual_heatmap_marsilea_focused(self, signaling=None, pvalue_threshold=0.05,
                                           min_interaction_threshold=0, color_heatmap="Reds", 
                                           add_dendrogram=True, add_row_sum=True, add_col_sum=True,
+                                          show_row_names=False, show_col_names=False,
                                           linewidth=0.5, figsize=(8, 6), title="Communication Heatmap"):
         """
         Draw a focused Marsilea heatmap keeping only active cell types.
@@ -1840,6 +1945,10 @@ class CellChatViz(CellChatVizPlus):
             If ``True``, show outgoing totals as side annotations.
         add_col_sum : bool
             If ``True``, show incoming totals as top annotations.
+        show_row_names : bool
+            If ``True``, place sender cell-type labels beside the focused heatmap rows.
+        show_col_names : bool
+            If ``True``, place receiver cell-type labels below the focused heatmap columns.
         linewidth : float
             Cell border width in the heatmap.
         figsize : tuple
@@ -1953,6 +2062,10 @@ class CellChatViz(CellChatVizPlus):
             size=0.14,
             pad=0.02,
         )
+        if show_row_names:
+            h.add_left(ma.plotter.Labels(active_cell_types, fontsize=9), pad=0.08)
+        if show_col_names:
+            h.add_bottom(ma.plotter.Labels(active_cell_types, fontsize=9), pad=0.08)
         
         # Add legends
         h.add_legends()
@@ -2060,7 +2173,7 @@ class CellChatViz(CellChatVizPlus):
         return fig, ax
     
     def netVisual_hierarchy(self, pathway_name=None, sources=None, targets=None,
-                           pvalue_threshold=0.05, figsize=(14, 10)):
+                           pvalue_threshold=0.05, top_n=None, figsize=(14, 10)):
         """
         Visualize directed communication as a two-layer hierarchy plot.
 
@@ -2078,6 +2191,9 @@ class CellChatViz(CellChatVizPlus):
             Optional receiver cell types to keep.
         pvalue_threshold : float
             P-value threshold for selecting significant ligand-receptor pairs.
+        top_n : int or None
+            Maximum number of sender->receiver edges retained after pathway
+            filtering. When ``None``, keep all significant edges.
         figsize : tuple
             Figure size in inches as ``(width, height)``.
 
@@ -2131,59 +2247,95 @@ class CellChatViz(CellChatVizPlus):
             ax.text(0.5, 0.5, 'No interactions found for specified sources/targets', 
                    ha='center', va='center', fontsize=16)
             return fig, ax
-        
-        sources_unique = df_int['source'].unique()
-        targets_unique = df_int['target'].unique()
-        
+
+        if top_n is not None and top_n > 0 and len(df_int) > top_n:
+            df_int = df_int.sort_values('weight', ascending=False).head(int(top_n)).copy()
+
+        outgoing_strength = df_int.groupby('source', observed=True)['weight'].sum().sort_values(ascending=False)
+        incoming_strength = df_int.groupby('target', observed=True)['weight'].sum().sort_values(ascending=False)
+        sources_unique = outgoing_strength.index.astype(str).tolist()
+        targets_unique = incoming_strength.index.astype(str).tolist()
+
         # Position nodes
-        source_y = np.linspace(0.1, 0.9, len(sources_unique))
-        target_y = np.linspace(0.1, 0.9, len(targets_unique))
-        
-        source_pos = {cell: (0.2, y) for cell, y in zip(sources_unique, source_y)}
-        target_pos = {cell: (0.8, y) for cell, y in zip(targets_unique, target_y)}
-        
+        top_margin = 0.92
+        bottom_margin = 0.08
+        source_y = np.linspace(bottom_margin, top_margin, len(sources_unique))
+        target_y = np.linspace(bottom_margin, top_margin, len(targets_unique))
+
+        source_x = 0.14
+        target_x = 0.86
+        source_pos = {cell: (source_x, y) for cell, y in zip(sources_unique, source_y)}
+        target_pos = {cell: (target_x, y) for cell, y in zip(targets_unique, target_y)}
+
+        max_nodes = max(len(sources_unique), len(targets_unique), 1)
+        node_height = float(np.clip(0.78 / max_nodes, 0.03, 0.065))
+        node_width = 0.18 if max_nodes <= 8 else 0.16
+        font_size = int(np.clip(12 - 0.28 * max_nodes, 7, 11))
+
         # Draw nodes
         # Get consistent cell type colors
         cell_colors = self._get_cell_type_colors()
         
         for cell, (x, y) in source_pos.items():
-            cell_color = cell_colors.get(cell, '#lightblue')
-            rect = FancyBboxPatch((x-0.08, y-0.03), 0.16, 0.06,
-                                 boxstyle="round,pad=0.01",
-                                 facecolor=cell_color, edgecolor='black', alpha=0.7)
+            cell_color = cell_colors.get(cell, '#ADD8E6')
+            rect = FancyBboxPatch((x - node_width / 2.0, y - node_height / 2.0),
+                                 node_width, node_height,
+                                 boxstyle="round,pad=0.008,rounding_size=0.014",
+                                 facecolor=cell_color, edgecolor='#5B5B5B', linewidth=1.0, alpha=0.82)
             ax.add_patch(rect)
-            ax.text(x, y, cell, ha='center', va='center', fontsize=10)
+            ax.text(x, y, cell, ha='center', va='center', fontsize=font_size)
         
         for cell, (x, y) in target_pos.items():
-            cell_color = cell_colors.get(cell, '#lightcoral')
-            rect = FancyBboxPatch((x-0.08, y-0.03), 0.16, 0.06,
-                                 boxstyle="round,pad=0.01",
-                                 facecolor=cell_color, edgecolor='black', alpha=0.7)
+            cell_color = cell_colors.get(cell, '#F08080')
+            rect = FancyBboxPatch((x - node_width / 2.0, y - node_height / 2.0),
+                                 node_width, node_height,
+                                 boxstyle="round,pad=0.008,rounding_size=0.014",
+                                 facecolor=cell_color, edgecolor='#5B5B5B', linewidth=1.0, alpha=0.82)
             ax.add_patch(rect)
-            ax.text(x, y, cell, ha='center', va='center', fontsize=10)
+            ax.text(x, y, cell, ha='center', va='center', fontsize=font_size)
         
         # Draw edges
         max_weight = df_int['weight'].max()
+        edge_groups = {}
         for _, row in df_int.iterrows():
             source = row['source']
             target = row['target']
             weight = row['weight']
-            
             if source in source_pos and target in target_pos:
-                arrow = ConnectionPatch(source_pos[source], target_pos[target],
-                                      "data", "data",
-                                      arrowstyle="->", shrinkA=10, shrinkB=10,
-                                      mutation_scale=20, fc="gray",
-                                      linewidth=weight/max_weight * 5,
-                                      alpha=0.6)
+                edge_groups.setdefault(source, []).append((target, float(weight)))
+
+        for source, edges in edge_groups.items():
+            sender_color = cell_colors.get(source, '#1f77b4')
+            custom_cmap = self._create_custom_colormap(sender_color)
+            weights = [weight for _, weight in edges]
+            if len(weights) > 1 and max(weights) > min(weights):
+                norm_weights = [(weight - min(weights)) / (max(weights) - min(weights)) for weight in weights]
+            else:
+                norm_weights = [0.55] * len(weights)
+
+            for (target, weight), color_scale in zip(edges, norm_weights):
+                arrow = ConnectionPatch(
+                    source_pos[source],
+                    target_pos[target],
+                    "data",
+                    "data",
+                    arrowstyle="->",
+                    shrinkA=14,
+                    shrinkB=14,
+                    mutation_scale=12,
+                    fc=custom_cmap(color_scale),
+                    ec=custom_cmap(color_scale),
+                    linewidth=0.8 + (weight / max_weight) * 3.2,
+                    alpha=0.5,
+                )
                 ax.add_artist(arrow)
         
         ax.set_xlim(0, 1)
         ax.set_ylim(0, 1)
         ax.set_title(f'Hierarchy Plot{" - " + pathway_name if pathway_name else ""}', 
-                    fontsize=16)
-        ax.text(0.2, -0.05, 'Sources', ha='center', fontsize=12, weight='bold')
-        ax.text(0.8, -0.05, 'Targets', ha='center', fontsize=12, weight='bold')
+                    fontsize=15)
+        ax.text(source_x, -0.035, 'Sources', ha='center', fontsize=12, weight='bold')
+        ax.text(target_x, -0.035, 'Targets', ha='center', fontsize=12, weight='bold')
         ax.axis('off')
         
         plt.tight_layout()
@@ -2368,7 +2520,7 @@ class CellChatViz(CellChatVizPlus):
                     
                     sig_mask = pvals < pvalue_threshold
                     if np.any(sig_mask):
-                        matrix[sender_idx, receiver_idx] = np.sum(means[sig_mask])
+                        matrix[sender_idx, receiver_idx] += np.sum(means[sig_mask])
             
             pathway_networks[pathway] = matrix
         
@@ -2815,6 +2967,7 @@ class CellChatViz(CellChatVizPlus):
                 sources=source_cells,
                 targets=target_cells,
                 pvalue_threshold=pvalue_threshold,
+                top_n=top_n,
                 figsize=figsize
             )
             
@@ -2888,7 +3041,7 @@ class CellChatViz(CellChatVizPlus):
                     all_pathway_means.extend(valid_means)
                     
                     # Check if there are significant interactions
-                    if np.any(valid_pvals < 0.05):
+                    if np.any(valid_pvals < pathway_pvalue_threshold):
                         significant_cell_pairs.append(f"{sender}|{receiver}")
             
             if len(all_pathway_pvals) == 0:
@@ -2923,18 +3076,20 @@ class CellChatViz(CellChatVizPlus):
                 combined_pval = 1.0
                 combined_stat = 0.0
             
+            significant_mask = all_pathway_pvals < pathway_pvalue_threshold
+
             # Calculate pathway statistics
             pathway_stats[pathway] = {
                 'n_lr_pairs': len(pathway_lr_pairs),
                 'n_tests': len(all_pathway_pvals),
-                'n_significant_interactions': np.sum(all_pathway_pvals < 0.05),
+                'n_significant_interactions': np.sum(significant_mask),
                 'mean_expression': np.mean(all_pathway_means),
                 'max_expression': np.max(all_pathway_means),
                 'combined_pvalue': combined_pval,
                 'combined_statistic': combined_stat,
-                'significant_cell_pairs': significant_cell_pairs,
+                'significant_cell_pairs': list(dict.fromkeys(significant_cell_pairs)),
                 'lr_pairs': pathway_lr_pairs,
-                'significance_rate': np.sum(all_pathway_pvals < 0.05) / len(all_pathway_pvals)
+                'significance_rate': np.sum(significant_mask) / len(all_pathway_pvals)
             }
             
             pathway_pvalues.append(combined_pval)
@@ -3370,7 +3525,9 @@ class CellChatViz(CellChatVizPlus):
         
         # Add title
         if title_name:
-            ax.set_title(title_name, fontsize=fontsize + 4, pad=20)
+            ax.set_title("")
+            fig.suptitle(title_name, fontsize=fontsize + 1, y=0.97)
+            fig.subplots_adjust(top=0.76)
         
         # Save file
         if save:
@@ -3574,7 +3731,8 @@ class CellChatViz(CellChatVizPlus):
             ax.text(0.5, 0.5, message, ha='center', va='center', fontsize=16)
             ax.axis('off')
             if title_name:
-                ax.set_title(title_name, fontsize=16, pad=20)
+                ax.set_title("")
+                fig.suptitle(title_name, fontsize=14, y=0.97)
             return fig, ax
         
         # Prepare colors
@@ -3624,7 +3782,9 @@ class CellChatViz(CellChatVizPlus):
         # Add title
         if title_name is None:
             title_name = f"Ligand-Receptor Communication{title_suffix}"
-        ax.set_title(title_name, fontsize=fontsize + 4, pad=20)
+        ax.set_title("")
+        fig.suptitle(title_name, fontsize=fontsize + 1, y=0.97)
+        fig.subplots_adjust(top=0.76)
         
         # Save file
         if save:

--- a/omicverse/pl/_cpdbviz_plus.py
+++ b/omicverse/pl/_cpdbviz_plus.py
@@ -14,6 +14,7 @@ import warnings
 warnings.filterwarnings('ignore')
 from matplotlib.colors import LinearSegmentedColormap
 import matplotlib.colors as mcolors
+from ._heatmap_marsilea import _warn_if_broken_marsilea_version
 try:
     import marsilea as ma
     import marsilea.plotter as mp
@@ -89,7 +90,7 @@ def _constrain_texts_to_axes(ax, texts, *, x_pad=0.03, y_pad=0.04):
             text.set_va("center")
 
 
-def _repel_texts(ax, texts, *, font_stroke=2.6):
+def _repel_texts(ax, texts, *, font_stroke=2.6, x_values=None, y_values=None, arrow=False):
     text_items = [text for text in texts if str(text.get_text()).strip()]
     if not text_items:
         return
@@ -100,15 +101,32 @@ def _repel_texts(ax, texts, *, font_stroke=2.6):
     except ImportError:
         warnings.warn("adjustText library not found. Using deterministic fallback label offsets instead.")
     else:
+        adjust_kwargs = {
+            "ax": ax,
+            "expand_points": (1.28, 1.42),
+            "expand_text": (1.24, 1.48),
+            "force_points": 0.75,
+            "force_text": 0.72,
+            "force_explode": 0.35,
+            "avoid_self": True,
+            "ensure_inside_axes": True,
+            "arrowprops": (
+                {
+                    "arrowstyle": "-",
+                    "color": "#8A8A8A",
+                    "alpha": 0.58,
+                    "lw": 0.75,
+                }
+                if arrow
+                else None
+            ),
+        }
+        if x_values is not None and y_values is not None:
+            adjust_kwargs["x"] = list(x_values)
+            adjust_kwargs["y"] = list(y_values)
         adjust_text(
             text_items,
-            ax=ax,
-            expand_points=(1.2, 1.3),
-            expand_text=(1.18, 1.35),
-            force_points=0.5,
-            force_text=0.5,
-            ensure_inside_axes=False,
-            arrowprops=None,
+            **adjust_kwargs,
         )
 
     _constrain_texts_to_axes(ax, text_items)
@@ -563,7 +581,9 @@ class CellChatVizPlus:
                 signaling_str = ', '.join(signaling) if len(signaling) <= 3 else f"{len(signaling)} pathways"
                 title_name += f"\nSignaling: {signaling_str}"
         
-        ax.set_title(title_name, fontsize=fontsize + 2, pad=20)
+        ax.set_title("")
+        fig.suptitle(title_name, fontsize=fontsize + 1, y=0.97)
+        fig.subplots_adjust(top=0.78)
         
         # Add cell type color legend
         if show_legend:
@@ -710,6 +730,8 @@ class CellChatVizPlus:
             from sklearn.preprocessing import normalize
         except ImportError:
             raise ImportError("marsilea and sklearn packages are required. Please install them: pip install marsilea scikit-learn")
+
+        _warn_if_broken_marsilea_version(ma)
         
         # Handle sender cell types
         if sources_use is None:
@@ -2635,15 +2657,26 @@ class CellChatVizPlus:
             signaling=signaling
         )
         
+        signaling_is_explicit = signaling is not None
+
         # Create AnnData object for filtering
         ad_signal = ad.AnnData(cell_matrix)
         ad_signal.var['mean'] = ad_signal.X.mean(axis=0)
         ad_signal.var['min'] = ad_signal.X.min(axis=0)
+        ad_signal.var['max'] = ad_signal.X.max(axis=0)
         
-        # Filter pathways with low signaling strength
-        valid_pathways = ad_signal.var['min'][ad_signal.var['min'] > min_threshold].index
+        # When pathways are explicitly requested upstream (for example via top-N
+        # auto-selection in ccc_heatmap), keep all non-empty pathways rather than
+        # applying a second aggressive min-across-cell-types filter that can
+        # collapse the heatmap to a single row.
+        if signaling_is_explicit:
+            valid_pathways = ad_signal.var.index[ad_signal.var['max'] > 0]
+        else:
+            valid_pathways = ad_signal.var.index[ad_signal.var['min'] > min_threshold]
         
         if len(valid_pathways) == 0:
+            if signaling_is_explicit:
+                raise ValueError("No signaling pathways remain after filtering empty pathway rows.")
             raise ValueError(f"No pathways found with minimum signal strength > {min_threshold}")
         
         # Get filtered data matrix (transpose: pathway x cell type)
@@ -2699,7 +2732,13 @@ class CellChatVizPlus:
             h.add_title(auto_title, fontsize=fontsize + 2, pad=0.02)
         
         # Render figure
-        h.render()
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message="Using categorical units to plot a list of strings that are all parsable as floats or dates.*",
+                category=UserWarning,
+            )
+            h.render()
         
         # Save figure
         if save:
@@ -2843,7 +2882,7 @@ class CellChatVizPlus:
         ax1.set_yticklabels(lr_contrib['lr_pair'], fontsize=font_size)
         ax1.set_xlabel('Contribution Score', fontsize=font_size + 2)
         ax1.set_title('Top Contributing L-R Pairs', fontsize=font_size + 2)
-        ax1.grid(axis='x', alpha=0.3)
+        ax1.grid(axis='x', alpha=0.22, linewidth=0.7)
         
         # 右图：按信号通路分组的贡献
         pathway_contrib = df_contrib.groupby('pathway')['contribution'].sum().sort_values(ascending=False)
@@ -3625,7 +3664,7 @@ class CellChatVizPlus:
         
         # 添加数值标签
         for i, (bar, percent) in enumerate(zip(bars, top_df['contribution_percent'])):
-            ax1.text(bar.get_width() + 0.5, bar.get_y() + bar.get_height()/2, 
+            ax1.text(bar.get_width() + 0.3, bar.get_y() + bar.get_height()/2, 
                     f'{percent:.1f}%', va='center', fontsize=9)
         
         # 右图：显著性 vs 强度散点图
@@ -3663,7 +3702,15 @@ class CellChatVizPlus:
         ax2.set_ylabel('Number of Significant Cell Pairs')
         ax2.set_title('L-R Pair Activity vs Significance')
         ax2.margins(x=0.12, y=0.18)
-        _repel_texts(ax2, texts, font_stroke=2.5)
+        ax2.grid(True, alpha=0.22, linewidth=0.7)
+        _repel_texts(
+            ax2,
+            texts,
+            font_stroke=2.5,
+            x_values=top_df['total_strength'].astype(float).to_numpy(),
+            y_values=top_df['significant_pairs'].astype(float).to_numpy(),
+            arrow=True,
+        )
         
         # 添加colorbar
         cbar = plt.colorbar(scatter, ax=ax2)

--- a/omicverse/pl/_dotplot.py
+++ b/omicverse/pl/_dotplot.py
@@ -5,6 +5,7 @@ import numpy as np
 import pandas as pd
 import marsilea as ma
 import marsilea.plotter as mp
+import warnings
 from matplotlib.colors import Normalize, Colormap
 from matplotlib.axes import Axes as _AxesSubplot
 from anndata import AnnData
@@ -163,6 +164,15 @@ def dotplot(
         If `return_fig` is True, returns the figure object.
         If `show` is False, returns axes dictionary.
     """
+    marsilea_version = getattr(ma, "__version__", "")
+    if marsilea_version.startswith("0.5.6"):
+        warnings.warn(
+            "marsilea 0.5.6 has an upstream legend regression that can hide "
+            "the dotplot colorbar. Please upgrade marsilea to 0.5.7 or newer.",
+            UserWarning,
+            stacklevel=2,
+        )
+
     # Convert var_names to list if string
     original_var_names_dict = None
     if isinstance(var_names, str):

--- a/omicverse/pl/_heatmap_marsilea.py
+++ b/omicverse/pl/_heatmap_marsilea.py
@@ -31,6 +31,19 @@ def _import_marsilea():
     return ma, mp
 
 
+def _warn_if_broken_marsilea_version(ma) -> None:
+    marsilea_version = getattr(ma, "__version__", "")
+    if marsilea_version.startswith("0.5.6"):
+        import warnings
+
+        warnings.warn(
+            "marsilea 0.5.6 has an upstream legend regression that can hide "
+            "SizedHeatmap colorbars. Please upgrade marsilea to 0.5.7 or newer.",
+            UserWarning,
+            stacklevel=2,
+        )
+
+
 def _resolve_palette(n_colors):
     if n_colors <= len(palette_28):
         return palette_28[:n_colors]
@@ -214,8 +227,6 @@ def _draw_custom_legends(
                 except Exception:
                     pass
 
-    # Measure the occupied plotting area first so the custom legend column can
-    # be placed just outside the visible heatmap content.
     content_x1 = 0.0
     content_y0, content_y1 = 1.0, 0.0
     for ax in fig.axes:
@@ -239,8 +250,6 @@ def _draw_custom_legends(
         fig.canvas.draw()
         renderer = fig.canvas.get_renderer()
 
-    # Assemble the legend stack off-canvas to measure its footprint without
-    # disturbing the original plot layout.
     temp_ax = fig.add_axes([0, 0, 1, 1])
     temp_ax.set_axis_off()
 
@@ -267,8 +276,6 @@ def _draw_custom_legends(
     legend_width_frac = (extent.xmax - extent.xmin) / (fig_w * dpi)
     temp_ax.remove()
 
-    # Reserve only the width that the stacked legends actually need, then draw
-    # them in a dedicated axis to keep titles and font styling consistent.
     pad_frac = pad / fig_w
     legend_x = content_x1 + pad_frac
     legend_width = min(legend_width_frac + 0.02, 0.35)

--- a/omicverse/single/__init__.py
+++ b/omicverse/single/__init__.py
@@ -67,8 +67,10 @@ from ._cpdb import (
     cpdb_interaction_filtered,
     cpdb_submeans_exacted,cpdb_exact_target,
     cpdb_exact_source,cellphonedb_v5,
-    run_cellphonedb_v5
+    run_cellphonedb_v5, format_cpdb_results, format_cpdb_results_for_viz
 )
+from ._liana import run_liana, format_liana_results, format_liana_results_for_viz
+from ._comm import to_comm_adata, extract_comm_adata
 
 from ._scgsea import (
     geneset_aucell,pathway_aucell,pathway_aucell_enrichment,
@@ -302,6 +304,13 @@ __all__ = [
     'cpdb_exact_source',
     'cellphonedb_v5',
     'run_cellphonedb_v5',
+    'format_cpdb_results',
+    'format_cpdb_results_for_viz',
+    'run_liana',
+    'format_liana_results',
+    'format_liana_results_for_viz',
+    'to_comm_adata',
+    'extract_comm_adata',
     # Pathway and functional analysis
     'geneset_aucell',
     'pathway_aucell',

--- a/omicverse/single/_comm.py
+++ b/omicverse/single/_comm.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+from typing import Mapping
+
+import anndata
+import pandas as pd
+
+
+_DEFAULT_RESULT_UNS_KEYS = (
+    "liana_res",
+    "cpdb_results",
+    "cellphonedb_results",
+    "cpdb_res",
+    "comm_adata",
+)
+_LIANA_PRIMARY_COLUMNS = {"source", "target", "ligand_complex", "receptor_complex"}
+
+
+def _is_comm_adata(adata: anndata.AnnData) -> bool:
+    return (
+        isinstance(adata, anndata.AnnData)
+        and {"sender", "receiver"}.issubset(adata.obs.columns)
+        and {"means", "pvalues"}.issubset(adata.layers.keys())
+    )
+
+
+def _looks_like_liana_results(value) -> bool:
+    return isinstance(value, pd.DataFrame) and _LIANA_PRIMARY_COLUMNS.issubset(value.columns)
+
+
+def _looks_like_cpdb_results(value) -> bool:
+    if not isinstance(value, Mapping):
+        return False
+    return {"means", "pvalues"}.issubset(value.keys()) and all(
+        isinstance(value[key], pd.DataFrame) for key in ("means", "pvalues")
+    )
+
+
+def _resolve_uns_key(adata: anndata.AnnData, requested_key: str | None) -> str | None:
+    if requested_key is not None and requested_key in adata.uns:
+        return requested_key
+    for candidate in _DEFAULT_RESULT_UNS_KEYS:
+        if candidate in adata.uns:
+            return candidate
+    return None
+
+
+def to_comm_adata(
+    adata: anndata.AnnData | None = None,
+    *,
+    data=None,
+    result_uns_key: str | None = None,
+    score_key: str = "specificity_rank",
+    pvalue_key: str = "specificity_rank",
+    inverse_score: bool = True,
+    inverse_pvalue: bool = False,
+    classification: str | Mapping[str, str] | None = None,
+    classification_reference: str | pd.DataFrame | None = "cellchat",
+    classification_fallback: str | None = "family",
+    separator: str = "|",
+) -> anndata.AnnData:
+    """
+    Convert a supported CCC result object into OmicVerse communication AnnData.
+
+    Parameters
+    ----------
+    adata
+        Input AnnData. May already be a communication AnnData or may contain
+        supported CCC results in ``adata.uns``.
+    data
+        Explicit result object to convert. Supported inputs are:
+        communication AnnData, LIANA result DataFrame, or CellPhoneDB result dict.
+    result_uns_key
+        Preferred ``adata.uns`` key to inspect when ``data`` is omitted.
+    """
+    from ._cpdb import format_cpdb_results
+    from ._liana import format_liana_results
+
+    if data is not None:
+        if isinstance(data, anndata.AnnData) and _is_comm_adata(data):
+            return data
+        if _looks_like_liana_results(data):
+            return format_liana_results(
+                liana_res=data,
+                score_key=score_key,
+                pvalue_key=pvalue_key,
+                inverse_score=inverse_score,
+                inverse_pvalue=inverse_pvalue,
+                classification=classification,
+                classification_reference=classification_reference,
+                classification_fallback=classification_fallback,
+            )
+        if _looks_like_cpdb_results(data):
+            return format_cpdb_results(data, separator=separator)
+        raise TypeError(
+            "`data` must be a communication AnnData, LIANA result DataFrame, or "
+            "CellPhoneDB result dict."
+        )
+
+    if adata is None:
+        raise ValueError("Provide either `adata` or `data`.")
+
+    if _is_comm_adata(adata):
+        return adata
+
+    resolved_key = _resolve_uns_key(adata, result_uns_key)
+    if resolved_key is None:
+        raise ValueError(
+            "Could not find a supported communication result in `adata.uns`. "
+            f"Tried: {list(_DEFAULT_RESULT_UNS_KEYS)}."
+        )
+
+    value = adata.uns[resolved_key]
+    if isinstance(value, anndata.AnnData) and _is_comm_adata(value):
+        return value
+    if _looks_like_liana_results(value):
+        return format_liana_results(
+            adata=adata,
+            uns_key=resolved_key,
+            score_key=score_key,
+            pvalue_key=pvalue_key,
+            inverse_score=inverse_score,
+            inverse_pvalue=inverse_pvalue,
+            classification=classification,
+            classification_reference=classification_reference,
+            classification_fallback=classification_fallback,
+        )
+    if _looks_like_cpdb_results(value):
+        return format_cpdb_results(value, separator=separator)
+
+    raise ValueError(
+        f"`adata.uns['{resolved_key}']` is not a supported communication result. "
+        "Expected LIANA results, CellPhoneDB results, or a communication AnnData."
+    )
+
+
+def extract_comm_adata(
+    adata: anndata.AnnData | None = None,
+    *,
+    data=None,
+    result_uns_key: str | None = None,
+    score_key: str = "specificity_rank",
+    pvalue_key: str = "specificity_rank",
+    inverse_score: bool = True,
+    inverse_pvalue: bool = False,
+    classification: str | Mapping[str, str] | None = None,
+    classification_reference: str | pd.DataFrame | None = "cellchat",
+    classification_fallback: str | None = "family",
+    separator: str = "|",
+) -> anndata.AnnData:
+    """Alias of :func:`to_comm_adata` for users who prefer extraction wording."""
+    return to_comm_adata(
+        adata=adata,
+        data=data,
+        result_uns_key=result_uns_key,
+        score_key=score_key,
+        pvalue_key=pvalue_key,
+        inverse_score=inverse_score,
+        inverse_pvalue=inverse_pvalue,
+        classification=classification,
+        classification_reference=classification_reference,
+        classification_fallback=classification_fallback,
+        separator=separator,
+    )

--- a/omicverse/single/_cpdb.py
+++ b/omicverse/single/_cpdb.py
@@ -454,6 +454,8 @@ def cellphonedb_v5(adata,
                            cleanup_temp=True,
                            debug=False,
                            separator='|',
+                           results_key: str = 'cpdb_results',
+                           comm_key: str = 'cpdb_comm',
                            **kwargs):
     """
     Run CellPhoneDB statistical analysis with proper file handling
@@ -496,7 +498,10 @@ def cellphonedb_v5(adata,
     Returns
     -------
     Tuple[dict,anndata.AnnData]
-        Raw CellPhoneDB result dict and formatted AnnData for visualization.
+        Raw CellPhoneDB result dict and formatted communication AnnData. The
+        same objects are also written to ``adata.uns[results_key]`` and
+        ``adata.uns[comm_key]`` so downstream ``ov.pl.ccc_*`` plots can work
+        directly on the original ``adata``.
     """
     import os
     import tempfile
@@ -651,7 +656,9 @@ def cellphonedb_v5(adata,
         # Step 7: Format results for visualization
         print("   - Formatting results for visualization...")
         
-        adata_cpdb = format_cpdb_results_for_viz(cpdb_results, separator=separator)
+        adata_cpdb = format_cpdb_results(cpdb_results, separator=separator)
+        adata.uns[results_key] = cpdb_results
+        adata.uns[comm_key] = adata_cpdb
         
         print(f"   - Created visualization AnnData: {adata_cpdb.shape}")
         print(f"   - Cell interactions: {adata_cpdb.n_obs}")
@@ -673,7 +680,7 @@ def cellphonedb_v5(adata,
         print("✅ CellPhoneDB analysis pipeline completed!")
 
 
-def format_cpdb_results_for_viz(cpdb_results, separator='|'):
+def format_cpdb_results(cpdb_results, separator='|'):
     """
     Format CellPhoneDB results into AnnData object for CellChatViz
     
@@ -732,8 +739,14 @@ def format_cpdb_results_for_viz(cpdb_results, separator='|'):
     # Add interaction classification if available
     if 'classification' in adata_cpdb.var.columns:
         print(f"   - Found {adata_cpdb.var['classification'].nunique()} pathway classifications")
-    
+    adata_cpdb.uns["comm_source"] = "cellphonedb"
+    adata_cpdb.uns["cpdb_separator"] = separator
     return adata_cpdb
+
+
+def format_cpdb_results_for_viz(cpdb_results, separator='|'):
+    """Backward-compatible alias of :func:`format_cpdb_results`."""
+    return format_cpdb_results(cpdb_results, separator=separator)
 
 
 def create_cellchatviz_from_cpdb(cpdb_results, separator='|', palette=None):
@@ -755,7 +768,7 @@ def create_cellchatviz_from_cpdb(cpdb_results, separator='|', palette=None):
         Initialized visualization object.
     """
     # Format results
-    adata_cpdb = format_cpdb_results_for_viz(cpdb_results, separator=separator)
+    adata_cpdb = format_cpdb_results(cpdb_results, separator=separator)
     
     # Create and return CellChatViz object
     from ..pl._cpdbviz import CellChatViz
@@ -921,6 +934,8 @@ def run_cellphonedb_v5(adata,
                            cleanup_temp=True,
                            debug=False,
                            separator='|',
+                           results_key: str = 'cpdb_results',
+                           comm_key: str = 'cpdb_comm',
                            **kwargs):
     """
     Run CellPhoneDB statistical analysis with automatic database download
@@ -964,7 +979,10 @@ def run_cellphonedb_v5(adata,
     Returns
     -------
     Tuple[dict,anndata.AnnData]
-        Raw CellPhoneDB result dict and visualization-ready AnnData.
+        Raw CellPhoneDB result dict and visualization-ready communication
+        AnnData. The same objects are also written to
+        ``adata.uns[results_key]`` and ``adata.uns[comm_key]`` so downstream
+        ``ov.pl.ccc_*`` plots can work directly on the original ``adata``.
 
     Examples
     --------
@@ -1118,7 +1136,9 @@ def run_cellphonedb_v5(adata,
         # Step 7: Format results for visualization
         print("   - Formatting results for visualization...")
         
-        adata_cpdb = format_cpdb_results_for_viz(cpdb_results, separator=separator)
+        adata_cpdb = format_cpdb_results(cpdb_results, separator=separator)
+        adata.uns[results_key] = cpdb_results
+        adata.uns[comm_key] = adata_cpdb
         
         print(f"   - Created visualization AnnData: {adata_cpdb.shape}")
         print(f"   - Cell interactions: {adata_cpdb.n_obs}")

--- a/omicverse/single/_liana.py
+++ b/omicverse/single/_liana.py
@@ -1,0 +1,739 @@
+from __future__ import annotations
+
+import re
+from functools import lru_cache
+from pathlib import Path
+from typing import Mapping
+
+import numpy as np
+import pandas as pd
+import scanpy as sc
+
+from .._registry import register_function
+
+
+_LIANA_PRIMARY_COLUMNS = ("source", "target", "ligand_complex", "receptor_complex")
+_LIANA_CELLCHAT_REFERENCE = {
+    "cellchat_human": "cellchat_interactions_and_tfs_human.csv",
+    "cellchat_mouse": "cellchat_interactions_and_tfs_mouse.csv",
+}
+
+
+def _get_liana_res(
+    *,
+    adata=None,
+    liana_res: pd.DataFrame | None = None,
+    uns_key: str = "liana_res",
+) -> pd.DataFrame:
+    if liana_res is not None:
+        return liana_res.copy()
+    if adata is None:
+        raise ValueError("Provide either `liana_res` or `adata` with LIANA results in `adata.uns`.")
+    if uns_key not in adata.uns:
+        raise KeyError(f"`adata.uns['{uns_key}']` not found.")
+
+    value = adata.uns[uns_key]
+    if isinstance(value, pd.DataFrame):
+        return value.copy()
+
+    raise TypeError(
+        f"`adata.uns['{uns_key}']` must be a pandas DataFrame, got {type(value).__name__}."
+    )
+
+
+def _validate_liana_res(liana_res: pd.DataFrame) -> pd.DataFrame:
+    missing = [column for column in _LIANA_PRIMARY_COLUMNS if column not in liana_res.columns]
+    if missing:
+        raise ValueError(
+            "LIANA results are missing required columns: "
+            f"{missing}. Expected {list(_LIANA_PRIMARY_COLUMNS)}."
+        )
+
+    result = liana_res.copy()
+    for column in _LIANA_PRIMARY_COLUMNS:
+        result[column] = result[column].astype(str)
+
+    duplicate_subset = list(_LIANA_PRIMARY_COLUMNS)
+    for candidate in ("sample", "context", "condition", "dataset"):
+        if candidate in result.columns:
+            duplicate_subset.append(candidate)
+            result[candidate] = result[candidate].astype(str)
+            break
+
+    duplicated = result.duplicated(subset=duplicate_subset, keep=False)
+    if duplicated.any():
+        duplicate_count = int(duplicated.sum())
+        raise ValueError(
+            "LIANA results contain duplicated source-target-ligand-receptor combinations "
+            f"({duplicate_count} duplicated rows). Aggregate or deduplicate before formatting."
+        )
+    return result
+
+
+def _complex_tokens(value, *, uppercase: bool = True) -> list[str]:
+    text = str(value).strip()
+    if not text or text.lower() == "nan":
+        return []
+    text = text.replace("(", "").replace(")", "").replace(" ", "").replace("+", "_")
+    tokens = []
+    for token in text.split("_"):
+        normalized = re.sub(r"[^A-Za-z0-9-]", "", token)
+        if not normalized:
+            continue
+        tokens.append(normalized.upper() if uppercase else normalized)
+    return tokens
+
+
+def _normalize_complex(value) -> str:
+    tokens = _complex_tokens(value, uppercase=True)
+    if not tokens:
+        return ""
+    return "_".join(sorted(dict.fromkeys(tokens)))
+
+
+def _normalized_lr_key(ligand, receptor) -> str:
+    ligand_key = _normalize_complex(ligand)
+    receptor_key = _normalize_complex(receptor)
+    if not ligand_key or not receptor_key:
+        return ""
+    return f"{ligand_key}||{receptor_key}"
+
+
+def _parse_interaction_name_2(value) -> tuple[str, str]:
+    text = str(value).strip()
+    if not text or text.lower() == "nan":
+        return "", ""
+    parts = re.split(r"\s+-\s+", text, maxsplit=1)
+    if len(parts) != 2:
+        return "", ""
+    return parts[0].strip(), parts[1].strip()
+
+
+def _first_mode(values: pd.Series):
+    clean = values.dropna().astype(str).str.strip()
+    clean = clean.loc[clean.ne("")]
+    if clean.empty:
+        return np.nan
+    counts = clean.value_counts()
+    top = counts.loc[counts == counts.max()].index.tolist()
+    return sorted(top)[0]
+
+
+def _infer_cellchat_reference_name(liana_res: pd.DataFrame) -> str:
+    human_like = 0
+    mouse_like = 0
+    for column in ("ligand_complex", "receptor_complex"):
+        for value in liana_res[column].astype(str):
+            for token in _complex_tokens(value, uppercase=False):
+                letters = re.sub(r"[^A-Za-z]", "", token)
+                if not letters:
+                    continue
+                if letters.isupper():
+                    human_like += 1
+                elif letters[:1].isupper() and letters[1:] == letters[1:].lower():
+                    mouse_like += 1
+    return "cellchat_mouse" if mouse_like > human_like else "cellchat_human"
+
+
+@lru_cache(maxsize=4)
+def _load_builtin_classification_reference(name: str) -> pd.DataFrame:
+    if name not in _LIANA_CELLCHAT_REFERENCE:
+        available = sorted(["cellchat", *_LIANA_CELLCHAT_REFERENCE.keys()])
+        raise ValueError(
+            f"Unsupported `classification_reference={name!r}`. Available built-ins: {available}."
+        )
+    base_dir = Path(__file__).resolve().parents[1] / "datasets" / "data_files" / "TF"
+    return pd.read_csv(base_dir / _LIANA_CELLCHAT_REFERENCE[name], index_col=0)
+
+
+def _prepare_reference_frame(reference: pd.DataFrame) -> pd.DataFrame:
+    ref = reference.copy()
+    classification_column = None
+    for candidate in ("classification", "pathway_name", "signaling"):
+        if candidate in ref.columns:
+            classification_column = candidate
+            break
+    if classification_column is None:
+        raise ValueError(
+            "Classification reference must contain one of: "
+            "`classification`, `pathway_name`, or `signaling`."
+        )
+
+    ligand = pd.Series("", index=ref.index, dtype=object)
+    receptor = pd.Series("", index=ref.index, dtype=object)
+    if "interaction_name_2" in ref.columns:
+        parsed = ref["interaction_name_2"].apply(_parse_interaction_name_2)
+        ligand = parsed.map(lambda pair: pair[0])
+        receptor = parsed.map(lambda pair: pair[1])
+    has_parsed_pairs = "interaction_name_2" in ref.columns
+    if {"ligand_complex", "receptor_complex"}.issubset(ref.columns):
+        ligand = ligand.where(ligand.astype(str).str.strip() != "", ref["ligand_complex"])
+        receptor = receptor.where(receptor.astype(str).str.strip() != "", ref["receptor_complex"])
+    elif {"ligand", "receptor"}.issubset(ref.columns):
+        ligand = ligand.where(ligand.astype(str).str.strip() != "", ref["ligand"])
+        receptor = receptor.where(receptor.astype(str).str.strip() != "", ref["receptor"])
+    elif not has_parsed_pairs:
+        raise ValueError(
+            "Classification reference must contain `interaction_name_2`, "
+            "`ligand_complex`/`receptor_complex`, or `ligand`/`receptor` columns."
+        )
+
+    prepared = pd.DataFrame(index=ref.index)
+    prepared["classification_value"] = ref[classification_column].astype(str)
+    prepared["normalized_key"] = [
+        _normalized_lr_key(ligand_value, receptor_value)
+        for ligand_value, receptor_value in zip(ligand, receptor)
+    ]
+    prepared = prepared.loc[
+        (prepared["normalized_key"].astype(str) != "")
+        & (prepared["classification_value"].astype(str).str.strip() != "")
+    ]
+    return prepared
+
+
+def _reference_classification_series(
+    liana_res: pd.DataFrame,
+    *,
+    classification_reference: str | pd.DataFrame,
+) -> tuple[pd.Series, str]:
+    if isinstance(classification_reference, str):
+        reference_name = classification_reference
+        if reference_name == "cellchat":
+            reference_name = _infer_cellchat_reference_name(liana_res)
+        reference = _load_builtin_classification_reference(reference_name)
+    elif isinstance(classification_reference, pd.DataFrame):
+        reference_name = "custom_reference"
+        reference = classification_reference
+    else:
+        raise TypeError(
+            "`classification_reference` must be a built-in reference name or a pandas DataFrame."
+        )
+
+    prepared_reference = _prepare_reference_frame(reference)
+    mapping = prepared_reference.groupby("normalized_key", observed=True)["classification_value"].agg(_first_mode)
+    pair_keys = pd.Series(
+        [
+            _normalized_lr_key(ligand, receptor)
+            for ligand, receptor in zip(
+                liana_res["ligand_complex"].astype(str),
+                liana_res["receptor_complex"].astype(str),
+            )
+        ],
+        index=liana_res.index,
+        dtype=object,
+    )
+    return pair_keys.map(mapping), reference_name
+
+
+def _infer_family_label(ligand_complex, receptor_complex) -> str:
+    tokens = _complex_tokens(ligand_complex, uppercase=True) + _complex_tokens(
+        receptor_complex, uppercase=True
+    )
+    if not tokens:
+        return "Unclassified"
+
+    token_set = set(tokens)
+
+    def startswith_any(prefixes) -> bool:
+        return any(any(token.startswith(prefix) for prefix in prefixes) for token in token_set)
+
+    if startswith_any(("CXCL", "CXCR", "CX3CL", "CX3CR", "ACKR")):
+        return "CXCL"
+    if startswith_any(("CCL", "CCR")):
+        return "CCL"
+    if startswith_any(("XCL", "XCR")):
+        return "XCL"
+    if startswith_any(("TNF", "TNFR", "TNFRSF", "TNFSF", "FAS", "FASLG", "TRAIL", "LTA", "LTB")):
+        return "TNF"
+    if startswith_any(("TGFB", "TGFBR")):
+        return "TGFb"
+    if startswith_any(("BMP", "BMPR", "ACVR", "GDF", "LEFTY", "INHBA", "INHBB")):
+        return "BMP"
+    if startswith_any(("WNT", "FZD", "LRP", "ROR")):
+        return "WNT"
+    if startswith_any(("DLL", "JAG", "NOTCH")):
+        return "NOTCH"
+    if startswith_any(("FGF", "FGFR")):
+        return "FGF"
+    if startswith_any(("EGF", "EGFR", "ERBB", "HBEGF", "EREG", "NRG", "BTC", "AREG")):
+        return "EGF"
+    if startswith_any(("VEGF", "FLT", "KDR")):
+        return "VEGF"
+    if startswith_any(("PDGF", "PDGFR")):
+        return "PDGF"
+    if startswith_any(("SEMA", "PLXN", "NRP")):
+        return "Semaphorin/Plexin"
+    if startswith_any(("EFN", "EPH")):
+        return "Ephrin/EPH"
+    if startswith_any(("LGALS",)):
+        return "GALECTIN"
+    if startswith_any(("ANXA", "FPR", "F2R")):
+        return "ANNEXIN"
+    if startswith_any(("CD74", "HLA-D", "H2-AA", "H2-AB", "H2-EB", "H2-DM", "H2-O")):
+        return "MHC-II"
+    if startswith_any(("B2M", "HLA-A", "HLA-B", "HLA-C", "HLA-E", "HLA-F", "HLA-G", "H2-K", "H2-D", "H2-L")):
+        return "MHC-I"
+    if startswith_any(("HLA", "H2-")):
+        return "Antigen presentation"
+    if startswith_any(
+        (
+            "PDCD1",
+            "CD274",
+            "PDCD1LG",
+            "CTLA4",
+            "CD80",
+            "CD86",
+            "LAG3",
+            "HAVCR2",
+            "TIGIT",
+            "PVR",
+            "NECTIN",
+            "VSIR",
+            "SIRPA",
+            "CD47",
+            "CD200",
+            "CD200R",
+        )
+    ):
+        return "Immune checkpoint"
+    if startswith_any(("C1Q", "C2", "C3", "C4", "C5", "CFH", "CFB")):
+        return "COMPLEMENT"
+    if startswith_any(("FN1",)):
+        return "FN1"
+    if startswith_any(("LAMA", "LAMB", "LAMC")):
+        return "LAMININ"
+    if startswith_any(("COL",)):
+        return "COLLAGEN"
+    if startswith_any(("THBS",)):
+        return "THBS"
+    if startswith_any(("SPP1",)):
+        return "SPP1"
+    if startswith_any(("VCAN",)):
+        return "VCAN"
+    if startswith_any(("MK",)):
+        return "MK"
+    if startswith_any(("PTN",)):
+        return "PTN"
+    if startswith_any(("ITGA", "ITGB", "SDC", "CD44", "TNC")):
+        return "ECM/Adhesion"
+    if startswith_any(("IFN", "IFNAR", "IFNGR", "IL", "ILR", "OSM", "LIF", "CSF", "CSFR", "CNTF")):
+        return "Interleukin/Cytokine"
+    if "MIF" in token_set:
+        return "MIF"
+    return "Unclassified"
+
+
+def _resolve_classification(
+    liana_res: pd.DataFrame,
+    *,
+    classification: str | Mapping[str, str] | None = None,
+    classification_reference: str | pd.DataFrame | None = "cellchat",
+    classification_fallback: str | None = "family",
+) -> tuple[pd.Series, pd.Series, str | None]:
+    labels = pd.Series(np.nan, index=liana_res.index, dtype=object)
+    sources = pd.Series(np.nan, index=liana_res.index, dtype=object)
+    reference_name = None
+    pair_labels = (
+        liana_res["ligand_complex"].astype(str) + "-" + liana_res["receptor_complex"].astype(str)
+    )
+
+    def fill(values: pd.Series, source: str) -> None:
+        valid = values.notna() & (values.astype(str).str.strip() != "")
+        mask = labels.isna() & valid
+        if mask.any():
+            labels.loc[mask] = values.loc[mask].astype(str)
+            sources.loc[mask] = source
+
+    if isinstance(classification, str):
+        if classification not in liana_res.columns:
+            raise KeyError(f"`classification='{classification}'` not found in LIANA result columns.")
+        fill(liana_res[classification], f"column:{classification}")
+    elif isinstance(classification, Mapping):
+        fill(pair_labels.map(classification), "mapping")
+    elif classification is not None:
+        raise TypeError("`classification` must be a column name, a mapping, or None.")
+
+    if classification is None:
+        for candidate in ("classification", "pathway_name", "signaling"):
+            if candidate in liana_res.columns:
+                fill(liana_res[candidate], f"column:{candidate}")
+                break
+
+    if classification_reference is not None and labels.isna().any():
+        reference_labels, reference_name = _reference_classification_series(
+            liana_res,
+            classification_reference=classification_reference,
+        )
+        fill(reference_labels, f"reference:{reference_name}")
+
+    if labels.isna().any():
+        if classification_fallback == "family":
+            family_labels = pd.Series(
+                [
+                    _infer_family_label(ligand, receptor)
+                    for ligand, receptor in zip(
+                        liana_res["ligand_complex"].astype(str),
+                        liana_res["receptor_complex"].astype(str),
+                    )
+                ],
+                index=liana_res.index,
+                dtype=object,
+            )
+            fill(family_labels.where(family_labels.ne("Unclassified")), "family")
+        elif isinstance(classification_fallback, str) and classification_fallback.strip():
+            if classification_fallback == "unclassified":
+                pass
+            elif classification_fallback.startswith("label:"):
+                fallback_label = classification_fallback.split(":", 1)[1].strip()
+                if not fallback_label:
+                    raise ValueError(
+                        "`classification_fallback='label:<name>'` requires a non-empty fallback label."
+                    )
+                fill(
+                    pd.Series(fallback_label, index=liana_res.index, dtype=object),
+                    f"fallback:{fallback_label}",
+                )
+            else:
+                raise ValueError(
+                    "`classification_fallback` must be one of: 'family', 'unclassified', "
+                    "`label:<name>`, or None."
+                )
+        elif classification_fallback is None:
+            pass
+        else:
+            raise TypeError(
+                "`classification_fallback` must be a string strategy or None."
+            )
+
+    labels = labels.fillna("Unclassified").astype(str)
+    sources = sources.fillna("unclassified").astype(str)
+    return labels, sources, reference_name
+
+
+def _prepare_score_series(series: pd.Series, *, invert: bool, label: str) -> pd.Series:
+    values = pd.to_numeric(series, errors="coerce")
+    if values.isna().all():
+        raise ValueError(
+            f"Selected LIANA column `{label}` contains no numeric values after coercion. "
+            "For LIANA rank_aggregate outputs, `specificity_rank` is usually the safest "
+            "consensus column. `magnitude_rank` may be empty on some datasets / methods."
+        )
+
+    if invert:
+        finite = values[np.isfinite(values)]
+        if finite.empty:
+            return pd.Series(0.0, index=series.index, dtype=float)
+
+        if float(finite.min()) >= 0.0 and float(finite.max()) <= 1.0:
+            return (1.0 - values).fillna(0.0).clip(lower=0.0, upper=1.0).astype(float)
+
+        min_value = float(finite.min())
+        max_value = float(finite.max())
+        if np.isclose(max_value, min_value):
+            transformed = pd.Series(1.0, index=series.index, dtype=float)
+        else:
+            transformed = 1.0 - ((values - min_value) / (max_value - min_value))
+        transformed = transformed.fillna(0.0).clip(lower=0.0)
+        return transformed.astype(float)
+
+    return values.fillna(0.0).astype(float)
+
+
+@register_function(
+    aliases=["LIANA运行", "run_liana", "LIANA+"],
+    category="single",
+    description="Run LIANA / LIANA+ ligand-receptor inference and store the unified result table in `adata.uns`.",
+    prerequisites={"functions": [], "optional_functions": []},
+    requires={"obs": ["groupby"]},
+    produces={"uns": ["liana_res"]},
+    auto_fix="none",
+    examples=[
+        "ov.single.run_liana(adata, groupby='cell_type')",
+        "ov.single.run_liana(adata, groupby='cell_type', method='cellchat', key_added='cpdb_like_res')",
+    ],
+    related=["single.format_liana_results_for_viz", "pl.ccc_heatmap", "pl.ccc_network_plot", "pl.ccc_stat_plot"],
+)
+def run_liana(
+    adata,
+    *,
+    groupby: str,
+    method: str = "rank_aggregate",
+    key_added: str = "liana_res",
+    inplace: bool = True,
+    **kwargs,
+):
+    """
+    Run LIANA ligand-receptor inference on an AnnData object.
+
+    Parameters
+    ----------
+    adata
+        AnnData object used by LIANA.
+    groupby
+        Observation column with cell-type labels.
+    method
+        LIANA method name under ``liana.mt``. Defaults to ``'rank_aggregate'``.
+    key_added
+        Key used to store LIANA results in ``adata.uns`` when ``inplace=True``.
+    inplace
+        Whether to write results back to ``adata.uns``.
+    **kwargs
+        Forwarded to the selected LIANA method.
+
+    Returns
+    -------
+    pandas.DataFrame or AnnData
+        LIANA result table when ``inplace=False``; otherwise returns ``adata``.
+    """
+    try:
+        import liana as li
+    except ImportError as exc:  # pragma: no cover - exercised in optional dependency environments
+        raise ImportError(
+            "ov.single.run_liana requires the optional dependency `liana`. "
+            "Install it with `pip install liana` in a Python 3.10-3.13 environment."
+        ) from exc
+
+    if not hasattr(li.mt, method):
+        available = sorted(name for name in dir(li.mt) if not name.startswith("_"))
+        raise ValueError(f"Unknown LIANA method `{method}`. Available methods include: {available}.")
+
+    method_fn = getattr(li.mt, method)
+    result = method_fn(
+        adata,
+        groupby=groupby,
+        key_added=key_added,
+        inplace=inplace,
+        **kwargs,
+    )
+    return adata if inplace else result
+
+
+@register_function(
+    aliases=["LIANA结果格式化", "LIANA可视化格式化", "format_liana_results", "format_liana_results_for_viz", "LIANA转通信AnnData"],
+    category="single",
+    description="Convert LIANA aggregate results into OmicVerse communication AnnData compatible with `ov.pl.ccc_*`.",
+    prerequisites={"functions": [], "optional_functions": ["run_liana"]},
+    requires={"uns": ["liana_res"]},
+    produces={
+        "layers": ["means", "pvalues"],
+        "obs": ["sender", "receiver", "cell_type_pair"],
+        "var": ["interacting_pair", "classification", "gene_a", "gene_b"],
+    },
+    auto_fix="none",
+    examples=[
+        "comm_adata = ov.single.format_liana_results(adata)",
+        "comm_adata = ov.single.format_liana_results(adata, score_key='specificity_rank', pvalue_key='specificity_rank')",
+    ],
+    related=["single.run_liana", "pl.ccc_heatmap", "pl.ccc_network_plot", "pl.ccc_stat_plot"],
+)
+def format_liana_results(
+    adata=None,
+    *,
+    liana_res: pd.DataFrame | None = None,
+    uns_key: str = "liana_res",
+    score_key: str = "specificity_rank",
+    pvalue_key: str = "specificity_rank",
+    inverse_score: bool = True,
+    inverse_pvalue: bool = False,
+    classification: str | Mapping[str, str] | None = None,
+    classification_reference: str | pd.DataFrame | None = "cellchat",
+    classification_fallback: str | None = "family",
+):
+    """
+    Format LIANA results into the communication AnnData expected by ``ov.pl.ccc_*``.
+
+    Parameters
+    ----------
+    adata
+        AnnData containing ``adata.uns[uns_key]``.
+    liana_res
+        LIANA result table. If omitted, it is read from ``adata.uns[uns_key]``.
+    uns_key
+        Key in ``adata.uns`` that stores the LIANA result DataFrame.
+    score_key
+        Column used to populate ``layers['means']``. For current aggregated LIANA
+        results, ``'specificity_rank'`` is the safest default because
+        ``'magnitude_rank'`` can be empty on some datasets.
+    pvalue_key
+        Column used to populate ``layers['pvalues']``. For aggregated LIANA
+        results, ``'specificity_rank'`` is recommended.
+    inverse_score
+        Whether smaller values in ``score_key`` should be transformed to larger
+        communication strengths. This should stay ``True`` for rank-based scores.
+    inverse_pvalue
+        Whether smaller values in ``pvalue_key`` should be inverted before being
+        written to ``layers['pvalues']``. Keep ``False`` for rank / p-value-like
+        columns where smaller values indicate stronger support.
+    classification
+        Optional column name or ligand-receptor mapping used to populate
+        ``var['classification']``.
+    classification_reference
+        Optional built-in reference (``'cellchat'``, ``'cellchat_human'``,
+        ``'cellchat_mouse'``) or a custom DataFrame used to backfill pathway
+        annotations for interactions not covered by ``classification``.
+    classification_fallback
+        Fallback strategy for interactions still not covered after reference
+        matching. Use ``'family'`` for coarse signaling-family hints, a custom
+        string for a fixed fallback label, or ``None`` to keep
+        ``'Unclassified'``.
+
+    Returns
+    -------
+    anndata.AnnData
+        Communication AnnData with ``obs`` cell-type pairs and ``var`` LR pairs.
+    """
+    result = _validate_liana_res(_get_liana_res(adata=adata, liana_res=liana_res, uns_key=uns_key))
+
+    for key in (score_key, pvalue_key):
+        if key not in result.columns:
+            raise KeyError(f"`{key}` not found in LIANA result columns.")
+
+    result = result.copy()
+    result["score_value"] = _prepare_score_series(result[score_key], invert=inverse_score, label=score_key)
+    result["pvalue_value"] = _prepare_score_series(result[pvalue_key], invert=inverse_pvalue, label=pvalue_key)
+    result["cell_type_pair"] = result["source"].astype(str) + "|" + result["target"].astype(str)
+    sample_column = None
+    for candidate in ("sample", "context", "condition", "dataset"):
+        if candidate in result.columns:
+            sample_column = candidate
+            result["cell_type_pair"] = (
+                result["cell_type_pair"].astype(str) + "|" + candidate + "=" + result[candidate].astype(str)
+            )
+            break
+    result["interaction_key"] = (
+        result["ligand_complex"].astype(str) + " -> " + result["receptor_complex"].astype(str)
+    )
+    result["interacting_pair"] = (
+        result["ligand_complex"].astype(str) + "_" + result["receptor_complex"].astype(str)
+    )
+    result["pair_lr"] = (
+        result["ligand_complex"].astype(str) + "-" + result["receptor_complex"].astype(str)
+    )
+    (
+        result["classification_resolved"],
+        result["classification_source"],
+        reference_name,
+    ) = _resolve_classification(
+        result,
+        classification=classification,
+        classification_reference=classification_reference,
+        classification_fallback=classification_fallback,
+    )
+
+    obs_index = pd.Index(sorted(result["cell_type_pair"].unique()))
+    var_index = pd.Index(sorted(result["interaction_key"].unique()))
+
+    obs = pd.DataFrame(index=obs_index)
+    obs["sender"] = obs.index.to_series().str.split("|").str[0].astype(str)
+    obs["receiver"] = obs.index.to_series().str.split("|").str[1].astype(str)
+    obs["cell_type_pair"] = obs.index.astype(str)
+    if sample_column is not None:
+        sample_values = obs.index.to_series().str.extract(rf"\|{re.escape(sample_column)}=(.*)$", expand=False)
+        obs[sample_column] = sample_values.fillna("").astype(str)
+
+    var = (
+        result.loc[
+            :,
+            [
+                "interaction_key",
+                "interacting_pair",
+                "pair_lr",
+                "ligand_complex",
+                "receptor_complex",
+                "classification_resolved",
+                "classification_source",
+            ],
+        ]
+        .drop_duplicates("interaction_key")
+        .set_index("interaction_key")
+        .reindex(var_index)
+    )
+    var["interaction_name"] = var["interacting_pair"].astype(str)
+    var["interaction_name_2"] = (
+        var["ligand_complex"].astype(str) + " - " + var["receptor_complex"].astype(str)
+    )
+    var["classification"] = var["classification_resolved"].astype(str)
+    var["pathway_name"] = var["classification"].astype(str)
+    var["signaling"] = var["classification"].astype(str)
+    var["gene_a"] = var["ligand_complex"].astype(str)
+    var["gene_b"] = var["receptor_complex"].astype(str)
+    var["ligand"] = var["ligand_complex"].astype(str)
+    var["receptor"] = var["receptor_complex"].astype(str)
+    var["annotation_strategy"] = "liana_aggregate"
+    var["classification_source"] = var["classification_source"].astype(str)
+    var = var.loc[
+        :,
+        [
+            "interacting_pair",
+            "pair_lr",
+            "interaction_name",
+            "interaction_name_2",
+            "classification",
+            "pathway_name",
+            "signaling",
+            "gene_a",
+            "gene_b",
+            "ligand",
+            "receptor",
+            "annotation_strategy",
+            "classification_source",
+        ],
+    ]
+
+    score_matrix = (
+        result.pivot(index="cell_type_pair", columns="interaction_key", values="score_value")
+        .reindex(index=obs_index, columns=var_index)
+        .fillna(0.0)
+        .to_numpy(dtype=float)
+    )
+    pvalue_matrix = (
+        result.pivot(index="cell_type_pair", columns="interaction_key", values="pvalue_value")
+        .reindex(index=obs_index, columns=var_index)
+        .fillna(1.0)
+        .to_numpy(dtype=float)
+    )
+
+    comm_adata = sc.AnnData(X=score_matrix, obs=obs, var=var)
+    comm_adata.layers["means"] = score_matrix.copy()
+    comm_adata.layers["pvalues"] = pvalue_matrix.copy()
+
+    # Preserve the original LIANA metrics for advanced downstream use.
+    metric_columns = [
+        column
+        for column in result.columns
+        if column
+        not in {
+            "cell_type_pair",
+            "interaction_key",
+            "score_value",
+            "pvalue_value",
+            "classification_resolved",
+        }
+        and pd.api.types.is_numeric_dtype(result[column])
+    ]
+    for column in metric_columns:
+        matrix = (
+            result.pivot(index="cell_type_pair", columns="interaction_key", values=column)
+            .reindex(index=obs_index, columns=var_index)
+            .fillna(np.nan)
+            .to_numpy(dtype=float)
+        )
+        comm_adata.layers[column] = matrix
+
+    comm_adata.uns["liana_score_key"] = score_key
+    comm_adata.uns["liana_pvalue_key"] = pvalue_key
+    comm_adata.uns["liana_uns_key"] = uns_key
+    comm_adata.uns["liana_sample_key"] = sample_column or "none"
+    comm_adata.uns["liana_classification_reference"] = reference_name or "none"
+    comm_adata.uns["liana_classification_fallback"] = (
+        classification_fallback if classification_fallback is not None else "Unclassified"
+    )
+    comm_adata.uns["liana_classification_source_counts"] = (
+        var["classification_source"].value_counts().to_dict()
+    )
+    return comm_adata
+
+
+def format_liana_results_for_viz(*args, **kwargs):
+    """Backward-compatible alias of :func:`format_liana_results`."""
+    return format_liana_results(*args, **kwargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ dependencies = [
     'tqdm',
     'requests>=2.0',
     'transformers>=0.30',
-    'marsilea',
+    'marsilea!=0.5.6',
     #'wandb',
     'openai>=1.0',
     'omicverse-skills>=0.2.0',

--- a/tests/architecture/test_optional_torch_dependencies.py
+++ b/tests/architecture/test_optional_torch_dependencies.py
@@ -177,9 +177,12 @@ def _install_single_dependency_stubs():
             "plot_weights": object(),
         },
         "omicverse.single._scdrug": {
-            "autoResolution": object(),
             "writeGEP": object(),
             "Drug_Response": object(),
+        },
+        "omicverse.single._autoresolution": {
+            "auto_resolution": object(),
+            "autoResolution": object(),
         },
         "omicverse.single._cpdb": {
             "cpdb_network_cal": object(),
@@ -191,6 +194,17 @@ def _install_single_dependency_stubs():
             "cpdb_exact_source": object(),
             "cellphonedb_v5": object(),
             "run_cellphonedb_v5": object(),
+            "format_cpdb_results": object(),
+            "format_cpdb_results_for_viz": object(),
+        },
+        "omicverse.single._liana": {
+            "run_liana": object(),
+            "format_liana_results": object(),
+            "format_liana_results_for_viz": object(),
+        },
+        "omicverse.single._comm": {
+            "to_comm_adata": object(),
+            "extract_comm_adata": object(),
         },
         "omicverse.single._scgsea": {
             "geneset_aucell": object(),
@@ -247,6 +261,7 @@ def _install_single_dependency_stubs():
             "list_checkpoints": object(),
             "cleanup_checkpoints": object(),
         },
+        "omicverse.single._monocle": {"Monocle": object()},
         "omicverse.single._lazy_step_by_step": {
             "lazy_step_qc": object(),
             "lazy_step_preprocess": object(),
@@ -276,6 +291,10 @@ def _install_single_dependency_stubs():
         "omicverse.single._velo": {"Velo": object(), "velocity_embedding": object()},
         "omicverse.single._milo_dev": {"Milo": object()},
         "omicverse.single._markers": {"find_markers": object(), "get_markers": object()},
+        "omicverse.single._dynamic_features": {
+            "DynamicFeaturesResult": object(),
+            "dynamic_features": object(),
+        },
     }
 
     for module_name, attrs in module_defs.items():

--- a/tests/pl/test_ccc_heatmap_marsilea_warning.py
+++ b/tests/pl/test_ccc_heatmap_marsilea_warning.py
@@ -1,0 +1,151 @@
+import numpy as np
+import pandas as pd
+import pytest
+import matplotlib.pyplot as plt
+import sys
+from types import ModuleType
+from anndata import AnnData
+
+import omicverse.pl._ccc as ccc_mod
+import omicverse.pl._cpdbviz_plus as cpdbviz_plus_mod
+
+
+class _StubAnnotation:
+    def __init__(self, kind, *args, **kwargs):
+        self.kind = kind
+        self.args = args
+        self.kwargs = kwargs
+
+
+class _StubSizedHeatmap:
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+
+    def add_left(self, *args, **kwargs):
+        return None
+
+    def add_right(self, *args, **kwargs):
+        return None
+
+    def add_top(self, *args, **kwargs):
+        return None
+
+    def add_bottom(self, *args, **kwargs):
+        return None
+
+    def add_layer(self, *args, **kwargs):
+        return None
+
+    def add_dendrogram(self, *args, **kwargs):
+        return None
+
+    def add_legends(self, *args, **kwargs):
+        return None
+
+    def add_title(self, *args, **kwargs):
+        return None
+
+    def render(self, *args, **kwargs):
+        return object()
+
+
+class _StubMA:
+    __version__ = "0.5.6"
+    SizedHeatmap = _StubSizedHeatmap
+
+
+class _StubMP:
+    @staticmethod
+    def Numbers(*args, **kwargs):
+        return _StubAnnotation("Numbers", *args, **kwargs)
+
+    @staticmethod
+    def Colors(*args, **kwargs):
+        return _StubAnnotation("Colors", *args, **kwargs)
+
+    @staticmethod
+    def MarkerMesh(*args, **kwargs):
+        return _StubAnnotation("MarkerMesh", *args, **kwargs)
+
+
+def test_dot_matrix_plot_warns_for_broken_marsilea_056(monkeypatch):
+    monkeypatch.setattr(ccc_mod, "_import_marsilea", lambda: (_StubMA, _StubMP))
+    def _fake_render_plot(plotter):
+        fig, _ax = plt.subplots()
+        return fig
+
+    monkeypatch.setattr(ccc_mod, "_render_plot", _fake_render_plot)
+
+    matrix = pd.DataFrame([[1.0, 2.0], [0.5, 1.5]], index=["r1", "r2"], columns=["c1", "c2"])
+    size_matrix = pd.DataFrame([[1.0, 0.0], [0.5, 1.0]], index=matrix.index, columns=matrix.columns)
+
+    with pytest.warns(UserWarning, match="marsilea 0.5.6"):
+        ccc_mod._dot_matrix_plot(
+            matrix,
+            size_matrix,
+            color_label="Communication score",
+            title="Bubble",
+            cmap="Reds",
+            figsize=(6, 4),
+            border=False,
+            add_text=False,
+        )
+
+
+def test_netvisual_bubble_marsilea_warns_for_broken_marsilea_056(monkeypatch):
+    monkeypatch.setattr(cpdbviz_plus_mod, "MARSILEA_AVAILABLE", True)
+    calls = []
+    monkeypatch.setattr(
+        cpdbviz_plus_mod,
+        "_warn_if_broken_marsilea_version",
+        lambda ma: calls.append(getattr(ma, "__version__", "")),
+    )
+
+    marsilea_mod = ModuleType("marsilea")
+    marsilea_mod.__version__ = "0.5.6"
+    marsilea_mod.SizedHeatmap = _StubSizedHeatmap
+    marsilea_mod.__path__ = []
+    plotter_mod = ModuleType("marsilea.plotter")
+    plotter_mod.Numbers = _StubMP.Numbers
+    plotter_mod.Colors = _StubMP.Colors
+    plotter_mod.MarkerMesh = _StubMP.MarkerMesh
+    marsilea_mod.plotter = plotter_mod
+
+    sklearn_mod = ModuleType("sklearn")
+    sklearn_mod.__path__ = []
+    preprocessing_mod = ModuleType("sklearn.preprocessing")
+    preprocessing_mod.normalize = lambda x, axis=0: np.asarray(x, dtype=float)
+    sklearn_mod.preprocessing = preprocessing_mod
+
+    monkeypatch.setitem(sys.modules, "marsilea", marsilea_mod)
+    monkeypatch.setitem(sys.modules, "marsilea.plotter", plotter_mod)
+    monkeypatch.setitem(sys.modules, "sklearn", sklearn_mod)
+    monkeypatch.setitem(sys.modules, "sklearn.preprocessing", preprocessing_mod)
+
+    viz = cpdbviz_plus_mod.CellChatVizPlus.__new__(cpdbviz_plus_mod.CellChatVizPlus)
+    viz.cell_types = ["A", "B"]
+    viz._get_cell_type_colors = lambda: {"A": "#111111", "B": "#222222"}
+
+    adata = AnnData(np.zeros((2, 2)))
+    adata.obs = pd.DataFrame({"sender": ["A", "B"], "receiver": ["B", "A"]}, index=["p1", "p2"])
+    adata.var = pd.DataFrame(
+        {
+            "classification": ["Pathway1", "Pathway2"],
+            "gene_a": ["Lig1", "Lig2"],
+            "gene_b": ["Rec1", "Rec2"],
+        },
+        index=["f1", "f2"],
+    )
+    adata.layers["pvalues"] = np.array([[0.01, 0.2], [0.03, 0.04]])
+    adata.layers["means"] = np.array([[0.5, 0.0], [0.6, 0.7]])
+    viz.adata = adata
+
+    with pytest.raises(Exception):
+        viz.netVisual_bubble_marsilea(
+            signaling=["Pathway1"],
+            top_interactions=None,
+            figsize=(6, 4),
+        )
+
+    assert calls == ["0.5.6"]

--- a/tests/pl/test_ccc_plots.py
+++ b/tests/pl/test_ccc_plots.py
@@ -6,6 +6,7 @@ import numpy as np
 import pandas as pd
 import pytest
 import sys
+import warnings
 from anndata import AnnData
 from matplotlib.axes import Axes
 from matplotlib.figure import Figure
@@ -27,9 +28,11 @@ from _ccc_plot_data import (
 try:
     import omicverse as ov
     import omicverse.pl._ccc as ccc_mod
+    import omicverse.pl._cpdbviz as cpdbviz_mod
 except Exception as exc:  # pragma: no cover - environment guard for optional deps
     ov = None
     ccc_mod = None
+    cpdbviz_mod = None
     pytestmark = pytest.mark.skip(reason=f"omicverse import failed in test env: {exc}")
 
 @pytest.fixture()
@@ -58,14 +61,146 @@ def _assert_figure_and_axes(fig, ax) -> None:
     assert isinstance(ax, Axes)
 
 
+def _build_comm_adata_with_duplicate_pairs() -> AnnData:
+    obs = pd.DataFrame(
+        {
+            "sender": ["A", "A", "B"],
+            "receiver": ["B", "B", "A"],
+        },
+        index=["A|B#1", "A|B#2", "B|A#1"],
+    )
+    var = pd.DataFrame(
+        {
+            "interacting_pair": ["L1_R1", "L2_R2"],
+            "interaction_name": ["L1_R1", "L2_R2"],
+            "interaction_name_2": ["L1 - R1", "L2 - R2"],
+            "classification": ["TNF", "TNF"],
+            "gene_a": ["L1", "L2"],
+            "gene_b": ["R1", "R2"],
+        },
+        index=["L1_R1", "L2_R2"],
+    )
+    means = np.array(
+        [
+            [1.0, 0.0],
+            [2.0, 3.0],
+            [4.0, 5.0],
+        ],
+        dtype=float,
+    )
+    pvalues = np.array(
+        [
+            [0.01, 0.20],
+            [0.03, 0.04],
+            [0.01, 0.01],
+        ],
+        dtype=float,
+    )
+    adata = AnnData(X=means.copy(), obs=obs, var=var)
+    adata.layers["means"] = means.copy()
+    adata.layers["pvalues"] = pvalues.copy()
+    return adata
+
+
+def _build_raw_liana_adata(*, uns_key: str = "liana_res", shifted: bool = False) -> AnnData:
+    adata = AnnData(X=np.zeros((1, 1), dtype=float))
+    specificity = [0.01, 0.04, 0.15, 0.03]
+    magnitude = [0.02, 0.10, 0.30, 0.05]
+    if shifted:
+        specificity = [0.03, 0.07, 0.20, 0.05]
+        magnitude = [0.06, 0.14, 0.34, 0.09]
+    adata.uns[uns_key] = pd.DataFrame(
+        {
+            "source": ["B", "B", "T", "T"],
+            "target": ["T", "Myeloid", "B", "Myeloid"],
+            "ligand_complex": ["CXCL13", "TNF", "IL7", "MIF"],
+            "receptor_complex": ["CXCR5", "TNFRSF1A", "IL7R", "CD74_CXCR4"],
+            "magnitude_rank": magnitude,
+            "specificity_rank": specificity,
+        }
+    )
+    return adata
+
+
+def _build_raw_liana_sample_adata() -> AnnData:
+    base = _build_raw_liana_adata()
+    rows = []
+    for sample, offset in (("sample_1", 0.0), ("sample_2", 0.03)):
+        frame = base.uns["liana_res"].copy()
+        frame["sample"] = sample
+        frame["specificity_rank"] = frame["specificity_rank"] + offset
+        frame["magnitude_rank"] = frame["magnitude_rank"] + offset
+        rows.append(frame)
+    base.uns["liana_res"] = pd.concat(rows, ignore_index=True)
+    return base
+
+
+def _build_raw_liana_condition_adata() -> AnnData:
+    base = _build_raw_liana_adata()
+    rows = []
+    for condition, offset in (("ctrl", 0.0), ("stim", 0.03)):
+        frame = base.uns["liana_res"].copy()
+        frame["condition"] = condition
+        frame["specificity_rank"] = frame["specificity_rank"] + offset
+        frame["magnitude_rank"] = frame["magnitude_rank"] + offset
+        rows.append(frame)
+    base.uns["liana_res"] = pd.concat(rows, ignore_index=True)
+    return base
+
+
+def _build_raw_cpdb_adata(*, uns_key: str = "cpdb_results") -> AnnData:
+    adata = AnnData(X=np.zeros((1, 1), dtype=float))
+    adata.uns[uns_key] = {
+        "means": pd.DataFrame(
+            {
+                "id_cp_interaction": [1, 2],
+                "interacting_pair": ["CXCL13_CXCR5", "TNF_TNFRSF1A"],
+                "interaction_name_2": ["CXCL13 - CXCR5", "TNF - TNFRSF1A"],
+                "gene_a": ["CXCL13", "TNF"],
+                "gene_b": ["CXCR5", "TNFRSF1A"],
+                "classification": ["CXCL", "TNF"],
+                "B|T": [0.8, 0.5],
+                "T|B": [0.1, 0.3],
+            }
+        ),
+        "pvalues": pd.DataFrame(
+            {
+                "id_cp_interaction": [1, 2],
+                "interacting_pair": ["CXCL13_CXCR5", "TNF_TNFRSF1A"],
+                "interaction_name_2": ["CXCL13 - CXCR5", "TNF - TNFRSF1A"],
+                "gene_a": ["CXCL13", "TNF"],
+                "gene_b": ["CXCR5", "TNFRSF1A"],
+                "classification": ["CXCL", "TNF"],
+                "B|T": [0.01, 0.02],
+                "T|B": [0.3, 0.2],
+            }
+        ),
+    }
+    return adata
+
+
+@pytest.fixture()
+def raw_liana_adata() -> AnnData:
+    return _build_raw_liana_adata()
+
+
+@pytest.fixture()
+def raw_liana_comparison_adata() -> AnnData:
+    return _build_raw_liana_adata(shifted=True)
+
+
+@pytest.fixture()
+def raw_cpdb_adata() -> AnnData:
+    return _build_raw_cpdb_adata()
+
+
 @pytest.mark.parametrize(
     ("plot_type", "kwargs"),
     [
         ("heatmap", {"display_by": "aggregation"}),
         ("focused_heatmap", {"display_by": "aggregation"}),
         ("heatmap", {"display_by": "interaction", "sender_use": "EVT_1", "facet_by": "sender", "top_n": 2}),
-        ("dot", {"display_by": "aggregation", "top_n": 2}),
-        ("dot", {"display_by": "interaction", "sender_use": "EVT_1", "facet_by": "sender", "top_n": 2}),
+        ("dot", {"display_by": "interaction", "sender_use": "EVT_1", "top_n": 2}),
         ("bubble", {"display_by": "aggregation", "top_n": 2}),
         ("bubble_lr", {"pair_lr_use": "MDK_SDC1"}),
         ("bubble", {"display_by": "interaction", "receiver_use": "dNK1", "facet_by": "receiver", "top_n": 2}),
@@ -148,11 +283,15 @@ def test_ccc_heatmap_diff_heatmap_prefers_diverging_cmap_and_text_for_small_disc
         comm_adata,
         comparison_adata=comparison_comm_adata,
         plot_type="diff_heatmap",
+        show_row_names=True,
+        show_col_names=True,
         show=False,
     )
     _assert_figure_and_axes(fig, ax)
     assert captured["kwargs"]["cmap"] == "RdBu_r"
     assert captured["kwargs"]["add_text"] is True
+    assert captured["kwargs"]["show_row_names"] is True
+    assert captured["kwargs"]["show_col_names"] is True
 
 
 def test_ccc_heatmap_diff_heatmap_requires_comparison_adata(comm_adata: AnnData) -> None:
@@ -190,12 +329,16 @@ def test_ccc_heatmap_aggregation_routes_through_cellchatviz_backend(monkeypatch,
         plot_type="heatmap",
         display_by="aggregation",
         signaling="MK",
+        show_row_names=True,
+        show_col_names=True,
         show=False,
     )
 
     _assert_figure_and_axes(fig, ax)
     assert called["plotter"] == "plotter"
     assert called["kwargs"]["signaling"] == ["MK"]
+    assert called["kwargs"]["show_row_names"] is True
+    assert called["kwargs"]["show_col_names"] is True
 
 
 def test_ccc_heatmap_aggregation_rejects_interaction_filters(comm_adata: AnnData) -> None:
@@ -276,6 +419,40 @@ def test_ccc_network_plot_diff_network_returns_figure_and_axes(
     _assert_figure_and_axes(fig, ax)
 
 
+def test_ccc_network_plot_rejects_unknown_plot_type(comm_adata: AnnData) -> None:
+    with pytest.raises(ValueError, match="Unsupported `plot_type='pathway1'`"):
+        ov.pl.ccc_network_plot(
+            comm_adata,
+            plot_type="pathway1",
+            signaling="MK",
+            show=False,
+        )
+
+
+def test_ccc_network_plot_pathway_forwards_top_n(monkeypatch, comm_adata: AnnData) -> None:
+    captured: dict[str, object] = {}
+
+    class _StubViz:
+        def netVisual_aggregate(self, **kwargs):
+            captured.update(kwargs)
+            return plt.subplots(figsize=kwargs.get("figsize", (7, 7)))
+
+    monkeypatch.setattr(ccc_mod, "_build_cellchatviz", lambda adata, *, palette=None: _StubViz())
+
+    fig, ax = ov.pl.ccc_network_plot(
+        comm_adata,
+        plot_type="pathway",
+        signaling="MK",
+        top_n=7,
+        show=False,
+    )
+
+    _assert_figure_and_axes(fig, ax)
+    assert captured["signaling"] == ["MK"]
+    assert captured["layout"] == "circle"
+    assert captured["top_n"] == 7
+
+
 @pytest.mark.parametrize(
     ("plot_type", "method_name"),
     [
@@ -304,6 +481,52 @@ def test_ccc_network_plot_individual_circle_variants_use_more_visible_edge_defau
     fig, ax = ov.pl.ccc_network_plot(comm_adata, plot_type=plot_type, show=False)
     _assert_figure_and_axes(fig, ax)
     assert called["kwargs"]["edge_width_max"] == 12
+
+
+@pytest.mark.parametrize(
+    ("plot_type", "extra_kwargs"),
+    [
+        ("individual_outgoing", {"sender_use": ["EVT_1", "EVT_2"], "receiver_use": ["DSC_1", "DSC_2"]}),
+        ("individual_incoming", {"sender_use": ["EVT_1", "EVT_2"], "receiver_use": ["DSC_1", "DSC_2"]}),
+    ],
+)
+def test_ccc_network_plot_individual_circle_variants_forward_grid_and_celltype_filters(
+    monkeypatch, comm_adata: AnnData, plot_type: str, extra_kwargs: dict
+) -> None:
+    called: dict[str, object] = {}
+
+    class _StubViz:
+        def netVisual_individual_circle(self, **kwargs):
+            called["kwargs"] = kwargs
+            fig, _ = plt.subplots()
+            return fig
+
+        def netVisual_individual_circle_incoming(self, **kwargs):
+            called["kwargs"] = kwargs
+            fig, _ = plt.subplots()
+            return fig
+
+    monkeypatch.setattr(ccc_mod, "_build_cellchatviz", lambda adata, *, palette=None: _StubViz())
+
+    fig, ax = ov.pl.ccc_network_plot(
+        comm_adata,
+        plot_type=plot_type,
+        ncols=3,
+        nrows=2,
+        show=False,
+        **extra_kwargs,
+    )
+    _assert_figure_and_axes(fig, ax)
+    assert called["kwargs"]["ncols"] == 3
+    assert called["kwargs"]["nrows"] == 2
+    assert called["kwargs"]["sender_use"] == extra_kwargs["sender_use"]
+    assert called["kwargs"]["receiver_use"] == extra_kwargs["receiver_use"]
+
+
+def test_cellchatviz_individual_outgoing_omits_redundant_legend(comm_adata: AnnData) -> None:
+    viz = ov.pl.CellChatViz(comm_adata)
+    fig = viz.netVisual_individual_circle(figsize=(6, 4), ncols=2)
+    assert not fig.legends
 
 
 def test_ccc_network_plot_diff_network_uses_cell_type_node_colors(
@@ -412,6 +635,16 @@ def test_ccc_stat_plot_interaction_sankey_returns_figure_and_axes(comm_adata: An
     assert ax.get_title() == ""
 
 
+def test_ccc_stat_plot_rejects_invalid_display_by(comm_adata: AnnData) -> None:
+    with pytest.raises(ValueError, match="Unsupported `display_by='aggregate'`"):
+        ov.pl.ccc_stat_plot(
+            comm_adata,
+            plot_type="sankey",
+            display_by="aggregate",
+            show=False,
+        )
+
+
 @pytest.mark.parametrize("plot_type", ["arrow", "sigmoid"])
 def test_ccc_network_plot_interaction_flow_has_middle_stage_labels(comm_adata: AnnData, plot_type: str) -> None:
     fig, ax = ov.pl.ccc_network_plot(
@@ -495,6 +728,57 @@ def test_ccc_network_plot_bipartite_aligns_ligand_and_receptor_labels(comm_adata
     )
     receptor_text = text_lookup[receptor_label]
     assert abs(ligand_text.get_position()[1] - receptor_text.get_position()[1]) < 1e-6
+
+
+def test_ccc_network_plot_bipartite_receiver_labels_keep_vertical_separation(comm_adata: AnnData) -> None:
+    fig, ax = ov.pl.ccc_network_plot(
+        comm_adata,
+        plot_type="bipartite",
+        ligand="TGFB1",
+        top_n=6,
+        show=False,
+    )
+    _assert_figure_and_axes(fig, ax)
+    receiver_texts = [
+        text for text in ax.texts
+        if text.get_text().strip()
+        and text.get_position()[0] > 2.9
+    ]
+    y_positions = sorted(float(text.get_position()[1]) for text in receiver_texts)
+    if len(y_positions) > 1:
+        diffs = np.diff(y_positions)
+        assert float(diffs.min()) > 0.015
+
+
+def test_ccc_network_plot_embedding_network_hides_on_plot_celltype_labels(
+    comm_adata: AnnData,
+) -> None:
+    node_positions = pd.DataFrame(
+        {
+            "x": [-1.0, 1.0, 0.0],
+            "y": [0.0, 0.0, 1.0],
+        },
+        index=["EVT_1", "VCT", "dNK1"],
+    )
+    embedding_points = pd.DataFrame(
+        {
+            "x": [-1.1, -0.9, 0.9, 1.1, -0.1, 0.1],
+            "y": [0.1, -0.1, 0.1, -0.1, 0.9, 1.1],
+            "cell_type": ["EVT_1", "EVT_1", "VCT", "VCT", "dNK1", "dNK1"],
+        }
+    )
+    fig, ax = ov.pl.ccc_network_plot(
+        comm_adata,
+        plot_type="embedding_network",
+        node_positions=node_positions,
+        embedding_points=embedding_points,
+        show=False,
+    )
+    _assert_figure_and_axes(fig, ax)
+    text_labels = {text.get_text().strip() for text in ax.texts if text.get_text().strip()}
+    assert all("EVT_1" not in label for label in text_labels)
+    assert all("VCT" not in label for label in text_labels)
+    assert all("nCells:" not in label for label in text_labels)
 
 
 def test_interaction_display_lookup_formats_lr_labels_and_cleans_complex_suffix() -> None:
@@ -716,7 +1000,6 @@ def test_ccc_network_plot_pathway_forwards_top_n_to_cellchatviz_backend(
         comm_adata,
         plot_type="pathway",
         signaling="TGFb",
-        layout="circle",
         top_n=5,
         show=False,
     )
@@ -743,6 +1026,16 @@ def test_ccc_network_plot_diffusion_rejects_sender_filter(comm_adata: AnnData) -
             comm_adata,
             plot_type="diffusion",
             sender_use="EVT_1",
+            show=False,
+        )
+
+
+def test_ccc_network_plot_rejects_invalid_display_by(comm_adata: AnnData) -> None:
+    with pytest.raises(ValueError, match="Unsupported `display_by='aggregate'`"):
+        ov.pl.ccc_network_plot(
+            comm_adata,
+            plot_type="arrow",
+            display_by="aggregate",
             show=False,
         )
 
@@ -819,29 +1112,14 @@ def test_ccc_stat_plot_pathway_summary_rejects_pair_lr_filter(comm_adata: AnnDat
         )
 
 
-def test_ccc_heatmap_sender_facet_groups_columns_without_sender_filter(comm_adata: AnnData) -> None:
-    fig, ax = ov.pl.ccc_heatmap(
-        comm_adata,
-        plot_type="dot",
-        display_by="interaction",
-        facet_by="sender",
-        top_n=2,
-        top_n_pairs=0,
-        show=False,
-    )
-    _assert_figure_and_axes(fig, ax)
-    ticklabels = [tick.get_text() for tick in ax.get_xticklabels()]
-    assert ticklabels == [
-        "EVT_1 -> EVT_1",
-        "EVT_1 -> VCT",
-        "EVT_1 -> dNK1",
-        "VCT -> EVT_1",
-        "VCT -> VCT",
-        "VCT -> dNK1",
-        "dNK1 -> EVT_1",
-        "dNK1 -> VCT",
-        "dNK1 -> dNK1",
-    ]
+def test_ccc_heatmap_matrix_dot_has_been_removed(comm_adata: AnnData) -> None:
+    with pytest.raises(ValueError, match="has been removed"):
+        ov.pl.ccc_heatmap(
+            comm_adata,
+            plot_type="matrix_dot",
+            display_by="interaction",
+            show=False,
+        )
 
 
 def test_ccc_heatmap_focused_heatmap_avoids_extra_annotation_text(comm_adata: AnnData) -> None:
@@ -893,19 +1171,6 @@ def test_cellchatviz_role_network_variants_hide_value_one_annotations_and_marsil
     plt.close(fig)
 
 
-def test_ccc_heatmap_interaction_top_n_also_limits_pair_columns(comm_adata: AnnData) -> None:
-    fig, ax = ov.pl.ccc_heatmap(
-        comm_adata,
-        plot_type="heatmap",
-        display_by="interaction",
-        facet_by="sender",
-        top_n=2,
-        show=False,
-    )
-    _assert_figure_and_axes(fig, ax)
-    assert len(ax.get_xticklabels()) <= 2
-
-
 def test_ccc_heatmap_accepts_named_palette_string(comm_adata: AnnData) -> None:
     fig, ax = ov.pl.ccc_network_plot(
         comm_adata,
@@ -940,6 +1205,538 @@ def test_ccc_scatter_includes_receiver_only_groups(comm_adata_with_receiver_only
     # the test only cares that receiver-only group labels are present.
     labels = {text.get_text() for text in ax.texts if text.get_text()}
     assert labels == {"EVT_1", "dNK1", "SCT"}
+
+
+def test_ccc_heatmap_auto_resolves_liana_adata(raw_liana_adata: AnnData) -> None:
+    fig, ax = ov.pl.ccc_heatmap(
+        raw_liana_adata,
+        plot_type="heatmap",
+        display_by="aggregation",
+        signaling="TNF",
+        top_n=3,
+        show=False,
+    )
+    _assert_figure_and_axes(fig, ax)
+
+
+def test_ccc_heatmap_dot_rejects_aggregation_display(raw_liana_adata: AnnData) -> None:
+    with pytest.raises(ValueError, match="only supports `display_by='interaction'`"):
+        ov.pl.ccc_heatmap(
+            raw_liana_adata,
+            plot_type="dot",
+            display_by="aggregation",
+            top_n=3,
+            show=False,
+        )
+
+
+@pytest.mark.parametrize("plot_type", ["source_target_dot", "tile"])
+def test_ccc_heatmap_liana_style_views(raw_liana_adata: AnnData, plot_type: str) -> None:
+    fig, ax = ov.pl.ccc_heatmap(
+        raw_liana_adata,
+        plot_type=plot_type,
+        display_by="interaction",
+        top_n=3,
+        pvalue_threshold=0.2,
+        show=False,
+    )
+    _assert_figure_and_axes(fig, ax)
+
+
+def test_ccc_heatmap_tile_uses_side_specific_row_labels(raw_liana_adata: AnnData) -> None:
+    fig, ax = ov.pl.ccc_heatmap(
+        raw_liana_adata,
+        plot_type="tile",
+        display_by="interaction",
+        top_n=3,
+        pvalue_threshold=0.2,
+        show=False,
+    )
+    _assert_figure_and_axes(fig, ax)
+    main_axes = [axis for axis in fig.axes if axis.get_xlabel() == "Cell type"]
+    assert len(main_axes) == 2
+    left_axis, right_axis = main_axes
+    assert left_axis.get_ylabel() == "Source ligand"
+    assert right_axis.get_ylabel() == "Target receptor"
+    assert right_axis.yaxis.get_label_position() == "right"
+    assert any(tick.get_text() for tick in left_axis.get_yticklabels())
+    assert any(tick.get_text() for tick in right_axis.get_yticklabels())
+
+
+def test_ccc_heatmap_liana_sample_dot_view() -> None:
+    raw_liana_adata = _build_raw_liana_sample_adata()
+    fig, ax = ov.pl.ccc_heatmap(
+        raw_liana_adata,
+        plot_type="sample_dot",
+        display_by="interaction",
+        top_n=2,
+        pvalue_threshold=0.2,
+        sample_key="sample",
+        show=False,
+    )
+    _assert_figure_and_axes(fig, ax)
+
+
+def test_ccc_heatmap_liana_sample_dot_autodetects_non_sample_context_key() -> None:
+    raw_liana_adata = _build_raw_liana_condition_adata()
+    fig, ax = ov.pl.ccc_heatmap(
+        raw_liana_adata,
+        plot_type="sample_dot",
+        display_by="interaction",
+        top_n=2,
+        pvalue_threshold=0.2,
+        show=False,
+    )
+    _assert_figure_and_axes(fig, ax)
+
+
+def test_ccc_heatmap_liana_sample_dot_hides_nonfirst_panel_pair_labels() -> None:
+    raw_liana_adata = _build_raw_liana_sample_adata()
+    fig, ax = ov.pl.ccc_heatmap(
+        raw_liana_adata,
+        plot_type="sample_dot",
+        display_by="interaction",
+        top_n=4,
+        pvalue_threshold=0.2,
+        sample_key="sample",
+        ncols=2,
+        show=False,
+    )
+    _assert_figure_and_axes(fig, ax)
+    titled_axes = [axis for axis in fig.axes if axis.get_title()]
+    assert len(titled_axes) >= 2
+    assert any(tick.get_text() for tick in titled_axes[0].get_yticklabels())
+    assert all(not tick.get_text() for tick in titled_axes[1].get_yticklabels())
+    assert any(text.get_text() == "Sender -> receiver" for text in fig.texts)
+
+
+def test_ccc_heatmap_pathway_bubble_can_autoselect_top_pathways(raw_liana_adata: AnnData) -> None:
+    fig, ax = ov.pl.ccc_heatmap(
+        raw_liana_adata,
+        plot_type="pathway_bubble",
+        top_n=3,
+        pvalue_threshold=0.2,
+        show=False,
+    )
+    _assert_figure_and_axes(fig, ax)
+
+
+def test_ccc_heatmap_pathway_bubble_autoselect_does_not_relimit_interactions(monkeypatch, raw_liana_adata: AnnData) -> None:
+    called: dict[str, object] = {}
+
+    class _StubViz:
+        def netVisual_bubble_marsilea(self, **kwargs):
+            called["kwargs"] = kwargs
+            return "plotter"
+
+    monkeypatch.setattr(
+        ccc_mod,
+        "_pathway_summary_table",
+        lambda *args, **kwargs: pd.DataFrame({"pathway": ["P1", "P2", "P3"]}),
+    )
+    monkeypatch.setattr(ccc_mod, "_build_cellchatviz", lambda adata, *, palette=None: _StubViz())
+    monkeypatch.setattr(ccc_mod, "_render_plotter_figure", lambda plotter, *, title=None: plt.subplots())
+
+    fig, ax = ov.pl.ccc_heatmap(
+        raw_liana_adata,
+        plot_type="pathway_bubble",
+        top_n=3,
+        pvalue_threshold=0.2,
+        show=False,
+    )
+
+    _assert_figure_and_axes(fig, ax)
+    assert called["kwargs"]["signaling"] is not None
+    assert len(called["kwargs"]["signaling"]) == 3
+    assert called["kwargs"]["top_interactions"] is None
+
+
+def test_ccc_heatmap_role_heatmap_and_pathway_bubble_suppress_categorical_unit_warning(
+    monkeypatch,
+    raw_liana_adata: AnnData,
+) -> None:
+    class _StubViz:
+        def netAnalysis_signalingRole_heatmap(self, **kwargs):
+            warnings.warn(
+                "Using categorical units to plot a list of strings that are all parsable as floats or dates.",
+                UserWarning,
+            )
+            return "role_plotter", [], pd.DataFrame([[1.0]])
+
+        def netVisual_bubble_marsilea(self, **kwargs):
+            warnings.warn(
+                "Using categorical units to plot a list of strings that are all parsable as floats or dates.",
+                UserWarning,
+            )
+            return "bubble_plotter"
+
+    monkeypatch.setattr(ccc_mod, "_build_cellchatviz", lambda adata, *, palette=None: _StubViz())
+    monkeypatch.setattr(ccc_mod, "_render_plotter_figure", lambda plotter, *, title=None: plt.subplots())
+    monkeypatch.setattr(
+        ccc_mod,
+        "_pathway_summary_table",
+        lambda *args, **kwargs: pd.DataFrame({"pathway": ["P1", "P2", "P3"]}),
+    )
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        fig1, ax1 = ov.pl.ccc_heatmap(
+            raw_liana_adata,
+            plot_type="role_heatmap",
+            pattern="incoming",
+            top_n=3,
+            figsize=(4, 2),
+            show=False,
+        )
+        fig2, ax2 = ov.pl.ccc_heatmap(
+            raw_liana_adata,
+            plot_type="pathway_bubble",
+            top_n=3,
+            figsize=(3, 3),
+            show=False,
+        )
+    _assert_figure_and_axes(fig1, ax1)
+    _assert_figure_and_axes(fig2, ax2)
+    assert not any("Using categorical units to plot a list of strings" in str(w.message) for w in caught)
+
+
+def test_ccc_stat_plot_pathway_summary_places_sig_labels_inside_bars(comm_adata: AnnData) -> None:
+    fig, ax = ov.pl.ccc_stat_plot(
+        comm_adata,
+        plot_type="pathway_summary",
+        top_n=4,
+        min_expression=0.0,
+        strength_threshold=0.0,
+        min_significant_pairs=1,
+        show=False,
+    )
+    _assert_figure_and_axes(fig, ax)
+    text_items = [text for text in ax.texts if "sig" in text.get_text()]
+    assert text_items
+    assert all(text.get_color() in {"#1F1F1F", "#FFFFFF", "#4A4A4A"} for text in text_items)
+
+
+def test_ccc_stat_plot_pathway_summary_moves_short_bar_labels_outside(comm_adata: AnnData) -> None:
+    fig, ax = ov.pl.ccc_stat_plot(
+        comm_adata,
+        plot_type="pathway_summary",
+        top_n=8,
+        min_expression=0.0,
+        strength_threshold=0.0,
+        min_significant_pairs=1,
+        show=False,
+    )
+    _assert_figure_and_axes(fig, ax)
+    bar_patches = [patch for patch in ax.patches if patch.get_width() > 0]
+    text_items = [text for text in ax.texts if "sig" in text.get_text()]
+    assert text_items
+    for text, patch in zip(text_items, bar_patches):
+        if text.get_color() == "#4A4A4A":
+            assert text.get_position()[0] > patch.get_x() + patch.get_width()
+
+
+def test_ccc_stat_plot_pathway_summary_respects_verbose_false(comm_adata: AnnData, capsys) -> None:
+    fig, ax = ov.pl.ccc_stat_plot(
+        comm_adata,
+        plot_type="pathway_summary",
+        top_n=4,
+        min_expression=0.0,
+        strength_threshold=0.0,
+        min_significant_pairs=1,
+        verbose=False,
+        show=False,
+    )
+    _assert_figure_and_axes(fig, ax)
+    captured = capsys.readouterr()
+    assert "Calculating cell communication strength" not in captured.out
+    assert "Pathway significance analysis results" not in captured.out
+
+
+def test_ccc_stat_plot_pathway_summary_respects_verbose_true(comm_adata: AnnData, capsys) -> None:
+    fig, ax = ov.pl.ccc_stat_plot(
+        comm_adata,
+        plot_type="pathway_summary",
+        top_n=4,
+        min_expression=0.0,
+        strength_threshold=0.0,
+        min_significant_pairs=1,
+        verbose=True,
+        show=False,
+    )
+    _assert_figure_and_axes(fig, ax)
+    captured = capsys.readouterr()
+    assert "Calculating cell communication strength" in captured.out
+    assert "Pathway significance analysis results" in captured.out
+
+
+def test_ccc_heatmap_dot_supports_multirow_source_facets(raw_liana_adata: AnnData) -> None:
+    fig, ax = ov.pl.ccc_heatmap(
+        raw_liana_adata,
+        plot_type="dot",
+        display_by="interaction",
+        top_n=4,
+        pvalue_threshold=0.2,
+        ncols=2,
+        show=False,
+    )
+    _assert_figure_and_axes(fig, ax)
+    assert len(fig.axes) >= 3
+
+
+def test_ccc_heatmap_dot_hides_upper_row_target_labels(raw_liana_adata: AnnData) -> None:
+    fig, ax = ov.pl.ccc_heatmap(
+        raw_liana_adata,
+        plot_type="dot",
+        display_by="interaction",
+        top_n=4,
+        pvalue_threshold=0.2,
+        ncols=1,
+        show=False,
+    )
+    _assert_figure_and_axes(fig, ax)
+    facet_axes = [axis for axis in fig.axes if axis.get_title()]
+    upper_row_axes = facet_axes[:-1]
+    lower_row_axes = facet_axes[-1:]
+    assert upper_row_axes
+    assert lower_row_axes
+    assert all(not any(tick.get_text() for tick in axis.get_xticklabels()) for axis in upper_row_axes)
+    assert all(any(tick.get_text() for tick in axis.get_xticklabels()) for axis in lower_row_axes)
+
+
+def test_ccc_heatmap_dot_shows_target_labels_on_last_visible_panel_per_column(raw_liana_adata: AnnData) -> None:
+    adata = _build_raw_liana_adata()
+    extra = adata.uns["liana_res"].copy()
+    extra["source"] = "Myeloid"
+    adata.uns["liana_res"] = pd.concat([adata.uns["liana_res"], extra], ignore_index=True)
+    fig, ax = ov.pl.ccc_heatmap(
+        adata,
+        plot_type="dot",
+        display_by="interaction",
+        top_n=5,
+        pvalue_threshold=0.2,
+        ncols=2,
+        show=False,
+    )
+    _assert_figure_and_axes(fig, ax)
+    facet_axes = [axis for axis in fig.axes if axis.get_title()]
+    assert len(facet_axes) >= 3
+    # Last visible panel in column 2 should still show bottom x labels even
+    # when the final grid row is incomplete.
+    assert any(tick.get_text() for tick in facet_axes[1].get_xticklabels())
+
+
+def test_ccc_heatmap_dot_collapses_to_single_facet_when_sender_filter_leaves_one_source(
+    raw_liana_adata: AnnData,
+) -> None:
+    fig, ax = ov.pl.ccc_heatmap(
+        raw_liana_adata,
+        plot_type="dot",
+        display_by="interaction",
+        sender_use="B",
+        top_n=4,
+        pvalue_threshold=0.2,
+        nrows=2,
+        figsize=(8, 3),
+        show=False,
+    )
+    _assert_figure_and_axes(fig, ax)
+    facet_axes = [axis for axis in fig.axes if axis.get_title()]
+    assert len(facet_axes) == 1
+    assert any(tick.get_text() for tick in facet_axes[0].get_xticklabels())
+
+
+def test_ccc_heatmap_dot_respects_explicit_figsize(raw_liana_adata: AnnData) -> None:
+    target_size = (5.5, 2.75)
+    fig, ax = ov.pl.ccc_heatmap(
+        raw_liana_adata,
+        plot_type="dot",
+        display_by="interaction",
+        sender_use="B",
+        top_n=4,
+        pvalue_threshold=0.2,
+        figsize=target_size,
+        show=False,
+    )
+    _assert_figure_and_axes(fig, ax)
+    width, height = fig.get_size_inches()
+    assert width == pytest.approx(target_size[0], abs=0.05)
+    assert height == pytest.approx(target_size[1], abs=0.05)
+
+
+def test_ccc_heatmap_dot_auto_sizes_when_figsize_is_none(raw_liana_adata: AnnData) -> None:
+    fig, ax = ov.pl.ccc_heatmap(
+        raw_liana_adata,
+        plot_type="dot",
+        display_by="interaction",
+        top_n=4,
+        pvalue_threshold=0.2,
+        figsize=None,
+        show=False,
+    )
+    _assert_figure_and_axes(fig, ax)
+    width, height = fig.get_size_inches()
+    assert width > 0
+    assert height > 0
+
+
+def test_ccc_heatmap_diff_heatmap_auto_resolves_liana_comparison_adata(
+    raw_liana_adata: AnnData,
+    raw_liana_comparison_adata: AnnData,
+) -> None:
+    fig, ax = ov.pl.ccc_heatmap(
+        raw_liana_adata,
+        comparison_adata=raw_liana_comparison_adata,
+        plot_type="diff_heatmap",
+        top_n=2,
+        show=False,
+    )
+    _assert_figure_and_axes(fig, ax)
+
+
+def test_ccc_network_plot_auto_resolves_liana_adata_with_custom_uns_key() -> None:
+    raw_adata = _build_raw_liana_adata(uns_key="custom_results")
+    fig, ax = ov.pl.ccc_network_plot(
+        raw_adata,
+        plot_type="circle",
+        display_by="interaction",
+        result_uns_key="custom_results",
+        top_n=3,
+        show=False,
+    )
+    _assert_figure_and_axes(fig, ax)
+
+
+def test_ccc_heatmap_auto_resolves_cpdb_adata(raw_cpdb_adata: AnnData) -> None:
+    fig, ax = ov.pl.ccc_heatmap(
+        raw_cpdb_adata,
+        plot_type="heatmap",
+        display_by="interaction",
+        top_n=2,
+        show=False,
+    )
+    _assert_figure_and_axes(fig, ax)
+
+
+def test_ccc_network_plot_auto_resolves_cpdb_adata(raw_cpdb_adata: AnnData) -> None:
+    fig, ax = ov.pl.ccc_network_plot(
+        raw_cpdb_adata,
+        plot_type="circle",
+        display_by="interaction",
+        top_n=2,
+        show=False,
+    )
+    _assert_figure_and_axes(fig, ax)
+
+
+def test_ccc_heatmap_source_target_dot_warns_as_compatibility_alias(raw_liana_adata: AnnData) -> None:
+    with pytest.warns(FutureWarning, match="compatibility alias"):
+        fig, ax = ov.pl.ccc_heatmap(
+            raw_liana_adata,
+            plot_type="source_target_dot",
+            display_by="interaction",
+            top_n=3,
+            pvalue_threshold=0.2,
+            show=False,
+        )
+    _assert_figure_and_axes(fig, ax)
+
+
+def test_ccc_heatmap_source_target_tile_warns_as_compatibility_alias(raw_liana_adata: AnnData) -> None:
+    with pytest.warns(FutureWarning, match="compatibility alias"):
+        fig, ax = ov.pl.ccc_heatmap(
+            raw_liana_adata,
+            plot_type="source_target_tile",
+            display_by="interaction",
+            top_n=3,
+            pvalue_threshold=0.2,
+            show=False,
+        )
+    _assert_figure_and_axes(fig, ax)
+
+
+def test_ccc_stat_plot_auto_resolves_liana_adata(raw_liana_adata: AnnData) -> None:
+    fig, ax = ov.pl.ccc_stat_plot(
+        raw_liana_adata,
+        plot_type="pathway_summary",
+        top_n=4,
+        min_expression=0.0,
+        strength_threshold=0.0,
+        min_significant_pairs=1,
+        show=False,
+    )
+    _assert_figure_and_axes(fig, ax)
+
+
+def test_ccc_heatmap_tile_uses_distinct_ligand_and_receptor_row_labels(raw_liana_adata: AnnData) -> None:
+    fig, ax = ov.pl.ccc_heatmap(
+        raw_liana_adata,
+        plot_type="tile",
+        display_by="interaction",
+        top_n=6,
+        pvalue_threshold=0.2,
+        show=False,
+    )
+    _assert_figure_and_axes(fig, ax)
+    heatmap_axes = [axis for axis in fig.axes if axis.get_xlabel() == "Cell type"]
+    assert len(heatmap_axes) >= 2
+    left_labels = [tick.get_text() for tick in heatmap_axes[0].get_yticklabels() if tick.get_text()]
+    right_labels = [tick.get_text() for tick in heatmap_axes[1].get_yticklabels() if tick.get_text()]
+    assert left_labels
+    assert right_labels
+    assert left_labels != right_labels
+
+
+def test_ccc_plot_plain_anndata_without_comm_or_liana_raises() -> None:
+    plain = AnnData(X=np.zeros((1, 1), dtype=float))
+    with pytest.raises(ValueError, match="Could not find a supported communication result"):
+        ov.pl.ccc_heatmap(plain, show=False)
+
+
+def test_cellchatviz_aggregates_duplicate_sender_receiver_rows() -> None:
+    duplicate_comm_adata = _build_comm_adata_with_duplicate_pairs()
+    viz = ov.pl.CellChatViz(duplicate_comm_adata)
+
+    mean_df = viz.mean(count_min=1.0)
+    pvalue_df = viz.pvalue(count_min=1.0)
+    pathway_networks = viz.compute_pathway_network(pvalue_threshold=0.05)
+    pathway_comm = viz.compute_pathway_communication(
+        method="mean",
+        min_lr_pairs=1,
+        min_expression=1.0,
+    )
+
+    assert mean_df.loc["A", "B"] == pytest.approx(6.0)
+    assert pvalue_df.loc["A", "B"] == pytest.approx((0.01 + 0.03 + 0.04) / 3.0)
+    assert pathway_networks["TNF"][viz.cell_types.index("A"), viz.cell_types.index("B")] == pytest.approx(6.0)
+    assert pathway_comm["TNF"]["communication_matrix"].loc["A", "B"] == pytest.approx(2.0)
+    assert pathway_comm["TNF"]["pvalue_matrix"].loc["A", "B"] == pytest.approx(0.01)
+    assert pathway_comm["TNF"]["n_valid_interactions"].loc["A", "B"] == pytest.approx(3.0)
+
+
+def test_cellchatviz_get_signaling_pathways_respects_custom_threshold() -> None:
+    duplicate_comm_adata = _build_comm_adata_with_duplicate_pairs()
+    viz = ov.pl.CellChatViz(duplicate_comm_adata)
+
+    significant_pathways, pathway_stats = viz.get_signaling_pathways(
+        min_interactions=1,
+        pathway_pvalue_threshold=0.02,
+        method="mean",
+        correction_method=None,
+        min_expression=1.0,
+    )
+    tighter_pathways, _ = viz.get_signaling_pathways(
+        min_interactions=1,
+        pathway_pvalue_threshold=0.017,
+        method="mean",
+        correction_method=None,
+        min_expression=1.0,
+    )
+
+    assert significant_pathways == ["TNF"]
+    assert tighter_pathways == []
+    assert pathway_stats["TNF"]["n_significant_interactions"] == 3
+    assert pathway_stats["TNF"]["significance_rate"] == pytest.approx(3.0 / 5.0)
+    assert pathway_stats["TNF"]["significant_cell_pairs"] == ["A|B", "B|A"]
 
 
 def test_ccc_violin_uses_non_vertical_interaction_labels(comm_adata: AnnData) -> None:

--- a/tests/pl/test_dotplot.py
+++ b/tests/pl/test_dotplot.py
@@ -1,0 +1,93 @@
+import numpy as np
+import pandas as pd
+import pytest
+import warnings
+from anndata import AnnData
+
+import omicverse.pl._dotplot as dotplot_mod
+
+
+class _StubAnnotation:
+    def __init__(self, kind, *args, **kwargs):
+        self.kind = kind
+        self.args = args
+        self.kwargs = kwargs
+
+
+class _StubSizedHeatmap:
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+
+    def add_top(self, *args, **kwargs):
+        return None
+
+    def add_left(self, *args, **kwargs):
+        return None
+
+    def add_right(self, *args, **kwargs):
+        return None
+
+    def add_dendrogram(self, *args, **kwargs):
+        return None
+
+    def add_legends(self, *args, **kwargs):
+        return None
+
+    def group_cols(self, *args, **kwargs):
+        return None
+
+    def render(self):
+        return object()
+
+
+@pytest.fixture
+def simple_adata():
+    adata = AnnData(
+        np.array(
+            [
+                [1.0, 0.0, 2.0],
+                [2.0, 1.0, 0.0],
+                [0.0, 3.0, 1.0],
+                [1.0, 2.0, 2.0],
+            ]
+        )
+    )
+    adata.var_names = ["g1", "g2", "g3"]
+    adata.obs["cell_type"] = pd.Categorical(["A", "A", "B", "B"])
+    return adata
+
+
+@pytest.fixture
+def stub_marsilea(monkeypatch):
+    monkeypatch.setattr(dotplot_mod.ma, "SizedHeatmap", _StubSizedHeatmap)
+    monkeypatch.setattr(dotplot_mod.mp, "Labels", lambda *a, **k: _StubAnnotation("Labels", *a, **k))
+    monkeypatch.setattr(dotplot_mod.mp, "Colors", lambda *a, **k: _StubAnnotation("Colors", *a, **k))
+    monkeypatch.setattr(dotplot_mod.mp, "Numbers", lambda *a, **k: _StubAnnotation("Numbers", *a, **k))
+
+
+def test_dotplot_warns_for_broken_marsilea_056(simple_adata, stub_marsilea, monkeypatch):
+    monkeypatch.setattr(dotplot_mod.ma, "__version__", "0.5.6")
+
+    with pytest.warns(UserWarning, match="marsilea 0.5.6"):
+        dotplot_mod.dotplot(
+            simple_adata,
+            ["g1", "g2"],
+            groupby="cell_type",
+            show=False,
+        )
+
+
+def test_dotplot_does_not_warn_for_fixed_marsilea_versions(simple_adata, stub_marsilea, monkeypatch):
+    monkeypatch.setattr(dotplot_mod.ma, "__version__", "0.5.7")
+
+    with warnings.catch_warnings(record=True) as record:
+        warnings.simplefilter("always")
+        dotplot_mod.dotplot(
+            simple_adata,
+            ["g1", "g2"],
+            groupby="cell_type",
+            show=False,
+        )
+
+    assert not [w for w in record if "marsilea 0.5.6" in str(w.message)]

--- a/tests/single/test_comm_adapter.py
+++ b/tests/single/test_comm_adapter.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+from anndata import AnnData
+
+try:
+    import omicverse as ov
+except Exception as exc:  # pragma: no cover - environment guard
+    ov = None
+    pytestmark = pytest.mark.skip(reason=f"omicverse import failed in test env: {exc}")
+
+
+@pytest.fixture()
+def cpdb_results() -> dict[str, pd.DataFrame]:
+    means = pd.DataFrame(
+        {
+            "id_cp_interaction": [1, 2],
+            "interacting_pair": ["CXCL13_CXCR5", "TNF_TNFRSF1A"],
+            "gene_a": ["CXCL13", "TNF"],
+            "gene_b": ["CXCR5", "TNFRSF1A"],
+            "classification": ["CXCL", "TNF"],
+            "B|T": [0.8, 0.5],
+            "T|B": [0.1, 0.3],
+        }
+    )
+    pvalues = pd.DataFrame(
+        {
+            "id_cp_interaction": [1, 2],
+            "interacting_pair": ["CXCL13_CXCR5", "TNF_TNFRSF1A"],
+            "gene_a": ["CXCL13", "TNF"],
+            "gene_b": ["CXCR5", "TNFRSF1A"],
+            "classification": ["CXCL", "TNF"],
+            "B|T": [0.01, 0.02],
+            "T|B": [0.3, 0.2],
+        }
+    )
+    return {"means": means, "pvalues": pvalues}
+
+
+def test_format_liana_results_alias_matches_backward_compatible_name() -> None:
+    liana_res = pd.DataFrame(
+        {
+            "source": ["B"],
+            "target": ["T"],
+            "ligand_complex": ["CXCL13"],
+            "receptor_complex": ["CXCR5"],
+            "specificity_rank": [0.02],
+        }
+    )
+    new_comm = ov.single.format_liana_results(liana_res=liana_res)
+    old_comm = ov.single.format_liana_results_for_viz(liana_res=liana_res)
+    assert new_comm.shape == old_comm.shape
+    assert list(new_comm.obs.columns) == list(old_comm.obs.columns)
+    assert list(new_comm.var.columns) == list(old_comm.var.columns)
+
+
+def test_format_cpdb_results_builds_comm_adata(cpdb_results: dict[str, pd.DataFrame]) -> None:
+    comm_adata = ov.single.format_cpdb_results(cpdb_results)
+    assert comm_adata.shape == (2, 2)
+    assert list(comm_adata.obs.columns) == ["sender", "receiver"]
+    assert "means" in comm_adata.layers
+    assert "pvalues" in comm_adata.layers
+    assert comm_adata.obs.loc["B|T", "sender"] == "B"
+    assert comm_adata.obs.loc["B|T", "receiver"] == "T"
+    assert comm_adata.var.iloc[0]["interaction_name"] == "CXCL13_CXCR5"
+    assert comm_adata.uns["comm_source"] == "cellphonedb"
+
+
+def test_to_comm_adata_extracts_cpdb_results_from_uns(cpdb_results: dict[str, pd.DataFrame]) -> None:
+    adata = AnnData(X=np.zeros((1, 1), dtype=float))
+    adata.uns["cpdb_results"] = cpdb_results
+    comm_adata = ov.single.to_comm_adata(adata)
+    extracted = ov.single.extract_comm_adata(adata, result_uns_key="cpdb_results")
+    assert comm_adata.shape == extracted.shape == (2, 2)
+    assert float(comm_adata.layers["means"][0, 0]) == pytest.approx(0.8)

--- a/tests/single/test_liana_adapter.py
+++ b/tests/single/test_liana_adapter.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import matplotlib
+import matplotlib.pyplot as plt
+import pandas as pd
+import pytest
+from matplotlib.axes import Axes
+from matplotlib.figure import Figure
+
+
+matplotlib.use("Agg")
+
+try:
+    import omicverse as ov
+except Exception as exc:  # pragma: no cover - environment guard
+    ov = None
+    pytestmark = pytest.mark.skip(reason=f"omicverse import failed in test env: {exc}")
+
+
+@pytest.fixture()
+def liana_res() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "source": ["B", "B", "T", "T"],
+            "target": ["T", "Myeloid", "B", "Myeloid"],
+            "ligand_complex": ["CXCL13", "TNF", "IL7", "MIF"],
+            "receptor_complex": ["CXCR5", "TNFRSF1A", "IL7R", "CD74_CXCR4"],
+            "magnitude_rank": [0.02, 0.10, 0.30, 0.05],
+            "specificity_rank": [0.01, 0.04, 0.15, 0.03],
+            "lr_means": [4.1, 2.5, 1.2, 3.3],
+            "cellphone_pvals": [0.001, 0.02, 0.20, 0.01],
+        }
+    )
+
+
+@pytest.fixture()
+def classification_reference() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "interaction_name_2": ["CXCL13 - CXCR5", "MIF - (CD74+CXCR4)"],
+            "pathway_name": ["CXCL", "MIF"],
+        }
+    )
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+def _assert_figure_and_axes(fig, ax) -> None:
+    assert isinstance(fig, Figure)
+    assert isinstance(ax, Axes)
+
+
+def test_format_liana_results_for_viz_builds_comm_adata_from_aggregate_scores(
+    liana_res: pd.DataFrame,
+    classification_reference: pd.DataFrame,
+) -> None:
+    comm_adata = ov.single.format_liana_results_for_viz(
+        liana_res=liana_res,
+        score_key="magnitude_rank",
+        pvalue_key="specificity_rank",
+        classification={"CXCL13-CXCR5": "Chemokine", "TNF-TNFRSF1A": "TNF"},
+        classification_reference=classification_reference,
+    )
+
+    assert list(comm_adata.obs.columns) == ["sender", "receiver", "cell_type_pair"]
+    assert "means" in comm_adata.layers
+    assert "pvalues" in comm_adata.layers
+    assert comm_adata.shape == (4, 4)
+    assert comm_adata.obs.loc["B|T", "sender"] == "B"
+    assert comm_adata.obs.loc["B|T", "receiver"] == "T"
+    assert comm_adata.var.loc["CXCL13 -> CXCR5", "classification"] == "Chemokine"
+    assert comm_adata.var.loc["CXCL13 -> CXCR5", "classification_source"] == "mapping"
+    assert comm_adata.var.loc["MIF -> CD74_CXCR4", "classification"] == "MIF"
+    assert comm_adata.var.loc["MIF -> CD74_CXCR4", "classification_source"] == "reference:custom_reference"
+    assert comm_adata.var.loc["IL7 -> IL7R", "classification"] == "Interleukin/Cytokine"
+    assert comm_adata.var.loc["IL7 -> IL7R", "classification_source"] == "family"
+    assert comm_adata.var.loc["CXCL13 -> CXCR5", "interacting_pair"] == "CXCL13_CXCR5"
+    assert comm_adata.var.loc["CXCL13 -> CXCR5", "pair_lr"] == "CXCL13-CXCR5"
+    assert comm_adata.uns["liana_classification_reference"] == "custom_reference"
+    assert float(comm_adata["B|T", "CXCL13 -> CXCR5"].layers["means"][0, 0]) > float(
+        comm_adata["T|B", "IL7 -> IL7R"].layers["means"][0, 0]
+    )
+    assert float(comm_adata["B|T", "CXCL13 -> CXCR5"].layers["pvalues"][0, 0]) < 0.05
+    assert "magnitude_rank" in comm_adata.layers
+    assert "specificity_rank" in comm_adata.layers
+
+
+def test_format_liana_results_for_viz_rejects_unknown_classification_fallback(
+    liana_res: pd.DataFrame,
+) -> None:
+    with pytest.raises(ValueError, match="classification_fallback"):
+        ov.single.format_liana_results_for_viz(
+            liana_res=liana_res,
+            score_key="magnitude_rank",
+            pvalue_key="specificity_rank",
+            classification_reference=None,
+            classification_fallback="family1",
+        )
+
+
+def test_formatted_liana_comm_adata_feeds_ccc_plots(
+    liana_res: pd.DataFrame,
+    classification_reference: pd.DataFrame,
+) -> None:
+    comm_adata = ov.single.format_liana_results_for_viz(
+        liana_res=liana_res,
+        score_key="magnitude_rank",
+        pvalue_key="specificity_rank",
+        classification_reference=classification_reference,
+    )
+
+    fig1, ax1 = ov.pl.ccc_heatmap(
+        comm_adata,
+        plot_type="dot",
+        display_by="interaction",
+        top_n=3,
+        show=False,
+    )
+    _assert_figure_and_axes(fig1, ax1)
+
+    fig2, ax2 = ov.pl.ccc_network_plot(
+        comm_adata,
+        plot_type="circle",
+        display_by="interaction",
+        top_n=3,
+        show=False,
+    )
+    _assert_figure_and_axes(fig2, ax2)
+
+    fig3, ax3 = ov.pl.ccc_stat_plot(
+        comm_adata,
+        plot_type="bar",
+        display_by="interaction",
+        group_by="interaction",
+        top_n=3,
+        show=False,
+    )
+    _assert_figure_and_axes(fig3, ax3)
+
+    fig4, ax4 = ov.pl.ccc_heatmap(
+        comm_adata,
+        plot_type="heatmap",
+        display_by="aggregation",
+        signaling="TNF",
+        show=False,
+    )
+    _assert_figure_and_axes(fig4, ax4)
+
+    fig5, ax5 = ov.pl.ccc_stat_plot(
+        comm_adata,
+        plot_type="pathway_summary",
+        top_n=4,
+        min_expression=0.0,
+        strength_threshold=0.0,
+        pvalue_threshold=0.2,
+        min_significant_pairs=1,
+        show=False,
+    )
+    _assert_figure_and_axes(fig5, ax5)


### PR DESCRIPTION
## Summary

This PR consolidates the cell-cell communication workflow in OmicVerse across two layers:

  1. unified communication adapters for LIANA and CellPhoneDB
  2. a stabilized `ccc_*` visualization stack with improved layout, filtering, and compatibility behavior

The goal is to make `adata -> communication result -> ccc_* visualization` a consistent workflow across LIANA and CellPhoneDB, while reducing plot-
  specific inconsistencies and layout issues.

## What Changed

### Communication adapters
  - added a unified communication conversion layer via `ov.single.to_comm_adata(...)`
  - added / exposed LIANA and CellPhoneDB result formatting helpers
  - enabled `ccc_*` plotting functions to resolve compatible communication results directly from `adata`
  - aligned LIANA and CellPhoneDB inputs to the same standardized communication `AnnData` structure

### Visualization consolidation
  - refined `ccc_heatmap`, `ccc_network_plot`, and `ccc_stat_plot`
  - improved plot-type validation and `display_by` validation
  - cleaned up multiple layout and labeling issues across:
    - dot / sample_dot / tile
    - pathway_bubble / role_heatmap / role_network
    - chord / lr_chord / gene_chord
    - embedding_network / bipartite / arrow / sigmoid
    - sankey / pathway_summary / lr_contribution / diff_heatmap
  - removed or downgraded redundant / confusing visualization behaviors where necessary
  - improved legend placement, title spacing, colorbar layout, and label collision handling

### Compatibility and dependency handling
  - added explicit `Marsilea` 0.5.6 regression warnings in plotting entry points
  - excluded `marsilea==0.5.6` from package dependency resolution