### PR TITLE
Fix CCC circle aggregation consistency and sender legends

### DIFF
--- a/omicverse/pl/_ccc.py
+++ b/omicverse/pl/_ccc.py
@@ -268,6 +268,7 @@ def _communication_long_table(
     if pair_lr_use is not None:
         long_df = long_df.loc[long_df["pair_lr"].isin(pair_lr_use)]
 
+    long_df = long_df.loc[long_df["significant"]].copy()
     return long_df.reset_index(drop=True)
 
 
@@ -3589,6 +3590,22 @@ def _draw_circle_network(
         connectionstyle="arc3,rad=0.15",
     )
     nx.draw_networkx_labels(graph, pos, font_size=10, ax=ax)
+    active_senders = list(dict.fromkeys(source for source, _ in graph.edges))
+    if 0 < len(active_senders) <= 20:
+        legend_handles = [
+            plt.Line2D([0], [0], color=colors[sender], lw=4, label=f"{sender} (sender)")
+            for sender in active_senders
+        ]
+        legend = ax.legend(
+            handles=legend_handles,
+            title="Sender",
+            loc="center left",
+            bbox_to_anchor=(1.02, 0.5),
+            frameon=False,
+            fontsize=8,
+        )
+        if legend is not None and legend.get_title() is not None:
+            legend.get_title().set_fontsize(9)
     ax.set_title(title or "Communication network")
     ax.set_axis_off()
     return fig, ax
@@ -4737,7 +4754,7 @@ def ccc_network_plot(
     classification_fallback: str | None = "family",
     pvalue_threshold: float = 0.05,
     value: Literal["sum", "mean", "max", "count"] = "sum",
-    top_n: int = 20,
+    top_n: int | None = None,
     ligand: str | None = None,
     receptor=None,
     normalize_to_sender: bool = True,
@@ -4810,9 +4827,11 @@ def ccc_network_plot(
     value : {"sum", "mean", "max", "count"}, default="sum"
         Aggregation statistic used when communication strengths are collapsed
         before plotting.
-    top_n : int, default=20
+    top_n : int or None, default=None
         Number of top pathways, interactions, or pairs retained for plot
-        types that rank results before drawing.
+        types that rank results before drawing. Circle-style network views keep
+        all significant edges by default; flow-style views use an internal
+        default of 20 when ``top_n`` is omitted.
     ligand : str or None, default=None
         Ligand name used by ligand-centric plots such as ``bipartite`` or
         ligand-receptor chord views.
@@ -4884,6 +4903,7 @@ def ccc_network_plot(
         func_name="ccc_network_plot",
     )
     _validate_display_by(display_by, func_name="ccc_network_plot")
+    flow_top_n = 20 if top_n is None else top_n
 
     adata = _resolve_comm_adata(
         adata,
@@ -5241,7 +5261,7 @@ def ccc_network_plot(
             ),
             display_by=display_by,
             value=value,
-            top_n=top_n,
+            top_n=flow_top_n,
         )
         fig, ax = _draw_arrow_network(
             flow_edges,
@@ -5264,7 +5284,7 @@ def ccc_network_plot(
             ),
             display_by=display_by,
             value=value,
-            top_n=top_n,
+            top_n=flow_top_n,
         )
         fig, ax = _draw_sigmoid_network(
             flow_edges,

--- a/omicverse/pl/_cpdbviz.py
+++ b/omicverse/pl/_cpdbviz.py
@@ -2903,44 +2903,76 @@ class CellChatViz(CellChatVizPlus):
         
         # Choose visualization method based on layout type
         if layout == 'circle':
-            title = f"Signaling Pathway: {', '.join(signaling)} (Circle)"
-            from ._ccc import ccc_network_plot
-
-            try:
-                # Route aggregated circle rendering through the Python-native CCC
-                # backend so pathway circles share the same visual language as
-                # `ov.pl.ccc_network_plot(..., plot_type="circle")`.
-                fig, ax = ccc_network_plot(
-                    self.adata,
-                    plot_type="circle",
-                    signaling=signaling,
-                    sender_use=vertex_sender,
-                    receiver_use=vertex_receiver,
-                    pvalue_threshold=pvalue_threshold,
-                    value="sum",
-                    top_n=top_n,
-                    palette=self.palette,
-                    figsize=figsize,
-                    title=title,
-                    show=False,
-                    save=False,
-                )
-            except ValueError:
+            if pathway_matrix.sum() == 0:
                 fig, ax = plt.subplots(figsize=figsize)
-                if vertex_sender is not None or vertex_receiver is not None:
-                    sender_str = f"senders: {vertex_sender}" if vertex_sender else "any senders"
-                    receiver_str = f"receivers: {vertex_receiver}" if vertex_receiver else "any receivers"
-                    message = (
-                        f'No interactions found for pathway(s): {", ".join(signaling)}\n'
-                        f'with {sender_str} and {receiver_str}'
-                    )
-                    fontsize = 14
-                else:
-                    message = f'No significant interactions found for pathway(s): {", ".join(signaling)}'
-                    fontsize = 16
-                ax.text(0.5, 0.5, message, ha='center', va='center', fontsize=fontsize)
+                ax.text(0.5, 0.5, f'No significant interactions found for pathway(s): {", ".join(signaling)}',
+                       ha='center', va='center', fontsize=16)
                 ax.axis('off')
                 return fig, ax
+
+            title = f"Signaling Pathway: {', '.join(signaling)} (Circle)"
+
+            if vertex_sender is not None or vertex_receiver is not None:
+                filtered_matrix = np.zeros_like(pathway_matrix)
+
+                for i, sender_type in enumerate(self.cell_types):
+                    for j, receiver_type in enumerate(self.cell_types):
+                        sender_ok = (vertex_sender is None) or (sender_type in vertex_sender)
+                        receiver_ok = (vertex_receiver is None) or (receiver_type in vertex_receiver)
+
+                        if sender_ok and receiver_ok and pathway_matrix[i, j] > 0:
+                            filtered_matrix[i, j] = pathway_matrix[i, j]
+
+                pathway_matrix = filtered_matrix
+
+                if pathway_matrix.sum() == 0:
+                    fig, ax = plt.subplots(figsize=figsize)
+                    sender_str = f"senders: {vertex_sender}" if vertex_sender else "any senders"
+                    receiver_str = f"receivers: {vertex_receiver}" if vertex_receiver else "any receivers"
+                    ax.text(0.5, 0.5, f'No interactions found for pathway(s): {", ".join(signaling)}\nwith {sender_str} and {receiver_str}',
+                           ha='center', va='center', fontsize=14)
+                    ax.axis('off')
+                    return fig, ax
+
+            if top_n is not None and top_n > 0:
+                positive_edges = np.argwhere(pathway_matrix > 0)
+                if len(positive_edges) > int(top_n):
+                    edge_weights = pathway_matrix[pathway_matrix > 0]
+                    keep_order = np.argsort(edge_weights)[::-1][:int(top_n)]
+                    top_matrix = np.zeros_like(pathway_matrix)
+                    for edge_idx in keep_order:
+                        sender_idx, receiver_idx = positive_edges[edge_idx]
+                        top_matrix[sender_idx, receiver_idx] = pathway_matrix[sender_idx, receiver_idx]
+                    pathway_matrix = top_matrix
+
+            if focused_view:
+                fig, ax = self.netVisual_circle_focused(
+                    matrix=pathway_matrix,
+                    title=title,
+                    edge_width_max=edge_width_max,
+                    vertex_size_max=vertex_size_max,
+                    show_labels=show_labels,
+                    cmap=cmap,
+                    figsize=figsize,
+                    min_interaction_threshold=0,
+                    use_sender_colors=use_sender_colors,
+                    use_curved_arrows=use_curved_arrows,
+                    curve_strength=curve_strength
+                )
+            else:
+                fig, ax = self.netVisual_circle(
+                    matrix=pathway_matrix,
+                    title=title,
+                    edge_width_max=edge_width_max,
+                    vertex_size_max=vertex_size_max,
+                    show_labels=show_labels,
+                    cmap=cmap,
+                    figsize=figsize,
+                    use_sender_colors=use_sender_colors,
+                    use_curved_arrows=use_curved_arrows,
+                    curve_strength=curve_strength,
+                    adjust_text=adjust_text
+                )
         
         elif layout == 'hierarchy':
             # Determine source and target cells

--- a/tests/pl/test_ccc_plots.py
+++ b/tests/pl/test_ccc_plots.py
@@ -102,6 +102,78 @@ def _build_comm_adata_with_duplicate_pairs() -> AnnData:
     return adata
 
 
+def _build_comm_adata_with_high_nonsignificant_scores() -> AnnData:
+    obs = pd.DataFrame(
+        {
+            "sender": ["A", "A", "B", "B"],
+            "receiver": ["A", "B", "A", "B"],
+        },
+        index=["A|A", "A|B", "B|A", "B|B"],
+    )
+    var = pd.DataFrame(
+        {
+            "interacting_pair": ["L1_R1", "L2_R2"],
+            "interaction_name": ["L1_R1", "L2_R2"],
+            "interaction_name_2": ["L1 - R1", "L2 - R2"],
+            "classification": ["Pathway", "Pathway"],
+            "gene_a": ["L1", "L2"],
+            "gene_b": ["R1", "R2"],
+        },
+        index=["L1_R1", "L2_R2"],
+    )
+    means = np.array(
+        [
+            [1.0, 100.0],
+            [2.0, 200.0],
+            [3.0, 300.0],
+            [4.0, 400.0],
+        ],
+        dtype=float,
+    )
+    pvalues = np.array(
+        [
+            [0.01, 0.50],
+            [0.02, 0.50],
+            [0.50, 0.50],
+            [0.50, 0.50],
+        ],
+        dtype=float,
+    )
+    adata = AnnData(X=means.copy(), obs=obs, var=var)
+    adata.layers["means"] = means.copy()
+    adata.layers["pvalues"] = pvalues.copy()
+    return adata
+
+
+def _build_dense_pathway_comm_adata(n_cell_types: int = 5) -> AnnData:
+    cell_types = [f"Cell{i}" for i in range(n_cell_types)]
+    obs = pd.DataFrame(
+        [
+            {"sender": sender, "receiver": receiver}
+            for sender in cell_types
+            for receiver in cell_types
+        ],
+        index=[f"{sender}|{receiver}" for sender in cell_types for receiver in cell_types],
+    )
+    var = pd.DataFrame(
+        {
+            "interacting_pair": ["L1_R1"],
+            "interaction_name": ["L1_R1"],
+            "interaction_name_2": ["L1 - R1"],
+            "classification": ["Dense"],
+            "gene_a": ["L1"],
+            "gene_b": ["R1"],
+        },
+        index=["L1_R1"],
+    )
+    means = np.arange(1, n_cell_types * n_cell_types + 1, dtype=float).reshape(-1, 1)
+    pvalues = np.full_like(means, 0.01, dtype=float)
+    adata = AnnData(X=means.copy(), obs=obs, var=var)
+    adata.layers["means"] = means.copy()
+    adata.layers["pvalues"] = pvalues.copy()
+    return adata
+
+
 def _build_raw_liana_adata(*, uns_key: str = "liana_res", shifted: bool = False) -> AnnData:
     adata = AnnData(X=np.zeros((1, 1), dtype=float))
     specificity = [0.01, 0.04, 0.15, 0.03]
@@ -453,6 +525,52 @@ def test_ccc_network_plot_pathway_forwards_top_n(monkeypatch, comm_adata: AnnDat
     assert captured["top_n"] == 7
 
 
+def test_ccc_circle_keeps_all_edges(monkeypatch) -> None:
+    adata = _build_dense_pathway_comm_adata()
+    captured_lengths: list[int] = []
+
+    def _fake_draw_circle_network(edge_df, **kwargs):
+        captured_lengths.append(len(edge_df))
+        return plt.subplots(figsize=kwargs.get("figsize", (7, 7)))
+
+    monkeypatch.setattr(ccc_mod, "_draw_circle_network", _fake_draw_circle_network)
+
+    fig, ax = ov.pl.ccc_network_plot(
+        adata,
+        plot_type="circle",
+        signaling="Dense",
+        show=False,
+    )
+    _assert_figure_and_axes(fig, ax)
+
+    fig, ax = ov.pl.ccc_network_plot(
+        adata,
+        plot_type="circle",
+        signaling="Dense",
+        top_n=7,
+        show=False,
+    )
+    _assert_figure_and_axes(fig, ax)
+
+    assert captured_lengths == [25, 7]
+
+
+def test_ccc_circle_sender_legend() -> None:
+    adata = _build_comm_adata_with_high_nonsignificant_scores()
+
+    fig, ax = ov.pl.ccc_network_plot(
+        adata,
+        plot_type="circle",
+        signaling="Pathway",
+        show=False,
+    )
+
+    _assert_figure_and_axes(fig, ax)
+    legend = ax.get_legend()
+    assert legend is not None
+    assert [text.get_text() for text in legend.get_texts()] == ["A (sender)"]
+
+
 @pytest.mark.parametrize(
     ("plot_type", "method_name"),
     [
@@ -614,7 +732,11 @@ def test_ccc_stat_plot_interaction_sankey_returns_figure_and_axes(comm_adata: An
         show=False,
     )
     _assert_figure_and_axes(fig, ax)
-    interaction_texts = [text for text in ax.texts if "CXCL12" in text.get_text() or "TGFB1" in text.get_text()]
+    interaction_texts = [
+        text
+        for text in ax.texts
+        if "FN1" in text.get_text() or "MIF" in text.get_text()
+    ]
     assert interaction_texts
     assert all(text.get_rotation() == 0 for text in interaction_texts)
     assert any(" - " in text.get_text() for text in interaction_texts)


### PR DESCRIPTION
## Summary

This PR fixes inconsistent CCC circle network results reported in #713.

The issue came from newer circle plotting paths aggregating communication scores differently from the legacy `CellChatViz.netVisual_aggregate` behavior.
`netVisual_aggregate` in 1.7.7 only sums LR pairs with `pvalue < pvalue_threshold`, while newer shared CCC paths could include non-significant scores in aggregated edge weights.

## Changes

- Restored `CellChatViz.netVisual_aggregate(..., layout="circle")` to render from its significant-only pathway matrix.
- Updated shared `ccc_*` communication tables to keep only significant communication events.
- Changed `ccc_network_plot(..., plot_type="circle")` to keep all significant edges by default instead of defaulting to `top_n=20`.
- Preserved `top_n` as an explicit optional edge filter when users want truncation.
- Added sender legends to generic `ccc_network_plot` circle networks, because edge colors encode sender cell type.
- Added regression coverage for circle edge retention and sender legends.