### PR TITLE
fix(pl.plot1cell): stop hardcoding parchment background

### DIFF
--- a/omicverse/pl/_plot1cell.py
+++ b/omicverse/pl/_plot1cell.py
@@ -295,7 +295,7 @@ def plot1cell(
     cluster_palette=None,
     track_palette=None,
     track_palettes: Optional[Sequence] = None,
-    bg_color: str = "#F9F2E4",
+    bg_color: Optional[str] = None,
     gap_between_deg: float = 2.0,
     gap_start_deg: float = 12.0,
     cluster_track_width: float = 0.035,
@@ -431,9 +431,10 @@ def plot1cell(
     outer = r_outer_ring + tick_margin + cluster_label_pad + label_margin
     ax.set_xlim(-outer, outer)
     ax.set_ylim(-outer, outer)
-    ax.set_facecolor(bg_color)
-    if created_fig:
-        fig.patch.set_facecolor(bg_color)
+    if bg_color is not None:
+        ax.set_facecolor(bg_color)
+        if created_fig:
+            fig.patch.set_facecolor(bg_color)
     ax.set_axis_off()
 
     # --- 4. Scatter + KDE -----------------------------------------


### PR DESCRIPTION
## Summary
- `plot1cell` defaulted `bg_color='#F9F2E4'` and then called `ax.set_facecolor(bg_color)` + `fig.patch.set_facecolor(bg_color)` unconditionally, overriding whatever `ov.pl.plot_set()` (or the user's rcParams) had configured.
- Switch the default to `bg_color=None` and gate the `set_facecolor` calls behind `bg_color is not None`, so the plot now inherits the user-configured background by default.
- Opt-in for the R-style parchment remains: `ov.pl.plot1cell(..., bg_color='#F9F2E4')`.

## Test plan
- [x] `pytest tests/pl/test_plot1cell.py -x` → 9/9 pass (existing smoke suite exercises the default no-tracks, with-tracks, and return_data paths).