### PR TITLE
fix(pp): preprocess(mode='shiftlog|seurat') no longer raises UnboundLocalError (#706)

### DIFF
--- a/omicverse/pp/_highly_variable_genes.py
+++ b/omicverse/pp/_highly_variable_genes.py
@@ -175,7 +175,7 @@ def _highly_variable_genes_seurat_v3(  # noqa: PLR0912, PLR0915
             stacklevel=3,
         )
 
-    df["means"], df["variances"] = _get_mean_var(data, axis=0, correction=1)
+    df["means"], df["variances"] = _get_mean_var(data, axis=0)
 
     if batch_key is None:
         batch_info = pd.Categorical(np.zeros(adata.shape[0], dtype=int))
@@ -186,7 +186,7 @@ def _highly_variable_genes_seurat_v3(  # noqa: PLR0912, PLR0915
     for b in np.unique(batch_info):
         data_batch = data[batch_info == b]
 
-        mean, var = _get_mean_var(data_batch, axis=0, correction=1)
+        mean, var = _get_mean_var(data_batch, axis=0)
         not_const = var > 0
         estimat_var = np.zeros(data.shape[1], dtype=np.float64)
 

--- a/omicverse/pp/_preprocess.py
+++ b/omicverse/pp/_preprocess.py
@@ -771,8 +771,8 @@ def preprocess(
             normalize_pearson_residuals(adata)
 
         if method_list[1] == 'pearson': # Size normalization + scanpy batch aware HVGs selection
-            from .experimental import highly_variable_genes
-            highly_variable_genes(
+            from .experimental import highly_variable_genes as _hvg_pearson
+            _hvg_pearson(
                 adata,
                 flavor="pearson_residuals",
                 layer='counts',
@@ -782,7 +782,13 @@ def preprocess(
             if no_cc:
                 remove_cc_genes(adata, organism=organism, corr_threshold=0.1)
         elif method_list[1] == 'seurat':
-            highly_variable_genes(
+            # Use the in-package implementation in
+            # `omicverse.pp._highly_variable_genes`, which natively
+            # supports `flavor='seurat_v3'`. The experimental variant in
+            # `.experimental` only supports `flavor='pearson_residuals'`,
+            # which is why the bare-name call here used to crash.
+            from ._highly_variable_genes import highly_variable_genes as _hvg_seurat
+            _hvg_seurat(
                 adata,
                 flavor="seurat_v3",
                 layer='counts',

--- a/tests/pp/test_preprocess_hvg_seurat_unboundlocal.py
+++ b/tests/pp/test_preprocess_hvg_seurat_unboundlocal.py
@@ -1,0 +1,97 @@
+"""Regression test for issue #706.
+
+`ov.pp.preprocess(mode="shiftlog|seurat", ...)` raised::
+
+    UnboundLocalError: cannot access local variable 'highly_variable_genes'
+    where it is not associated with a value
+
+…while the sibling `mode="shiftlog|pearson"` worked. Root cause was a
+local-name shadowing bug in `omicverse/pp/_preprocess.py::preprocess`:
+the `'pearson'` branch did ``from .experimental import
+highly_variable_genes`` inline, which Python promoted to a function-scope
+local-name binding. The `'seurat'` branch then referenced the same
+name *without* importing it — so when it ran (the `'pearson'` branch
+hadn't), Python raised `UnboundLocalError`.
+
+Even if the import had worked, the experimental
+`highly_variable_genes` only supports ``flavor='pearson_residuals'``
+(see ``omicverse/pp/experimental/_highly_variable_genes.py:324``),
+so the seurat branch should have been calling
+``sc.pp.highly_variable_genes(flavor='seurat_v3', ...)`` from the
+start — mirroring the rapids GPU branch a few lines below.
+
+This test pins both modes (pearson + seurat) so neither path can
+regress to the old bug.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import scipy.sparse as sp
+from anndata import AnnData
+
+
+def _synthetic_counts_adata(n_cells: int = 200, n_genes: int = 300,
+                            seed: int = 0) -> AnnData:
+    """Small Poisson-counts AnnData with a plausible HVG signal.
+
+    The first 30 genes get a 5× count boost so HVG selection finds
+    real candidates instead of returning an arbitrary 2k slice from
+    noise. Pre-fixate one absurdly high count so any future
+    `qc`-style filter that looks at `max(layer) < log(1e4)` doesn't
+    misclassify the matrix as already-log-normalised.
+    """
+    rng = np.random.default_rng(seed)
+    counts = rng.poisson(lam=2.0, size=(n_cells, n_genes)).astype(np.int32)
+    counts[:, :30] += rng.poisson(lam=8.0, size=(n_cells, 30)).astype(np.int32)
+    counts[0, 0] = 30  # ensures max > log(1e4) ≈ 9.21
+    adata = AnnData(X=sp.csr_matrix(counts.astype(np.float32)))
+    adata.var_names = [f"Gene{i:04d}" for i in range(n_genes)]
+    adata.obs_names = [f"cell{i:04d}" for i in range(n_cells)]
+    # `preprocess()` reads from `adata.layers['counts']` for HVG
+    # selection regardless of the chosen flavor.
+    adata.layers['counts'] = adata.X.copy()
+    return adata
+
+
+@pytest.mark.parametrize("hvg_method", ["seurat", "pearson"])
+def test_preprocess_shiftlog_modes_do_not_raise_unboundlocal(hvg_method):
+    """Both `shiftlog|<hvg>` modes must run end-to-end and write
+    `adata.var['highly_variable']`.
+
+    Before the fix, the `seurat` parametrisation raised:
+
+        UnboundLocalError: cannot access local variable
+        'highly_variable_genes' where it is not associated with a value
+
+    while the `pearson` parametrisation passed. We pin both so a
+    future refactor that re-introduces the local-shadow can't drop
+    only the seurat path silently.
+    """
+    import omicverse as ov
+
+    adata = _synthetic_counts_adata()
+
+    # NB: `no_cc=False` skips the cell-cycle gene removal that would
+    # otherwise pull a curated mouse / human gene list from the
+    # package data — irrelevant to the HVG-selection bug we're pinning.
+    ov.pp.preprocess(
+        adata,
+        mode=f"shiftlog|{hvg_method}",
+        n_HVGs=200,
+        target_sum=10000,
+        no_cc=False,
+    )
+
+    assert "highly_variable" in adata.var.columns, (
+        f"preprocess(mode='shiftlog|{hvg_method}') did not set "
+        f"`adata.var['highly_variable']`"
+    )
+    n_hvg = int(adata.var["highly_variable"].sum())
+    # We asked for 200 HVGs; the actual count can drift slightly
+    # because of ties / batch effects, but it should clearly be
+    # in the right ballpark.
+    assert 100 <= n_hvg <= 250, (
+        f"preprocess(mode='shiftlog|{hvg_method}') selected {n_hvg} HVGs; "
+        f"expected ~200 from `n_HVGs=200`"
+    )


### PR DESCRIPTION
Fixes #706.

## Reproducer

```python
adata = ov.pp.preprocess(adata, mode="shiftlog|pearson", n_HVGs=2000, target_sum=10000)  # works
adata = ov.pp.preprocess(adata, mode="shiftlog|seurat",  n_HVGs=2000, target_sum=10000)  # raises
```

```
UnboundLocalError: cannot access local variable 'highly_variable_genes'
where it is not associated with a value
```

## Root cause

Two compounding bugs surfaced together. The first explains the user's `UnboundLocalError`; the second was hiding behind it and would have crashed the seurat path with a different error as soon as the import was wired correctly.

### Bug 1 — local-name shadowing (`omicverse/pp/_preprocess.py`)

The `'pearson'` branch did `from .experimental import highly_variable_genes` *inline*. Python's scoping rules promote that import to a function-scope binding — the bare name `highly_variable_genes` becomes a *local* of the entire `preprocess` body. The `'seurat'` branch then referenced the same bare name without ever assigning to it, so when the `'pearson'` branch hadn't been taken (mode = seurat), Python raised `UnboundLocalError`.

The rapids GPU branch a few lines below (`elif method_list[1] == 'seurat': rsc.pp.highly_variable_genes(...)`) confirms the intended dispatch — for CPU the analogous call is the in-package HVG, not the experimental shim (which only supports `flavor='pearson_residuals'`).

### Bug 2 — stale `correction=1` kwarg (`omicverse/pp/_highly_variable_genes.py`)

`_highly_variable_genes_seurat_v3` calls `_get_mean_var(..., correction=1)` at lines 178 and 189. But the in-package `omicverse.pp._utils._get_mean_var` signature only accepts `(X, *, axis)` — no `correction` kwarg. The kwarg is a leftover from scanpy's signature (which the function was originally adapted from), where `correction=1` toggles unbiased-estimator variance. Our `_get_mean_var` already applies that correction unconditionally (line 62: `var *= X.shape[axis] / (X.shape[axis] - 1)`), so the kwarg was a no-op even back when scanpy was the host — it just trips a `TypeError` now.

This bug was masked by Bug 1: the seurat path never reached `_get_mean_var` because the call site crashed earlier with `UnboundLocalError`.

## Fix

```diff
# omicverse/pp/_preprocess.py
-        if method_list[1] == 'pearson':
-            from .experimental import highly_variable_genes
-            highly_variable_genes(
+        if method_list[1] == 'pearson':
+            from .experimental import highly_variable_genes as _hvg_pearson
+            _hvg_pearson(
                 adata,
                 flavor="pearson_residuals",
                 ...
             )
         elif method_list[1] == 'seurat':
-            highly_variable_genes(
+            from ._highly_variable_genes import highly_variable_genes as _hvg_seurat
+            _hvg_seurat(
                 adata,
                 flavor="seurat_v3",
                 ...
             )
```

```diff
# omicverse/pp/_highly_variable_genes.py
-    df["means"], df["variances"] = _get_mean_var(data, axis=0, correction=1)
+    df["means"], df["variances"] = _get_mean_var(data, axis=0)
-        mean, var = _get_mean_var(data_batch, axis=0, correction=1)
+        mean, var = _get_mean_var(data_batch, axis=0)
```

- Both inline imports are aliased (`_hvg_pearson` / `_hvg_seurat`) so the bound names are unambiguous and can't shadow the public `highly_variable_genes` defined later in the same module.
- The seurat branch now dispatches to the in-package `omicverse.pp._highly_variable_genes.highly_variable_genes`, which natively supports `flavor='seurat_v3'`. **No scanpy import.**
- The two `correction=1` kwargs are dropped — the underlying `_get_mean_var` already does what scanpy's `correction=1` would do.

## Regression test

`tests/pp/test_preprocess_hvg_seurat_unboundlocal.py` parametrises over both `seurat` and `pearson` modes and asserts `adata.var['highly_variable']` gets populated. Pre-fix the `seurat` parametrisation raised `UnboundLocalError`; both pass post-fix.

```
$ pytest tests/pp/test_preprocess_hvg_seurat_unboundlocal.py -v
tests/pp/test_preprocess_hvg_seurat_unboundlocal.py::test_preprocess_shiftlog_modes_do_not_raise_unboundlocal[seurat]   PASSED
tests/pp/test_preprocess_hvg_seurat_unboundlocal.py::test_preprocess_shiftlog_modes_do_not_raise_unboundlocal[pearson]  PASSED
===== 2 passed in 19.95s =====
```

## Test plan

- [x] `pytest tests/pp/test_preprocess_hvg_seurat_unboundlocal.py` — 2/2 pass
- [x] Manual repro against the issue's snippet (`mode="shiftlog|seurat", n_HVGs=2000, target_sum=10000`) no longer raises and produces an HVG column
- [x] `mode="shiftlog|pearson"` (the previously-working path) still works
- [x] No scanpy import added — the seurat branch uses the in-package `omicverse.pp._highly_variable_genes.highly_variable_genes`
- [ ] Reviewer: spot-check the rapids branch — it was already calling `rsc.pp.highly_variable_genes(flavor='seurat_v3', ...)`, so this PR brings the cpu branch into the same shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)