### PR TITLE
fix(pl): preserve explicit feature_labels in dynamic_heatmap

### DIFF
--- a/omicverse/pl/_heatmap_marsilea.py
+++ b/omicverse/pl/_heatmap_marsilea.py
@@ -2381,7 +2381,7 @@ def dynamic_heatmap(
         label_names = _labels_from_targets(
             list(matrix.index),
             feature_labels,
-            min_gap=max(2, matrix.shape[0] // 45),
+            min_gap=1,
         )
     elif show_row_names:
         label_names = list(matrix.index)


### PR DESCRIPTION
Fix `dynamic_heatmap` so explicit `feature_labels` are not aggressively filtered before rendering.

Previously, `feature_labels` were passed through `_labels_from_targets(..., min_gap=...)`, which could drop user-requested labels before `Marsilea` had a chance to lay them out. This PR preserves explicit labels and leaves collision handling to Marsilea's `AnnoLabels`.