### PR TITLE
fix(pl): volcano misclassifies significant genes when sig column uses…

### DIFF
--- a/omicverse/bulk/_Deseq2.py
+++ b/omicverse/bulk/_Deseq2.py
@@ -612,7 +612,8 @@ class pyDEG(object):
             #max mean of between each value in group1 and group2
             #result=result[result['padj']<alpha]
             result['sig']='normal'
-            result.loc[result['qvalue']<alpha,'sig']='sig'
+            result.loc[(result['qvalue'] < alpha) & (result['log2FC'] > 0), 'sig'] = 'up'
+            result.loc[(result['qvalue'] < alpha) & (result['log2FC'] < 0), 'sig'] = 'down'
             print(f"✅ Differential expression analysis completed.")
             
             self.result=result
@@ -716,7 +717,8 @@ class pyDEG(object):
             result['log2FC'] = result['log2FoldChange']
             result['abs(log2FC)'] = abs(result['log2FC'])
             result['sig'] = 'normal'
-            result.loc[result['qvalue'] < alpha, 'sig'] = 'sig'
+            result.loc[(result['qvalue'] < alpha) & (result['log2FC'] > 0), 'sig'] = 'up'
+            result.loc[(result['qvalue'] < alpha) & (result['log2FC'] < 0), 'sig'] = 'down'
             self.result = result
             print(f"✅ Differential expression analysis completed.")
             return result
@@ -776,7 +778,8 @@ class pyDEG(object):
             #max mean of between each value in group1 and group2
             #result=result[result['padj']<alpha]
             result['sig']='normal'
-            result.loc[result['qvalue']<alpha,'sig']='sig'
+            result.loc[(result['qvalue'] < alpha) & (result['log2FC'] > 0), 'sig'] = 'up'
+            result.loc[(result['qvalue'] < alpha) & (result['log2FC'] < 0), 'sig'] = 'down'
             self.result=result
             print(f"✅ Differential expression analysis completed.")
             return result
@@ -838,7 +841,8 @@ class pyDEG(object):
             #max mean of between each value in group1 and group2
             #result=result[result['padj']<alpha]
             result['sig']='normal'
-            result.loc[result['qvalue']<alpha,'sig']='sig'
+            result.loc[(result['qvalue'] < alpha) & (result['log2FC'] > 0), 'sig'] = 'up'
+            result.loc[(result['qvalue'] < alpha) & (result['log2FC'] < 0), 'sig'] = 'down'
 
             result['F']=fit_eb.F.reshape(-1)
             result['t']=fit_eb.t.values.reshape(-1)

