### PR TITLE
fix(io): load Xenium V2 / Prime morphology_focus channels (#708)

### DIFF
--- a/omicverse/io/spatial/_xenium.py
+++ b/omicverse/io/spatial/_xenium.py
@@ -119,59 +119,128 @@ def _load_experiment_metadata(root: Path) -> dict:
         return {}
 
 
+def _morphology_candidates(root: Path, name: str) -> list[Path]:
+    """Build a search-ordered list of candidate morphology OME-TIFFs.
+
+    Xenium morphology images ship in three layouts:
+
+    * **V1**: ``morphology_focus.ome.tif`` / ``morphology_mip.ome.tif`` at the
+      ``outs`` root.
+    * **V2 / Prime (directory)**: ``morphology_focus/morphology_focus_NNNN.ome.tif``
+      with one file per stain channel (e.g. ``_0000`` = DAPI).
+    * **V2 (flat)**: same per-channel files but written next to ``cells.parquet``.
+
+    The returned list honours the user's ``image_key``:
+
+    * ``"morphology_focus"`` / ``"morphology_mip"`` — pick the V1 file if it
+      exists; otherwise fall back to the first V2 channel (``_0000``).
+    * ``"morphology_focus_NNNN"`` — prefer the specific V2 channel; fall back to
+      other V2 channels and finally V1 layouts so an explicit channel still
+      yields *some* image when the requested channel is missing.
+    """
+    name = (name or "morphology_focus").strip()
+    focus_dir = root / "morphology_focus"
+    v2_files: list[Path] = []
+    if focus_dir.is_dir():
+        v2_files.extend(sorted(focus_dir.glob("morphology_focus_*.ome.tif")))
+    v2_files.extend(sorted(root.glob("morphology_focus_*.ome.tif")))
+
+    candidates: list[Path] = []
+    if name.startswith("morphology_focus_") or name.startswith("morphology_mip_"):
+        target = f"{name}.ome.tif"
+        # Specific channel first, then siblings as fallback.
+        for f in v2_files:
+            if f.name == target:
+                candidates.append(f)
+        for f in v2_files:
+            if f.name != target:
+                candidates.append(f)
+        # Also allow a flat-named file at root (rare, but cheap to check).
+        candidates.append(root / target)
+    else:
+        # Generic key — V1 first, then V2 channels.
+        candidates.append(root / f"{name}.ome.tif")
+        candidates.extend(v2_files)
+        if name != "morphology_focus":
+            candidates.append(root / "morphology_focus.ome.tif")
+
+    seen: set[Path] = set()
+    unique: list[Path] = []
+    for cand in candidates:
+        if cand in seen:
+            continue
+        seen.add(cand)
+        unique.append(cand)
+    return unique
+
+
+def _read_pyramid(cand: Path, max_dim: int) -> tuple[np.ndarray, float]:
+    """Read one OME-TIFF, returning ``(image_2d, downsample_factor)``.
+
+    ``_multifile=False`` keeps tifffile from following the OME-XML's references
+    to *sibling* per-channel files (Xenium V2 / Prime ships
+    ``morphology_focus_0000.ome.tif`` with TiffData/UUID entries pointing at
+    ``_0001``…``_0003``). With the default ``_multifile=True`` tifffile merges
+    those into a single multi-channel series, which silently breaks the
+    pyramid-level walk below — so we always read each file as its own
+    single-channel pyramid and pick the channel up the directory listing.
+    """
+    import tifffile
+
+    with tifffile.TiffFile(cand, _multifile=False) as tif:
+        series = tif.series[0]
+        levels = getattr(series, "levels", None) or [series]
+        full_h, full_w = levels[0].shape[-2:]
+        target_idx = 0
+        for i, lvl in enumerate(levels):
+            h, w = lvl.shape[-2:]
+            if max(h, w) <= max_dim:
+                target_idx = i
+                break
+        else:
+            target_idx = len(levels) - 1
+        target = levels[target_idx]
+        arr = target.asarray()
+    while arr.ndim > 2:
+        arr = arr[0]
+    downsample = arr.shape[0] / full_h if full_h else 1.0
+    return arr, float(downsample)
+
+
 def _load_morphology_image(
     root: Path,
     name: str,
     max_dim: int = 4096,
-) -> Optional[tuple[np.ndarray, float]]:
+) -> Optional[tuple[np.ndarray, float, Path]]:
     """Load a morphology image (OME-TIFF) and its downsample factor.
 
-    Xenium output ships either a flat ``morphology_focus.ome.tif`` /
-    ``morphology_mip.ome.tif`` (V1) or a ``morphology_focus/morphology_focus_0000.ome.tif``
-    directory layout (V2+). The file is a multi-resolution pyramid; we pick the
-    highest-resolution level whose largest dimension fits under ``max_dim`` so the
-    in-memory array is bounded while remaining usable for overlay. Returns the
-    image and the ``chosen_level_size / full_res_size`` downsample factor so
-    coordinates can still be mapped into image-pixel space later.
+    Returns ``(image_2d, downsample, source_path)`` or ``None`` if no candidate
+    could be read. Failures for individual candidates are surfaced via
+    ``_progress(..., level='warn')`` so the user can see *which* file failed
+    rather than a generic "no morphology image loaded".
     """
