### PR TITLE
fix: remove hardcoded user-specific paths and possible_paths fallback lists

### DIFF
--- a/omicverse/llm/UCE/data_proc/data_utils.py
+++ b/omicverse/llm/UCE/data_proc/data_utils.py
@@ -364,20 +364,14 @@ def get_spec_chrom_csv(path=None):
     Get the species to chrom csv file
     """
     if path is None:
-        # Try to find the CSV file in common locations
-        possible_paths = [
-            "/dfs/project/cross-species/yanay/code/all_to_chrom_pos.csv",  # Original default
-            "./all_to_chrom_pos.csv",
-            Path.cwd() / "all_to_chrom_pos.csv",
-        ]
-        
-        for possible_path in possible_paths:
-            if Path(possible_path).exists():
-                path = possible_path
-                break
-        
-        if path is None:
-            raise FileNotFoundError("Could not find all_to_chrom_pos.csv file in any expected location")
+        cwd_csv = Path.cwd() / "all_to_chrom_pos.csv"
+        if cwd_csv.exists():
+            path = str(cwd_csv)
+        else:
+            raise FileNotFoundError(
+                "all_to_chrom_pos.csv not found in current directory. Pass an "
+                "explicit path= or place the file at ./all_to_chrom_pos.csv."
+            )
     
     gene_to_chrom_pos = pd.read_csv(path)
     gene_to_chrom_pos["spec_chrom"] = pd.Categorical(gene_to_chrom_pos["species"] + "_" +  gene_to_chrom_pos["chromosome"]) # add the spec_chrom list

--- a/omicverse/single/_cpdb.py
+++ b/omicverse/single/_cpdb.py
@@ -601,30 +601,18 @@ def cellphonedb_v5(adata,
             except Exception:
                 cache_path = Path(os.path.expanduser("~/.omicverse/data_lake/cellphonedb.zip"))
 
-            possible_paths = [
-                str(cache_path),
-                './cellphonedb.zip',
-                '~/cellphonedb.zip',
-                '/oak/stanford/groups/xiaojie/steorra/software/cellphonedb.zip',
-            ]
-
-            for path in possible_paths:
-                expanded_path = os.path.expanduser(path)
-                if os.path.exists(expanded_path):
-                    cpdb_file_path = expanded_path
-                    break
-
-            if cpdb_file_path is None:
-                if auto_download:
-                    print("   - CellPhoneDB DB not found locally; auto-downloading...")
-                    cache_path.parent.mkdir(parents=True, exist_ok=True)
-                    cpdb_file_path = download_cellphonedb_database(str(cache_path))
-                else:
-                    raise FileNotFoundError(
-                        "CellPhoneDB database not found. Pass cpdb_file_path=, "
-                        "set auto_download=True, or call "
-                        "ov.single.download_cellphonedb_database() first."
-                    )
+            if cache_path.exists():
+                cpdb_file_path = str(cache_path)
+            elif auto_download:
+                print("   - CellPhoneDB DB not found locally; auto-downloading...")
+                cache_path.parent.mkdir(parents=True, exist_ok=True)
+                cpdb_file_path = download_cellphonedb_database(str(cache_path))
+            else:
+                raise FileNotFoundError(
+                    "CellPhoneDB database not found. Pass cpdb_file_path=, "
+                    "set auto_download=True, or call "
+                    "ov.single.download_cellphonedb_database() first."
+                )
         
         print(f"   - Using CellPhoneDB database: {cpdb_file_path}")
         
@@ -817,7 +805,7 @@ def create_cellchatviz_from_cpdb(cpdb_results, separator='|', palette=None):
     auto_fix='none',
     examples=[
         'ov.single.download_cellphonedb_database()',
-        'ov.single.download_cellphonedb_database("/scratch/foo/cellphonedb.zip")',
+        'ov.single.download_cellphonedb_database("./cellphonedb.zip")',
     ],
     related=['single.cellphonedb_v5', 'single.validate_cpdb_database']
 )


### PR DESCRIPTION
## Summary

Two functions were resolving a missing reference file by walking a hand-maintained list of fallback locations that included user-specific absolute paths. Replaced both with a single canonical lookup, so the resolution rule is:

1. Caller-provided path → use it
2. Else: a single well-known cache location → use it if present
3. Else: auto-download (where applicable) or raise FileNotFoundError

Concretely:

- `omicverse/single/_cpdb.py` — `cellphonedb_v5(...)` was trying four locations including `/oak/stanford/groups/xiaojie/steorra/software/cellphonedb.zip` (a leftover from earlier development on a Stanford GPU cluster). Now checks only `$OVAGENT_HOME/data_lake/cellphonedb.zip` and falls back to `download_cellphonedb_database` when `auto_download=True`. The registry example for `download_cellphonedb_database` also switched from `"/scratch/foo/cellphonedb.zip"` to `"./cellphonedb.zip"`.
- `omicverse/llm/UCE/data_proc/data_utils.py` — `get_spec_chrom_csv(...)` was trying `/dfs/project/cross-species/yanay/code/all_to_chrom_pos.csv` (the original UCE author's filesystem path, never present on any installed copy) before falling back to cwd. Now checks `cwd / all_to_chrom_pos.csv` only, raises a clear FileNotFoundError otherwise.

Why this matters: the multi-fallback pattern silently masks the real intent — there is one canonical place to look. Hardcoded absolute paths from a developer's machine are dead weight in upstream and confuse readers about where the file is *supposed* to be.

## Test plan

- [ ] `ov.single.cellphonedb_v5(adata)` on a fresh `OVAGENT_HOME` auto-downloads the DB and runs end-to-end
- [ ] `ov.single.cellphonedb_v5(adata, auto_download=False)` raises `FileNotFoundError` with an actionable message when the DB is missing
- [ ] `omicverse.llm.UCE.data_proc.data_utils.get_spec_chrom_csv()` resolves `./all_to_chrom_pos.csv` when present, raises `FileNotFoundError` when absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)