--- a/omicverse/pl/_bulk.py
+++ b/omicverse/pl/_bulk.py
@@ -115,6 +115,12 @@ def volcano(result,pval_name='qvalue',fc_name='log2FC',pval_max=None,FC_max=None
         print(f"   {Colors.FAIL}❌ Missing required columns: {Colors.BOLD}{missing_cols}{Colors.ENDC}")
         raise ValueError(f"Missing required columns: {missing_cols}")
     
+    valid_sig = {'up', 'down', 'normal'}
+    if not set(result['sig'].unique()).issubset(valid_sig):
+        result['sig'] = 'normal'
+        result.loc[(result[fc_name] > fc_max) & (result[pval_name] < pval_threshold), 'sig'] = 'up'
+        result.loc[(result[fc_name] < fc_min) & (result[pval_name] < pval_threshold), 'sig'] = 'down'
+
     # Calculate gene counts by significance
     sig_counts = result['sig'].value_counts()
     total_sig = sig_counts.get('up', 0) + sig_counts.get('down', 0)
@@ -160,13 +166,13 @@ def volcano(result,pval_name='qvalue',fc_name='log2FC',pval_max=None,FC_max=None
         suggestions.append(f"     {Colors.GREEN}Suggested: {Colors.BOLD}fc_max={new_fc_max}, fc_min={new_fc_min}{Colors.ENDC}")
     
     # Check plot size based on gene label settings
-    if plot_genes_num > 20 and figsize[0] < 6:
+    if plot_genes_num is not None and plot_genes_num > 20 and figsize[0] < 6:
         suggestions.append(f"   {Colors.WARNING}▶ Many gene labels with small plot:{Colors.ENDC}")
         suggestions.append(f"     {Colors.CYAN}Current: plot_genes_num={Colors.BOLD}{plot_genes_num}{Colors.ENDC}{Colors.CYAN}, figsize={Colors.BOLD}{figsize}{Colors.ENDC}")
         suggestions.append(f"     {Colors.GREEN}Suggested: {Colors.BOLD}figsize=(6, 6){Colors.ENDC} or {Colors.BOLD}plot_genes_num=15{Colors.ENDC}")
     
     # Check if gene labels might be too small
-    if plot_genes_fontsize < 8 and plot_genes_num > 15:
+    if plot_genes_fontsize < 8 and plot_genes_num is not None and plot_genes_num > 15:
         suggestions.append(f"   {Colors.WARNING}▶ Small font with many labels:{Colors.ENDC}")
         suggestions.append(f"     {Colors.CYAN}Current: plot_genes_fontsize={Colors.BOLD}{plot_genes_fontsize}{Colors.ENDC}{Colors.CYAN}, plot_genes_num={Colors.BOLD}{plot_genes_num}{Colors.ENDC}")
         suggestions.append(f"     {Colors.GREEN}Suggested: {Colors.BOLD}plot_genes_fontsize=10{Colors.ENDC} or {Colors.BOLD}plot_genes_num=10{Colors.ENDC}")
@@ -202,13 +208,13 @@ def volcano(result,pval_name='qvalue',fc_name='log2FC',pval_max=None,FC_max=None
             optimized_params.append(f"fc_max={new_fc_max}")
             optimized_params.append(f"fc_min={new_fc_min}")
         
-        if plot_genes_num > 20 and figsize[0] < 6:
+        if plot_genes_num is not None and plot_genes_num > 20 and figsize[0] < 6:
             optimized_params.append("figsize=(6, 6)")
         elif abs(figsize[0] - figsize[1]) > 2:
             optimal_size = max(figsize)
             optimized_params.append(f"figsize=({optimal_size}, {optimal_size})")
         
-        if plot_genes_fontsize < 8 and plot_genes_num > 15:
+        if plot_genes_fontsize < 8 and plot_genes_num is not None and plot_genes_num > 15:
             optimized_params.append("plot_genes_fontsize=10")
         
         if plot_genes is not None:
@@ -269,7 +275,7 @@ def volcano(result,pval_name='qvalue',fc_name='log2FC',pval_max=None,FC_max=None
             linestyle="--",
             color='black')
     #设置横标签与纵标签
-    ax.set_ylabel(r'$-log_{10}(qvalue)$',titlefont)                                    
+    ax.set_ylabel(rf'$-log_{{10}}({pval_name})$',titlefont)
     ax.set_xlabel(r'$log_{2}FC$',titlefont)
     #设置标题
     ax.set_title(title,titlefont)

--- a/omicverse/single/_deg_ct.py
+++ b/omicverse/single/_deg_ct.py
@@ -495,7 +495,8 @@ class DEG:
             res['qvalue']=md_d['pvals_adj'].tolist()
             res['size']=np.abs(res['log2FC'])/10
             res['sig']='normal'
-            res.loc[res['padj']<0.05,'sig']='sig'
+            res.loc[(res['padj'] < 0.05) & (res['log2FC'] > 0), 'sig'] = 'up'
+            res.loc[(res['padj'] < 0.05) & (res['log2FC'] < 0), 'sig'] = 'down'
             res['-log(pvalue)'] = -np.log10(res['pvalue'])
             res['-log(qvalue)'] = -np.log10(res['qvalue'])
             #calculate the Mean of the self.adata_test's genes(var)


### PR DESCRIPTION
## Summary
- ov.pl.volcano failed to display up/down-regulated genes when the input `sig` column used values other than 'up'/'down'/'normal' (e.g. 'sig' from DEG pipelines). All colored significant points disappeared, and the legend showed "up=0, down=0".
- The y-axis label was hardcoded as "-log10(qvalue)" regardless of the `pval_name` parameter.
- `plot_genes_num=None` crashed on comparison operators.

## Root Cause
`ov.single.DEGct` and `pyDEG.deg_analysis` (ttest, DEseq2, edgepy, limma) all set `sig='sig'` for significant genes without distinguishing up vs down. `ov.pl.volcano` only matched on 'up'/'down'/'normal'.

## Fix
1. **ov.pl.volcano** (belt): defensive re-classification when `sig` column contains non-standard values; dynamic y-axis label; None-guard for plot_genes_num
2. **ov.single.DEGct** (suspenders): classify 'up'/'down' using log2FC
3. **pyDEG.deg_analysis** (suspenders): same for all 4 methods

Closes #711