### PR TITLE
fix(bulk2single/bayesprism): ThetaPost columns are cell types, not genes — closes #612

### DIFF
--- a/omicverse/external/bulk2single/pybayesprism/gibbs.py
+++ b/omicverse/external/bulk2single/pybayesprism/gibbs.py
@@ -328,7 +328,14 @@ class GibbsSampler:
                 X_input = [X[i, :] for i in np.arange(X.shape[0])]
                 star_input = zip(X_input, repeat(phi), repeat(alpha), repeat(gibbs_idx), repeat(seed))
                 gibbs_list = pool.starmap(GibbsSampler.sample_theta_n , tqdm.tqdm(star_input, total=len(X_input)))
-            return ThetaPost.new(self.X.index, self.X.columns, gibbs_list)
+            # ThetaPost indexes columns by cell type (shape of theta_n),
+            # not by gene. Earlier revisions passed ``self.X.columns`` here,
+            # which left the theta buffer at shape (n_samples, n_genes);
+            # when gibbs_list[i]['theta_n'] came back at shape (n_celltypes,)
+            # it broadcast-errored as
+            #   "could not broadcast input array from shape (K,) into (G,)"
+            # See omicverse/omicverse#612.
+            return ThetaPost.new(self.X.index, phi.index, gibbs_list)
 
 
     def run_gibbs_refTumor(self):

