### PR TITLE
Refactor color assignment logic in wgcna.py

### DIFF
--- a/omicverse/external/PyWGCNA/wgcna.py
+++ b/omicverse/external/PyWGCNA/wgcna.py
@@ -2333,7 +2333,8 @@ class pyWGCNA(GeneExp):
 
         colors = np.empty(nLabels.shape[0], dtype=object)
         fin = [v is not None for v in nLabels.Value]
-        colors[np.where(not fin)[0].tolist()] = naColor
+        fin = np.atleast_1d(fin)
+        colors[~fin] = naColor
         finLabels = nLabels.loc[fin, :]
         colors[fin] = [extColorSeq[x] for x in finLabels.Value]
 


### PR DESCRIPTION
Line 2336 in the original wgcna.py may cause an error: 
`colors[np.where(not fin)[0].tolist()] = naColor`


Error message:
Calling nonzero on 0d arrays is not allowed. Use np.atleast_1d(scalar).nonzero() instead. If the context of this error is of the form arr[nonzero(cond)], just use arr[cond]. 
Cause of the error:
The code applies np.nonzero() / np.where()-style indexing to a 0-dimensional array (here is the 'fin'), which is no longer allowed in newer versions of NumPy. NumPy officially deprecated calling nonzero on 0d arrays starting from version 1.17, and in later versions this now raises a ValueError.
"fin" is  a list here, and "not fin" returns a bool value. I suspect that "colors" is supposed to be indexed with a boolean list or array, rather than a single boolean scalar, so that naColor can be assigned to the corresponding positions.

After the fix, the test runs successfully.