### PR TITLE
feat(single): add Seurat-style CCA (pyccasc) to batch_correction — closes #669

### DIFF
--- a/omicverse/single/_batch.py
+++ b/omicverse/single/_batch.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import Optional
+
 from ..pp import scale,pca
 import scanpy as sc
 import numpy as np
@@ -20,6 +24,7 @@ _BATCH_OBSM = {
     "Concord":   "X_concord",
     "cca":       "X_cca",
     "seurat_cca": "X_cca",
+    "CCA":       "X_cca",
 }
 
 @monitor
@@ -276,22 +281,22 @@ def batch_correction(adata:anndata.AnnData,batch_key:str,
         add_reference(adata,'Concord','batch correction with Concord')
         return cur_ccd
     elif methods in ('cca', 'seurat_cca', 'CCA'):
-        try:
-            from cca_py import run_cca_anndata  # noqa: F401
-        except ImportError as exc:
-            raise ImportError(
-                "methods='cca' needs the pyccasc package "
-                "(pure-Python Seurat RunCCA, no R required). "
-                "Install with `pip install pyccasc`."
-            ) from exc
-
+        # Helper raises ImportError with a pyccasc install hint on its own
+        # if cca_py is missing; no need for a double import guard here.
         _run_cca_batch_correction(
             adata, batch_key=batch_key, n_pcs=n_pcs, **kwargs,
         )
         add_reference(adata, 'CCA', 'batch correction with Seurat CCA '
                                      '(pyccasc)')
+        return adata
     else:
         print('Not supported')
+
+
+_CCA_HELPER_KWARGS = {
+    "reference", "layer", "features", "standardize_inputs",
+    "seed", "key_added",
+}
 
 
 def _run_cca_batch_correction(
@@ -299,13 +304,14 @@ def _run_cca_batch_correction(
     *,
     batch_key: str,
     n_pcs: int = 50,
-    reference: str | None = None,
-    layer: str | None = None,
-    features: list | None = None,
+    reference: Optional[str] = None,
+    layer: Optional[str] = None,
+    features: Optional[list] = None,
     standardize_inputs: bool = True,
-    seed: int | None = 42,
+    seed: Optional[int] = None,
     key_added: str = "X_cca",
-) -> None:
+    **kwargs,
+) -> anndata.AnnData:
     """Seurat-style CCA integration over an arbitrary batch count.
 
     Delegates the 2-batch case to ``cca_py.run_cca_anndata`` and
@@ -329,13 +335,38 @@ def _run_cca_batch_correction(
         Name of the batch to use as the CCA reference when there are
         >2 batches. ``None`` → use the largest batch. Ignored for the
         2-batch case (either batch can play the reference role).
-    layer, features, standardize_inputs, seed, key_added
+    layer, features, standardize_inputs, key_added
         Forwarded to ``cca_py.run_cca_anndata``.
+    seed
+        Reproducibility seed forwarded to pyccasc. ``None`` (default)
+        matches the scikit-learn ``random_state=None`` convention —
+        pass e.g. ``seed=42`` for deterministic runs.
+    **kwargs
+        Unrecognised kwargs are warned and dropped rather than raised,
+        to match the loose-kwarg contract of the other
+        :func:`batch_correction` backends.
     """
-    from cca_py import run_cca_anndata
+    import warnings
+    try:
+        from cca_py import run_cca_anndata
+    except ImportError as exc:
+        raise ImportError(
+            "methods='cca' needs the pyccasc package "
+            "(pure-Python Seurat RunCCA, no R required). "
+            "Install with `pip install pyccasc`."
+        ) from exc
+
+    if kwargs:
+        warnings.warn(
+            "methods='cca' ignored unknown kwargs "
+            f"{sorted(kwargs)} — supported kwargs are "
+            f"{sorted(_CCA_HELPER_KWARGS)}.",
+            UserWarning, stacklevel=3,
+        )
 
     batches = adata.obs[batch_key].astype(str).to_numpy()
-    unique = list(dict.fromkeys(batches))  # preserve first-seen order
+    # order-preserving deduplification: keep batches in first-seen order
+    unique = list(dict.fromkeys(batches))
     if len(unique) < 2:
         raise ValueError(
             f"{batch_key!r} has {len(unique)} unique values; "
@@ -367,12 +398,17 @@ def _run_cca_batch_correction(
         else:
             ref_name = max(unique, key=lambda b: splits[b].n_obs)
         non_ref = [b for b in unique if b != ref_name]
+        # Invariant: we keep the reference's CCA projection from the
+        # **first** pair. Subsequent pairs would overwrite it inside
+        # splits[ref_name].obsm, so we snapshot after the first call and
+        # restore at the end. ``ref_emb`` is guaranteed to be populated
+        # because non_ref is non-empty (len(unique) >= 3 here).
         ref_emb = None
         for i, other in enumerate(non_ref):
             # run_cca_anndata writes both adata1 (ref) and adata2 (other)
             # — we reuse the reference's projection from the *first*
-            # pair, discard it on subsequent pairs. That's the pragmatic
-            # choice; strict anchors à la Seurat 3 are a v2 follow-up.
+            # pair, discard it on subsequent pairs. Strict anchors à la
+            # Seurat 3 are a v2 follow-up.
             run_cca_anndata(
                 splits[ref_name], splits[other],
                 features=features, layer=layer,
@@ -383,8 +419,8 @@ def _run_cca_batch_correction(
             )
             if i == 0:
                 ref_emb = splits[ref_name].obsm[key_added].copy()
-        # Re-install the first-pair ref embedding (may have been
-        # overwritten by the last pair).
+        # Re-install the first-pair ref embedding (overwritten by later
+        # pair calls).
         splits[ref_name].obsm[key_added] = ref_emb
 
     # Concatenate back to the original adata in sample order
@@ -398,6 +434,8 @@ def _run_cca_batch_correction(
         "num_cc": int(n_pcs),
         "n_batches": len(unique),
         "batches": unique,
+        "reference": reference,
     }
+    return adata
 
     

--- a/omicverse/single/_batch.py
+++ b/omicverse/single/_batch.py
@@ -18,13 +18,15 @@ _BATCH_OBSM = {
     "scVI":      "X_scVI",
     "CellANOVA": "X_cellanova",
     "Concord":   "X_concord",
+    "cca":       "X_cca",
+    "seurat_cca": "X_cca",
 }
 
 @monitor
 @register_function(
     aliases=["批次校正", "batch_correction", "batch_correct", "数据整合", "去批次效应"],
     category="single",
-    description="Comprehensive batch effect correction using multiple methods including Harmony, Combat, Scanorama, scVI, and CellANOVA",
+    description="Comprehensive batch effect correction using multiple methods including Harmony, Combat, Scanorama, scVI, CellANOVA, Concord, and Seurat-style CCA",
     prerequisites={
         'optional_functions': ['preprocess', 'scale', 'pca']
     },
@@ -49,7 +51,10 @@ _BATCH_OBSM = {
         "# CellANOVA with control samples",
         "control_dict = {'pool1': ['batch1', 'batch2']}",
         "ov.single.batch_correction(adata, batch_key='batch', methods='CellANOVA',",
-        "                           control_dict=control_dict)"
+        "                           control_dict=control_dict)",
+        "# Seurat-style CCA (no PyTorch, no CUDA; pure scipy)",
+        "ov.single.batch_correction(adata, batch_key='batch', methods='cca',",
+        "                           n_pcs=30)",
     ],
     related=["pp.preprocess", "utils.mde", "utils.embedding"]
 )
@@ -71,9 +76,13 @@ def batch_correction(adata:anndata.AnnData,batch_key:str,
     methods : str, default='harmony'
         Integration backend. Supported values include ``'harmony'``,
         ``'combat'``, ``'scanorama'``, ``'scVI'``, ``'CellANOVA'``,
-        and ``'Concord'``.
+        ``'Concord'``, and ``'cca'`` / ``'seurat_cca'`` — the pure-Python
+        port of ``Seurat::RunCCA`` (via the `pyccasc` package, no R /
+        rpy2 required).
     n_pcs : int, default=50
-        Number of principal components used when recomputing embeddings.
+        Number of principal components / canonical components used by the
+        selected backend. For ``'cca'`` this is the number of canonical
+        components (``num_cc`` in pyccasc terms).
     **kwargs
         Additional method-specific keyword arguments passed to the selected
         backend implementation.
@@ -266,7 +275,129 @@ def batch_correction(adata:anndata.AnnData,batch_key:str,
         cur_ccd.fit_transform(output_key='X_concord')
         add_reference(adata,'Concord','batch correction with Concord')
         return cur_ccd
+    elif methods in ('cca', 'seurat_cca', 'CCA'):
+        try:
+            from cca_py import run_cca_anndata  # noqa: F401
+        except ImportError as exc:
+            raise ImportError(
+                "methods='cca' needs the pyccasc package "
+                "(pure-Python Seurat RunCCA, no R required). "
+                "Install with `pip install pyccasc`."
+            ) from exc
+
+        _run_cca_batch_correction(
+            adata, batch_key=batch_key, n_pcs=n_pcs, **kwargs,
+        )
+        add_reference(adata, 'CCA', 'batch correction with Seurat CCA '
+                                     '(pyccasc)')
     else:
         print('Not supported')
+
+
+def _run_cca_batch_correction(
+    adata: anndata.AnnData,
+    *,
+    batch_key: str,
+    n_pcs: int = 50,
+    reference: str | None = None,
+    layer: str | None = None,
+    features: list | None = None,
+    standardize_inputs: bool = True,
+    seed: int | None = 42,
+    key_added: str = "X_cca",
+) -> None:
+    """Seurat-style CCA integration over an arbitrary batch count.
+
+    Delegates the 2-batch case to ``cca_py.run_cca_anndata`` and
+    generalises to N batches by running pairwise CCA against a
+    reference batch (the largest batch by default, or the batch named
+    by ``reference=``). Non-reference batches get their own CCA
+    projection; the reference uses its projection from the *first*
+    pair.
+
+    All per-batch embeddings are concatenated in the original sample
+    order and written to ``adata.obsm[key_added]`` so downstream
+    neighbours/UMAP/clustering can consume it like any other embedding.
+
+    Parameters
+    ----------
+    adata, batch_key
+        As in :func:`batch_correction`.
+    n_pcs
+        Forwarded as ``num_cc`` to pyccasc.
+    reference
+        Name of the batch to use as the CCA reference when there are
+        >2 batches. ``None`` → use the largest batch. Ignored for the
+        2-batch case (either batch can play the reference role).
+    layer, features, standardize_inputs, seed, key_added
+        Forwarded to ``cca_py.run_cca_anndata``.
+    """
+    from cca_py import run_cca_anndata
+
+    batches = adata.obs[batch_key].astype(str).to_numpy()
+    unique = list(dict.fromkeys(batches))  # preserve first-seen order
+    if len(unique) < 2:
+        raise ValueError(
+            f"{batch_key!r} has {len(unique)} unique values; "
+            f"CCA integration requires ≥2 batches."
+        )
+
+    # One split per batch label (keeps indices so we can re-assemble)
+    splits = {b: adata[batches == b].copy() for b in unique}
+
+    if len(unique) == 2:
+        a_name, b_name = unique
+        run_cca_anndata(
+            splits[a_name], splits[b_name],
+            features=features, layer=layer,
+            num_cc=n_pcs,
+            standardize_inputs=standardize_inputs,
+            key_added=key_added,
+            seed=seed,
+        )
+    else:
+        # Choose reference batch: explicit arg > largest
+        if reference is not None:
+            if reference not in splits:
+                raise KeyError(
+                    f"reference={reference!r} not in {batch_key!r} "
+                    f"(have {unique})"
+                )
+            ref_name = reference
+        else:
+            ref_name = max(unique, key=lambda b: splits[b].n_obs)
+        non_ref = [b for b in unique if b != ref_name]
+        ref_emb = None
+        for i, other in enumerate(non_ref):
+            # run_cca_anndata writes both adata1 (ref) and adata2 (other)
+            # — we reuse the reference's projection from the *first*
+            # pair, discard it on subsequent pairs. That's the pragmatic
+            # choice; strict anchors à la Seurat 3 are a v2 follow-up.
+            run_cca_anndata(
+                splits[ref_name], splits[other],
+                features=features, layer=layer,
+                num_cc=n_pcs,
+                standardize_inputs=standardize_inputs,
+                key_added=key_added,
+                seed=seed,
+            )
+            if i == 0:
+                ref_emb = splits[ref_name].obsm[key_added].copy()
+        # Re-install the first-pair ref embedding (may have been
+        # overwritten by the last pair).
+        splits[ref_name].obsm[key_added] = ref_emb
+
+    # Concatenate back to the original adata in sample order
+    emb_dim = next(iter(splits.values())).obsm[key_added].shape[1]
+    full = np.empty((adata.n_obs, emb_dim), dtype=np.float64)
+    for b in unique:
+        idx = np.where(batches == b)[0]
+        full[idx] = splits[b].obsm[key_added]
+    adata.obsm[key_added] = full
+    adata.uns.setdefault("cca", {})[key_added] = {
+        "num_cc": int(n_pcs),
+        "n_batches": len(unique),
+        "batches": unique,
+    }
 
     

--- a/tests/test_single_batch_cca.py
+++ b/tests/test_single_batch_cca.py
@@ -75,6 +75,38 @@ class TestBatchCorrectionCCA:
         )
         assert "X_cca" in adata.obsm
 
+    def test_returns_adata_for_chaining(self):
+        """batch_correction(methods='cca') must return adata so the
+        ``adata = batch_correction(adata, methods='cca')`` pattern
+        works — matches scanorama / OOM branches."""
+        import omicverse as ov
+
+        adata = _toy_adata(n_batches=2)
+        out = ov.single.batch_correction(
+            adata, batch_key="batch", methods="cca", n_pcs=6,
+        )
+        assert out is adata
+        assert "X_cca" in out.obsm
+
+    def test_unknown_kwargs_warn_not_raise(self):
+        """Unknown kwargs (e.g. typos) should warn and continue rather
+        than raising TypeError — matches the loose-kwarg contract of
+        the other backends."""
+        import warnings
+        import omicverse as ov
+
+        adata = _toy_adata(n_batches=2)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            ov.single.batch_correction(
+                adata, batch_key="batch", methods="cca", n_pcs=6,
+                n_layer=2,  # deliberate typo-like extra kwarg
+            )
+        msgs = [str(w.message) for w in caught]
+        assert any("ignored unknown kwargs" in m and "n_layer" in m
+                   for m in msgs), msgs
+        assert "X_cca" in adata.obsm
+
     def test_single_batch_raises(self):
         import omicverse as ov
 
@@ -119,7 +151,6 @@ class TestBatchCorrectionCCA:
         bt = adata.obs["batch"].to_numpy()
         ct = adata.obs["cell_type"].to_numpy()
         # cross-batch, same celltype
-        m_cross = np.zeros_like(D, dtype=bool)
         m_within_ct = (ct[:, None] == ct[None, :]) & (bt[:, None] != bt[None, :])
         np.fill_diagonal(m_within_ct, False)
         d_cross_same_ct = D[m_within_ct].mean()

--- a/tests/test_single_batch_cca.py
+++ b/tests/test_single_batch_cca.py
@@ -1,0 +1,132 @@
+"""Tests for the ``methods='cca'`` branch of ``ov.single.batch_correction``.
+
+Gated on ``pyccasc`` availability; skipped when the package isn't
+installed so CI that doesn't pull the optional dep stays green.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+import anndata as ad
+
+pyccasc = pytest.importorskip("cca_py")
+
+
+def _toy_adata(n_per_batch=60, n_genes=150, n_batches=3, seed=0):
+    """Synthetic AnnData with a planted per-batch mean shift + a shared
+    cell-type signal. Downstream CCA integration should pull the
+    shared signal up while removing the per-batch mean shift from the
+    first component."""
+    rng = np.random.default_rng(seed)
+    Xs, batches, cell_types = [], [], []
+    for bi in range(n_batches):
+        X = rng.standard_normal((n_per_batch, n_genes)).astype(np.float64)
+        # Per-batch additive offset on the first 20 genes
+        X[:, :20] += bi * 3.0
+        # Shared cell-type 1 (first half) on genes 20:40
+        X[: n_per_batch // 2, 20:40] += 2.5
+        # Shared cell-type 2 (second half) on genes 40:60
+        X[n_per_batch // 2:, 40:60] += 2.5
+        Xs.append(X)
+        batches.extend([f"b{bi}"] * n_per_batch)
+        cell_types.extend(
+            ["A"] * (n_per_batch // 2) + ["B"] * (n_per_batch - n_per_batch // 2)
+        )
+    X = np.vstack(Xs)
+    obs = pd.DataFrame(
+        {"batch": batches, "cell_type": cell_types},
+        index=[f"s{i}" for i in range(X.shape[0])],
+    )
+    var = pd.DataFrame(index=[f"g{j}" for j in range(n_genes)])
+    return ad.AnnData(X=X, obs=obs, var=var)
+
+
+class TestBatchCorrectionCCA:
+    def test_two_batch_writes_x_cca(self):
+        import omicverse as ov
+
+        adata = _toy_adata(n_batches=2)
+        ov.single.batch_correction(
+            adata, batch_key="batch", methods="cca", n_pcs=10,
+        )
+        assert "X_cca" in adata.obsm
+        assert adata.obsm["X_cca"].shape == (adata.n_obs, 10)
+
+    def test_three_batch_writes_x_cca(self):
+        import omicverse as ov
+
+        adata = _toy_adata(n_batches=3)
+        ov.single.batch_correction(
+            adata, batch_key="batch", methods="cca", n_pcs=12,
+        )
+        assert adata.obsm["X_cca"].shape == (adata.n_obs, 12)
+        meta = adata.uns["cca"]["X_cca"]
+        assert meta["n_batches"] == 3
+        assert meta["num_cc"] == 12
+        assert set(meta["batches"]) == {"b0", "b1", "b2"}
+
+    def test_seurat_cca_alias(self):
+        import omicverse as ov
+
+        adata = _toy_adata(n_batches=2)
+        ov.single.batch_correction(
+            adata, batch_key="batch", methods="seurat_cca", n_pcs=10,
+        )
+        assert "X_cca" in adata.obsm
+
+    def test_single_batch_raises(self):
+        import omicverse as ov
+
+        adata = _toy_adata(n_batches=1)
+        with pytest.raises(ValueError, match="requires ≥2 batches"):
+            ov.single.batch_correction(
+                adata, batch_key="batch", methods="cca", n_pcs=5,
+            )
+
+    def test_unknown_reference_raises(self):
+        import omicverse as ov
+
+        adata = _toy_adata(n_batches=3)
+        with pytest.raises(KeyError, match="reference"):
+            ov.single.batch_correction(
+                adata, batch_key="batch", methods="cca", n_pcs=5,
+                reference="bogus",
+            )
+
+    def test_reference_batch_selection(self):
+        import omicverse as ov
+
+        adata = _toy_adata(n_batches=3)
+        ov.single.batch_correction(
+            adata, batch_key="batch", methods="cca", n_pcs=8,
+            reference="b1",
+        )
+        assert adata.obsm["X_cca"].shape == (adata.n_obs, 8)
+
+    def test_integration_brings_same_celltype_closer(self):
+        """After CCA, within-celltype distances (cross-batch) should be
+        smaller than within-batch cross-celltype distances."""
+        from sklearn.metrics import pairwise_distances
+        import omicverse as ov
+
+        adata = _toy_adata(n_batches=2, n_per_batch=40)
+        ov.single.batch_correction(
+            adata, batch_key="batch", methods="cca", n_pcs=10,
+        )
+        E = adata.obsm["X_cca"]
+        D = pairwise_distances(E)
+        bt = adata.obs["batch"].to_numpy()
+        ct = adata.obs["cell_type"].to_numpy()
+        # cross-batch, same celltype
+        m_cross = np.zeros_like(D, dtype=bool)
+        m_within_ct = (ct[:, None] == ct[None, :]) & (bt[:, None] != bt[None, :])
+        np.fill_diagonal(m_within_ct, False)
+        d_cross_same_ct = D[m_within_ct].mean()
+        # same batch, different celltype
+        m_within_bt_diff_ct = (bt[:, None] == bt[None, :]) & (ct[:, None] != ct[None, :])
+        d_same_bt_diff_ct = D[m_within_bt_diff_ct].mean()
+        assert d_cross_same_ct < d_same_bt_diff_ct, (
+            f"CCA failed to integrate: cross-batch same-ct={d_cross_same_ct:.3f}"
+            f" vs same-batch diff-ct={d_same_bt_diff_ct:.3f}"
+        )


### PR DESCRIPTION
Closes #669 — user-requested Seurat CCA integration method for `ov.single.batch_correction`.

## What

Add `methods='cca'` (aliases: `'seurat_cca'`, `'CCA'`) to `ov.single.batch_correction`. The backend is **`pyccasc`** — a pure-Python re-implementation of `Seurat::RunCCA` that the same author (@Starlitnightly) published on PyPI. No R / rpy2 needed.

## How it wires in

- `pip install pyccasc` is the only new runtime dependency (optional — `ImportError` with a clear install hint if missing).
- Integrated embedding lands in `adata.obsm['X_cca']`, matching the naming convention of the other methods (`X_pca_harmony`, `X_combat`, …).
- `n_pcs` is reused as `num_cc` (number of canonical components) for this backend.
- Helper `_run_cca_batch_correction` generalises the 2-batch case (direct call to `cca_py.run_cca_anndata`) to any batch count via pairwise CCA against a reference batch:
  - 2 batches → single `run_cca_anndata` call.
  - >2 batches → reference = largest batch by default, or `reference='batch_name'`. Each non-reference batch gets its pairwise projection against the reference; reference keeps its projection from the first pair.
  - All per-batch embeddings are concatenated back in the **original sample order** to `obsm['X_cca']`.
- Provenance in `adata.uns['cca']['X_cca']` records `num_cc / n_batches / batches`.
- `_BATCH_OBSM` bumped so the `@tracked` viz layer auto-colours the new embedding by `batch_key` in the report.

## Usage

```python
# 2-batch integration
ov.single.batch_correction(adata, batch_key='batch', methods='cca', n_pcs=20)

# Multi-batch (pick reference explicitly if needed)
ov.single.batch_correction(
    adata, batch_key='batch', methods='cca', n_pcs=30,
    reference='batch_A',
)
```

## Tests

`tests/test_single_batch_cca.py` — 7 cases, all gated on `pyccasc` being importable (so CI without the optional dep skips gracefully):

- 2-batch + 3-batch write correct shape & provenance
- `'seurat_cca'` alias works
- Single-batch / unknown-reference error paths
- `reference=` selection
- **Semantic check**: on a synthetic dataset with planted batch offsets + a shared cell-type signal, cross-batch same-celltype distances end up smaller than same-batch different-celltype distances after CCA. This is the integration invariant we actually care about.

## Scope not in this PR

- Seurat-style FindIntegrationAnchors (MNN-based anchor filtering on top of CCA). The v1 here is "CCA shared space, concat by sample order" — sufficient for dimensionality-reduction + downstream clustering. Anchors can be a v2 follow-up.

## Test plan

- [x] `pytest tests/test_single_batch_cca.py` — 7 pass
- [x] `ov.single.batch_correction(adata, methods='cca')` verified end-to-end on synthetic 2/3-batch data
- [ ] CI run (this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
