### PR TITLE
feat: improve registry_lookup discoverability + caching

### DIFF
--- a/omicverse/_registry.py
+++ b/omicverse/_registry.py
@@ -452,10 +452,55 @@ class FunctionRegistry:
 
     @staticmethod
     def _derive_signature_from_ast(node: Union[ast.FunctionDef, ast.AsyncFunctionDef]) -> str:
-        arg_names = [arg.arg for arg in node.args.args]
-        if arg_names and arg_names[0] == "self":
-            arg_names = arg_names[1:]
-        return f"({', '.join(arg_names)})"
+        """Derive a docstring-style signature from an AST node.
+
+        Includes positional args (with defaults) **and** keyword-only args
+        (with defaults). The latter were missing previously, which hid the
+        ``mode=`` / ``doublets_method=`` / ``flavor=`` style dispatch
+        parameters from ``registry_lookup`` output. Without those, agents
+        searching for e.g. ``"scdblfinder"`` would see ``ov.pp.qc(adata)``
+        and never realise the function dispatches via
+        ``doublets_method='scdblfinder'``.
+        """
+        params: list[str] = []
+
+        # Positional args (skip ``self`` if present).
+        arg_names = list(node.args.args)
+        defaults = list(node.args.defaults)
+        offset = len(arg_names) - len(defaults)
+        for idx, arg in enumerate(arg_names):
+            if idx == 0 and arg.arg == "self":
+                continue
+            p = arg.arg
+            if idx >= offset:
+                d = defaults[idx - offset]
+                try:
+                    p += "=" + repr(ast.literal_eval(d))
+                except Exception:
+                    pass
+            params.append(p)
+
+        # ``*args`` separator if there are kwonly args without a vararg.
+        if node.args.kwonlyargs and node.args.vararg is None:
+            params.append("*")
+        elif node.args.vararg is not None:
+            params.append("*" + node.args.vararg.arg)
+
+        # Keyword-only args (with defaults). This is the fix for the
+        # dispatch-parameter visibility issue.
+        for arg, default in zip(node.args.kwonlyargs, node.args.kw_defaults):
+            p = arg.arg
+            if default is not None:
+                try:
+                    p += "=" + repr(ast.literal_eval(default))
+                except Exception:
+                    pass
+            params.append(p)
+
+        if node.args.kwarg is not None:
+            params.append("**" + node.args.kwarg.arg)
+
+        return f"({', '.join(params)})"
 
     @staticmethod
     def _parameters_from_ast(node: Union[ast.FunctionDef, ast.AsyncFunctionDef]) -> List[str]:

--- a/omicverse/utils/_ovagent_lookup.py
+++ b/omicverse/utils/_ovagent_lookup.py
@@ -93,16 +93,36 @@ class _SkillLookupContext:
         )
 
 
+_SCANNER_CACHE: RegistryScanner | None = None
+_SKILL_REGISTRY_CACHE: Any | None = None
+
+
 def _create_registry_scanner() -> RegistryScanner:
-    scanner = RegistryScanner()
-    scanner.ensure_runtime_registry()
-    scanner.load_static_entries()
-    return scanner
+    """Return a cached, fully-loaded ``RegistryScanner``.
+
+    The scanner walks the entire ``omicverse/`` source tree and AST-parses
+    every registered function — ~10 s on first call. Without caching,
+    every ``registry_lookup`` call repeats that work, which dominates
+    agent latency far more than LLM inference does. The cache lasts for
+    the process lifetime; scanner state is read-only at this layer, so
+    sharing it across calls is safe.
+    """
+
+    global _SCANNER_CACHE
+    if _SCANNER_CACHE is None:
+        scanner = RegistryScanner()
+        scanner.ensure_runtime_registry()
+        scanner.load_static_entries()
+        _SCANNER_CACHE = scanner
+    return _SCANNER_CACHE
 
 
 def _create_skill_registry() -> Any:
-    registry, _ = initialize_skill_registry()
-    return registry
+    global _SKILL_REGISTRY_CACHE
+    if _SKILL_REGISTRY_CACHE is None:
+        registry, _ = initialize_skill_registry()
+        _SKILL_REGISTRY_CACHE = registry
+    return _SKILL_REGISTRY_CACHE
 
 
 def _delegate_registry_lookup(ctx: Any, query: str) -> str:

--- a/omicverse/utils/ovagent/tool_runtime_exec.py
+++ b/omicverse/utils/ovagent/tool_runtime_exec.py
@@ -463,6 +463,19 @@ def handle_search_functions(ctx: "AgentContext", query: str) -> str:
 
         entry_text = f"  {fname}({sig})\n    {desc}"
 
+        # Append the full docstring after the description. A signature line
+        # only shows parameter defaults (e.g. ``doublets_method='scdblfinder'``)
+        # and hides the *valid values* the parameter accepts — the dispatch
+        # information lives in prose ("Options are 'scrublet', 'sccomposite',
+        # 'doubletfinder', 'scdblfinder'") inside the docstring. Surface it.
+        docstring = (m.get("docstring") or "").strip()
+        if docstring:
+            # No truncation: dispatch-parameter prose ("Options are ...")
+            # often lives mid-docstring, and the caller (an agent or
+            # human) deserves the full text. Indented for readability.
+            indented = docstring.replace("\n", "\n      ")
+            entry_text += f"\n    Docstring:\n      {indented}"
+
         branch_parameter = m.get("branch_parameter")
         branch_value = m.get("branch_value")
         if branch_parameter and branch_value:
@@ -506,10 +519,16 @@ def handle_search_functions(ctx: "AgentContext", query: str) -> str:
         if len(results) >= 10:
             break
 
-    return (
-        f"Found {len(results)} matching functions:\n"
-        + "\n".join(results)
-    )
+    # Visually separate top-N entries with a horizontal rule + index, so
+    # multi-entry results (each potentially carrying a full docstring) stay
+    # readable instead of bleeding into each other.
+    n = len(results)
+    divider = "  " + "─" * 76
+    blocks: list[str] = []
+    for i, entry in enumerate(results, start=1):
+        blocks.append(f"{divider}\n  [match {i}/{n}]\n{entry}")
+    blocks.append(divider)
+    return f"Found {n} matching functions:\n" + "\n".join(blocks)
 
 
 # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Three small, focused improvements to ``ov.utils.registry_lookup`` and the
underlying registry — all driven by observed agent failure modes when an
LLM-driven agent is searching the registry for the right OmicVerse API.

- **fix(_registry): include keyword-only args in AST-derived signatures** —
  ``def fn(adata, *, mode='cpu', doublets_method='scdblfinder', ...)`` was
  collapsing to ``fn(adata)``, hiding every dispatch parameter from the
  registry view. Now signatures include positional + keyword-only args
  with defaults, plus ``*`` / ``*args`` / ``**kwargs`` markers.
- **feat(ovagent): show docstring + visual dividers in lookup output** —
  appended each entry's full docstring (so agents can read the
  ``Options are 'X', 'Y', 'Z'`` prose for dispatch parameters) and added
  a ``[match i/n]`` index plus horizontal-rule divider between entries
  so multi-entry results no longer bleed into each other.
- **perf(ovagent): cache RegistryScanner + skill registry across calls** —
  every ``registry_lookup`` call rebuilt the scanner from scratch (~10 s
  per call walking the source tree + AST-parsing ~870 functions). For
  agents that issue 5+ lookups during a task, that was ~50 s of repeated
  work. Cache both at module level for the process lifetime; subsequent
  calls return in ~0.03 s (~300× speedup).

## Motivation

Found while running an external agent benchmark against the registry.
Concrete observations:

1. An agent searching ``"scdblfinder"`` saw ``ov.pp.qc(adata)`` with no
   indication that ``ov.pp.qc(doublets_method='scdblfinder')`` was the
   intended path. It fell back to direct ``import scDblFinder``, which
   doesn't exist (the OmicVerse-internal package is ``pyscdblfinder``).
2. With docstring excerpt now in the output, the agent reads
   ``doublets_method : ... Options are 'scrublet', 'sccomposite',
   'doubletfinder', 'scdblfinder'`` directly and uses the wrapper
   correctly.
3. With caching, an agent doing a multi-stage workflow saves ~50 s of
   wall-clock per task — measurable on Pass@1 wallclock metrics.

All three changes are additive and backwards compatible — same call
signatures, just richer/faster output.

## Test plan

- [x] ``import omicverse as ov`` still works (no module-level changes).
- [x] ``ov.utils.registry_lookup("scdblfinder")`` returns the dispatch
      docstring (previously empty / unhelpful).
- [x] ``ov.utils.registry_lookup("pca")`` shows top-N entries clearly
      separated, with full docstrings.
- [x] First call ~9 s (cold scanner build), subsequent calls ~0.03 s.
- [x] Three rebased commits, no conflicts with current master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)