-    candidates = []
-    focus_dir = root / "morphology_focus"
-    if focus_dir.is_dir():
-        candidates.extend(sorted(focus_dir.glob("morphology_focus_*.ome.tif")))
-    candidates.append(root / f"{name}.ome.tif")
+    candidates = _morphology_candidates(root, name)
+    if not candidates:
+        return None
+
+    try:
+        import tifffile  # noqa: F401
+    except ImportError:
+        warnings.warn(
+            "tifffile not installed — skipping morphology image. "
+            "`pip install tifffile` to enable H&E / DAPI overlay."
+        )
+        return None
+
     for cand in candidates:
         if not cand.exists():
             continue
         try:
-            import tifffile
-
-            with tifffile.TiffFile(cand) as tif:
-                series = tif.series[0]
-                levels = getattr(series, "levels", None) or [series]
-                # Full-res is levels[0]; walk down pyramid until both dims fit.
-                full_h, full_w = levels[0].shape[-2:]
-                target_idx = 0
-                for i, lvl in enumerate(levels):
-                    h, w = lvl.shape[-2:]
-                    if max(h, w) <= max_dim:
-                        target_idx = i
-                        break
-                else:
-                    target_idx = len(levels) - 1
-                target = levels[target_idx]
-                arr = target.asarray()
-            while arr.ndim > 2:
-                arr = arr[0]
-            downsample = arr.shape[0] / full_h if full_h else 1.0
-            return arr, float(downsample)
-        except ImportError:
-            warnings.warn(
-                "tifffile not installed — skipping morphology image. "
-                "`pip install tifffile` to enable H&E / DAPI overlay."
-            )
-            return None
+            arr, downsample = _read_pyramid(cand, max_dim=max_dim)
         except Exception as exc:
-            warnings.warn(f"Failed to read {cand.name}: {exc}")
+            _progress(f"Failed to read {cand}: {exc}", level="warn")
+            continue
+        return arr, downsample, cand
     return None
 
 
