### PR TITLE
feat(single,pl): CellVote consensus score + flow layout for embedding panels

### DIFF
--- a/omicverse/pl/_scatterplot_backend.py
+++ b/omicverse/pl/_scatterplot_backend.py
@@ -146,8 +146,9 @@ def embedding(
     ax: Optional[Axes] = None,
     return_fig: Optional[bool] = None,
     marker: Union[str, Sequence[str]] = '.',
-    arrow_scale: float = 10, 
+    arrow_scale: float = 10,
     arrow_width: float = 0.005,
+    layout: Literal['grid', 'flow'] = 'grid',
     **kwargs,
 ) -> Union[Figure, Axes, None]:
     r"""Scatter plot for user specified embedding basis (e.g. umap, pca, etc).
@@ -353,6 +354,13 @@ def embedding(
     # Plotting #
     ############
     axs = []
+    # Per-panel colorbar axes, keyed by id(panel_ax). Populated only for
+    # continuous-color panels rendered with frameon ∈ {'small', False}.
+    # `_flow_layout_panels` consults this dict to drag the colorbar
+    # alongside the panel when it gets repositioned, otherwise the
+    # colorbar stays pinned at its original figure coordinates while the
+    # panel migrates left/right — the visual bug visible at issue review.
+    panel_colorbars: dict = {}
 
     # use itertools.product to make a plot for each color and for each component
     # For example if color=[gene1, gene2] and components=['1,2, '2,3'].
@@ -611,6 +619,7 @@ def embedding(
                 # 手动创建colorbar轴：[left, bottom, width, height]
                 # Use ax.figure instead of pl.gcf() to ensure correct figure in multi-panel plots
                 cax1 = ax.figure.add_axes([pos.x1 + cb_pad, cb_bottom, cb_width, cb_height])
+                panel_colorbars[id(ax)] = cax1
 
                 cb = pl.colorbar(cax, cax=cax1, orientation="vertical")
                 # Remove integer=True to allow float values in colorbar ticks
@@ -626,6 +635,13 @@ def embedding(
             #pl.colorbar(
             #    cax, ax=ax, pad=0.01, fraction=0.08, aspect=30, location=colorbar_loc
             #)
+
+    # Flow layout: re-position panels left-to-right (with wrap) so that
+    # each panel + its external legend takes its actual footprint, never
+    # overlapping a neighboring panel. Only meaningful when multiple
+    # panels exist (i.e. grid is not None).
+    if layout == 'flow' and grid is not None and axs:
+        _flow_layout_panels(fig, axs, panel_colorbars=panel_colorbars)
 
     if return_fig is True:
         return fig
@@ -660,6 +676,135 @@ def _panel_grid(hspace, wspace, ncols, num_panels):
         wspace=wspace,
     )
     return fig, gs
+
+
+def _flow_layout_panels(fig, axs, panel_colorbars=None, gap=0.3, margin=0.3):
+    r"""Reposition multi-panel axes left-to-right with wrap.
+
+    Each panel's "footprint" includes its external categorical legend
+    (if any) *and* any per-panel colorbar axes registered in
+    ``panel_colorbars``, so panels are guaranteed not to overlap
+    regardless of legend label length / category count / colorbar
+    presence. Wraps to the next row when a panel would exceed
+    ``fig_width - margin``. Resizes the figure height if total layout
+    exceeds the initial height.
+
+    Parameters
+    ----------
+    fig : matplotlib.figure.Figure
+        Figure containing ``axs``.
+    axs : list[matplotlib.axes.Axes]
+        Panel axes in plotting order. Each axes may carry an external
+        legend created via ``ax.legend(bbox_to_anchor=...,
+        bbox_transform=ax.transAxes)``; the legend follows the axes
+        when ``set_position`` is called, so this routine only needs to
+        re-position the axes themselves.
+    panel_colorbars : dict[int, matplotlib.axes.Axes] or None
+        Mapping of ``id(panel_ax) -> colorbar_ax`` for panels that
+        rendered a continuous-color colorbar via
+        ``fig.add_axes([...])`` (the ``frameon='small' / False``
+        branch). The colorbar's offset is captured *before* the panel
+        moves, then re-applied relative to the new panel position so
+        the colorbar travels with its panel. Unlike legends, colorbars
+        live in figure coordinates and do not follow the panel
+        automatically.
+    """
+    if not axs:
+        return
+    fig.canvas.draw()
+    renderer = fig.canvas.get_renderer()
+    inv = fig.dpi_scale_trans.inverted()
+    fig_w_in = fig.get_figwidth()
+
+    # ── Pass 1: measure each panel's full footprint in inches ───────
+    items = []
+    for ax in axs:
+        ax_bbox = ax.get_window_extent(renderer).transformed(inv)
+        x0, x1 = ax_bbox.x0, ax_bbox.x1
+        y0, y1 = ax_bbox.y0, ax_bbox.y1
+
+        lg = ax.get_legend()
+        if lg is not None:
+            lg_bbox = lg.get_window_extent(renderer).transformed(inv)
+            x0 = min(x0, lg_bbox.x0); x1 = max(x1, lg_bbox.x1)
+            y0 = min(y0, lg_bbox.y0); y1 = max(y1, lg_bbox.y1)
+
+        # Include per-panel colorbar bbox so the panel reserves space for it
+        cb_ax = (panel_colorbars or {}).get(id(ax))
+        cb_pos_pre = cb_ax.get_position() if cb_ax is not None else None
+        ax_pos_pre = ax.get_position()  # for delta computation
+        if cb_ax is not None:
+            cb_bbox = cb_ax.get_window_extent(renderer).transformed(inv)
+            x0 = min(x0, cb_bbox.x0); x1 = max(x1, cb_bbox.x1)
+            y0 = min(y0, cb_bbox.y0); y1 = max(y1, cb_bbox.y1)
+
+        items.append({
+            'ax': ax,
+            'full_w': x1 - x0,
+            'full_h': y1 - y0,
+            'ax_dx': ax_bbox.x0 - x0,   # axes offset within full bbox
+            'ax_dy': ax_bbox.y0 - y0,
+            'ax_w':  ax_bbox.width,
+            'ax_h':  ax_bbox.height,
+            'cb_ax': cb_ax,
+            'cb_pos_pre': cb_pos_pre,
+            'ax_pos_pre': ax_pos_pre,
+        })
+
+    # ── Pass 2: assign positions left-to-right with wrap ─────────────
+    placements = []
+    cursor_x = margin
+    cumulative_top = 0.0   # inches from top of current logical layout
+    row_max_h = 0.0
+    for it in items:
+        if cursor_x + it['full_w'] > fig_w_in - margin and cursor_x > margin:
+            # wrap to next row
+            cursor_x = margin
+            cumulative_top += row_max_h + gap
+            row_max_h = 0.0
+        placements.append((cursor_x, cumulative_top))
+        cursor_x += it['full_w'] + gap
+        row_max_h = max(row_max_h, it['full_h'])
+
+    total_h_in = cumulative_top + row_max_h + 2 * margin
+    if total_h_in > fig.get_figheight():
+        fig.set_figheight(total_h_in)
+    fig_h_in = fig.get_figheight()
+
+    # ── Pass 3: apply positions (figure-relative) ────────────────────
+    for it, (x_in, top_in) in zip(items, placements):
+        # full bbox top in figure coords (measured from figure bottom)
+        full_top_y = fig_h_in - margin - top_in
+        full_bot_y = full_top_y - it['full_h']
+        ax_x = x_in + it['ax_dx']
+        ax_y = full_bot_y + it['ax_dy']
+        new_pos_norm = [
+            ax_x / fig_w_in,
+            ax_y / fig_h_in,
+            it['ax_w'] / fig_w_in,
+            it['ax_h'] / fig_h_in,
+        ]
+        it['ax'].set_position(new_pos_norm)
+
+        # Drag the panel's colorbar along by re-applying the same
+        # (figure-normalised) offset it had from the panel pre-move.
+        cb_ax = it['cb_ax']
+        if cb_ax is not None:
+            ap = it['ax_pos_pre']
+            cp = it['cb_pos_pre']
+            # offset of cb origin from panel origin, normalised by panel size
+            dx_rel = (cp.x0 - ap.x0) / ap.width if ap.width else 0
+            dy_rel = (cp.y0 - ap.y0) / ap.height if ap.height else 0
+            cb_w_rel = cp.width / ap.width if ap.width else cp.width
+            cb_h_rel = cp.height / ap.height if ap.height else cp.height
+            new_panel_w = new_pos_norm[2]
+            new_panel_h = new_pos_norm[3]
+            cb_ax.set_position([
+                new_pos_norm[0] + dx_rel * new_panel_w,
+                new_pos_norm[1] + dy_rel * new_panel_h,
+                cb_w_rel * new_panel_w,
+                cb_h_rel * new_panel_h,
+            ])
 
 
 def _get_vboundnorm(

--- a/omicverse/single/__init__.py
+++ b/omicverse/single/__init__.py
@@ -89,7 +89,7 @@ from ._gptcelltype import gptcelltype,gpt4celltype,get_cluster_celltype
 from ._gptcelltype_local import gptcelltype_local
 from ._sccaf import SCCAF_assessment,plot_roc,SCCAF_optimize_all,color_long
 from ._multimap import TFIDF_LSI,Wrapper,Integration,Batch
-from ._cellvote import get_cluster_celltype,CellVote
+from ._cellvote import get_cluster_celltype,CellVote,cellvote_consensus_score
 from ._deg_ct import DCT,DEG
 from ._lazy_function import lazy
 from ._lazy_report import generate_scRNA_report

--- a/omicverse/single/_cellvote.py
+++ b/omicverse/single/_cellvote.py
@@ -1,6 +1,160 @@
 
+import re
 import requests
 from .._registry import register_function
+
+
+# ── Consensus score helpers ─────────────────────────────────────────────
+#
+# Used by CellVote.vote() to attach a per-cluster confidence score to the
+# final consensus label. Three complementary metrics are computed from the
+# 5 candidate labels (one per voting method) and the LLM-arbitrated pick:
+#
+#   n_unique         - number of distinct labels after normalisation (1..N)
+#   plurality        - fraction of methods agreeing with the most common label
+#   vote_agreement   - fraction of methods whose label is semantically
+#                       consistent with the final pick (Jaccard ≥ threshold
+#                       on normalised token sets)
+#   confidence       - (plurality + vote_agreement) / 2 ∈ [0, 1]
+#
+# Normalisation is intentionally simple — lowercase, strip punctuation,
+# drop noise tokens ('cell', 'positive', ...), expand acronyms
+# ('NK' → 'natural killer', 'DC' → 'dendritic', ...). It is *not* an
+# ontology lookup; the goal is to handle "B cell" vs "B cells" vs
+# "B-cells" and "CD14-positive monocyte" vs "Classical monocyte" — not
+# to resolve fine-grained ontology relations.
+
+_CONSENSUS_STOP_TOKENS = {
+    'cell', 'cells', 'positive', 'negative', 'high', 'low', 'classical',
+}
+
+_CONSENSUS_SYNONYMS = {
+    'mono': 'monocyte', 'monocytes': 'monocyte',
+    'macs': 'macrophage', 'mac': 'macrophage',
+    'nk': 'natural killer', 'killer': 'natural killer',
+    'platelet': 'megakaryocyte', 'platelets': 'megakaryocyte',
+    'mk': 'megakaryocyte', 'mks': 'megakaryocyte',
+    'dc': 'dendritic', 'dcs': 'dendritic',
+    'cdc': 'dendritic', 'pdc': 'dendritic',
+    'tcm': 'naive', 'tem': 'memory', 'trm': 'memory',
+}
+
+
+def _normalize_label(label):
+    """Tokenise a free-form cell-type label for consensus comparison.
+
+    Returns the token set after lowercasing, punctuation stripping, stop
+    word filtering, and acronym expansion. Two labels that map to the
+    same (or highly overlapping) sets are treated as the same celltype.
+    """
+    s = str(label).lower()
+    s = re.sub(r'[,\-+/().]', ' ', s)
+    toks = []
+    for t in s.split():
+        t = _CONSENSUS_SYNONYMS.get(t, t)
+        if t in _CONSENSUS_STOP_TOKENS:
+            continue
+        toks.append(t)
+    return set(toks)
+
+
+def _jaccard(a, b):
+    A, B = _normalize_label(a), _normalize_label(b)
+    if not (A | B):
+        return 0.0
+    return len(A & B) / len(A | B)
+
+
+def cellvote_consensus_score(
+    adata,
+    clusters_key,
+    celltype_keys,
+    cellvote_labels,
+    jaccard_threshold=0.34,
+):
+    """Score the agreement between method-level labels and CellVote picks.
+
+    Parameters
+    ----------
+    adata : AnnData
+        Object holding per-cell labels for each method.
+    clusters_key : str
+        ``adata.obs`` column with cluster IDs (e.g. ``'leiden'``).
+    celltype_keys : list[str]
+        ``adata.obs`` columns produced by the upstream annotation
+        methods. Order does not matter.
+    cellvote_labels : dict
+        ``{cluster_id -> consensus_label}`` mapping (typically the
+        ``result`` dict returned by :meth:`CellVote.vote`).
+    jaccard_threshold : float, default ``0.34``
+        Minimum normalised-token Jaccard for a method's label to count
+        as supporting the consensus pick.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Per-cluster scores: ``n_cells, cellvote_label, n_unique,
+        plurality, vote_agreement, confidence, methods_supporting``.
+        Indexed by cluster ID (string).
+    """
+    import pandas as pd
+
+    n_methods = len(celltype_keys)
+    if n_methods == 0:
+        raise ValueError("`celltype_keys` must list at least one annotation column.")
+
+    # Dominant label per (cluster, method) — same heuristic vote() uses
+    per_method = pd.DataFrame({
+        col: adata.obs.groupby(clusters_key, observed=True)[col]
+                      .agg(lambda s: s.value_counts().index[0])
+        for col in celltype_keys
+    })
+
+    rows = []
+    cluster_sizes = adata.obs.groupby(clusters_key, observed=True).size()
+    for cid_raw, vote_label in cellvote_labels.items():
+        cid = str(cid_raw)
+        if cid not in per_method.index.astype(str).tolist():
+            # may happen if cellvote_labels keys mix int/str — try fallback
+            try:
+                row = per_method.loc[cid_raw]
+            except KeyError:
+                continue
+        else:
+            row = per_method.loc[per_method.index.astype(str) == cid].iloc[0]
+        labels = list(row)
+
+        # plurality (after token-set normalisation, ties broken by first occurrence)
+        norm_labels = [tuple(sorted(_normalize_label(l))) for l in labels]
+        counts = pd.Series(norm_labels).value_counts()
+        plurality = float(counts.iloc[0] / n_methods)
+        n_unique = int(len(counts))
+
+        # vote_agreement vs the final pick
+        sims = [_jaccard(l, vote_label) for l in labels]
+        n_agree = sum(s >= jaccard_threshold for s in sims)
+        vote_agreement = float(n_agree / n_methods)
+        confidence = float((plurality + vote_agreement) / 2)
+
+        # n_cells via the original (possibly non-string) cluster id
+        try:
+            n_cells = int(cluster_sizes.loc[cid_raw])
+        except KeyError:
+            n_cells = int(cluster_sizes.loc[cid])
+
+        rows.append({
+            'cluster':            cid,
+            'n_cells':            n_cells,
+            'cellvote_label':     vote_label,
+            'n_unique':           n_unique,
+            'plurality':          round(plurality, 3),
+            'vote_agreement':     round(vote_agreement, 3),
+            'confidence':         round(confidence, 3),
+            'methods_supporting': f'{n_agree}/{n_methods}',
+        })
+
+    df = pd.DataFrame(rows).set_index('cluster')
+    return df
 
 
 @register_function(
@@ -267,6 +421,29 @@ class CellVote(object):
             adata.obs["best_clusters"].map(result).astype("category")
         )
         adata.obs[result_key] = [i.capitalize() for i in adata.obs[result_key].tolist()]
+
+        # ── Per-cluster consensus score, written back to adata ─────────
+        # Quantifies how many of the candidate methods support the
+        # final label. Stored both per-cell (continuous) for plotting
+        # and as a per-cluster table in `uns` for inspection.
+        try:
+            score_df = cellvote_consensus_score(
+                adata,
+                clusters_key=clusters_key,
+                celltype_keys=celltype_keys,
+                cellvote_labels=result,
+            )
+            confidence_col = f'{result_key}_confidence'
+            adata.obs[confidence_col] = (
+                adata.obs[clusters_key].astype(str)
+                     .map(score_df['confidence'].to_dict())
+                     .astype(float)
+            )
+            adata.uns[f'{result_key}_score_table'] = score_df.reset_index().to_dict('list')
+        except Exception as exc:
+            # Scoring is a convenience signal — never fail vote() on it.
+            print(f"⚠️  CellVote consensus score skipped: {exc}")
+
         return result
 
 

--- a/tests/architecture/test_optional_torch_dependencies.py
+++ b/tests/architecture/test_optional_torch_dependencies.py
@@ -253,6 +253,7 @@ def _install_single_dependency_stubs():
         "omicverse.single._cellvote": {
             "get_cluster_celltype": object(),
             "CellVote": object(),
+            "cellvote_consensus_score": object(),
         },
         "omicverse.single._deg_ct": {"DCT": object(), "DEG": object()},
         "omicverse.single._lazy_function": {"lazy": object()},


### PR DESCRIPTION
## Summary

Resolves #694 by adding a quantitative confidence score to `CellVote`, and fixes the multi-panel UMAP legend-overlap issue exposed when CellVote tutorials plot 5+ annotation columns side-by-side.

### Code changes

* **`ov.single.CellVote.vote()`** — now writes `adata.obs[f'{result_key}_confidence']` (per-cell, in [0, 1]) and `adata.uns[f'{result_key}_score_table']` (per-cluster). Scoring lives in the new `cellvote_consensus_score()` helper exported as `ov.single.cellvote_consensus_score`.
* **`ov.pl.embedding`** — new `layout: 'grid' | 'flow'` kwarg (default `'grid'`, fully backwards compatible). `'flow'` measures each panel's full footprint (axes + legend + colorbar) and re-positions panels left-to-right with wrap. Categorical legends follow the panel via `transAxes`; per-panel colorbars are now tracked in `panel_colorbars` and dragged along.
* Tutorial bump in `omicverse_guide` submodule — replaces the old prose `t_cellvote.md` with an executable `t_cellvote.ipynb`.

### Why this matters for #694

The issue requested an updated `CellVote` that picks the **best** celltype. Picking better requires a way to evaluate the pick. The new score does exactly that:

* Real example from PBMC3k: in one run, the LLM mis-labelled a 165-cell monocyte cluster as "NK cell". Every other method called it non-classical monocyte. `vote_agreement=0.2`, `confidence=0.4` — the lowest in the entire run, exactly the diagnostic the issue asks for.

### How the score is built

Three metrics per cluster, on the 5 candidate labels and the final CellVote pick:

* `n_unique` — distinct labels after token-set normalisation
* `plurality` — fraction of methods agreeing with the most common label
* `vote_agreement` — fraction of methods whose label is semantically consistent with the CellVote pick (token-set Jaccard ≥ 0.34, with synonym + plural normalisation: "B cell" / "B cells" / "B-cells" collapse; "CD14-positive monocyte" / "Classical monocyte" collapse)
* `confidence = (plurality + vote_agreement) / 2`

No extra LLM call — fully offline scoring after the existing arbitration finishes.

### Flow layout — why it's opt-in

`layout='grid'` is preserved as the default to avoid breaking existing scripts/notebooks/CI that rely on the current layout. Users opt in with `layout='flow'` on multi-panel calls. The flow path was validated on the 7-panel CellVote tutorial; before/after PNGs included in the linked tutorial PR.

## Test plan

- [x] `CellVote.vote()` now writes `_confidence` + `_score_table` (executed in `omicverse_guide#docs/Tutorials-single/t_cellvote.ipynb`)
- [x] `ov.pl.umap(..., layout='flow')` renders 7-panel UMAP without panel/legend overlap
- [x] `ov.pl.umap(..., layout='flow')` keeps colorbar attached to its panel when the panel migrates during flow
- [x] `ov.pl.umap(...)` without `layout` argument falls back to existing grid behaviour (smoke check)
- [ ] CI to confirm no regressions on the existing `tests/` suite

## Companion PR

The `omicverse_guide` submodule is bumped to [`omicverse/omicverse-tutorials#docs/cellvote-confidence-tutorial`](https://github.com/omicverse/omicverse-tutorials/pull/new/docs/cellvote-confidence-tutorial). Both should land together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)