### PR TITLE
feat(ovagent): resilience + live LLM trace + auto-download missing references

### DIFF
--- a/omicverse/bulk/_Deseq2.py
+++ b/omicverse/bulk/_Deseq2.py
@@ -25,19 +25,41 @@ from ..pl import volcano
     ],
     related=["bulk.deseq2_normalize", "utils.gene_symbol_to_ensembl", "pp.filter_genes"]
 )
-def Matrix_ID_mapping(data:pd.DataFrame,gene_ref_path:str,keep_unmapped:bool=True)->pd.DataFrame:
+def Matrix_ID_mapping(data:pd.DataFrame,gene_ref_path:str,keep_unmapped:bool=True,
+                      auto_download:bool=True)->pd.DataFrame:
     r"""Map gene IDs in the input data to gene symbols using a reference table.
 
     Arguments:
         data: The input data containing gene IDs as index.
         gene_ref_path: The path to the reference table containing the mapping from gene IDs to gene symbols.
         keep_unmapped: Whether to keep genes that are not found in the mapping table. If True, unmapped genes retain their original IDs. If False, unmapped genes are removed (original behavior). Default: True.
+        auto_download: If the reference at ``gene_ref_path`` is missing AND its
+            basename matches a known omicverse pair (``pair_GRCh38.tsv``,
+            ``pair_GRCh37.tsv``, ``pair_GRCm39.tsv``, ``pair_danRer11.tsv``),
+            call :func:`ov.utils.download_geneid_annotation_pair` to fetch the
+            standard pairs into ``./genesets/`` and resolve from there.
 
     Returns:
         data: The input data with gene IDs mapped to gene symbols.
 
     """
-    
+
+    import os
+    if auto_download and not os.path.exists(gene_ref_path):
+        known_pairs = {
+            'pair_GRCh38.tsv', 'pair_GRCh37.tsv',
+            'pair_GRCm39.tsv', 'pair_danRer11.tsv',
+        }
+        basename = os.path.basename(gene_ref_path)
+        if basename in known_pairs:
+            from ..utils._data import download_geneid_annotation_pair
+            print(f"......Gene-ID pair '{basename}' missing locally; "
+                  f"auto-downloading via ov.utils.download_geneid_annotation_pair()...")
+            download_geneid_annotation_pair()
+            cand = os.path.join('./genesets', basename)
+            if os.path.exists(cand):
+                gene_ref_path = cand
+
     pair=pd.read_csv(gene_ref_path,sep='\t',index_col=0)
     
     if keep_unmapped:

--- a/omicverse/datasets/_datasets.py
+++ b/omicverse/datasets/_datasets.py
@@ -716,12 +716,17 @@ def pancreatic_endocrinogenesis(
     related=['datasets.pancreatic_endocrinogenesis', 'datasets.get_adata']
 )
 def pancreas_cellrank(
-    url: str = "https://figshare.com/ndownloader/files/25060877",
+    url: str = "https://github.com/theislab/scvelo_notebooks/raw/master/data/Pancreas/endocrinogenesis_day15.h5ad",
     filename: str = "pancreas_cellrank.h5ad",
 ) -> AnnData:
     """The pancreas cellrank dataset used in https://github.com/theislab/scvelo_notebooks/tree/master/data/Pancreas.
 
     This data consists of 13,913 genes across 2,930 cells.
+
+    Note: The previous figshare URL (files/25060877) returned a 2KB HTML error
+    page instead of the dataset, causing an infinite redownload loop.
+    Switched the default to the scvelo_notebooks GitHub raw URL, which is the
+    upstream source that scvelo / cellrank also use.
     """
     adata = get_adata(url, filename)
     return adata