--- a/tests/test_bayesprism_thetapost.py
+++ b/tests/test_bayesprism_thetapost.py
@@ -1,0 +1,108 @@
+"""Regression test for the BayesPrism ThetaPost shape-mismatch bug
+reported in omicverse/omicverse#612.
+
+Before the fix, ``run_gibbs_refPhi`` passed ``self.X.columns`` (= gene
+names, shape n_genes) to ``ThetaPost.new`` as the ``cell_type`` argument.
+The resulting ``theta`` buffer had shape ``(n_bulk, n_genes)``, but the
+Gibbs sampler returned ``theta_n`` of shape ``(n_cell_types,)`` for each
+sample — producing::
+
+    ValueError: could not broadcast input array from shape (K,) into shape (G,)
+
+This test builds a tiny synthetic reference + pseudobulk, runs
+``my_prism.run(fast_mode=False)``, and checks that the returned theta
+has the right orientation (samples × cell types) and sums to 1.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+import anndata as ad
+
+
+def _synthetic_ref_and_bulk(seed: int = 0):
+    """Three cell types × 150 genes; each type has a 40-gene high-expression
+    block so the reference is identifiable. Pseudobulk is
+    ``sum(80 T + 60 B + 60 M)`` random ref-cells → expected proportions
+    40 / 30 / 30 %."""
+    rng = np.random.default_rng(seed)
+    n_per = 70
+    n_genes = 150
+    n_bulk = 6
+
+    cell_types = np.array(["T"] * n_per + ["B"] * n_per + ["M"] * n_per)
+    X_ref = rng.poisson(4.0, size=(3 * n_per, n_genes)).astype(np.float64)
+    for i, ct in enumerate(["T", "B", "M"]):
+        mask = cell_types == ct
+        X_ref[mask, i * 40:(i + 1) * 40] += rng.poisson(
+            60, size=(mask.sum(), 40)
+        )
+    adata_ref = ad.AnnData(
+        X=X_ref,
+        obs=pd.DataFrame(
+            {"celltype": cell_types},
+            index=[f"c{i}" for i in range(3 * n_per)],
+        ),
+        var=pd.DataFrame(index=[f"g{j}" for j in range(n_genes)]),
+    )
+
+    mix = np.zeros((n_bulk, n_genes))
+    for s in range(n_bulk):
+        pick = np.concatenate([
+            rng.choice(np.where(cell_types == "T")[0], size=80),
+            rng.choice(np.where(cell_types == "B")[0], size=60),
+            rng.choice(np.where(cell_types == "M")[0], size=60),
+        ])
+        mix[s] = X_ref[pick].sum(axis=0)
+    mixture = pd.DataFrame(
+        mix,
+        index=[f"s{i}" for i in range(n_bulk)],
+        columns=adata_ref.var_names,
+    )
+    return adata_ref, mixture
+
+
+class TestBayesPrismThetaShape:
+    def test_final_theta_is_samples_by_celltypes(self):
+        """Regression for omicverse/omicverse#612: theta dataframe
+        returned by BayesPrism must be indexed by bulk samples and
+        columned by reference cell types, not genes."""
+        from omicverse.external.bulk2single.pybayesprism.prism import Prism
+
+        adata_ref, mixture = _synthetic_ref_and_bulk(seed=0)
+        my_prism = Prism.new_anndata(
+            reference_adata=adata_ref, mixture=mixture,
+            cell_type_key="celltype", cell_state_key="celltype",
+            key=None, outlier_cut=0.5, outlier_fraction=0.01,
+        )
+        bp = my_prism.run(n_cores=2, fast_mode=False)
+        theta = bp.posterior_theta_f.theta
+
+        # Dimensions: samples × cell types, not samples × genes
+        assert theta.shape[0] == mixture.shape[0]
+        assert theta.shape[1] == 3
+        assert list(theta.columns) == ["T", "B", "M"]
+        assert list(theta.index) == list(mixture.index)
+
+        # Compositional constraint: every sample's proportions sum to ~1
+        np.testing.assert_allclose(
+            theta.sum(axis=1).to_numpy(), 1.0, atol=0.01,
+        )
+
+    def test_recovers_planted_proportions(self):
+        """Known mix 40/30/30 should be recovered to within ±5 pp."""
+        from omicverse.external.bulk2single.pybayesprism.prism import Prism
+
+        adata_ref, mixture = _synthetic_ref_and_bulk(seed=1)
+        my_prism = Prism.new_anndata(
+            reference_adata=adata_ref, mixture=mixture,
+            cell_type_key="celltype", cell_state_key="celltype",
+            key=None, outlier_cut=0.5, outlier_fraction=0.01,
+        )
+        bp = my_prism.run(n_cores=2, fast_mode=False)
+        theta = bp.posterior_theta_f.theta
+        mean = theta.mean(axis=0)
+        assert abs(mean["T"] - 0.40) < 0.05, mean
+        assert abs(mean["B"] - 0.30) < 0.05, mean
+        assert abs(mean["M"] - 0.30) < 0.05, mean


### PR DESCRIPTION
Closes #612 — `ov.bulk.Deconvolution(...).deconvolution(method='bayesprism', fast_mode=False)` crashing with

```
ValueError: could not broadcast input array from shape (3,) into shape (13260,)
```

at `theta_post.py:18`.

## Root cause

`GibbsSampler.run_gibbs_refPhi` (the `final=True` branch) was returning:

```python
return ThetaPost.new(self.X.index, self.X.columns, gibbs_list)
```

`self.X` is the bulk mixture (n_samples × n_genes), so `self.X.columns` is the **gene list**. Inside `ThetaPost.new(bulk_id, cell_type, gibbs_list)` this allocated `theta = np.zeros((n_samples, n_genes))` and then tried to fill each row with the Gibbs-sampler output `theta_n` of shape `(n_cell_types,)` — which broadcast-errored because `n_cell_types` ≠ `n_genes` (3 vs 13260 in the reporter's data).

The sibling `not final` branch correctly passes `phi.index` (cell-type axis of the reference phi matrix) as the cell_type argument to `JointPost.new`. The final branch was passing gene names instead — probably a copy-paste slip from `JointPost.new(bulk_id, gene_id, cell_type, gibbs_list)` which has an extra positional arg.

## Fix

One line in `omicverse/external/bulk2single/pybayesprism/gibbs.py`:

```diff
-            return ThetaPost.new(self.X.index, self.X.columns, gibbs_list)
+            return ThetaPost.new(self.X.index, phi.index, gibbs_list)
```

Plus an explanatory comment pointing at #612 and a regression test.

## Verification

`tests/test_bayesprism_thetapost.py` (2 cases, both passing):

1. `test_final_theta_is_samples_by_celltypes` — builds a 3-celltype × 150-gene pseudobulk, asserts `theta.shape == (n_samples, 3)`, columns are `['T','B','M']`, and row sums ≈ 1.
2. `test_recovers_planted_proportions` — ground-truth mix is 40 / 30 / 30 %; BayesPrism must recover that within ±5 pp on each cell type.

Both pass in ~3 s each in the `omicdev` env on the fix branch. Pre-fix code hits the original `ValueError` exactly as reported in #612.

## Test plan

- [x] `pytest tests/test_bayesprism_thetapost.py` — 2 pass
- [ ] CI run (this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
