### PR TITLE
chore(deps): bump omicverse-skills to >=0.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ dependencies = [
     'marsilea!=0.5.6',
     #'wandb',
     'openai>=1.0',
-    'omicverse-skills>=0.2.0',
+    'omicverse-skills>=0.3.0',
     'omicverse-notebook>=0.1.4',
     #'cvxpy>=1.3',
     'zarr<3.0.0',


### PR DESCRIPTION
## Summary

[omicverse-skills v0.3.0](https://pypi.org/project/omicverse-skills/0.3.0/) was published today. This PR pins the minimum dependency so omicverse users automatically pick up the new skill catalog.

## What v0.3.0 ships (high-level)

- **+17 B-tier skills** (60 total — up 60%):
  - **Metabolomics (4)**: preprocessing / multivariate / untargeted+lipidomics / pathway+multifactor
  - **Microbiome (5)**: 16S amplicon+DADA2 / DA comparison / meta-analysis / phylogeny / micro-metabol-paired
  - **Trajectory (3)**: monocle2 / VIA (+velocity) / cellrank fate
  - **CCC**: LIANA
  - **Annotation extras (3)**: MetaTiME / CellMatch (Cell Ontology) / CellVote (consensus)
  - **Bulk cell-type deconvolution**: TAPE / Scaden / BayesPrism / OmicsTweezer
- **+ `omicverse_skills.notebook_index`** module — skill ↔ tutorial fingerprinting (md5 + mtime + git) with a `check_freshness` CLI. Lets downstream tooling detect when an upstream tutorial change warrants re-reviewing the corresponding skill.
- Extensions to existing skills: `spatial-tutorials` (+ Xenium preprocessing + FlashDeconv backend), `plotting-visualization` (+ `ov.pl.plot1cell`).

## API compatibility

The v0.2.0 → v0.3.0 step is purely additive on the public surface that omicverse imports today (`omicverse_skills.{list_skills, load_skill_text, skill_root}`, used in `omicverse/utils/skill_registry.py`). No removals, no signature changes. Newly exposed: `load_index`, `index_path`, `check_freshness`, `format_freshness_report`, `build_index`, `SKILL_NOTEBOOK_MAP`.

## Test plan

- [x] One-line change in `pyproject.toml` (`>=0.2.0` → `>=0.3.0`); no behaviour to test
- [ ] CI install resolves omicverse-skills==0.3.0 from PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)