@@ -214,8 +283,11 @@ def read_xenium(
           cells.csv.gz    (or cells.parquet)# per-cell metadata incl. centroids
           experiment.xenium                 # run / panel metadata (JSON)
           morphology_focus.ome.tif          # V1 focused morphology image (optional)
-          morphology_focus/                 # V2+ morphology folder (optional)
-              morphology_focus_0000.ome.tif
+          morphology_focus/                 # V2 / Prime morphology folder (optional)
+              morphology_focus_0000.ome.tif  # DAPI
+              morphology_focus_0001.ome.tif  # boundary stain
+              morphology_focus_0002.ome.tif  # interior stain
+              morphology_focus_0003.ome.tif  # 4th channel (Prime panels)
 
     Parameters
     ----------
@@ -231,9 +303,16 @@ def read_xenium(
         (hundreds of MB); pass ``False`` for lightweight tutorials that only need
         the centroid scatter.
     image_key
-        Which morphology image to prefer when both ``morphology_focus`` and
-        ``morphology_mip`` are shipped. One of ``'morphology_focus'``,
-        ``'morphology_mip'``, ``'morphology'``.
+        Which morphology image to load. Accepts:
+
+        * ``'morphology_focus'`` / ``'morphology_mip'`` — V1 layout files at
+          the outs root; falls back to the first V2 channel (``_0000``, DAPI)
+          when V1 files are absent.
+        * ``'morphology_focus_NNNN'`` — pick a specific V2 / Prime channel
+          (``_0000`` DAPI, ``_0001`` boundary, ``_0002`` interior, ``_0003``
+          alternative) from ``morphology_focus/``. If the requested channel
+          is missing, the reader falls back to the other available channels
+          rather than returning no image.
     image_max_dim
         Xenium OME-TIFFs are multi-resolution pyramids; this is the maximum
         pixel extent along either axis that we will load. The highest-resolution
@@ -373,10 +452,10 @@ def read_xenium(
     if load_image:
         loaded = _load_morphology_image(root, image_key, max_dim=image_max_dim)
         if loaded is not None:
-            img, downsample = loaded
+            img, downsample, src_path = loaded
             _progress(
                 f"Loaded morphology image {img.shape} "
-                f"(pyramid downsample {downsample:.4f}) from {root}"
+                f"(pyramid downsample {downsample:.4f}) from {src_path}"
             )
             uns_spatial["images"]["hires"] = img
             # Rescale so that micron × scalef lands on the downsampled image.
@@ -385,7 +464,14 @@ def read_xenium(
                 spot_diameter_fullres * downsample
             )
         else:
-            _progress("No morphology image loaded (set load_image=False to silence).", level="warn")
+            tried = _morphology_candidates(root, image_key)
+            tried_repr = ", ".join(str(p) for p in tried) if tried else "no candidates"
+            _progress(
+                "No morphology image loaded (tried: "
+                f"{tried_repr}). Set load_image=False to silence, or pass a "
+                "specific channel via image_key='morphology_focus_0000'.",
+                level="warn",
+            )
 
     has_geometry = False
     if load_boundaries:

--- a/tests/test_io_xenium_morphology.py
+++ b/tests/test_io_xenium_morphology.py
@@ -1,0 +1,247 @@
+"""Regression test for the V2 / Prime Xenium morphology loader (issue #708).
+
+Real Xenium Prime ``outs.zip`` is many tens of GB, so this test builds a tiny
+synthetic ``outs/`` directory that mirrors the V2 layout — including the
+``morphology_focus/`` directory of per-channel OME-TIFF pyramids — and exercises
+the loader end-to-end with ``load_image=True``.
+
+What it covers:
+
+- ``morphology_focus/morphology_focus_NNNN.ome.tif`` discovery (V2 / Prime
+  layout). Pre-fix this case silently produced
+  ``[Xenium] No morphology image loaded`` because tifffile's default
+  ``_multifile=True`` followed the OME-XML cross-references between the four
+  per-channel files and broke the pyramid-level walk.
+- ``image_key='morphology_focus_0000'`` selecting the requested channel.
+- Pyramid-level selection: reader picks the highest-resolution level whose
+  largest dimension fits under ``image_max_dim`` and reports the correct
+  downsample factor.
+- Fallback when the requested channel is missing: the loader still returns
+  another available channel rather than ``None``.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import h5py
+import numpy as np
+import pandas as pd
+import pytest
+import scipy.sparse as sp
+
+
+N_CELLS = 12
+N_GENES = 6
+PIXEL_SIZE_UM = 0.2125
+FULL_H, FULL_W = 800, 600  # full-res morphology image size
+PYRAMID_DOWNSAMPLES = (1, 2, 4)  # → (800,600), (400,300), (200,150)
+
+
+def _write_cell_feature_matrix_h5(path: Path) -> tuple[list[str], list[str]]:
+    rng = np.random.default_rng(0)
+    mat = sp.random(
+        N_GENES, N_CELLS, density=0.6, format="csc",
+        random_state=0,
+        data_rvs=lambda size: rng.integers(1, 10, size=size),
+    ).astype(np.int32)
+
+    cell_ids = [f"cell{i:03d}" for i in range(N_CELLS)]
+    gene_ids = [f"GENE{i:03d}" for i in range(N_GENES)]
+
+    with h5py.File(path, "w") as f:
+        m = f.create_group("matrix")
+        m.create_dataset("barcodes",
+                         data=np.array([s.encode() for s in cell_ids], dtype="|S20"))
+        m.create_dataset("data", data=mat.data)
+        m.create_dataset("indices", data=mat.indices.astype(np.int64))
+        m.create_dataset("indptr", data=mat.indptr.astype(np.int64))
+        m.create_dataset("shape", data=np.array(mat.shape, dtype=np.int32))
+        feats = m.create_group("features")
+        feats.create_dataset("id",
+                             data=np.array([s.encode() for s in gene_ids], dtype="|S20"))
+        feats.create_dataset("name",
+                             data=np.array([s.encode() for s in gene_ids], dtype="|S20"))
+        feats.create_dataset("feature_type",
+                             data=np.array([b"Gene Expression"] * N_GENES, dtype="|S30"))
+        feats.create_dataset("genome",
+                             data=np.array([b"GRCh38"] * N_GENES, dtype="|S10"))
+        feats.create_dataset("_all_tag_keys", data=np.array([b"genome"], dtype="|S10"))
+    return cell_ids, gene_ids
+
+
+def _write_cells_parquet(path: Path, cell_ids: list[str]) -> None:
+    rng = np.random.default_rng(1)
+    df = pd.DataFrame({
+        "cell_id": cell_ids,
+        "x_centroid": rng.uniform(0, 100, size=N_CELLS).astype(np.float64),
+        "y_centroid": rng.uniform(0, 100, size=N_CELLS).astype(np.float64),
+        "transcript_counts": rng.integers(50, 500, size=N_CELLS),
+        "cell_area": rng.uniform(20, 100, size=N_CELLS),
+        "nucleus_area": rng.uniform(10, 50, size=N_CELLS),
+    })
+    df.to_parquet(path, index=False)
+
+
+def _write_experiment_xenium(path: Path) -> dict:
+    meta = {
+        "major_version": 7,
+        "minor_version": 0,
+        "run_name": "Synthetic Xenium Prime",
+        "region_name": "synthetic_v2",
+        "panel_name": "Synthetic Prime Panel",
+        "pixel_size": PIXEL_SIZE_UM,
+    }
+    path.write_text(json.dumps(meta, indent=2))
+    return meta
+
+
+def _write_v2_morphology_pyramid(out_path: Path, channel_idx: int) -> None:
+    """Write a multi-resolution OME-TIFF with cross-file UUID refs (V2 layout).
+
+    The four per-channel files reference one another in OME-XML — that is the
+    key thing the fix needed to handle, because tifffile's default ``_multifile``
+    behaviour follows those refs and merges the files into one logical 4-channel
+    series, breaking the pyramid walk.
+    """
+    import tifffile
+
+    rng = np.random.default_rng(100 + channel_idx)
+    base = rng.integers(0, 255, size=(FULL_H, FULL_W), dtype=np.uint8)
+
+    # Build pyramid (level 0 = full-res; subsequent levels halved).
+    levels = [base]
+    for ds in PYRAMID_DOWNSAMPLES[1:]:
+        levels.append(base[::ds, ::ds].copy())
+
+    # OME-XML can be omitted; tifffile generates a sensible default. The
+    # default *does* include UUID-based references that link sibling files in
+    # the same directory under the OME spec — exactly what triggers the bug.
+    with tifffile.TiffWriter(out_path, ome=True, bigtiff=True) as tif:
+        tif.write(
+            levels[0],
+            subifds=len(levels) - 1,
+            tile=(256, 256),
+            metadata={"axes": "YX"},
+        )
+        for lvl in levels[1:]:
+            tif.write(lvl, subfiletype=1, tile=(256, 256))
+
+
+@pytest.fixture
+def xenium_v2_bundle(tmp_path: Path) -> dict:
+    pytest.importorskip("tifffile")
+
+    root = tmp_path / "outs"
+    root.mkdir()
+    cell_ids, gene_ids = _write_cell_feature_matrix_h5(root / "cell_feature_matrix.h5")
+    _write_cells_parquet(root / "cells.parquet", cell_ids)
+    meta = _write_experiment_xenium(root / "experiment.xenium")
+
+    focus_dir = root / "morphology_focus"
+    focus_dir.mkdir()
+    channel_files = []
+    for ci in range(4):
+        cand = focus_dir / f"morphology_focus_{ci:04d}.ome.tif"
+        _write_v2_morphology_pyramid(cand, ci)
+        channel_files.append(cand)
+
+    return {
+        "root": root,
+        "cell_ids": cell_ids,
+        "gene_ids": gene_ids,
+        "meta": meta,
+        "channel_files": channel_files,
+    }
+
+
+def test_v2_default_image_key_loads_first_channel(xenium_v2_bundle) -> None:
+    """``image_key='morphology_focus'`` (default) should pick up the V2 dir."""
+    from omicverse.io.spatial import read_xenium
+
+    adata = read_xenium(
+        xenium_v2_bundle["root"],
+        load_image=True,
+        image_max_dim=512,  # forces selection of a downsampled level
+        load_boundaries=False,
+    )
+    library_id = next(iter(adata.uns["spatial"]))
+    img = adata.uns["spatial"][library_id]["images"].get("hires")
+    assert img is not None, (
+        "Pre-fix regression: V2 layout produced 'No morphology image loaded'."
+    )
+    # max_dim=512 should pick level-1 (downsample 1/2): (400, 300)
+    assert max(img.shape) <= 512
+    assert img.ndim == 2
+
+    # tissue_hires_scalef must be rescaled by the chosen pyramid downsample.
+    sf = adata.uns["spatial"][library_id]["scalefactors"]["tissue_hires_scalef"]
+    expected = (1.0 / PIXEL_SIZE_UM) * (img.shape[0] / FULL_H)
+    assert sf == pytest.approx(expected, rel=1e-6)
+
+
+def test_v2_specific_channel_key_selects_that_channel(xenium_v2_bundle) -> None:
+    """Issue #708 path: ``image_key='morphology_focus_0001'`` finds channel 1."""
+    from omicverse.io.spatial._xenium import (
+        _load_morphology_image,
+        _morphology_candidates,
+    )
+
+    cands = _morphology_candidates(
+        xenium_v2_bundle["root"], "morphology_focus_0001"
+    )
+    # The requested channel must be tried *first*.
+    assert cands[0].name == "morphology_focus_0001.ome.tif"
+    # All four V2 channels appear as fallbacks.
+    assert {c.name for c in cands if c.name.startswith("morphology_focus_")} >= {
+        f"morphology_focus_{i:04d}.ome.tif" for i in range(4)
+    }
+
+    loaded = _load_morphology_image(
+        xenium_v2_bundle["root"], "morphology_focus_0001", max_dim=512
+    )
+    assert loaded is not None
+    arr, downsample, src = loaded
+    assert src.name == "morphology_focus_0001.ome.tif"
+    assert arr.ndim == 2
+    assert 0 < downsample <= 1.0
+
+
+def test_v2_missing_specific_channel_falls_back(xenium_v2_bundle) -> None:
+    """Asking for a non-existent channel must fall back to a sibling."""
+    from omicverse.io.spatial._xenium import _load_morphology_image
+
+    # Remove channel 2 to force fallback.
+    (xenium_v2_bundle["root"] / "morphology_focus" /
+     "morphology_focus_0002.ome.tif").unlink()
+
+    loaded = _load_morphology_image(
+        xenium_v2_bundle["root"], "morphology_focus_0002", max_dim=512
+    )
+    assert loaded is not None
+    _, _, src = loaded
+    assert src.name in {
+        "morphology_focus_0000.ome.tif",
+        "morphology_focus_0001.ome.tif",
+        "morphology_focus_0003.ome.tif",
+    }
+
+
+def test_v1_layout_still_works(tmp_path: Path) -> None:
+    """V1 ``morphology_focus.ome.tif`` at outs root must still load."""
+    pytest.importorskip("tifffile")
+
+    root = tmp_path / "outs"
+    root.mkdir()
+    cell_ids, _ = _write_cell_feature_matrix_h5(root / "cell_feature_matrix.h5")
+    _write_cells_parquet(root / "cells.parquet", cell_ids)
+    _write_experiment_xenium(root / "experiment.xenium")
+    _write_v2_morphology_pyramid(root / "morphology_focus.ome.tif", 0)
+
+    from omicverse.io.spatial import read_xenium
+
+    adata = read_xenium(
+        root, load_image=True, image_max_dim=512, load_boundaries=False
+    )
+    library_id = next(iter(adata.uns["spatial"]))
+    assert adata.uns["spatial"][library_id]["images"].get("hires") is not None


### PR DESCRIPTION
## Summary

Closes #708.

`ov.io.read_xenium` used to fail silently with `[Xenium] No morphology image loaded` on Xenium V2 / Prime datasets even when the requested `morphology_focus_NNNN.ome.tif` was present. Root cause: the V2 OME-XML in `morphology_focus_0000.ome.tif` contains `TiffData/UUID` entries that cross-reference the four sibling per-channel files, and tifffile's default `_multifile=True` followed those refs to silently merge them into a single multi-channel series — which broke the pyramid-level walk and made every read attempt return without a usable image.

Fix:

- Open per-channel OME-TIFFs with `_multifile=False` so each file is treated as its own single-channel pyramid.
- When `image_key='morphology_focus_NNNN'` is passed (the user's exact case), put that channel at the front of the candidate list and fall back to siblings only if it can't be read.
- Surface per-candidate read failures via `_progress(..., level='warn')` instead of generic `warnings.warn`, so users can see *which* file failed.
- Improved docstring to document V1 vs V2 / Prime layouts and the channel-key semantics.

## Validation

End-to-end on real 10x data:

- **V2 (Xenium Prime FFPE Human Prostate, 5006 genes / 193K cells)**: all four channels (`morphology_focus_0000` … `_0003`) load 1901×3385 from the 1/16 pyramid level. Pre-fix all four failed silently.
- **V1 (Xenium V1 FF Mouse Brain, 248 genes / 162K cells)**: `morphology_focus.ome.tif` still loads 2070×3022 — V1 backwards-compatible.

Plus 4 new synthetic-bundle unit tests (`tests/test_io_xenium_morphology.py`) covering V2 directory layout, candidate ordering, channel fallback, and V1 layout. All existing `test_io_atera.py` tests still pass.

## Test plan

- [x] `pytest tests/test_io_xenium_morphology.py` (4 tests)
- [x] `pytest tests/test_io_atera.py` (6 tests, no regression)
- [x] Manual: `ov.io.read_xenium(v2_outs, image_key='morphology_focus_0000')` returns image on real Xenium Prime data
- [x] Manual: V1 layout (`morphology_focus.ome.tif` at outs root) still loads on real V1 data

🤖 Generated with [Claude Code](https://claude.com/claude-code)