### PR TITLE
feat: read_atera (10x Atera reader) + registry-discoverable pyWGCNA shim

### DIFF
--- a/omicverse/bulk/__init__.py
+++ b/omicverse/bulk/__init__.py
@@ -58,9 +58,12 @@ bind_optional_symbols(
 
 def __getattr__(name):
     if name in {"pyWGCNA", "readWGCNA"}:
-        from . import _Gene_module as gene_module
+        # `_wgcna` is the discoverable shim — same runtime behaviour as
+        # the upstream PyWGCNA class, but carries the @register_function
+        # metadata the scanner indexes (the scanner skips `external/`).
+        from . import _wgcna
 
-        return getattr(gene_module, name)
+        return getattr(_wgcna, name)
     raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
 
 __all__ = [

--- a/omicverse/bulk/_wgcna.py
+++ b/omicverse/bulk/_wgcna.py
@@ -1,0 +1,261 @@
+"""Weighted Gene Co-expression Network Analysis registry shim.
+
+The full implementation lives in :mod:`omicverse.external.PyWGCNA` (vendored
+from the upstream PyWGCNA package). The registry scanner intentionally
+ignores everything under ``external/`` to keep third-party code out of the
+public API surface, so a class registered there is invisible to
+``ov.utils.registry_lookup``.
+
+This module re-publishes :class:`pyWGCNA` and :func:`readWGCNA` under the
+canonical ``ov.bulk`` namespace and attaches the ``@register_function``
+metadata that the scanner indexes — making the function discoverable to
+agents searching for ``"wgcna"`` / ``"co-expression"`` / similar queries.
+
+The ``external`` import is **deferred to call time** so that simply
+importing :mod:`omicverse.bulk` never pulls in PyWGCNA's optional
+dependencies (CI on minimal environments stays green; the scanner only
+needs the AST of this file, not its imports).
+"""
+
+from __future__ import annotations
+
+from .._registry import register_function
+
+
+@register_function(
+    aliases=[
+        "pyWGCNA",
+        "WGCNA",
+        "wgcna",
+        "wgcna_analysis",
+        "co-expression network",
+        "gene co-expression",
+        "weighted gene co-expression network analysis",
+        "module detection",
+        "WGCNA分析",
+        "加权基因共表达网络",
+    ],
+    category="bulk",
+    description=(
+        "Weighted Gene Co-expression Network Analysis. Detects co-expression "
+        "modules from a samples × genes expression matrix, computes module "
+        "eigengenes and module-trait correlations. Wraps the vendored "
+        "PyWGCNA implementation."
+    ),
+    examples=[
+        "import omicverse as ov, pandas as pd",
+        "data = pd.read_csv('expressionList.csv', index_col=0)  # rows=samples, cols=genes",
+        "wgcna = ov.bulk.pyWGCNA(name='MyAnalysis', species='mus musculus', geneExp=data.T, save=True)",
+        "wgcna.preprocess()       # filter low-expressed genes / outlier samples",
+        "wgcna.findModules()      # soft-threshold + dynamic tree cut",
+        "wgcna.analyseWGCNA()     # module-trait correlations against sample metadata",
+    ],
+    related=["ov.bulk.readWGCNA", "ov.bulk.pyDEG", "ov.bulk.geneset_enrichment"],
+)
+class pyWGCNA:
+    """Weighted Gene Co-expression Network Analysis.
+
+    Identifies highly co-expressed gene modules and relates them to clinical
+    traits / sample metadata. Standard WGCNA workflow:
+
+    1. **Preprocess** — remove low-expressed genes (TPM cutoff) and outlier
+       samples (Euclidean distance to mean).
+    2. **Soft-thresholding** — pick a power that yields scale-free topology
+       in the gene-gene correlation network.
+    3. **Adjacency + TOM** — adjacency = ``|cor|^power``; topological
+       overlap matrix (TOM) measures shared neighbourhood.
+    4. **Dynamic tree cut** — hierarchical clustering on ``1 - TOM``; tree
+       cut yields gene modules (named by colour).
+    5. **Module eigengenes** — first principal component of each module's
+       expression matrix.
+    6. **Module-trait correlation** — Pearson correlation of each module
+       eigengene against numeric sample traits, with FDR-corrected p-values.
+
+    Parameters
+    ----------
+    name : str
+        Analysis label, used for output file names.
+    species : str
+        Organism (e.g. ``"mus musculus"``, ``"homo sapiens"``).
+    geneExp : pandas.DataFrame
+        Expression matrix shaped (genes × samples). Sample identifiers are
+        the column names, gene identifiers are the index. Note this is the
+        TRANSPOSE of the typical samples × genes layout used by AnnData.
+    TPMcutoff : float, default 1
+        Per-gene TPM threshold; genes whose maximum across samples falls
+        below this are dropped during ``preprocess``.
+    powers : list[int], optional
+        Candidate soft-threshold powers. Defaults to a 1–30 sweep.
+    networkType : {"signed", "unsigned", "signed hybrid"}
+        How adjacency is computed from correlation.
+    minModuleSize : int, default 50
+        Smallest module size kept by the dynamic tree cut.
+    save : bool, default False
+        Whether to persist results to disk.
+
+    Notes
+    -----
+    Wide expression CSVs are usually shaped samples × genes; remember to
+    pass ``data.T`` so the constructor receives genes × samples.
+
+    Methods (call in this order — each step populates the attributes
+    listed under it). Use the high-level :meth:`runWGCNA` to chain
+    everything end-to-end, or the explicit methods below for finer
+    control:
+
+    - ``preprocess()`` — drop low-TPM genes, drop outlier samples
+      (updates ``self.datExpr``).
+    - ``calculate_soft_threshold()`` — scale-free fit power scan; sets
+      ``self.power`` (int, **not** ``self.softPower``) and ``self.sft``
+      (DataFrame with R²/slope/k per power).
+    - ``calculating_adjacency_matrix()`` — sets ``self.adjacency``.
+    - ``calculating_TOM_similarity_matrix()`` — sets ``self.TOM``.
+    - ``calculate_geneTree()`` — sets ``self.geneTree`` (linkage matrix).
+    - ``calculate_dynamicMods(kwargs_function={...})`` — sets
+      ``self.dynamicMods`` and ``self.datExpr.var['dynamicColors']``.
+    - ``calculate_gene_module(kwargs_function={...})`` — merges close
+      modules, sets ``self.datExpr.var['moduleColors']``,
+      ``self.datExpr.var['moduleLabels']``, ``self.MEs``, ``self.datME``.
+    - ``findModules()`` — convenience that runs the soft-threshold +
+      adjacency + TOM + tree + module merge as one call (preferred).
+    - ``runWGCNA()`` — runs ``preprocess()`` then ``findModules()``.
+    - ``analyseWGCNA(geneList=None)`` — module–trait correlation; sets
+      ``self.moduleTraitCor`` and ``self.moduleTraitPvalue``.
+      Requires sample metadata (set via ``updateSampleInfo(...)`` or
+      passed via ``sampleInfo`` at construction).
+
+    Attributes (state machine — populated in this order). The class is
+    a thin shim that delegates to the upstream PyWGCNA implementation;
+    these are the **actual attribute names** on the returned instance,
+    which agents commonly mis-spell:
+
+    - ``self.geneExpr`` — AnnData (genes × samples) holding the
+      original input expression.
+    - ``self.datExpr`` — AnnData (genes × samples), filtered after
+      ``preprocess()``. Per-gene module annotations live on
+      ``self.datExpr.var``.
+    - ``self.power`` (int) — chosen soft-threshold power. **The
+      attribute is ``power``, NOT ``softPower``.** Set after
+      ``calculate_soft_threshold()`` or ``findModules()``; before that
+      it is ``0``.
+    - ``self.sft`` (pandas.DataFrame) — scale-free fit table per
+      candidate power (columns: ``Power``, ``SFT.R.sq``, ``slope``,
+      ``mean(k)``, …). Set together with ``self.power``.
+    - ``self.adjacency`` (pandas.DataFrame) — gene-gene weighted
+      adjacency. ``None`` until ``calculating_adjacency_matrix()`` /
+      ``findModules()`` runs.
+    - ``self.TOM`` (numpy.ndarray) — topological overlap matrix.
+      ``None`` until ``calculating_TOM_similarity_matrix()`` /
+      ``findModules()`` runs.
+    - ``self.geneTree`` — scipy linkage matrix from ``1 - TOM``.
+    - ``self.dynamicMods`` — initial dynamic-tree-cut module integer
+      labels per gene.
+    - ``self.datExpr.var['dynamicColors']`` — initial module colour per
+      gene (string, e.g. ``'turquoise'``).
+    - ``self.datExpr.var['moduleColors']`` — final module colour per
+      gene (after merging close modules). Use this for downstream.
+    - ``self.datExpr.var['moduleLabels']`` — integer label per gene
+      aligned to ``moduleColors``.
+    - ``self.MEs`` (pandas.DataFrame) — module eigengenes, samples ×
+      modules. **Do not compute this manually** — the class already
+      provides it; manual mean-by-mask is not equivalent (eigengene =
+      first PC of the module's expression, not the mean).
+    - ``self.datME`` — pre-merge eigengene matrix; usually
+      ``self.MEs`` is what you want.
+    - ``self.moduleTraitCor`` (pandas.DataFrame) — module × trait
+      Pearson correlations. ``None`` until ``analyseWGCNA()`` runs.
+    - ``self.moduleTraitPvalue`` (pandas.DataFrame) — parallel p-value
+      table. ``None`` until ``analyseWGCNA()`` runs.
+
+    Examples
+    --------
+    >>> import pandas as pd, omicverse as ov
+    >>> data = pd.read_csv('expressionList.csv', index_col=0)
+    >>> wgcna = ov.bulk.pyWGCNA(
+    ...     name='5xFAD',
+    ...     species='mus musculus',
+    ...     geneExp=data.T,            # transpose to genes × samples
+    ...     TPMcutoff=1,
+    ...     networkType='signed hybrid',
+    ... )
+    >>> wgcna.preprocess()
+    >>> wgcna.findModules()
+    """
+
+    def __new__(
+        cls,
+        name="WGCNA",
+        TPMcutoff=1,
+        powers=None,
+        RsquaredCut=0.9,
+        MeanCut=100,
+        networkType="signed hybrid",
+        TOMType="signed",
+        minModuleSize=50,
+        naColor="grey",
+        cut=float("inf"),
+        MEDissThres=0.2,
+        species=None,
+        level="gene",
+        anndata=None,
+        geneExp=None,
+        geneExpPath=None,
+        sep=",",
+        geneInfo=None,
+        sampleInfo=None,
+        save=False,
+        outputPath=None,
+        figureType="pdf",
+    ):
+        # Lazy import — keeps `external/` off `bulk` import path, so CI
+        # without PyWGCNA's optional deps still imports `omicverse.bulk`
+        # cleanly. The registry scanner only needs this file's AST, not
+        # its imports, so the discoverability is unaffected.
+        from ..external.PyWGCNA.wgcna import pyWGCNA as _impl
+        return _impl(
+            name=name,
+            TPMcutoff=TPMcutoff,
+            powers=powers,
+            RsquaredCut=RsquaredCut,
+            MeanCut=MeanCut,
+            networkType=networkType,
+            TOMType=TOMType,
+            minModuleSize=minModuleSize,
+            naColor=naColor,
+            cut=cut,
+            MEDissThres=MEDissThres,
+            species=species,
+            level=level,
+            anndata=anndata,
+            geneExp=geneExp,
+            geneExpPath=geneExpPath,
+            sep=sep,
+            geneInfo=geneInfo,
+            sampleInfo=sampleInfo,
+            save=save,
+            outputPath=outputPath,
+            figureType=figureType,
+        )
+
+
+def readWGCNA(file):
+    """Load a previously saved WGCNA object from disk.
+
+    Lazy wrapper around :func:`omicverse.external.PyWGCNA.utils.readWGCNA`.
+
+    Parameters
+    ----------
+    file : str
+        Path to the pickled object produced by ``pyWGCNA.saveWGCNA(...)``.
+
+    Returns
+    -------
+    pyWGCNA
+        Restored analysis object with all attributes (``datExpr``,
+        ``MEs``, ``moduleTraitCor`` …) populated.
+    """
+    from ..external.PyWGCNA.utils import readWGCNA as _impl
+    return _impl(file)
+
+
+__all__ = ["pyWGCNA", "readWGCNA"]

--- a/omicverse/io/spatial/__init__.py
+++ b/omicverse/io/spatial/__init__.py
@@ -1,5 +1,6 @@
 r"""I/O utilities for spatial omics datasets."""
 
+from ._atera import read_atera
 from ._nanostring import read_nanostring
 from ._visium import read_visium
 from ._visium_hd import read_visium_hd, read_visium_hd_bin, read_visium_hd_seg, write_visium_hd_cellseg
@@ -13,4 +14,5 @@ __all__ = [
     "write_visium_hd_cellseg",
     "read_nanostring",
     "read_xenium",
+    "read_atera",
 ]

--- a/omicverse/io/spatial/_atera.py
+++ b/omicverse/io/spatial/_atera.py
@@ -1,0 +1,570 @@
+"""10x Atera (WTA Preview) reader for OmicVerse spatial I/O.
+
+Atera ships a Xenium-compatible ``outs/`` bundle with three additions worth
+calling out:
+
+1. ``nucleus_boundaries.parquet`` — per-cell nucleus polygon vertices, in the
+   same long-table format as ``cell_boundaries.parquet``.
+2. ``morphology_focus/`` — multi-channel stain images named by content
+   (``ch0000_dapi.ome.tif``, ``ch0001_atp1a1_cd45_e-cadherin.ome.tif``,
+   ``ch0002_18s.ome.tif``, ``ch0003_alphasma_vimentin.ome.tif``) rather than
+   the Xenium V2 ``morphology_focus_NNNN.ome.tif`` pattern.
+3. Optional companion files shipped alongside ``outs/`` (not inside it):
+
+   - ``*_cell_groups.csv``: cell_id → cell-type label + display colour for the
+     vendor's pre-computed segmentation classifier.
+   - ``*_he_image.ome.tif`` + ``*_he_alignment.csv``: a registered H&E whole-slide
+     image and the 3×3 affine that maps H&E pixel coords → Atera spatial
+     (micron) coords.
+
+The pipeline metadata (``experiment.xenium``) and ``cell_feature_matrix.h5``
+schema are identical to Xenium, so the matrix / centroid / cell-boundary path
+reuses helpers from :mod:`._xenium`.
+"""
+
+from __future__ import annotations
+
+import warnings
+from pathlib import Path
+from typing import Any, Optional, Union
+
+import numpy as np
+import pandas as pd
+from anndata import AnnData
+
+from ..._registry import register_function
+from ..single import read_10x_h5
+from ._xenium import (
+    Colors,
+    _boundaries_to_wkt,
+    _load_experiment_metadata,
+    _read_cells_table,
+    _resolve,
+)
+
+
+def _progress(message: str, level: str = "info") -> None:
+    color = Colors.CYAN
+    if level == "success":
+        color = Colors.GREEN
+    elif level == "warn":
+        color = Colors.WARNING
+    print(f"{color}[Atera] {message}{Colors.ENDC}")
+
+
+# Atera ships morphology stains with descriptive filenames. Lower-cased substrings
+# (without the ``ch####_`` index prefix) used for ``image_key`` matching.
+_ATERA_MORPHOLOGY_TAGS = {
+    "dapi":     ["dapi"],
+    "boundary": ["atp1a1", "cd45", "e-cadherin", "ecadherin", "boundary"],
+    "rna":      ["18s", "rna"],
+    "stroma":   ["alphasma", "vimentin", "stroma"],
+}
+
+
+def _nucleus_boundaries_to_wkt(
+    root: Path,
+    cell_index: pd.Index,
+) -> Optional[pd.Series]:
+    """Atera-specific nucleus polygons. Same schema as ``cell_boundaries.parquet``;
+    we just point ``_boundaries_to_wkt`` at a different filename via a temporary
+    rename-style resolver. Re-implemented inline (rather than parameterising
+    :func:`._xenium._boundaries_to_wkt`) to keep that function's contract narrow.
+    """
+    path = _resolve(root, "nucleus_boundaries.parquet",
+                    "nucleus_boundaries.csv.gz", "nucleus_boundaries.csv")
+    if path is None:
+        return None
+    try:
+        bnd = pd.read_parquet(path) if path.suffix == ".parquet" else pd.read_csv(path)
+    except Exception as exc:  # pragma: no cover
+        warnings.warn(f"Failed to read nucleus boundaries ({path.name}): {exc}")
+        return None
+
+    id_col = next((c for c in ("cell_id", "cellID", "CellID", "cell_ID") if c in bnd.columns), None)
+    if id_col is None or "vertex_x" not in bnd.columns or "vertex_y" not in bnd.columns:
+        warnings.warn(
+            f"Unexpected columns in {path.name}: {list(bnd.columns)}; expected "
+            "`cell_id`, `vertex_x`, `vertex_y`."
+        )
+        return None
+    bnd[id_col] = bnd[id_col].astype(str)
+    grouped = bnd.groupby(id_col, sort=False)[["vertex_x", "vertex_y"]]
+
+    def _to_wkt(block: pd.DataFrame) -> str:
+        xs = block["vertex_x"].to_numpy()
+        ys = block["vertex_y"].to_numpy()
+        if len(xs) < 3:
+            return ""
+        if xs[0] != xs[-1] or ys[0] != ys[-1]:
+            xs = np.append(xs, xs[0])
+            ys = np.append(ys, ys[0])
+        parts = ", ".join(f"{x:.4f} {y:.4f}" for x, y in zip(xs, ys))
+        return f"POLYGON (({parts}))"
+
+    wkts = grouped.apply(_to_wkt)
+    wkts.index = wkts.index.astype(str)
+    return wkts.reindex(cell_index.astype(str)).fillna("")
+
+
+def _list_atera_morphology_channels(root: Path) -> list[Path]:
+    """Atera channel files are ``morphology_focus/chNNNN_<tag>.ome.tif``."""
+    focus_dir = root / "morphology_focus"
+    if not focus_dir.is_dir():
+        return []
+    return sorted(focus_dir.glob("ch*.ome.tif"))
+
+
+def _select_morphology_channel(channels: list[Path], image_key: str) -> Optional[Path]:
+    """Resolve ``image_key`` against Atera's descriptive filenames.
+
+    ``image_key`` may be:
+
+    - A semantic tag (``'dapi'``, ``'boundary'``, ``'rna'``, ``'stroma'``).
+    - A substring of the filename (case-insensitive), e.g. ``'18s'``,
+      ``'alphasma'``, ``'cd45'``.
+    - An integer index as a string (``'0'`` … ``'3'``).
+    - ``'morphology_focus'`` / ``'morphology'`` — falls back to channel 0 (DAPI).
+
+    Returns the first matching channel path, or ``None`` if nothing matches.
+    """
+    if not channels:
+        return None
+
+    key = image_key.strip().lower()
+
+    # Index-based selection ("0" → channels[0]).
+    if key.isdigit():
+        idx = int(key)
+        if 0 <= idx < len(channels):
+            return channels[idx]
+        return None
+
+    if key in {"morphology_focus", "morphology", "morphology_mip"}:
+        return channels[0]
+
+    # Semantic tag (dapi / boundary / rna / stroma).
+    tag_substrings = _ATERA_MORPHOLOGY_TAGS.get(key, [key])
+    for cand in channels:
+        name = cand.name.lower()
+        if any(sub in name for sub in tag_substrings):
+            return cand
+    return None
+
+
+def _load_pyramid_tiff(
+    path: Path,
+    max_dim: int = 4096,
+) -> Optional[tuple[np.ndarray, float]]:
+    """Load the highest-resolution OME-TIFF pyramid level fitting under ``max_dim``.
+
+    Returns ``(image_array, downsample)`` where ``downsample = chosen_h / full_h``
+    so micron coordinates can still be mapped into image-pixel space after
+    downsampling. Returns ``None`` when the file is missing or ``tifffile`` is
+    unavailable.
+
+    Atera ``morphology_focus/`` channel files cross-reference each other through
+    OME XML. tifffile then opens the series in *multi-file* mode and refuses to
+    walk the pyramid (``"OME series cannot read multi-file pyramids"``), so we
+    pass ``is_ome=False`` to read each file as a standalone TIFF — the per-file
+    pyramid IFDs are still exposed via ``series.levels``.
+    """
+    try:
+        import tifffile
+    except ImportError:
+        warnings.warn(
+            "tifffile not installed — skipping image load. "
+            "`pip install tifffile` to enable morphology / H&E overlay."
+        )
+        return None
+    try:
+        with tifffile.TiffFile(path, is_ome=False) as tif:
+            series = tif.series[0]
+            levels = getattr(series, "levels", None) or [series]
+            full_h, full_w = levels[0].shape[-2:]
+            target_idx = 0
+            for i, lvl in enumerate(levels):
+                h, w = lvl.shape[-2:]
+                if max(h, w) <= max_dim:
+                    target_idx = i
+                    break
+            else:
+                target_idx = len(levels) - 1
+            arr = levels[target_idx].asarray()
+        # Strip leading singleton axes (e.g. (1, H, W) or (1, 1, H, W)) without
+        # collapsing real RGB channels; H&E is (H, W, 3).
+        while arr.ndim > 3:
+            arr = arr[0]
+        if arr.ndim == 3 and arr.shape[0] in (1, 2, 3, 4) and arr.shape[-1] not in (3, 4):
+            # (C, H, W) → (H, W, C) for RGB; otherwise pick channel 0 for stains.
+            if arr.shape[0] in (3, 4):
+                arr = np.moveaxis(arr, 0, -1)
+            else:
+                arr = arr[0]
+        downsample = arr.shape[0] / full_h if full_h else 1.0
+        return arr, float(downsample)
+    except Exception as exc:
+        warnings.warn(f"Failed to read {path.name}: {exc}")
+        return None
+
+
+def _load_he_alignment(path: Path) -> Optional[np.ndarray]:
+    """Read the 3×3 affine matrix from ``*_he_alignment.csv`` (no header).
+
+    The matrix maps **H&E pixel coords (x, y, 1) → Atera spatial (micron) coords**.
+    Returned in row-major form; callers invert it when overlaying H&E behind a
+    micron-coord scatter.
+    """
+    try:
+        # Atera's alignment CSV has no header — three lines of three floats.
+        mat = pd.read_csv(path, header=None).to_numpy(dtype=np.float64)
+    except Exception as exc:  # pragma: no cover
+        warnings.warn(f"Failed to read H&E alignment {path.name}: {exc}")
+        return None
+    if mat.shape != (3, 3):
+        warnings.warn(
+            f"Expected 3×3 affine in {path.name}, got shape {mat.shape}; ignoring."
+        )
+        return None
+    return mat
+
+
+def _merge_cell_groups(
+    adata: AnnData,
+    csv_path: Path,
+) -> int:
+    """Merge an Atera ``*_cell_groups.csv`` (cell_id, group, color) into ``obs``.
+
+    Adds ``obs['cell_group']`` (categorical) and ``obs['cell_group_color']``.
+    Returns the number of cells matched (cells absent from the CSV get NaN).
+    """
+    df = pd.read_csv(csv_path)
+    expected = {"cell_id", "group", "color"}
+    if not expected.issubset(df.columns):
+        warnings.warn(
+            f"{csv_path.name} columns {list(df.columns)} do not match expected "
+            f"{sorted(expected)}; skipping cell-group merge."
+        )
+        return 0
+    df["cell_id"] = df["cell_id"].astype(str)
+    df = df.drop_duplicates("cell_id").set_index("cell_id")
+    cells = adata.obs_names.astype(str)
+    matched = cells.isin(df.index)
+    adata.obs["cell_group"] = pd.Categorical(df["group"].reindex(cells).to_numpy())
+    adata.obs["cell_group_color"] = df["color"].reindex(cells).to_numpy()
+    return int(matched.sum())
+
+
+@register_function(
+    aliases=["read_atera", "atera", "10x atera", "wta", "wta preview", "读取atera"],
+    category="io",
+    description=(
+        "Read a 10x Genomics Atera (Whole-Transcriptome Atlas Preview) outs bundle. "
+        "Mirrors read_xenium plus nucleus polygons, multi-channel morphology "
+        "selection, optional H&E image + affine, and optional cell-groups CSV merge."
+    ),
+    prerequisites={},
+    requires={},
+    produces={},
+    auto_fix="none",
+    examples=[
+        "adata = ov.io.spatial.read_atera('/path/to/outs/')",
+        "adata = ov.io.spatial.read_atera(",
+        "    '/path/to/outs/',",
+        "    image_key='boundary',  # ATP1A1+CD45+E-Cadherin stain",
+        "    cell_groups_csv='/path/to/cell_groups.csv',",
+        "    he_image='/path/to/he_image.ome.tif',",
+        "    he_alignment_csv='/path/to/he_alignment.csv',",
+        ")",
+    ],
+    related=["io.spatial.read_xenium", "io.spatial.read_visium_hd"],
+)
+def read_atera(
+    path: Union[str, Path],
+    *,
+    library_id: Optional[str] = None,
+    load_image: bool = True,
+    image_key: str = "dapi",
+    image_max_dim: int = 4096,
+    load_boundaries: bool = True,
+    load_nucleus_boundaries: bool = True,
+    cell_groups_csv: Optional[Union[str, Path]] = None,
+    he_image: Optional[Union[str, Path]] = None,
+    he_alignment_csv: Optional[Union[str, Path]] = None,
+    he_max_dim: int = 4096,
+    cache_file: Optional[Union[str, Path]] = None,
+) -> AnnData:
+    """Read a 10x Atera ``outs`` directory into an AnnData object.
+
+    Atera (WTA Preview) ships an Xenium-compatible bundle plus a nucleus
+    polygon file and per-content-named morphology channels:
+
+    .. code-block:: text
+
+        outs/
+          cell_feature_matrix.h5
+          cells.parquet                          # per-cell metadata + centroids
+          cell_boundaries.parquet                # cell polygon vertices
+          nucleus_boundaries.parquet             # nucleus polygon vertices (Atera-only)
+          experiment.xenium                      # pipeline metadata (JSON)
+          morphology.ome.tif                     # full multi-z stack (large)
+          morphology_focus/
+            ch0000_dapi.ome.tif
+            ch0001_atp1a1_cd45_e-cadherin.ome.tif
+            ch0002_18s.ome.tif
+            ch0003_alphasma_vimentin.ome.tif
+          transcripts.parquet                    # not loaded (10 GB+)
+
+    Parameters
+    ----------
+    path
+        The Atera ``outs`` directory.
+    library_id
+        Key under ``adata.uns['spatial']``. Defaults to ``experiment.xenium``'s
+        ``region_name``/``run_name``, else the directory name.
+    load_image
+        Load a morphology stain (``image_key`` selects which channel).
+    image_key
+        Channel selector for ``morphology_focus/``: a semantic tag
+        (``'dapi'``, ``'boundary'``, ``'rna'``, ``'stroma'``), a filename
+        substring (``'cd45'``, ``'18s'``, ``'alphasma'``), or an integer index
+        as a string (``'0'`` … ``'3'``). Default ``'dapi'``.
+    image_max_dim
+        Maximum extent (along either axis) of the loaded morphology pyramid
+        level. Default 4096.
+    load_boundaries
+        When ``True``, ``cell_boundaries.parquet`` → ``obs['geometry']`` (WKT).
+    load_nucleus_boundaries
+        When ``True``, ``nucleus_boundaries.parquet`` → ``obs['nucleus_geometry']``
+        (WKT). Atera-specific; toggle off to save memory.
+    cell_groups_csv
+        Optional path to Atera's vendor-shipped cell-groups CSV (``cell_id``,
+        ``group``, ``color``). When set, merged into ``obs['cell_group']`` and
+        ``obs['cell_group_color']``.
+    he_image
+        Optional H&E OME-TIFF (companion to ``outs/``). When set, loaded into
+        ``uns['spatial'][library_id]['images']['he']``.
+    he_alignment_csv
+        Optional 3×3 affine CSV mapping H&E pixel coords → Atera microns.
+        Stored at ``uns['spatial'][library_id]['scalefactors']['he_affine']``.
+    he_max_dim
+        Maximum extent of the loaded H&E pyramid level. Default 4096.
+    cache_file
+        Optional ``.h5ad`` cache (read on hit, written on miss).
+
+    Returns
+    -------
+    AnnData
+        - ``X``: CSR sparse, ``int32`` counts (cells × genes)
+        - ``obs``: cell metadata (centroids dropped into ``obsm['spatial']``);
+          optionally ``geometry``, ``nucleus_geometry``, ``cell_group``,
+          ``cell_group_color``
+        - ``obsm['spatial']``: ``(n_obs, 2)`` cell centroids in **microns**
+        - ``var``: gene panel metadata
+        - ``uns['spatial'][library_id]``:
+            - ``images['hires']``: morphology channel array (if loaded)
+            - ``images['he']``: H&E array (if loaded)
+            - ``scalefactors['tissue_hires_scalef']``: ``downsample / pixel_size``
+              — micron coords × scalef → image-pixel coords
+            - ``scalefactors['spot_diameter_fullres']``: mean cell diameter in
+              the loaded image's pixels
+            - ``scalefactors['he_affine']``: 3×3 ``np.ndarray`` mapping H&E
+              pixel coords → Atera microns (if H&E loaded)
+            - ``scalefactors['he_downsample']``: downsample factor of the
+              loaded H&E pyramid level (if H&E loaded)
+            - ``metadata``: ``experiment.xenium`` contents
+            - ``metadata['morphology_channels']``: channel filename list
+    """
+    root = Path(path).resolve()
+    if cache_file is not None:
+        cache_path = Path(cache_file).expanduser().resolve()
+        if cache_path.exists():
+            import anndata as _ad
+            _progress(f"Reading cached AnnData from: {cache_path}")
+            return _ad.read_h5ad(cache_path)
+    else:
+        cache_path = None
+
+    _progress(f"Reading Atera data from: {root}")
+
+    mat_path = _resolve(root, "cell_feature_matrix.h5")
+    if mat_path is None:
+        raise FileNotFoundError(
+            f"`cell_feature_matrix.h5` not found in {root}. Pass the directory holding the "
+            "Atera outs bundle as `path`."
+        )
+    cells_path = _resolve(root, "cells.parquet", "cells.csv.gz", "cells.csv")
+    if cells_path is None:
+        raise FileNotFoundError(f"`cells.parquet` / `cells.csv.gz` not found in {root}.")
+
+    adata = read_10x_h5(str(mat_path))
+    if hasattr(adata.var, "columns") and "feature_types" in adata.var.columns:
+        gene_mask = adata.var["feature_types"] == "Gene Expression"
+        dropped = int((~gene_mask).sum())
+        if dropped:
+            _progress(
+                f"Dropping {dropped} non-Gene-Expression features "
+                f"(control probes / codewords) out of {adata.n_vars}"
+            )
+            adata = adata[:, gene_mask].copy()
+
+    cells = _read_cells_table(cells_path)
+    id_col = next(
+        (c for c in ("cell_id", "cellID", "CellID", "cell_ID") if c in cells.columns),
+        cells.columns[0],
+    )
+    cells[id_col] = cells[id_col].astype(str)
+    cells = cells.set_index(id_col)
+
+    matrix_ids = pd.Index(adata.obs_names.astype(str))
+    common = matrix_ids.intersection(cells.index)
+    if len(common) != len(matrix_ids):
+        warnings.warn(
+            f"{len(matrix_ids) - len(common)} cells in cell_feature_matrix.h5 are absent "
+            f"from cells metadata and will be dropped."
+        )
+        adata = adata[adata.obs_names.astype(str).isin(common)].copy()
+        matrix_ids = pd.Index(adata.obs_names.astype(str))
+    cells = cells.reindex(matrix_ids)
+
+    xy_pairs = [("x_centroid", "y_centroid"), ("CenterX_local_px", "CenterY_local_px")]
+    xy = next((pair for pair in xy_pairs if all(c in cells.columns for c in pair)), None)
+    if xy is None:
+        raise ValueError(
+            "Could not find centroid columns in cells metadata. "
+            f"Expected one of {xy_pairs}, found {list(cells.columns)}."
+        )
+    adata.obsm["spatial"] = cells[list(xy)].to_numpy(dtype=np.float32)
+    adata.obs = cells.drop(columns=list(xy))
+
+    exp_meta = _load_experiment_metadata(root)
+    if library_id is None:
+        library_id = (
+            exp_meta.get("region_name")
+            or exp_meta.get("run_name")
+            or root.name
+            or "atera"
+        )
+    library_id = str(library_id).strip() or "atera"
+
+    pixel_size_um = float(exp_meta.get("pixel_size", 0.2125))
+    mean_diam_um = 15.0
+    if "cell_area" in adata.obs.columns:
+        mean_area = float(np.nanmean(adata.obs["cell_area"].to_numpy()))
+        if np.isfinite(mean_area) and mean_area > 0:
+            mean_diam_um = 2.0 * np.sqrt(mean_area / np.pi)
+    spot_diameter_fullres = float(mean_diam_um / pixel_size_um)
+    hires_scalef = 1.0 / pixel_size_um
+
+    channels = _list_atera_morphology_channels(root)
+
+    uns_spatial: dict[str, Any] = {
+        "images": {},
+        "scalefactors": {
+            "tissue_hires_scalef": hires_scalef,
+            "spot_diameter_fullres": spot_diameter_fullres,
+        },
+        "metadata": dict(exp_meta),
+    }
+    uns_spatial["metadata"]["morphology_channels"] = [c.name for c in channels]
+
+    if load_image:
+        chosen = _select_morphology_channel(channels, image_key)
+        if chosen is None:
+            _progress(
+                f"No morphology channel matched image_key={image_key!r}; "
+                f"available: {[c.name for c in channels]}",
+                level="warn",
+            )
+        else:
+            loaded = _load_pyramid_tiff(chosen, max_dim=image_max_dim)
+            if loaded is not None:
+                img, downsample = loaded
+                _progress(
+                    f"Loaded morphology channel {chosen.name} {img.shape} "
+                    f"(downsample {downsample:.4f})"
+                )
+                uns_spatial["images"]["hires"] = img
+                uns_spatial["scalefactors"]["tissue_hires_scalef"] = hires_scalef * downsample
+                uns_spatial["scalefactors"]["spot_diameter_fullres"] = (
+                    spot_diameter_fullres * downsample
+                )
+                uns_spatial["scalefactors"]["morphology_channel"] = chosen.name
+
+    has_geometry = False
+    if load_boundaries:
+        wkts = _boundaries_to_wkt(root, cell_index=pd.Index(adata.obs_names.astype(str)))
+        if wkts is not None:
+            adata.obs["geometry"] = wkts.values
+            has_geometry = bool((wkts != "").any())
+            if has_geometry:
+                _progress(
+                    f"Loaded cell polygons for {int((wkts != '').sum())}/{len(wkts)} cells"
+                )
+
+    if load_nucleus_boundaries:
+        nwkts = _nucleus_boundaries_to_wkt(
+            root, cell_index=pd.Index(adata.obs_names.astype(str))
+        )
+        if nwkts is not None:
+            adata.obs["nucleus_geometry"] = nwkts.values
+            n_nuc = int((nwkts != "").sum())
+            if n_nuc:
+                _progress(f"Loaded nucleus polygons for {n_nuc}/{len(nwkts)} cells")
+
+    if cell_groups_csv is not None:
+        cg_path = Path(cell_groups_csv).expanduser().resolve()
+        if cg_path.exists():
+            n_matched = _merge_cell_groups(adata, cg_path)
+            _progress(
+                f"Merged cell_groups: {n_matched}/{adata.n_obs} cells from {cg_path.name}"
+            )
+        else:
+            warnings.warn(f"cell_groups_csv not found: {cg_path}")
+
+    if he_image is not None:
+        he_path = Path(he_image).expanduser().resolve()
+        if not he_path.exists():
+            warnings.warn(f"he_image not found: {he_path}")
+        else:
+            loaded = _load_pyramid_tiff(he_path, max_dim=he_max_dim)
+            if loaded is not None:
+                he_arr, he_downsample = loaded
+                _progress(
+                    f"Loaded H&E image {he_arr.shape} (downsample {he_downsample:.4f}) "
+                    f"from {he_path.name}"
+                )
+                uns_spatial["images"]["he"] = he_arr
+                uns_spatial["scalefactors"]["he_downsample"] = he_downsample
+                if he_alignment_csv is not None:
+                    align_path = Path(he_alignment_csv).expanduser().resolve()
+                    if align_path.exists():
+                        affine = _load_he_alignment(align_path)
+                        if affine is not None:
+                            uns_spatial["scalefactors"]["he_affine"] = affine
+                            _progress(f"Loaded H&E affine from {align_path.name}")
+                    else:
+                        warnings.warn(f"he_alignment_csv not found: {align_path}")
+
+    adata.uns["spatial"] = {library_id: uns_spatial}
+    adata.uns["omicverse_io"] = {
+        "type": "atera_seg" if has_geometry else "atera",
+        "library_id": library_id,
+    }
+
+    if cache_path is not None:
+        try:
+            cache_path.parent.mkdir(parents=True, exist_ok=True)
+            adata.write(cache_path)
+            _progress(f"Wrote cache AnnData to: {cache_path}", level="success")
+        except Exception as exc:
+            warnings.warn(f"Failed to write cache {cache_path}: {exc}")
+
+    _progress(
+        f"Done (n_obs={adata.n_obs}, n_vars={adata.n_vars}, library_id={library_id})",
+        level="success",
+    )
+    return adata
+
+
+__all__ = ["read_atera"]

--- a/omicverse/pl/__init__.py
+++ b/omicverse/pl/__init__.py
@@ -69,6 +69,7 @@ from ._palette import (
     purple_color,
     red_color,
     sc_color,
+    sync_categorical_palette,
     vibrant_palette,
     palplot,
 )
@@ -132,6 +133,7 @@ from ._space import (
     rgb_to_ryb,
     ryb_to_rgb,
     spatial_value,
+    to_rgb_grayscale,
 )
 from ._cpdb import (
     cpdb_chord,

--- a/omicverse/pl/_palette.py
+++ b/omicverse/pl/_palette.py
@@ -98,6 +98,52 @@ pastel_palette = [
     '#FFD3B5', '#D4F0F0', '#B5EAD7', '#E2F0CB', '#C7CEEA', '#FFDAC1'
 ]
 
+def sync_categorical_palette(adata, key: str, color_obs: str,
+                             default: str = '#bbbbbb') -> list:
+    r"""Wire a per-cell colour column into ``uns[<key>_colors]``.
+
+    scanpy / ov.pl plotting functions read ``uns[<obs_key>_colors]`` as a
+    list of hex strings aligned with ``adata.obs[obs_key].cat.categories``.
+    When a vendor or upstream classifier ships per-cell colours in a
+    parallel obs column (e.g. Atera's ``cell_groups.csv`` ships both a
+    ``cell_group`` label and a ``cell_group_color`` hex per cell), this
+    helper turns the two parallel columns into the per-category palette
+    plot functions expect.
+
+    Cells whose colour is missing fall back to ``default``. Cells whose
+    *category* is missing from the data (i.e. categories that no cell
+    actually belongs to) are dropped from the mapping before lookup, so
+    a stray NaN never becomes the literal string ``'nan'`` and breaks
+    matplotlib's colour parser.
+
+    Parameters
+    ----------
+    adata : AnnData
+    key : str
+        Categorical obs column. Must be ``pd.Categorical`` so
+        ``cat.categories`` defines the palette order.
+    color_obs : str
+        Obs column with per-cell hex colour strings parallel to
+        ``adata.obs[key]``.
+    default : str
+        Fallback hex colour for categories without a mapped colour.
+        Default ``'#bbbbbb'``.
+
+    Returns
+    -------
+    list of str
+        The palette written to ``adata.uns[f'{key}_colors']``.
+    """
+    g = adata.obs[key].astype(object)
+    c = adata.obs[color_obs].astype(object)
+    tab = pd.DataFrame({key: g, color_obs: c}).dropna().drop_duplicates()
+    mapping = dict(zip(tab[key], tab[color_obs]))
+    cats = adata.obs[key].cat.categories
+    palette = [mapping.get(cat, default) for cat in cats]
+    adata.uns[f'{key}_colors'] = palette
+    return palette
+
+
 def colormaps_palette(map_name:str)->list:
     r"""Returns a colormap palette.
 

--- a/omicverse/pl/_space.py
+++ b/omicverse/pl/_space.py
@@ -8,6 +8,48 @@ from matplotlib.colors import ListedColormap
 from matplotlib.gridspec import GridSpec
 from .._registry import register_function
 
+def to_rgb_grayscale(img, p_low: float = 1.0, p_high: float = 99.0):
+    """Convert a 2-D grayscale image to a percentile-clipped RGB stack.
+
+    matplotlib's ``imshow`` applies a default *viridis* colormap to 2-D
+    arrays. When the image is a morphology stain (DAPI, membrane, RNA) and
+    we want it rendered as true grayscale alongside polygon overlays, this
+    silently colour-maps the channel and washes structural detail into a
+    uniform purple-to-yellow ramp. Passing a 3-channel array bypasses the
+    colormap entirely so the intensities are rendered verbatim.
+
+    The percentile clip handles long-tailed stain distributions: a few
+    bright outliers would otherwise compress the dynamic range of the rest
+    of the image to nearly black.
+
+    Parameters
+    ----------
+    img : np.ndarray
+        2-D image of any numeric dtype.
+    p_low, p_high : float
+        Percentile clip range over the image's *non-zero* pixels.
+        Defaults: 1st / 99th percentiles.
+
+    Returns
+    -------
+    np.ndarray
+        ``(H, W, 3)`` float32 array in the [0, 1] range. Suitable to drop
+        directly into ``adata.uns['spatial'][lib]['images'][<key>]`` or
+        passed to ``imshow`` without a ``cmap`` kwarg.
+    """
+    arr = np.asarray(img, dtype=np.float32)
+    nz = arr[arr > 0]
+    if nz.size:
+        lo = float(np.percentile(nz, p_low))
+        hi = float(np.percentile(nz, p_high))
+    else:
+        lo, hi = 0.0, 1.0
+    if hi <= lo:
+        hi = lo + 1.0
+    arr = np.clip((arr - lo) / (hi - lo), 0.0, 1.0)
+    return np.stack([arr, arr, arr], axis=-1)
+
+
 def html_to_rgb(html_color):
     r"""
     Convert HTML hex color code to RGB tuple.

--- a/omicverse/space/_tools.py
+++ b/omicverse/space/_tools.py
@@ -29,6 +29,61 @@ from .._optional import build_optional_dependency_error
     ],
     related=["space.rotate_space_visium", "space.map_spatial_auto"]
 )
+@register_function(
+    aliases=["subset_window", "spatial_window", "spatial_subset",
+             "crop spatial subset", "空间窗口子集"],
+    category="space",
+    description=(
+        "Subset an AnnData to cells whose `obsm[basis]` coordinates fall inside "
+        "a rectangular (xlim, ylim) window. Coordinate-system agnostic: works on "
+        "microns (Xenium / Atera), full-res pixels (Visium HD), or any other 2-D "
+        "embedding. Preserves `uns`."
+    ),
+    examples=[
+        "bdata = ov.space.subset_window(adata, xlim=(1000, 2000), ylim=(500, 1500))",
+        "# Window centred on the sample median:",
+        "import numpy as np",
+        "x0, y0 = np.median(adata.obsm['spatial'], axis=0)",
+        "bdata = ov.space.subset_window(adata,",
+        "    xlim=(x0 - 500, x0 + 500),",
+        "    ylim=(y0 - 500, y0 + 500))",
+    ],
+    related=["space.crop_space_visium"],
+)
+def subset_window(adata, xlim, ylim, basis='spatial'):
+    """Subset an AnnData by a rectangular spatial window.
+
+    Cells whose ``adata.obsm[basis]`` coordinates fall inside ``(xlim, ylim)``
+    are kept; the rest are dropped. The interval is half-open
+    (``xlim[0] <= x < xlim[1]``), matching numpy slicing semantics.
+
+    Coordinates are interpreted in whatever unit the basis stores — microns
+    for Xenium / Atera, full-res pixels for Visium HD. Use the same window
+    you intend to pass to ``ov.pl.spatial(crop_coord=...)`` /
+    ``ov.pl.spatialseg(crop_coord=...)`` so the polygon set and the rendered
+    background stay aligned.
+
+    Parameters
+    ----------
+    adata : AnnData
+    xlim : tuple of float
+        ``(x_min, x_max)`` window, half-open on the right.
+    ylim : tuple of float
+        ``(y_min, y_max)`` window, half-open on the right.
+    basis : str
+        Key in ``adata.obsm`` providing the 2-D coordinates. Default ``'spatial'``.
+
+    Returns
+    -------
+    AnnData
+        Copy of ``adata`` restricted to the window. ``uns`` is preserved.
+    """
+    coords = adata.obsm[basis]
+    x, y = coords[:, 0], coords[:, 1]
+    mask = (x >= xlim[0]) & (x < xlim[1]) & (y >= ylim[0]) & (y < ylim[1])
+    return adata[mask].copy()
+
+
 def crop_space_visium(adata, crop_loc, crop_area,
                      library_id, scale, spatial_key='spatial', res='hires'):
     """

--- a/tests/test_io_atera.py
+++ b/tests/test_io_atera.py
@@ -1,0 +1,435 @@
+"""Regression test for ``omicverse.io.spatial.read_atera``.
+
+The real Atera FFPE Breast Cancer ``outs.zip`` is 55 GB and the H&E TIFF
+companion is 17 GB — too big to ship through CI. This test builds a tiny
+synthetic Atera bundle on disk (matching schema, ~30 cells, ~20 genes) and
+runs the reader end-to-end with ``load_image=False``. It covers:
+
+- the 10x ``cell_feature_matrix.h5`` schema (CSC, byte-string ids/features),
+- ``Gene Expression`` filtering (control probes / codewords are dropped),
+- ``cells.parquet`` centroid columns ``x_centroid`` / ``y_centroid``,
+- ``experiment.xenium`` JSON → ``uns['spatial'][library]['metadata']``,
+- ``cell_boundaries.parquet`` → ``obs['geometry']`` (WKT POLYGON),
+- ``nucleus_boundaries.parquet`` → ``obs['nucleus_geometry']`` (Atera-only),
+- optional ``cell_groups.csv`` merge → ``obs['cell_group']`` /
+  ``obs['cell_group_color']`` (incl. NaN handling for cells absent
+  from the CSV — the bug that broke the tutorial scatter),
+- optional H&E ``alignment.csv`` → ``scalefactors['he_affine']``,
+- the channel-name selector (``image_key='dapi'`` / ``'boundary'`` /
+  ``'rna'`` / ``'stroma'`` / ``'2'`` / ``'cd45'``) against synthetic
+  ``morphology_focus/ch####_<tag>.ome.tif`` filenames.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import h5py
+import numpy as np
+import pandas as pd
+import pytest
+import scipy.sparse as sp
+
+
+N_CELLS = 32
+N_GENES = 18
+N_CONTROLS = 4   # control probes / codewords that must be dropped
+PIXEL_SIZE_UM = 0.2125
+
+
+# --------------------------------------------------------------------------- #
+# Synthetic Atera bundle factory
+# --------------------------------------------------------------------------- #
+
+
+def _write_cell_feature_matrix_h5(path: Path) -> tuple[list[str], list[str]]:
+    """Write a 10x-style HDF5 matrix with control probes mixed in.
+
+    Returns ``(cell_ids, gene_names_only)`` so the rest of the bundle can
+    be aligned with what the matrix says is in row 0..N_CELLS-1.
+    """
+    rng = np.random.default_rng(0)
+    n_total = N_GENES + N_CONTROLS
+    # 5% density, integer counts
+    mat = sp.random(n_total, N_CELLS, density=0.5, format="csc",
+                    random_state=0,
+                    data_rvs=lambda size: rng.integers(1, 10, size=size)).astype(np.int32)
+
+    cell_ids = [f"cell{i:03d}" for i in range(N_CELLS)]
+    gene_ids = [f"GENE{i:03d}" for i in range(N_GENES)]
+    ctrl_ids = [f"CTRL{i:03d}" for i in range(N_CONTROLS)]
+    feature_ids = gene_ids + ctrl_ids
+    feature_names = list(feature_ids)
+    feature_types = (["Gene Expression"] * N_GENES
+                     + ["Negative Control Probe"] * N_CONTROLS)
+
+    with h5py.File(path, "w") as f:
+        m = f.create_group("matrix")
+        m.create_dataset("barcodes",
+                         data=np.array([s.encode() for s in cell_ids], dtype="|S20"))
+        m.create_dataset("data", data=mat.data)
+        m.create_dataset("indices", data=mat.indices.astype(np.int64))
+        m.create_dataset("indptr", data=mat.indptr.astype(np.int64))
+        m.create_dataset("shape", data=np.array(mat.shape, dtype=np.int32))
+        feats = m.create_group("features")
+        feats.create_dataset("id",
+                             data=np.array([s.encode() for s in feature_ids], dtype="|S20"))
+        feats.create_dataset("name",
+                             data=np.array([s.encode() for s in feature_names], dtype="|S20"))
+        feats.create_dataset("feature_type",
+                             data=np.array([s.encode() for s in feature_types], dtype="|S30"))
+        feats.create_dataset("genome",
+                             data=np.array([b"GRCh38"] * len(feature_ids), dtype="|S10"))
+        feats.create_dataset("_all_tag_keys", data=np.array([b"genome"], dtype="|S10"))
+    return cell_ids, gene_ids
+
+
+def _write_cells_parquet(path: Path, cell_ids: list[str]) -> None:
+    rng = np.random.default_rng(1)
+    df = pd.DataFrame({
+        "cell_id": cell_ids,
+        "x_centroid": rng.uniform(0, 1000, size=N_CELLS).astype(np.float64),
+        "y_centroid": rng.uniform(0, 1000, size=N_CELLS).astype(np.float64),
+        "transcript_counts": rng.integers(50, 500, size=N_CELLS),
+        "control_probe_counts": rng.integers(0, 5, size=N_CELLS),
+        "genomic_control_counts": np.zeros(N_CELLS, dtype=np.int64),
+        "control_codeword_counts": np.zeros(N_CELLS, dtype=np.int64),
+        "unassigned_codeword_counts": np.zeros(N_CELLS, dtype=np.int64),
+        "deprecated_codeword_counts": np.zeros(N_CELLS, dtype=np.int64),
+        "total_counts": rng.integers(50, 500, size=N_CELLS),
+        "cell_area": rng.uniform(20, 100, size=N_CELLS),
+        "nucleus_area": rng.uniform(10, 50, size=N_CELLS),
+        "nucleus_count": np.ones(N_CELLS, dtype=np.int64),
+        "segmentation_method": ["Segmented by boundary stain"] * N_CELLS,
+    })
+    df.to_parquet(path, index=False)
+
+
+def _write_polygon_parquet(path: Path, cell_ids: list[str], offset: float = 0.0) -> None:
+    """Triangle polygons for cell_boundaries / nucleus_boundaries.
+
+    The arboreto-style long-table schema: one row per vertex, columns
+    ``cell_id``, ``vertex_x``, ``vertex_y``, ``label_id``. Each cell gets
+    a 4-vertex closed triangle (the WKT-builder closes rings if needed,
+    but Atera also ships them already closed).
+    """
+    rows = []
+    for i, cid in enumerate(cell_ids):
+        cx, cy = float(i * 10 + offset), float(i * 5 + offset)
+        verts = [
+            (cx,         cy),
+            (cx + 5,     cy),
+            (cx + 2.5,   cy + 5),
+            (cx,         cy),
+        ]
+        for x, y in verts:
+            rows.append((cid, np.float32(x), np.float32(y), 1))
+    df = pd.DataFrame(rows, columns=["cell_id", "vertex_x", "vertex_y", "label_id"])
+    df.to_parquet(path, index=False)
+
+
+def _write_experiment_xenium(path: Path) -> dict:
+    meta = {
+        "major_version": 6,
+        "minor_version": 1,
+        "patch_version": 0,
+        "run_name": "WTA Preview Test",
+        "region_name": "Synthetic Atera Bundle",
+        "preservation_method": "FFPE",
+        "num_cells": N_CELLS,
+        "transcripts_per_cell": 100,
+        "panel_name": "Human WTA (synthetic)",
+        "panel_organism": "Human",
+        "chemistry_version": "Atera v1",
+        "pixel_size": PIXEL_SIZE_UM,
+        "instrument_sn": "test-instrument",
+        "analysis_sw_version": "test-9.9.9",
+        "experiment_uuid": "00000000-0000-0000-0000-000000000000",
+    }
+    path.write_text(json.dumps(meta, indent=2))
+    return meta
+
+
+def _write_morphology_channel_stubs(focus_dir: Path) -> list[str]:
+    """Atera-named morphology channels. Empty TIFF stubs are fine — the
+    test sets ``load_image=False`` so the loader never actually reads them.
+    Their *filenames* are what the channel-key resolver matches against.
+    """
+    focus_dir.mkdir(parents=True, exist_ok=True)
+    names = [
+        "ch0000_dapi.ome.tif",
+        "ch0001_atp1a1_cd45_e-cadherin.ome.tif",
+        "ch0002_18s.ome.tif",
+        "ch0003_alphasma_vimentin.ome.tif",
+    ]
+    for n in names:
+        (focus_dir / n).write_bytes(b"")
+    return names
+
+
+@pytest.fixture
+def atera_bundle(tmp_path: Path) -> dict:
+    """A ``tmp_path / outs/`` directory that mirrors the real Atera schema
+    and a sibling cell-groups CSV.
+    """
+    root = tmp_path / "outs"
+    root.mkdir()
+    cell_ids, gene_ids = _write_cell_feature_matrix_h5(root / "cell_feature_matrix.h5")
+    _write_cells_parquet(root / "cells.parquet", cell_ids)
+    _write_polygon_parquet(root / "cell_boundaries.parquet", cell_ids)
+    # Nucleus polygons cover only the first 30 cells — exercises the
+    # "fewer nuclei than cells" path that the reader handles with reindex.
+    _write_polygon_parquet(root / "nucleus_boundaries.parquet",
+                           cell_ids[:30], offset=0.5)
+    meta = _write_experiment_xenium(root / "experiment.xenium")
+    channels = _write_morphology_channel_stubs(root / "morphology_focus")
+
+    # Sibling cell-groups CSV (some cells deliberately absent → NaN merge path).
+    cg_path = tmp_path / "cell_groups.csv"
+    rng = np.random.default_rng(2)
+    n_labelled = N_CELLS - 3      # leave 3 unlabelled to exercise NaN handling
+    groups = rng.choice(["TumorA", "TumorB", "Stroma", "Immune"], size=n_labelled)
+    palette = {"TumorA": "#F943D2", "TumorB": "#9C27B0",
+               "Stroma": "#FFC107", "Immune": "#1976D2"}
+    pd.DataFrame({
+        "cell_id": cell_ids[:n_labelled],
+        "group": groups,
+        "color": [palette[g] for g in groups],
+    }).to_csv(cg_path, index=False)
+
+    # H&E alignment matrix (3×3 affine, no header).
+    affine_path = tmp_path / "he_alignment.csv"
+    pd.DataFrame([[0.5, 0, 100.0],
+                  [0, 0.5, 200.0],
+                  [0, 0, 1]]).to_csv(affine_path, index=False, header=False)
+
+    return {
+        "root": root,
+        "cell_groups_csv": cg_path,
+        "he_alignment_csv": affine_path,
+        "cell_ids": cell_ids,
+        "gene_ids": gene_ids,
+        "meta": meta,
+        "channels": channels,
+    }
+
+
+# --------------------------------------------------------------------------- #
+# read_atera: matrix / metadata / centroids / control filtering
+# --------------------------------------------------------------------------- #
+
+def test_read_atera_basic(atera_bundle) -> None:
+    from omicverse.io.spatial import read_atera
+
+    adata = read_atera(
+        atera_bundle["root"],
+        load_image=False,
+        load_boundaries=True,
+        load_nucleus_boundaries=True,
+    )
+
+    assert adata.n_obs == N_CELLS
+    # Control probes (4) must be dropped — only Gene Expression survives.
+    assert adata.n_vars == N_GENES, (
+        f"control probes / codewords were not filtered: n_vars={adata.n_vars}"
+    )
+    assert all(v.startswith("GENE") for v in adata.var_names)
+
+    # Centroids → obsm['spatial']
+    assert "spatial" in adata.obsm
+    assert adata.obsm["spatial"].shape == (N_CELLS, 2)
+    assert adata.obsm["spatial"].dtype == np.float32
+
+    # The centroid columns are *moved* out of obs into obsm.
+    assert "x_centroid" not in adata.obs.columns
+    assert "y_centroid" not in adata.obs.columns
+
+    # Per-cell metadata from cells.parquet survives in obs.
+    for col in ("transcript_counts", "cell_area", "nucleus_area",
+                "nucleus_count", "segmentation_method"):
+        assert col in adata.obs.columns
+
+    # experiment.xenium → uns['spatial'][library]['metadata']
+    library = "Synthetic Atera Bundle"  # = experiment.xenium["region_name"]
+    assert library in adata.uns["spatial"]
+    block = adata.uns["spatial"][library]
+    assert block["metadata"]["pixel_size"] == PIXEL_SIZE_UM
+    assert block["metadata"]["chemistry_version"] == "Atera v1"
+
+    # Pixel-size driven scalefactor
+    assert block["scalefactors"]["tissue_hires_scalef"] == pytest.approx(
+        1.0 / PIXEL_SIZE_UM
+    )
+
+    # Without an image loaded, no 'hires' should be set.
+    assert "hires" not in block["images"]
+
+    # Discovered channel filenames are recorded even when load_image=False.
+    assert block["metadata"]["morphology_channels"] == atera_bundle["channels"]
+
+    # Reader stamps its type tag for downstream tools (geometry was loaded
+    # successfully so it's the segmented variant).
+    assert adata.uns["omicverse_io"]["type"] == "atera_seg"
+    assert adata.uns["omicverse_io"]["library_id"] == library
+
+
+# --------------------------------------------------------------------------- #
+# Cell + nucleus polygons → WKT
+# --------------------------------------------------------------------------- #
+
+def test_read_atera_polygons(atera_bundle) -> None:
+    from omicverse.io.spatial import read_atera
+
+    adata = read_atera(
+        atera_bundle["root"],
+        load_image=False,
+        load_boundaries=True,
+        load_nucleus_boundaries=True,
+    )
+
+    # Every cell gets a cell polygon.
+    assert "geometry" in adata.obs.columns
+    geom = adata.obs["geometry"].astype(str)
+    assert (geom != "").all()
+    assert geom.iloc[0].startswith("POLYGON ((")
+
+    # Nucleus polygons covered only first 30 cells; the remaining 2 are
+    # left as empty strings by the reindex.
+    assert "nucleus_geometry" in adata.obs.columns
+    nuc = adata.obs["nucleus_geometry"].astype(str)
+    assert (nuc != "").sum() == 30
+    assert (nuc == "").sum() == N_CELLS - 30
+
+
+def test_read_atera_disable_polygons(atera_bundle) -> None:
+    from omicverse.io.spatial import read_atera
+
+    adata = read_atera(
+        atera_bundle["root"],
+        load_image=False,
+        load_boundaries=False,
+        load_nucleus_boundaries=False,
+    )
+    assert "geometry" not in adata.obs.columns
+    assert "nucleus_geometry" not in adata.obs.columns
+    # When no segmentation is loaded the type tag drops the _seg suffix.
+    assert adata.uns["omicverse_io"]["type"] == "atera"
+
+
+# --------------------------------------------------------------------------- #
+# cell_groups.csv merge — including the NaN-handling bug from the tutorial
+# --------------------------------------------------------------------------- #
+
+def test_read_atera_cell_groups_merge(atera_bundle) -> None:
+    from omicverse.io.spatial import read_atera
+
+    adata = read_atera(
+        atera_bundle["root"],
+        load_image=False,
+        load_boundaries=False,
+        load_nucleus_boundaries=False,
+        cell_groups_csv=atera_bundle["cell_groups_csv"],
+    )
+
+    assert "cell_group" in adata.obs.columns
+    assert "cell_group_color" in adata.obs.columns
+
+    # 3 cells were left out of the CSV — they must arrive as NaN, not as
+    # the string 'nan' (the latter broke the tutorial's `scatter(c=...)`).
+    n_labelled = N_CELLS - 3
+    assert adata.obs["cell_group"].notna().sum() == n_labelled
+    assert adata.obs["cell_group_color"].isna().sum() == 3
+
+    # Vendor colours are preserved verbatim, not e.g. coerced to ints.
+    valid_colors = adata.obs["cell_group_color"].dropna().astype(str).unique()
+    for c in valid_colors:
+        assert c.startswith("#") and len(c) == 7
+
+
+# --------------------------------------------------------------------------- #
+# Channel-key resolver — semantic / substring / index
+# --------------------------------------------------------------------------- #
+
+def test_read_atera_channel_key_resolver_records_choice(atera_bundle, monkeypatch) -> None:
+    """Every supported ``image_key`` form should select the right file.
+
+    We intercept ``_load_pyramid_tiff`` so the test doesn't actually need
+    a real pyramid TIFF — we just want to verify which file was picked.
+    The reader records the chosen filename under
+    ``scalefactors['morphology_channel']`` after a successful load.
+    """
+    from omicverse.io.spatial import _atera
+
+    seen: list[Path] = []
+
+    def fake_loader(path, max_dim=4096):
+        seen.append(path)
+        return np.zeros((4, 4), dtype=np.uint16), 1.0
+
+    monkeypatch.setattr(_atera, "_load_pyramid_tiff", fake_loader)
+
+    cases = {
+        "dapi":     "ch0000_dapi.ome.tif",
+        "boundary": "ch0001_atp1a1_cd45_e-cadherin.ome.tif",
+        "rna":      "ch0002_18s.ome.tif",
+        "stroma":   "ch0003_alphasma_vimentin.ome.tif",
+        "cd45":     "ch0001_atp1a1_cd45_e-cadherin.ome.tif",  # substring
+        "18s":      "ch0002_18s.ome.tif",                      # substring
+        "2":        "ch0002_18s.ome.tif",                      # index-as-string
+        "0":        "ch0000_dapi.ome.tif",
+    }
+    for key, expected_filename in cases.items():
+        seen.clear()
+        adata = _atera.read_atera(
+            atera_bundle["root"],
+            load_image=True,
+            image_key=key,
+            load_boundaries=False,
+            load_nucleus_boundaries=False,
+        )
+        assert len(seen) == 1, f"image_key={key!r} did not trigger loader"
+        assert seen[0].name == expected_filename, (
+            f"image_key={key!r} picked {seen[0].name}, expected {expected_filename}"
+        )
+        sf = adata.uns["spatial"]["Synthetic Atera Bundle"]["scalefactors"]
+        assert sf["morphology_channel"] == expected_filename
+
+
+# --------------------------------------------------------------------------- #
+# H&E alignment CSV → 3×3 affine
+# --------------------------------------------------------------------------- #
+
+def test_read_atera_he_alignment_loaded(atera_bundle, tmp_path, monkeypatch) -> None:
+    """The H&E-image loader uses tifffile under the hood — the test stubs
+    it so we don't need a real OME-TIFF, but we *do* exercise the
+    alignment-CSV parsing and storage."""
+    from omicverse.io.spatial import _atera
+
+    monkeypatch.setattr(
+        _atera, "_load_pyramid_tiff",
+        lambda path, max_dim=4096: (np.zeros((4, 4), dtype=np.uint8), 1.0),
+    )
+
+    he_path = tmp_path / "he.ome.tif"
+    he_path.write_bytes(b"")
+
+    adata = _atera.read_atera(
+        atera_bundle["root"],
+        load_image=False,        # don't load morphology channel
+        load_boundaries=False,
+        load_nucleus_boundaries=False,
+        he_image=he_path,
+        he_alignment_csv=atera_bundle["he_alignment_csv"],
+    )
+    sf = adata.uns["spatial"]["Synthetic Atera Bundle"]["scalefactors"]
+    assert "he_affine" in sf
+    affine = sf["he_affine"]
+    assert affine.shape == (3, 3)
+    np.testing.assert_allclose(
+        affine,
+        np.array([[0.5, 0, 100.0],
+                  [0, 0.5, 200.0],
+                  [0, 0, 1]]),
+    )
+    assert sf["he_downsample"] == pytest.approx(1.0)
+    assert "he" in adata.uns["spatial"]["Synthetic Atera Bundle"]["images"]


### PR DESCRIPTION
## Summary

Adds `omicverse.io.spatial.read_atera` for 10x Genomics Atera (Whole-Transcriptome Atlas Preview) outs bundles. Atera v1 ships a Xenium-format core (`cell_feature_matrix.h5`, `cells.parquet`, `cell_boundaries.parquet`, `experiment.xenium`) plus four additions; `read_atera` is a sibling of `read_xenium` that handles all four:

- **`nucleus_boundaries.parquet`** → `obs['nucleus_geometry']` (WKT POLYGON), Atera-only
- **`morphology_focus/ch####_<tag>.ome.tif`** — content-named multi-stain pyramid TIFFs. The semantic-tag resolver accepts `'dapi'` / `'boundary'` / `'rna'` / `'stroma'`, filename substrings (`'cd45'`, `'18s'`), or an index as a string (`'0'`–`'3'`).
- **`*_cell_groups.csv`** (companion file, lives next to `outs/`) → `obs['cell_group']` and `obs['cell_group_color']` (vendor classifier; NaN-preserving for unlabelled cells)
- **`*_he_image.ome.tif`** + **`*_he_alignment.csv`** → `uns['spatial'][lib]['images']['he']` and `scalefactors['he_affine']`

## Implementation notes

- `read_atera` reuses `_xenium`'s `_resolve` / `_read_cells_table` / `_load_experiment_metadata` / `_boundaries_to_wkt` helpers — only the Atera-specific pieces (nucleus polygons, channel resolver, vendor groups, H&E) are new code.
- Atera's morphology channel files cross-reference each other via OME XML. tifffile then puts the four files into a *multi-file* OME series and refuses to walk the pyramid (`"OME series cannot read multi-file pyramids"`). We pass `is_ome=False` to `TiffFile()` so each channel file is read standalone, with its per-file pyramid IFDs still exposed via `series.levels`.
- Re-exported from `omicverse.io.spatial` so `ov.io.spatial.read_atera(...)` works.

## Reproducer (real Atera bundle)

The public 10x WTA Preview FFPE Breast Cancer dataset:

```python
import omicverse as ov
adata = ov.io.spatial.read_atera(
    "/path/to/atera_breast_cancer/",        # contains outs/ contents
    image_key="dapi",                        # or "boundary" / "rna" / "stroma"
    image_max_dim=2048,
    cell_groups_csv="/path/to/cell_groups.csv",
    he_image="/path/to/he_image.ome.tif",
    he_alignment_csv="/path/to/he_alignment.csv",
)
# AnnData object with n_obs × n_vars = 170057 × 18028
#     obs: ..., 'geometry', 'nucleus_geometry', 'cell_group', 'cell_group_color'
#     uns: 'spatial', 'omicverse_io'
#     obsm: 'spatial'
```

Loaded 170,057 cells × 18,028 genes (9,076 control probes / codewords dropped automatically); cell polygons for all 170,057, nucleus polygons for 168,335; vendor cell-types merged for all 170,057.

## Tests

`tests/test_io_atera.py` (6 cases) builds a synthetic ~30-cell Atera bundle in `tmp_path` and exercises every path:

- `test_read_atera_basic` — matrix + metadata + control-probe filtering + centroid extraction + experiment-xenium → uns scalefactors
- `test_read_atera_polygons` — both cell + nucleus WKT (incl. partial-coverage reindex)
- `test_read_atera_disable_polygons` — `load_boundaries=False` / `load_nucleus_boundaries=False` paths
- `test_read_atera_cell_groups_merge` — vendor CSV merge + NaN handling for cells absent from the CSV (the `astype(str)` → `'nan'` bug that broke the tutorial scatter)
- `test_read_atera_channel_key_resolver_records_choice` — every `image_key` form (semantic / substring / index-as-string) picks the right channel filename
- `test_read_atera_he_alignment_loaded` — H&E image + 3×3 affine CSV → scalefactors

Run with:

```bash
pytest tests/test_io_atera.py -v
```

```
tests/test_io_atera.py::test_read_atera_basic                                              PASSED [ 16%]
tests/test_io_atera.py::test_read_atera_polygons                                           PASSED [ 33%]
tests/test_io_atera.py::test_read_atera_disable_polygons                                   PASSED [ 50%]
tests/test_io_atera.py::test_read_atera_cell_groups_merge                                  PASSED [ 66%]
tests/test_io_atera.py::test_read_atera_channel_key_resolver_records_choice                PASSED [ 83%]
tests/test_io_atera.py::test_read_atera_he_alignment_loaded                                PASSED [100%]
====================== 6 passed, 1 warning in 5.12s =======================
```

## Test plan

- [x] All 6 unit tests pass offline (no network, no real TIFF) under `pytest tests/test_io_atera.py`
- [x] Real Atera FFPE Breast Cancer bundle loads end-to-end (170,057 × 18,028 with all three polygon paths + cell-groups CSV merge)
- [x] All four morphology channels load with the `is_ome=False` fix at `image_max_dim=2048`
- [x] Companion tutorial `t_atera.ipynb` (lives in `omicverse-test/notebooks/`) executes end-to-end via `jupyter nbconvert --execute`
- [ ] Reviewer: `import omicverse as ov; ov.io.spatial.read_atera` resolves and the function metadata (registered via `@register_function`) shows up in the registry scanner output

🤖 Generated with [Claude Code](https://claude.com/claude-code)