--- a/omicverse/pp/_qc.py
+++ b/omicverse/pp/_qc.py
@@ -785,6 +785,22 @@ def qc_cpu_gpu_mixed(adata:anndata.AnnData, mode='seurat',
         adata.obs['detected_genes'] = np.count_nonzero(adata.X, axis=1)
     adata.obs['cell_complexity'] = adata.obs['detected_genes'] / adata.obs['nUMIs']
 
+    # Scanpy-convention aliases — let LLM-generated code that follows scanpy
+    # tutorials (`adata.obs['pct_counts_mt']`, `adata.obs['n_counts']`,
+    # `adata.obs['total_counts']`, `adata.obs['n_genes']`) work without
+    # KeyError. ov uses 'mito_perc'/'nUMIs'/'detected_genes' internally;
+    # we mirror the values under standard scanpy names so both call styles
+    # succeed. Cheap (no data duplication, just dict assignment).
+    adata.obs['n_counts']        = adata.obs['nUMIs']
+    adata.obs['total_counts']    = adata.obs['nUMIs']
+    adata.obs['n_genes']         = adata.obs['detected_genes']
+    adata.obs['n_genes_by_counts'] = adata.obs['detected_genes']
+    adata.obs['pct_counts_mt']   = adata.obs['mito_perc']
+    if 'ribo_perc' in adata.obs.columns:
+        adata.obs['pct_counts_ribo'] = adata.obs['ribo_perc']
+    if 'hb_perc' in adata.obs.columns:
+        adata.obs['pct_counts_hb']   = adata.obs['hb_perc']
+
     # Display QC statistics in table format
     _print_qc_metrics_table(adata)
 
@@ -1171,6 +1187,22 @@ def qc_cpu(
         adata.obs['detected_genes'] = np.count_nonzero(adata.X, axis=1)
     adata.obs['cell_complexity'] = adata.obs['detected_genes'] / adata.obs['nUMIs']
 
+    # Scanpy-convention aliases — let LLM-generated code that follows scanpy
+    # tutorials (`adata.obs['pct_counts_mt']`, `adata.obs['n_counts']`,
+    # `adata.obs['total_counts']`, `adata.obs['n_genes']`) work without
+    # KeyError. ov uses 'mito_perc'/'nUMIs'/'detected_genes' internally;
+    # we mirror the values under standard scanpy names so both call styles
+    # succeed. Cheap (no data duplication, just dict assignment).
+    adata.obs['n_counts']        = adata.obs['nUMIs']
+    adata.obs['total_counts']    = adata.obs['nUMIs']
+    adata.obs['n_genes']         = adata.obs['detected_genes']
+    adata.obs['n_genes_by_counts'] = adata.obs['detected_genes']
+    adata.obs['pct_counts_mt']   = adata.obs['mito_perc']
+    if 'ribo_perc' in adata.obs.columns:
+        adata.obs['pct_counts_ribo'] = adata.obs['ribo_perc']
+    if 'hb_perc' in adata.obs.columns:
+        adata.obs['pct_counts_hb']   = adata.obs['hb_perc']
+
     # Display QC statistics in table format
     _print_qc_metrics_table(adata)
 
@@ -1546,6 +1578,22 @@ def qc_gpu(adata, mode='seurat',
     adata.obs['hb_perc'] = adata.obs['pct_counts_hb']/100
     adata.obs['detected_genes'] = adata.obs['n_genes_by_counts']
     adata.obs['cell_complexity'] = adata.obs['detected_genes'] / adata.obs['nUMIs']
+
+    # Scanpy-convention aliases — let LLM-generated code that follows scanpy
+    # tutorials (`adata.obs['pct_counts_mt']`, `adata.obs['n_counts']`,
+    # `adata.obs['total_counts']`, `adata.obs['n_genes']`) work without
+    # KeyError. ov uses 'mito_perc'/'nUMIs'/'detected_genes' internally;
+    # we mirror the values under standard scanpy names so both call styles
+    # succeed. Cheap (no data duplication, just dict assignment).
+    adata.obs['n_counts']        = adata.obs['nUMIs']
+    adata.obs['total_counts']    = adata.obs['nUMIs']
+    adata.obs['n_genes']         = adata.obs['detected_genes']
+    adata.obs['n_genes_by_counts'] = adata.obs['detected_genes']
+    adata.obs['pct_counts_mt']   = adata.obs['mito_perc']
+    if 'ribo_perc' in adata.obs.columns:
+        adata.obs['pct_counts_ribo'] = adata.obs['ribo_perc']
+    if 'hb_perc' in adata.obs.columns:
+        adata.obs['pct_counts_hb']   = adata.obs['hb_perc']
 
     # Display QC statistics in table format
     _print_qc_metrics_table(adata)

--- a/omicverse/single/__init__.py
+++ b/omicverse/single/__init__.py
@@ -67,7 +67,8 @@ from ._cpdb import (
     cpdb_interaction_filtered,
     cpdb_submeans_exacted,cpdb_exact_target,
     cpdb_exact_source,cellphonedb_v5,
-    run_cellphonedb_v5, format_cpdb_results, format_cpdb_results_for_viz
+    run_cellphonedb_v5, format_cpdb_results, format_cpdb_results_for_viz,
+    download_cellphonedb_database, validate_cpdb_database,
 )
 from ._liana import run_liana, format_liana_results, format_liana_results_for_viz
 from ._comm import to_comm_adata, extract_comm_adata
@@ -304,6 +305,8 @@ __all__ = [
     'cpdb_exact_source',
     'cellphonedb_v5',
     'run_cellphonedb_v5',
+    'download_cellphonedb_database',
+    'validate_cpdb_database',
     'format_cpdb_results',
     'format_cpdb_results_for_viz',
     'run_liana',

--- a/omicverse/single/_cellmatch.py
+++ b/omicverse/single/_cellmatch.py
@@ -47,7 +47,7 @@ class CellOntologyMapper:
     🧬 Cell ontology mapping class using NLP
     """
     
-    def __init__(self, cl_obo_file=None, embeddings_path=None, model_name="all-mpnet-base-v2", local_model_dir=None):
+    def __init__(self, cl_obo_file=None, embeddings_path=None, model_name="all-mpnet-base-v2", local_model_dir=None, auto_download=True):
         """
         🚀 Initialize CellOntologyMapper
         
@@ -93,6 +93,17 @@ class CellOntologyMapper:
         elif cl_obo_file and os.path.exists(cl_obo_file):
             print("🔨 Creating ontology resources from OBO file...")
             self.create_ontology_resources(cl_obo_file)
+        elif cl_obo_file and auto_download:
+            from pathlib import Path
+            target_dir = str(Path(cl_obo_file).parent) or "new_ontology"
+            target_name = Path(cl_obo_file).name
+            print(f"📥 Cell Ontology file '{cl_obo_file}' missing; "
+                  f"auto-downloading via ov.single.download_cl()...")
+            downloaded = download_cl(output_dir=target_dir, filename=target_name)
+            if os.path.exists(downloaded):
+                self.create_ontology_resources(downloaded)
+            else:
+                print("?  download_cl returned but file missing; init empty mapper.")
         else:
             print("?  Initialized empty mapper, please use load_embeddings() or create_ontology_resources()")
     

--- a/omicverse/single/_cpdb.py
+++ b/omicverse/single/_cpdb.py
@@ -439,12 +439,13 @@ def cpdb2cellchat(df):
     return new_df
 
 
-def cellphonedb_v5(adata, 
+def cellphonedb_v5(adata,
                            celltype_key='celltype',
                            min_cell_fraction=0.005,
                            min_genes=200,
                            min_cells=3,
                            cpdb_file_path=None,
+                           auto_download=True,
                            iterations=1000,
                            threshold=0.1,
                            pvalue=0.05,
@@ -474,6 +475,12 @@ def cellphonedb_v5(adata,
         Minimum number of cells required per gene
     cpdb_file_path:str or None
         Path to CellPhoneDB database zip file. If None, will try to find automatically
+        (cache → ./cellphonedb.zip → ~/cellphonedb.zip), and auto-download if missing.
+    auto_download:bool, default=True
+        If True and the database is not found locally, automatically download
+        from the official CellPhoneDB GitHub release into
+        ``$OVAGENT_HOME/data_lake/cellphonedb.zip``. Disable to fail fast in
+        offline environments.
     iterations:int
         Number of shufflings performed in the analysis
     threshold:float
@@ -588,24 +595,36 @@ def cellphonedb_v5(adata,
         
         # Step 5: Find CellPhoneDB database if not provided
         if cpdb_file_path is None:
-            # Try common locations
+            try:
+                from ..utils._ovagent_paths import ovagent_home
+                cache_path = ovagent_home() / "data_lake" / "cellphonedb.zip"
+            except Exception:
+                cache_path = Path(os.path.expanduser("~/.omicverse/data_lake/cellphonedb.zip"))
+
             possible_paths = [
-                '/oak/stanford/groups/xiaojie/steorra/software/cellphonedb.zip',
+                str(cache_path),
                 './cellphonedb.zip',
-                '~/cellphonedb.zip'
+                '~/cellphonedb.zip',
+                '/oak/stanford/groups/xiaojie/steorra/software/cellphonedb.zip',
             ]
-            
+
             for path in possible_paths:
                 expanded_path = os.path.expanduser(path)
                 if os.path.exists(expanded_path):
                     cpdb_file_path = expanded_path
                     break
-            
+
             if cpdb_file_path is None:
-                raise FileNotFoundError(
-                    "CellPhoneDB database not found. Please provide cpdb_file_path or "
-                    "place cellphonedb.zip in current directory"
-                )
+                if auto_download:
+                    print("   - CellPhoneDB DB not found locally; auto-downloading...")
+                    cache_path.parent.mkdir(parents=True, exist_ok=True)
+                    cpdb_file_path = download_cellphonedb_database(str(cache_path))
+                else:
+                    raise FileNotFoundError(
+                        "CellPhoneDB database not found. Pass cpdb_file_path=, "
+                        "set auto_download=True, or call "
+                        "ov.single.download_cellphonedb_database() first."
+                    )
         
         print(f"   - Using CellPhoneDB database: {cpdb_file_path}")
         
@@ -779,14 +798,42 @@ def create_cellchatviz_from_cpdb(cpdb_results, separator='|', palette=None):
     return viz
 
 
+@register_function(
+    aliases=[
+        'CellPhoneDB 数据库下载', 'CellPhoneDB database download',
+        'download_cellphonedb_database', 'download_cellphonedb',
+        'cpdb download', 'fetch cellphonedb',
+    ],
+    category="single",
+    description=(
+        "Download the CellPhoneDB v5 ligand-receptor database (cellphonedb.zip) "
+        "from the official GitHub mirror. Required by ov.single.cellphonedb_v5 "
+        "before running cell-cell communication analysis. Caches under "
+        "$OVAGENT_HOME/data_lake/cellphonedb.zip and is idempotent."
+    ),
+    prerequisites={},
+    requires={},
+    produces={},
+    auto_fix='none',
+    examples=[
+        'ov.single.download_cellphonedb_database()',
+        'ov.single.download_cellphonedb_database("/scratch/foo/cellphonedb.zip")',
+    ],
+    related=['single.cellphonedb_v5', 'single.validate_cpdb_database']
+)
 def download_cellphonedb_database(download_path=None, force_download=False):
     """
-    Download CellPhoneDB database with fallback URLs
-    
+    Download CellPhoneDB database with fallback URLs.
+
+    Uses ``ov.datasets.download_data_requests`` (the standard omicverse
+    downloader, with realistic User-Agent + tqdm progress + caching).
+
     Parameters
     ----------
     download_path:str or None
-        Target path of downloaded ``cellphonedb.zip`` file.
+        Target path of downloaded ``cellphonedb.zip`` file. If ``None``,
+        defaults to ``$OVAGENT_HOME/data_lake/cellphonedb.zip`` (so the
+        same cache is shared across ov.Agent sessions).
     force_download:bool
         Whether to redownload when file already exists.
 
@@ -796,63 +843,57 @@ def download_cellphonedb_database(download_path=None, force_download=False):
         Path to downloaded database archive.
     """
     import os
-    import urllib.request
-    import urllib.error
     from pathlib import Path
-    
+    from ..datasets._datasets import download_data_requests
+
     if download_path is None:
-        download_path = './cellphonedb.zip'
-    
+        try:
+            from ..utils._ovagent_paths import ovagent_home
+            download_path = ovagent_home() / "data_lake" / "cellphonedb.zip"
+        except Exception:
+            download_path = Path("./cellphonedb.zip")
+
     download_path = Path(download_path)
-    
-    # Check if file already exists
+
     if download_path.exists() and not force_download:
         print(f"✅ CellPhoneDB database already exists: {download_path}")
         return str(download_path)
-    
-    # URLs to try in order
+    if download_path.exists() and force_download:
+        download_path.unlink()
+
+    download_path.parent.mkdir(parents=True, exist_ok=True)
+
     download_urls = [
         "https://github.com/ventolab/cellphonedb-data/raw/refs/heads/master/cellphonedb.zip",
-        "https://starlit.oss-cn-beijing.aliyuncs.com/single/cellphonedb.zip"
+        "https://starlit.oss-cn-beijing.aliyuncs.com/single/cellphonedb.zip",
     ]
-    
+
     print("📥 Downloading CellPhoneDB database...")
-    
+    last_err = None
     for i, url in enumerate(download_urls, 1):
         try:
             print(f"   - Trying URL {i}/{len(download_urls)}: {url}")
-            
-            # Create directory if it doesn't exist
-            download_path.parent.mkdir(parents=True, exist_ok=True)
-            
-            # Download with progress
-            def show_progress(block_num, block_size, total_size):
-                if total_size > 0:
-                    percent = min(100, block_num * block_size * 100 / total_size)
-                    print(f"\r     Progress: {percent:.1f}%", end='', flush=True)
-            
-            urllib.request.urlretrieve(url, download_path, reporthook=show_progress)
-            print(f"\n✅ Successfully downloaded CellPhoneDB database to: {download_path}")
-            
-            # Verify file is not empty
-            if download_path.stat().st_size > 0:
-                return str(download_path)
-            else:
-                print(f"❌ Downloaded file is empty, trying next URL...")
-                download_path.unlink(missing_ok=True)
-                
-        except urllib.error.URLError as e:
-            print(f"\n❌ Failed to download from {url}: {e}")
-            download_path.unlink(missing_ok=True)
+            result = download_data_requests(
+                url=url,
+                file_path=download_path.name,
+                dir=str(download_path.parent),
+            )
+            if Path(result).stat().st_size > 0:
+                print(f"✅ Successfully downloaded CellPhoneDB database to: {result}")
+                return str(result)
+            Path(result).unlink(missing_ok=True)
+        except Exception as exc:
+            last_err = exc
+            print(f"   ✗ {url} failed: {exc}")
+            try:
+                download_path.unlink()
+            except FileNotFoundError:
+                pass
             continue
-        except Exception as e:
-            print(f"\n❌ Unexpected error downloading from {url}: {e}")
-            download_path.unlink(missing_ok=True)
-            continue
-    
+
     raise RuntimeError(
-        "Failed to download CellPhoneDB database from all available URLs. "
-        "Please check your internet connection or manually download the database."
+        "Failed to download CellPhoneDB database from all mirrors. "
+        f"Last error: {last_err}. Check network or pass cpdb_file_path= manually."
     )
 
 

--- a/omicverse/single/_tosica.py
+++ b/omicverse/single/_tosica.py
@@ -116,7 +116,7 @@ class pyTOSICA(object):
                  label_name:str='Celltype',mask_ratio:float=0.015,
                  max_g:int=300,max_gs:int=300,n_unannotated:int= 1,
                  embed_dim:int=48,depth:int=1,num_heads:int=4,batch_size:int=8,
-                 device:str='cuda:0'
+                 device:str='cuda:0',auto_download:bool=True,
                  ) -> None:
         r"""Initialize a pyTOSICA object for cell type classification.
 
@@ -187,9 +187,26 @@ class pyTOSICA(object):
             if '.gmt' in gmt_path:
                 gmt_path = gmt_path
             else:
-                gmt_path = tosica_backend["get_gmt"](gmt_path)
-                if gmt_path=="Error":
-                    print("You need to download the gene sets first using ov.utils.download_tosica_gmt()")
+                resolved = tosica_backend["get_gmt"](gmt_path)
+                if resolved == "Error":
+                    if auto_download:
+                        print("   - TOSICA GMT not found locally; auto-downloading via "
+                              "ov.utils.download_tosica_gmt()...")
+                        from ..utils._data import download_tosica_gmt
+                        download_tosica_gmt()
+                        resolved = tosica_backend["get_gmt"](gmt_path)
+                        if resolved == "Error":
+                            raise FileNotFoundError(
+                                f"TOSICA GMT '{gmt_path}' still missing after "
+                                "auto-download. Pass an explicit .gmt path."
+                            )
+                    else:
+                        raise FileNotFoundError(
+                            f"TOSICA GMT '{gmt_path}' not found. Call "
+                            "ov.utils.download_tosica_gmt() first or pass an "
+                            "explicit .gmt path."
+                        )
+                gmt_path = resolved
             
             reactome_dict = tosica_backend["read_gmt"](gmt_path, min_g=0, max_g=max_g)
             mask,pathway = tosica_backend["create_pathway_mask"](feature_list=genes,

--- a/omicverse/utils/_data.py
+++ b/omicverse/utils/_data.py
@@ -494,7 +494,7 @@ def download_tosica_gmt():
     ],
     related=["bulk.geneset_enrichment", "utils.download_tosica_gmt", "single.pathway_enrichment"]
 )
-def geneset_prepare(geneset_path,organism='Human',):
+def geneset_prepare(geneset_path,organism='Human',auto_download=True):
     r"""Load and prepare gene sets from GMT/TXT files for enrichment analysis.
 
     Parameters
@@ -503,6 +503,12 @@ def geneset_prepare(geneset_path,organism='Human',):
         Path to geneset file.
     organism : str
         Organism name used for gene-symbol case normalization.
+    auto_download : bool, default=True
+        If the path does not exist AND its basename matches a known
+        omicverse pathway resource (``GO_*_2021``, ``Reactome_2022``,
+        ``WikiPathway_2021_Human``, ``WikiPathways_2019_Mouse``), call
+        :func:`download_pathway_database` to fetch all standard genesets
+        into ``./genesets/`` and retry. Disable to fail fast offline.
 
     Returns
     -------
@@ -511,6 +517,21 @@ def geneset_prepare(geneset_path,organism='Human',):
     """
     result_dict = {}
     file_path=geneset_path
+    if auto_download and not os.path.exists(file_path):
+        known = {
+            'GO_Biological_Process_2021', 'GO_Cellular_Component_2021',
+            'GO_Molecular_Function_2021', 'WikiPathway_2021_Human',
+            'WikiPathways_2019_Mouse', 'Reactome_2022',
+        }
+        stem = os.path.splitext(os.path.basename(file_path))[0]
+        if stem in known:
+            print(f"   - Geneset '{stem}' missing locally; auto-downloading "
+                  f"via ov.utils.download_pathway_database()...")
+            download_pathway_database()
+            # download_pathway_database writes to ./genesets/
+            cand = os.path.join('./genesets', f'{stem}.txt')
+            if os.path.exists(cand):
+                file_path = cand
     with open(file_path, 'r', encoding='utf-8') as file:
         for idx,line in enumerate(file):
             line = line.strip()

--- a/omicverse/utils/_ovagent_paths.py
+++ b/omicverse/utils/_ovagent_paths.py
@@ -1,0 +1,27 @@
+"""Central resolver for ov.Agent storage root.
+
+Honors ``OVAGENT_HOME`` env var; falls back to ``~/.ovagent``. Lets users
+redirect all session / trace / context / notebook output to a scratch
+filesystem on hosts where /home is small or quota-constrained.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def ovagent_home() -> Path:
+    """Return the root directory for ov.Agent persistent state.
+
+    Resolution order:
+    1. ``$OVAGENT_HOME`` (if set and non-empty)
+    2. ``~/.ovagent``
+
+    The directory is **not** created here — callers append a subdir
+    (``runs``, ``sessions``, ``harness``, etc.) and `.mkdir(parents=True, exist_ok=True)`.
+    """
+    env = os.environ.get("OVAGENT_HOME", "").strip()
+    if env:
+        return Path(env).expanduser()
+    return Path.home() / ".ovagent"

--- a/omicverse/utils/agent_backend_openai.py
+++ b/omicverse/utils/agent_backend_openai.py
@@ -1367,6 +1367,12 @@ def _chat_tools_openai(
 
                 # Build raw message dict for re-injection into messages list
                 raw_msg = {"role": "assistant", "content": content}
+                # Preserve reasoning / thinking content (ollama, openai-o1, deepseek-r1).
+                # Without this, tool-call-only responses lose the model's chain-of-thought
+                # and the live trace shows only "decided to call N tool(s)".
+                _reasoning = getattr(msg, "reasoning", None) or getattr(msg, "reasoning_content", None)
+                if _reasoning:
+                    raw_msg["reasoning"] = _reasoning
                 if tc_list:
                     raw_msg["tool_calls"] = [
                         {

--- a/omicverse/utils/filesystem_context.py
+++ b/omicverse/utils/filesystem_context.py
@@ -136,7 +136,7 @@ class FilesystemContextManager:
         >>> relevant = ctx.get_relevant_context("dimensionality reduction")
     """
 
-    DEFAULT_BASE_DIR = Path.home() / ".ovagent" / "context"
+    DEFAULT_BASE_DIR = None  # resolved lazily via _ovagent_paths.ovagent_home()
     ENV_BASE_DIR = "OVAGENT_CONTEXT_DIR"
 
     # Categories for organizing notes
@@ -179,7 +179,8 @@ class FilesystemContextManager:
         elif env_base_dir:
             self.base_dir = Path(env_base_dir).expanduser()
         else:
-            self.base_dir = self.DEFAULT_BASE_DIR
+            from ._ovagent_paths import ovagent_home
+            self.base_dir = ovagent_home() / "context"
         self.session_id = session_id or self._generate_session_id()
         self.parent_session_id = parent_session_id
         self.max_notes_per_category = max_notes_per_category

--- a/omicverse/utils/harness/runtime_state.py
+++ b/omicverse/utils/harness/runtime_state.py
@@ -436,7 +436,7 @@ class RuntimeStateManager:
         output_root: Optional[Path] = None,
         max_output_chunks_per_task: int = 200,
     ) -> None:
-        self.output_root = Path(output_root or (Path.home() / ".ovagent" / "runtime_state"))
+        from .._ovagent_paths import ovagent_home as _oh; self.output_root = Path(output_root or (_oh() / "runtime_state"))
         self.output_root.mkdir(parents=True, exist_ok=True)
         self.max_output_chunks_per_task = max_output_chunks_per_task
         self._states: dict[str, SessionRuntimeState] = {}

--- a/omicverse/utils/harness/trace_store.py
+++ b/omicverse/utils/harness/trace_store.py
@@ -41,7 +41,7 @@ class RunTraceStore:
     """Filesystem-backed store for run traces and cleanup reports."""
 
     def __init__(self, root: Optional[Path] = None) -> None:
-        self.root = root or (Path.home() / ".ovagent" / "harness")
+        from .._ovagent_paths import ovagent_home as _oh; self.root = root or (_oh() / "harness")
         self.traces_dir = self.root / "traces"
         self.reports_dir = self.root / "reports"
         self.traces_dir.mkdir(parents=True, exist_ok=True)

--- a/omicverse/utils/ovagent/analysis_sandbox.py
+++ b/omicverse/utils/ovagent/analysis_sandbox.py
@@ -668,15 +668,33 @@ def build_sandbox_globals(ctx: "AgentContext") -> Dict[str, Any]:
         "openpyxl", "reportlab", "matplotlib", "seaborn",
         "scipy", "statsmodels", "sklearn",
     )
+    # Warn once per missing module instead of on every execute_code call —
+    # reportlab/openpyxl/etc. are optional skill modules; their absence is
+    # not actionable and the noise drowns out real errors in the trace.
+    global _SANDBOX_MODULE_WARNED
+    try:
+        _SANDBOX_MODULE_WARNED
+    except NameError:
+        _SANDBOX_MODULE_WARNED = set()
     for module_name in core_modules + skill_modules:
         try:
             allowed_modules[module_name] = __import__(module_name)
         except ImportError:
-            warnings.warn(
-                f"Module '{module_name}' is not available inside the agent sandbox.",
-                RuntimeWarning,
-                stacklevel=2,
-            )
+            if module_name not in _SANDBOX_MODULE_WARNED:
+                _SANDBOX_MODULE_WARNED.add(module_name)
+                # Demote optional skill modules to debug; only core is warning-worthy.
+                if module_name in core_modules:
+                    warnings.warn(
+                        f"Module '{module_name}' (core) is not available inside the agent sandbox.",
+                        RuntimeWarning,
+                        stacklevel=2,
+                    )
+                else:
+                    import logging as _lg
+                    _lg.getLogger(__name__).debug(
+                        "Optional sandbox module %r not installed (warned once); skipping.",
+                        module_name,
+                    )
 
     allowed_modules["os"] = SafeOsProxy()
 

--- a/omicverse/utils/ovagent/prompt_builder.py
+++ b/omicverse/utils/ovagent/prompt_builder.py
@@ -123,6 +123,53 @@ class PromptBuilder:
         if getattr(self._ctx, "_code_only_mode", False):
             engine.add_overlay(PromptOverlay("code_only_mode", CODE_ONLY_MODE, priority=80))
 
+        # Always-on: mandate registry-first workflow before any analysis code.
+        # Conditional rules ("if you use ov.* then search") get bypassed by
+        # models that fall back to plain scanpy/numpy. So we mandate UNCONDITIONALLY:
+        # Step 1 of every analysis MUST be search_functions to discover the
+        # specialist omicverse implementations the registry exposes.
+        engine.add_overlay(PromptOverlay(
+            "registry_first",
+            (
+                "MANDATORY WORKFLOW for any single-cell / spatial / multi-omics task:\n"
+                "  Step 1 (REQUIRED, FIRST tool call): call "
+                "search_functions(query=\"<task keywords>\") to discover the "
+                "omicverse functions designed for this task. The omicverse registry "
+                "contains 870 curated, GPU-aware, validated functions that handle "
+                "edge cases (sparse matrices, mt-prefix detection, version drift) "
+                "that handwritten scanpy/numpy code typically gets wrong.\n"
+                "  Step 2: prefer the ov.* functions returned by search_functions over "
+                "writing your own scanpy / numpy code. Falling back to handwritten "
+                "code is allowed ONLY after search_functions returns no relevant matches.\n"
+                "  Skipping Step 1 is a workflow violation that will fail the task."
+            ),
+            priority=10,    # Very high priority — render near the top of system prompt
+        ))
+
+        # Always-on: when a tool call fails with FileNotFoundError, missing-DB,
+        # or 'please download X first' messages, the model must search the
+        # function registry for the matching `download_*` helper before retrying
+        # the call or hand-coding a workaround. Many ov.* functions (cellphonedb_v5,
+        # TOSICA, geneset enrichment, gene-id mapping) require external reference
+        # files that have a paired `ov.*.download_*` function in the registry.
+        engine.add_overlay(PromptOverlay(
+            "missing_file_recovery",
+            (
+                "ERROR-RECOVERY RULE: if a tool call fails with one of:\n"
+                "  - FileNotFoundError\n"
+                "  - 'database not found' / 'please download'\n"
+                "  - 'missing required positional argument' for an *_path / *_file param\n"
+                "  - 'No such file or directory' for an external reference (genesets, "
+                "    cellphonedb DB, model checkpoint, GMT pathway file, gene-id annotation)\n"
+                "your NEXT tool call must be search_functions(query=\"download <missing thing>\") "
+                "to find the paired `download_*` helper, call that helper to fetch the file, "
+                "then retry the original call. Do NOT fabricate a path, write the algorithm "
+                "from scratch, or skip the step. Most ov.* functions that need a reference "
+                "file have a `ov.*.download_*` companion in the registry."
+            ),
+            priority=11,    # Just below registry_first
+        ))
+
         # Dynamic: skill listing overlay
         registry = self._ctx.skill_registry
         if registry is not None and getattr(registry, "skill_metadata", None):

--- a/omicverse/utils/ovagent/run_store.py
+++ b/omicverse/utils/ovagent/run_store.py
@@ -83,7 +83,7 @@ class RunStore:
     """Persist analysis runs under ``~/.ovagent/runs`` by default."""
 
     def __init__(self, root: Optional[Path] = None):
-        self.root = (root or (Path.home() / ".ovagent" / "runs")).expanduser()
+        from .._ovagent_paths import ovagent_home as _oh; self.root = (root or (_oh() / "runs")).expanduser()
         self.root.mkdir(parents=True, exist_ok=True)
 
     def _run_dir(self, run_id: str) -> Path:

--- a/omicverse/utils/ovagent/tool_runtime_exec.py
+++ b/omicverse/utils/ovagent/tool_runtime_exec.py
@@ -439,6 +439,22 @@ def handle_search_functions(ctx: "AgentContext", query: str) -> str:
     if not matches:
         return f"No functions found matching '{query}'. Try broader keywords."
 
+    # Live trace: surface registry ranking to the Reporter so users see what
+    # matched the query (top 10 by rank order returned by the registry).
+    try:
+        from ..agent_reporter import EventLevel as _EL
+        emit = getattr(ctx, "_emit", None)
+        if emit:
+            top = []
+            for i, m in enumerate(matches[:10]):
+                fname = m.get("full_name", m.get("short_name", "?"))
+                top.append(f"{i+1}. {fname}")
+            emit(_EL.INFO,
+                 f"🔎 search_functions(query={query!r}) → {len(matches)} matches; top: " + "; ".join(top),
+                 "registry_search")
+    except Exception:
+        pass
+
     results: List[str] = []
     for m in matches[:20]:
         fname = m.get("full_name", m.get("short_name", ""))

--- a/omicverse/utils/ovagent/tool_runtime_workspace.py
+++ b/omicverse/utils/ovagent/tool_runtime_workspace.py
@@ -173,7 +173,7 @@ def handle_enter_worktree(
             path, allow_relative=True
         )
     else:
-        worktree_root = Path.home() / ".ovagent" / "worktrees"
+        from .._ovagent_paths import ovagent_home as _oh; worktree_root = _oh() / "worktrees"
         worktree_root.mkdir(parents=True, exist_ok=True)
         worktree_path = worktree_root / branch.replace("/", "_")
     ctx._request_tool_approval(

--- a/omicverse/utils/ovagent/turn_controller.py
+++ b/omicverse/utils/ovagent/turn_controller.py
@@ -27,6 +27,7 @@ from ..harness import (
 from ..harness.runtime_state import runtime_state
 from ..harness.tool_catalog import normalize_tool_name
 from ..session_history import HistoryEntry
+from ..agent_errors import ProviderError
 
 from .context_budget import (
     BudgetSliceType,
@@ -653,7 +654,10 @@ class TurnController:
                         )
                         self._save_conversation_log(messages)
                         ctx._last_run_trace = recorder.trace
-                        return current_adata
+                        raise ProviderError(
+                            f"LLM chat call failed on turn {turn + 1}: {exc}",
+                            retryable=is_timeout,
+                        ) from exc
 
                 logger.info(
                     "agentic_llm_call_done turn=%d/%d elapsed_s=%.2f "
@@ -667,6 +671,41 @@ class TurnController:
 
                 if response.usage:
                     ctx.last_usage = response.usage
+
+                # Live trace: surface LLM-generated text + reasoning to the Reporter.
+                # Qwen3 thinking-mode and other reasoning models put their chain-of-thought
+                # in msg.reasoning (ollama, openai-o1) which our ChatResponse may drop.
+                # Pull from raw_message if present; emit content + reasoning + tool_call summary.
+                try:
+                    from ..agent_reporter import EventLevel as _EL
+                    raw = response.raw_message
+                    raw_dict = raw if isinstance(raw, dict) else {}
+                    if not raw_dict and isinstance(raw, list) and raw:
+                        for _item in raw:
+                            if isinstance(_item, dict) and _item.get("role") == "assistant":
+                                raw_dict = _item; break
+                    _reasoning = (raw_dict.get("reasoning")
+                                  or raw_dict.get("reasoning_content")
+                                  or "")
+                    _content = response.content or raw_dict.get("content") or ""
+                    _content = _content if isinstance(_content, str) else str(_content)
+                    if _reasoning:
+                        _r = str(_reasoning).strip()
+                        if len(_r) > 600:
+                            _r = _r[:600] + f"... [+{len(str(_reasoning)) - 600} chars]"
+                        ctx._emit(_EL.INFO, f"💭 thinking: {_r}", "llm_reasoning")
+                    if _content.strip():
+                        _t = _content.strip()
+                        if len(_t) > 600:
+                            _t = _t[:600] + f"... [+{len(_content) - 600} chars]"
+                        ctx._emit(_EL.INFO, f"💬 LLM: {_t}", "llm")
+                    if response.tool_calls:
+                        _names = ", ".join(tc.name for tc in response.tool_calls)
+                        ctx._emit(_EL.INFO,
+                                  f"🧠 LLM decided to call {len(response.tool_calls)} tool(s): {_names}",
+                                  "llm_decision")
+                except Exception:
+                    pass
 
                 if response.raw_message:
                     if isinstance(response.raw_message, list):
@@ -870,6 +909,20 @@ class TurnController:
                             },
                         )
                         _step_ids[sc.index] = tool_step_id
+                        # Live trace: surface tool call to user-visible Reporter.
+                        # Emits one line per dispatch with name + truncated args.
+                        try:
+                            from ..agent_reporter import EventLevel as _EL
+                            _args_preview = json.dumps(tc.arguments, default=str)
+                            if len(_args_preview) > 200:
+                                _args_preview = _args_preview[:200] + "..."
+                            ctx._emit(
+                                _EL.INFO,
+                                f"🔧 {canonical or tc.name}({_args_preview})",
+                                "tool_call",
+                            )
+                        except Exception:
+                            pass
                         await emitter.tool_dispatched(
                             canonical or tc.name,
                             tc.arguments,
@@ -1118,6 +1171,19 @@ class TurnController:
                                 category="tool",
                             )
                         )
+                        # Live trace: surface tool result to user-visible Reporter.
+                        try:
+                            from ..agent_reporter import EventLevel as _EL
+                            _out = tool_output if isinstance(tool_output, str) else str(tool_output)
+                            if len(_out) > 280:
+                                _out = _out[:280] + f"... [+{len(tool_output) - 280} chars]"
+                            ctx._emit(
+                                _EL.INFO,
+                                f"   ↳ {canonical or tc.name} → {_out}",
+                                "tool_result",
+                            )
+                        except Exception:
+                            pass
 
                         try:
                             parsed_tool_output = json.loads(tool_output)
@@ -1322,6 +1388,8 @@ class TurnController:
                         )
                     self._save_conversation_log(messages)
                     ctx._last_run_trace = recorder.trace
+                    if current_adata is None and final_summary:
+                        return final_summary
                     return current_adata
 
             # Post-loop
@@ -1377,6 +1445,8 @@ class TurnController:
                 )
             self._save_conversation_log(messages)
             ctx._last_run_trace = recorder.trace
+            if current_adata is None and final_summary:
+                return final_summary
             return current_adata
         except Exception as exc:
             recorder.add_step("error", summary=str(exc))

--- a/omicverse/utils/session_history.py
+++ b/omicverse/utils/session_history.py
@@ -37,7 +37,7 @@ class SessionHistory:
     """Append-only JSONL history file."""
 
     def __init__(self, path: Optional[Path] = None) -> None:
-        self._path = path or Path.home() / ".ovagent" / "history.jsonl"
+        from ._ovagent_paths import ovagent_home as _oh; self._path = path or (_oh() / "history.jsonl")
         self._path.parent.mkdir(parents=True, exist_ok=True)
 
     # ---- write ----

--- a/omicverse/utils/session_notebook_executor.py
+++ b/omicverse/utils/session_notebook_executor.py
@@ -80,7 +80,8 @@ class SessionNotebookExecutor:
     ):
         """Initialize SessionNotebookExecutor with configuration."""
         self.max_prompts_per_session = max_prompts_per_session
-        self.storage_dir = storage_dir or Path.home() / ".ovagent" / "sessions"
+        from ._ovagent_paths import ovagent_home
+        self.storage_dir = storage_dir or (ovagent_home() / "sessions")
         self.storage_dir.mkdir(exist_ok=True, parents=True)
         self.keep_notebooks = keep_notebooks
         self.timeout = timeout


### PR DESCRIPTION
## Summary

Three categories of improvements driven by failure modes observed when running ov.Agent / raw_llm / biomni against real single-cell tasks in benchmark conditions:

1. **Auto-download for missing reference files** — ov.* functions that need external references (CellPhoneDB DB, TOSICA pathway GMT, Cell Ontology OBO, gene-ID pair tables, geneset databases) now auto-fetch on first call instead of throwing FileNotFoundError. Each gains an `auto_download=True` kwarg that can be disabled to fail fast offline. Also fixes a stale figshare URL in `pancreas_cellrank` that returned a 2 KB HTML error page in an infinite redownload loop.
2. **Centralized `OVAGENT_HOME`** — new `omicverse.utils._ovagent_paths.ovagent_home()` (env-var with `~/.ovagent` fallback) threaded through filesystem context / harness / session / run / trace / notebook stores so users on hosts with quota-constrained `/home` can redirect to scratch.
3. **Live LLM trace** — `TurnController` now emits per-turn thinking / content / tool_calls to the Reporter, pulling reasoning from `raw_message["reasoning"]` so qwen3 / o1 / deepseek-r1 chain-of-thought is visible instead of silent dead air. Also raises `ProviderError` on LLM failure instead of silently returning unmodified adata.
4. **Mandatory prompt overlays** — `registry_first` (force `search_functions` first) and `missing_file_recovery` (search `download_*` on FileNotFoundError) made always-on; conditional advice was being bypassed by models that fall back to plain scanpy.
5. **Scanpy-convention obs aliases** — `ov.pp.qc.*` now mirrors its internal column names (`mito_perc` / `nUMIs` / `detected_genes`) under the standard scanpy names (`pct_counts_mt` / `n_counts` / `total_counts` / `n_genes_by_counts`) so LLM-generated code following scanpy tutorials interops without `KeyError`.

Detailed list of which functions changed is in the commit message.

## Test plan

- [ ] `ov.single.cellphonedb_v5(adata)` on a fresh `OVAGENT_HOME` auto-downloads the DB and runs end-to-end
- [ ] `ov.single.pyTOSICA(... gmt_path="...")` auto-downloads the GMT when missing
- [ ] `ov.single.CellOntologyMapper(cl_obo_file="cl.obo")` auto-downloads the ontology when missing
- [ ] `ov.bulk.Matrix_ID_mapping(df, "pair_GRCh38.tsv")` auto-downloads pairs into `./genesets/`
- [ ] `ov.utils.geneset_prepare("WikiPathway_2021_Human.txt")` auto-downloads pathway databases
- [ ] `ov.datasets.pancreas_cellrank()` resolves the new GitHub raw URL without redownload-loop
- [ ] `OVAGENT_HOME=/scratch/foo/.ovagent` redirects all session / trace / notebook output
- [ ] Running an ov.Agent task with a qwen3 / o1 / deepseek-r1 model surfaces `💭 thinking:` and `🧠 LLM decided to call N tool(s):` events in the Reporter
- [ ] Running with a model that fails its first call now reports `ProviderError` instead of silent success
- [ ] After `ov.pp.qc(...)`, `adata.obs['pct_counts_mt']` and `adata.obs['n_counts']` are populated alongside `mito_perc` / `nUMIs`
- [ ] Models that previously skipped `search_functions` and went straight to `numpy` now call `search_functions` first under the new `registry_first` overlay

🤖 Generated with [Claude Code](https://claude.com/claude-code)