### PR TITLE
feat(single): ov.single.CNV + ov.pl.cnv_* for single-cell copy-number variation

### DIFF
--- a/omicverse/pl/__init__.py
+++ b/omicverse/pl/__init__.py
@@ -154,6 +154,7 @@ from ._flowsig import (
     plot_flowsig_network,
 )
 from ._embedding import embedding_atlas
+from ._cnv import cnv_heatmap, cnv_summary, cnv_umap
 from ._density import add_density_contour, calculate_gene_density
 from ._plot1cell import plot1cell
 from ._cpdbviz import CellChatViz
@@ -392,4 +393,8 @@ __all__ = [
     "plot_pca_variance_ratio",
     "plot_pca_variance_ratio1",
     "gen_mpl_labels",
+    # @ _cnv
+    "cnv_heatmap",
+    "cnv_summary",
+    "cnv_umap",
 ]

--- a/omicverse/pl/_cnv.py
+++ b/omicverse/pl/_cnv.py
@@ -193,6 +193,40 @@ def _order_rows_by_group(
     return np.asarray(order, dtype=int), segs
 
 
+def _to_list(x) -> list:
+    if x is None:
+        return []
+    if isinstance(x, str):
+        return [x]
+    return list(x)
+
+
+def _categorical_palette(
+    series: pd.Series, adata: AnnData, key: str, default_palette
+) -> dict:
+    """Pick a {category → colour} mapping for a categorical column.
+
+    Re-uses ``adata.uns[f'{key}_colors']`` if scanpy / omicverse already
+    assigned colours to this column; else samples from the supplied palette.
+    """
+    cats = pd.Categorical(series).categories.tolist()
+    cat_colors_key = f"{key}_colors"
+    if cat_colors_key in adata.uns:
+        existing = list(adata.uns[cat_colors_key])
+        if len(existing) >= len(cats):
+            return {c: existing[i] for i, c in enumerate(cats)}
+    pal = list(default_palette)
+    return {c: pal[i % len(pal)] for i, c in enumerate(cats)}
+
+
+def _has_marsilea() -> bool:
+    try:
+        import marsilea  # noqa: F401
+        return True
+    except ImportError:
+        return False
+
+
 # ----------------------------------------------------------------------
 # cnv_heatmap
 # ----------------------------------------------------------------------
@@ -204,11 +238,14 @@ def _order_rows_by_group(
     description=(
         "Genome-wide CNV heatmap: cells × ordered genomic bins, gain in red "
         "and loss in blue, with an alternating chromosome ideogram bar on top "
-        "and optional row grouping by adata.obs['cnv_prediction'] / cell_type."
+        "and one or more coloured row-annotation strips on the left (e.g. "
+        "cell_type, cnv_prediction). Uses marsilea when available for clean "
+        "categorical legends; falls back to matplotlib text labels otherwise."
     ),
     examples=[
         "ov.pl.cnv_heatmap(adata)",
         "ov.pl.cnv_heatmap(adata, groupby='cnv_prediction')",
+        "ov.pl.cnv_heatmap(adata, groupby=['cell_type', 'cnv_prediction'])",
         "ov.pl.cnv_heatmap(adata, groupby='cell_type', max_value=0.6)",
     ],
     related=["pl.cnv_summary", "pl.cnv_umap", "single.CNV"],
@@ -216,15 +253,15 @@ def _order_rows_by_group(
 def cnv_heatmap(
     adata: AnnData,
     *,
-    groupby: Optional[str] = None,
+    groupby: Union[str, Sequence[str], None] = None,
     max_value: Optional[float] = None,
     figsize: tuple[float, float] = (8.0, 4.5),
     cmap=_CNV_CMAP,
-    show_group_labels: bool = True,
     standard_chromosomes_only: bool = True,
-    ax: Optional[Axes] = None,
+    backend: str = "auto",
     title: Optional[str] = None,
-) -> tuple[Figure, dict[str, Axes]]:
+    show: bool = True,
+):
     r"""Plot the genome-wide CNV heatmap.
 
     Parameters
@@ -232,37 +269,45 @@ def cnv_heatmap(
     adata : AnnData
         Must contain ``adata.obsm['X_cnv']`` and ``adata.uns['cnv']`` —
         populated by :class:`omicverse.single.CNV`.
-    groupby : str or None
-        Column in ``adata.obs`` used to sort and visually separate cell rows
-        (e.g. ``'cnv_prediction'`` to show aneuploid vs. diploid cells in
-        separate bands, or ``'cell_type'``).
+    groupby : str, list of str, or None
+        Column(s) in ``adata.obs`` used to sort cells and draw colour-coded
+        annotation strips on the left side of the heatmap. The first column
+        controls row ordering. Pass a list to stack multiple strips
+        (e.g. ``['cell_type', 'cnv_prediction']``).
     max_value : float or None
         Symmetric colour limit. If ``None``, set to the 99th percentile of
         ``|X_cnv|`` so a handful of extreme bins don't wash out the figure.
     figsize : tuple
-        Figure size in inches. Ignored when ``ax`` is passed.
+        Figure size in inches.
     cmap : matplotlib Colormap
         Diverging colormap. Default is a blue/white/red palette aligned with
         the figures in Gao et al. 2021 / inferCNV publications.
-    show_group_labels : bool
-        Whether to draw the group names as left-side annotations.
-    ax : matplotlib Axes or None
-        Pre-allocated heatmap axes. If ``None``, a new figure with the
-        ideogram subplot is created.
+    standard_chromosomes_only : bool, default True
+        Drop unplaced scaffolds / alt contigs (e.g. ``GL000220.1``) from the
+        plot so the right edge isn't crowded with tiny segments.
+    backend : {'auto', 'marsilea', 'matplotlib'}
+        ``'auto'`` picks marsilea when installed (recommended — it handles
+        categorical legends + multi-strip annotations cleanly), else falls
+        back to the matplotlib renderer.
     title : str or None
         Optional figure title.
+    show : bool, default True
+        Whether to render the figure (marsilea backend only — passed to
+        ``Heatmap.render()``).
 
     Returns
     -------
-    fig : matplotlib.figure.Figure
-    axes : dict
-        ``{'heatmap': Axes, 'ideogram': Axes}`` — handles for further tuning.
+    Marsilea backend: the rendered ``marsilea.Heatmap`` object (call
+        ``.figure`` for the matplotlib Figure).
+    Matplotlib backend: ``(fig, axes_dict)`` with keys
+        ``{'heatmap', 'ideogram', 'cbar'}``.
 
     Examples
     --------
     >>> import omicverse as ov
     >>> cnv = ov.single.CNV(adata, method='copykat').run()
     >>> ov.pl.cnv_heatmap(adata, groupby='cnv_prediction')
+    >>> ov.pl.cnv_heatmap(adata, groupby=['cell_type', 'cnv_prediction'])
     """
     X, chr_pos, _ = _get_cnv_data(adata)
     n_cells, n_bins_total = X.shape
@@ -272,7 +317,9 @@ def cnv_heatmap(
     X = X[:, col_slice]
     n_bins = X.shape[1]
 
-    row_order, group_segs = _order_rows_by_group(adata, groupby)
+    groupby_list = _to_list(groupby)
+    primary = groupby_list[0] if groupby_list else None
+    row_order, group_segs = _order_rows_by_group(adata, primary)
     X_ord = X[row_order]
 
     if max_value is None:
@@ -280,21 +327,34 @@ def cnv_heatmap(
         if max_value <= 0:
             max_value = 1.0
 
-    if ax is None:
-        fig = plt.figure(figsize=figsize)
-        gs = fig.add_gridspec(
-            2, 1, height_ratios=(0.5, 9.5), hspace=0.05, top=0.92, bottom=0.10
+    use_marsilea = backend == "marsilea" or (backend == "auto" and _has_marsilea())
+    if backend == "marsilea" and not _has_marsilea():
+        raise ImportError(
+            "backend='marsilea' but the marsilea package is not installed.\n"
+            "Install with `pip install marsilea` (or pass backend='matplotlib')."
         )
-        ideo_ax = fig.add_subplot(gs[0, 0])
-        hm_ax = fig.add_subplot(gs[1, 0], sharex=ideo_ax)
-    else:
-        hm_ax = ax
-        fig = hm_ax.figure
-        # Carve a thin axes above the heatmap axes for the ideogram.
-        bbox = hm_ax.get_position()
-        ideo_ax = fig.add_axes(
-            [bbox.x0, bbox.y1 + 0.005, bbox.width, bbox.height * 0.05]
+
+    if use_marsilea:
+        return _cnv_heatmap_marsilea(
+            adata,
+            X_ord=X_ord,
+            segments=segments,
+            row_order=row_order,
+            groupby_list=groupby_list,
+            max_value=max_value,
+            figsize=figsize,
+            cmap=cmap,
+            title=title,
+            show=show,
         )
+
+    # --- matplotlib fallback ---
+    fig = plt.figure(figsize=figsize)
+    gs = fig.add_gridspec(
+        2, 1, height_ratios=(0.5, 9.5), hspace=0.05, top=0.92, bottom=0.10
+    )
+    ideo_ax = fig.add_subplot(gs[0, 0])
+    hm_ax = fig.add_subplot(gs[1, 0], sharex=ideo_ax)
 
     _draw_ideogram(ideo_ax, segments)
 
@@ -312,21 +372,20 @@ def cnv_heatmap(
     for _, _, end in segments[:-1]:
         hm_ax.axvline(end, color="white", linewidth=0.4, alpha=0.7)
 
-    # Group dividers — horizontal black lines + optional left-side labels.
-    if groupby is not None and len(group_segs) > 1:
+    # Group dividers — horizontal black lines + left-side labels.
+    if primary is not None and len(group_segs) > 1:
         for _, _, row_end in group_segs[:-1]:
             hm_ax.axhline(row_end, color="black", linewidth=0.8)
-        if show_group_labels:
-            for label, row_start, row_end in group_segs:
-                hm_ax.text(
-                    -n_bins * 0.01,
-                    (row_start + row_end) / 2,
-                    label,
-                    ha="right",
-                    va="center",
-                    fontsize=9,
-                    rotation=0,
-                )
+        for label, row_start, row_end in group_segs:
+            hm_ax.text(
+                -n_bins * 0.01,
+                (row_start + row_end) / 2,
+                label,
+                ha="right",
+                va="center",
+                fontsize=9,
+                rotation=0,
+            )
 
     hm_ax.set_xticks([])
     hm_ax.set_yticks([])
@@ -349,6 +408,86 @@ def cnv_heatmap(
     )
 
     return fig, {"heatmap": hm_ax, "ideogram": ideo_ax, "cbar": cax}
+
+
+def _cnv_heatmap_marsilea(
+    adata: AnnData,
+    *,
+    X_ord: np.ndarray,
+    segments: list[tuple[str, int, int]],
+    row_order: np.ndarray,
+    groupby_list: list[str],
+    max_value: float,
+    figsize: tuple[float, float],
+    cmap,
+    title: Optional[str],
+    show: bool,
+):
+    """Marsilea-backed heatmap with chromosome ideogram + multi-strip row annotations."""
+    import marsilea as ma
+    import marsilea.plotter as mp
+
+    from ._palette import palette_28, palette_56
+
+    n_cells, n_bins = X_ord.shape
+
+    # Build a per-bin "which chromosome" array for the top strip.
+    chrom_per_bin = np.empty(n_bins, dtype=object)
+    for chrom, start, end in segments:
+        chrom_per_bin[start:end] = chrom.replace("chr", "")
+    # Stable, perceptually-uniform alternation that matches the matplotlib
+    # ideogram: even-indexed chromosomes light grey, odd-indexed dark.
+    ideo_palette: dict[str, str] = {}
+    for i, (chrom, _, _) in enumerate(segments):
+        ideo_palette[chrom.replace("chr", "")] = "#d8d8d8" if i % 2 == 0 else "#444444"
+
+    h = ma.Heatmap(
+        X_ord,
+        width=float(figsize[0]),
+        height=float(figsize[1]),
+        cmap=cmap,
+        vmin=-max_value,
+        vmax=max_value,
+        label="CN (log ratio)",
+    )
+
+    # Top: chromosome ideogram as a colour strip + chunk labels for each chrom.
+    h.add_top(
+        mp.Colors(chrom_per_bin, palette=ideo_palette),
+        size=0.18,
+        pad=0.0,
+        legend=False,
+    )
+    chunk_labels = [c.replace("chr", "") for c, _, _ in segments]
+    h.group_cols(chrom_per_bin, order=chunk_labels)
+    h.add_top(
+        mp.Chunk(chunk_labels, fill_colors=None, fontsize=8, rotation=0),
+        size=0.12,
+        pad=0.02,
+    )
+
+    # Left: one colour strip per groupby column (cell_type, cnv_prediction, …).
+    default_pal_28 = list(palette_28)
+    default_pal_56 = list(palette_56)
+    for i, key in enumerate(groupby_list):
+        if key not in adata.obs:
+            continue
+        values = adata.obs[key].astype(object).fillna("NA").values[row_order]
+        n_cats = len(pd.unique(values))
+        base_palette = default_pal_28 if n_cats <= len(default_pal_28) else default_pal_56
+        cat_palette = _categorical_palette(pd.Series(values), adata, key, base_palette)
+        h.add_left(
+            mp.Colors(values, palette=cat_palette, label=key),
+            size=0.18,
+            pad=0.0 if i == 0 else 0.02,
+            legend=True,
+        )
+
+    h.add_legends()
+    if title:
+        h.add_title(title, fontsize=11)
+    h.render()
+    return h
 
 
 # ----------------------------------------------------------------------

--- a/omicverse/pl/_cnv.py
+++ b/omicverse/pl/_cnv.py
@@ -237,23 +237,24 @@ def _has_marsilea() -> bool:
     category="pl",
     description=(
         "Genome-wide CNV heatmap: cells × ordered genomic bins, gain in red "
-        "and loss in blue, with an alternating chromosome ideogram bar on top "
-        "and one or more coloured row-annotation strips on the left (e.g. "
-        "cell_type, cnv_prediction). Uses marsilea when available for clean "
-        "categorical legends; falls back to matplotlib text labels otherwise."
+        "and loss in blue, with an alternating chromosome ideogram bar on top, "
+        "row ordering by `groupby` (one adata.obs column) plus optional extra "
+        "coloured annotation strips for `annotations` columns. Uses marsilea "
+        "when available; matplotlib fallback otherwise."
     ),
     examples=[
         "ov.pl.cnv_heatmap(adata)",
         "ov.pl.cnv_heatmap(adata, groupby='cnv_prediction')",
-        "ov.pl.cnv_heatmap(adata, groupby=['cell_type', 'cnv_prediction'])",
-        "ov.pl.cnv_heatmap(adata, groupby='cell_type', max_value=0.6)",
+        "# rows ordered by cnv_prediction; cell_type drawn as a 2nd colour strip",
+        "ov.pl.cnv_heatmap(adata, groupby='cnv_prediction', annotations=['cell_type'])",
     ],
     related=["pl.cnv_summary", "pl.cnv_umap", "single.CNV"],
 )
 def cnv_heatmap(
     adata: AnnData,
     *,
-    groupby: Union[str, Sequence[str], None] = None,
+    groupby: Optional[str] = None,
+    annotations: Union[str, Sequence[str], None] = None,
     max_value: Optional[float] = None,
     figsize: tuple[float, float] = (8.0, 4.5),
     cmap=_CNV_CMAP,
@@ -269,45 +270,51 @@ def cnv_heatmap(
     adata : AnnData
         Must contain ``adata.obsm['X_cnv']`` and ``adata.uns['cnv']`` —
         populated by :class:`omicverse.single.CNV`.
-    groupby : str, list of str, or None
-        Column(s) in ``adata.obs`` used to sort cells and draw colour-coded
-        annotation strips on the left side of the heatmap. The first column
-        controls row ordering. Pass a list to stack multiple strips
-        (e.g. ``['cell_type', 'cnv_prediction']``).
+    groupby : str or None
+        Single column in ``adata.obs`` that controls **row ordering** (cells
+        are bucketed by this category, preserving within-bucket order) and
+        the group-divider lines. To compare cells under multiple labellings,
+        call ``cnv_heatmap`` once per labelling rather than mixing them
+        here; alternatively use ``annotations`` (below) to layer extra
+        colour strips without affecting the order.
+    annotations : str, list of str, or None
+        Additional ``adata.obs`` columns drawn as coloured strips on the
+        **left** of the heatmap, in the order given. These never change the
+        row order — they are decorative overlays so the reader can see how a
+        secondary category (e.g. ``cell_type``) lines up against the primary
+        grouping. ``groupby`` is automatically prepended if not already in
+        the list.
     max_value : float or None
         Symmetric colour limit. If ``None``, set to the 99th percentile of
-        ``|X_cnv|`` so a handful of extreme bins don't wash out the figure.
+        ``|X_cnv|``.
     figsize : tuple
         Figure size in inches.
     cmap : matplotlib Colormap
-        Diverging colormap. Default is a blue/white/red palette aligned with
-        the figures in Gao et al. 2021 / inferCNV publications.
+        Diverging colormap. Default is a blue/white/red palette.
     standard_chromosomes_only : bool, default True
-        Drop unplaced scaffolds / alt contigs (e.g. ``GL000220.1``) from the
-        plot so the right edge isn't crowded with tiny segments.
+        Drop unplaced scaffolds / alt contigs from the plot.
     backend : {'auto', 'marsilea', 'matplotlib'}
-        ``'auto'`` picks marsilea when installed (recommended — it handles
-        categorical legends + multi-strip annotations cleanly), else falls
-        back to the matplotlib renderer.
+        ``'auto'`` picks marsilea when installed (recommended for clean
+        categorical legends), else falls back to the matplotlib renderer.
     title : str or None
-        Optional figure title.
+        Optional title.
     show : bool, default True
-        Whether to render the figure (marsilea backend only — passed to
-        ``Heatmap.render()``).
+        Whether to render the figure (marsilea only).
 
     Returns
     -------
-    Marsilea backend: the rendered ``marsilea.Heatmap`` object (call
-        ``.figure`` for the matplotlib Figure).
-    Matplotlib backend: ``(fig, axes_dict)`` with keys
-        ``{'heatmap', 'ideogram', 'cbar'}``.
+    Marsilea backend: ``marsilea.Heatmap`` (call ``.figure`` for the Figure).
+    Matplotlib backend: ``(fig, axes_dict)``.
 
     Examples
     --------
     >>> import omicverse as ov
     >>> cnv = ov.single.CNV(adata, method='copykat').run()
+    >>> # rows ordered by aneuploid / diploid:
     >>> ov.pl.cnv_heatmap(adata, groupby='cnv_prediction')
-    >>> ov.pl.cnv_heatmap(adata, groupby=['cell_type', 'cnv_prediction'])
+    >>> # same ordering, with cell_type overlaid as a 2nd colour strip:
+    >>> ov.pl.cnv_heatmap(adata, groupby='cnv_prediction',
+    ...                   annotations=['cell_type'])
     """
     X, chr_pos, _ = _get_cnv_data(adata)
     n_cells, n_bins_total = X.shape
@@ -317,9 +324,17 @@ def cnv_heatmap(
     X = X[:, col_slice]
     n_bins = X.shape[1]
 
-    groupby_list = _to_list(groupby)
-    primary = groupby_list[0] if groupby_list else None
-    row_order, group_segs = _order_rows_by_group(adata, primary)
+    # Annotation strip order: groupby first (so it visually anchors the row
+    # ordering), then the rest of `annotations` (any duplicate removed).
+    ann_list = _to_list(annotations)
+    strips: list[str] = []
+    if groupby is not None:
+        strips.append(groupby)
+    for a in ann_list:
+        if a != groupby and a not in strips:
+            strips.append(a)
+
+    row_order, group_segs = _order_rows_by_group(adata, groupby)
     X_ord = X[row_order]
 
     if max_value is None:
@@ -340,7 +355,7 @@ def cnv_heatmap(
             X_ord=X_ord,
             segments=segments,
             row_order=row_order,
-            groupby_list=groupby_list,
+            strips=strips,
             max_value=max_value,
             figsize=figsize,
             cmap=cmap,
@@ -416,7 +431,7 @@ def _cnv_heatmap_marsilea(
     X_ord: np.ndarray,
     segments: list[tuple[str, int, int]],
     row_order: np.ndarray,
-    groupby_list: list[str],
+    strips: list[str],
     max_value: float,
     figsize: tuple[float, float],
     cmap,
@@ -466,10 +481,12 @@ def _cnv_heatmap_marsilea(
         pad=0.02,
     )
 
-    # Left: one colour strip per groupby column (cell_type, cnv_prediction, …).
+    # Left: one colour strip per requested column. The first one is `groupby`
+    # (which controls row ordering) — anchored flush against the heatmap;
+    # subsequent strips are decorative `annotations`.
     default_pal_28 = list(palette_28)
     default_pal_56 = list(palette_56)
-    for i, key in enumerate(groupby_list):
+    for i, key in enumerate(strips):
         if key not in adata.obs:
             continue
         values = adata.obs[key].astype(object).fillna("NA").values[row_order]

--- a/omicverse/pl/_cnv.py
+++ b/omicverse/pl/_cnv.py
@@ -1,0 +1,548 @@
+r"""Plotting helpers for :class:`omicverse.single.CNV` outputs.
+
+Three functions, all reading the unified ``adata.obsm['X_cnv']`` /
+``adata.uns['cnv']`` schema that both CopyKAT and inferCNV write into:
+
+* :func:`cnv_heatmap` — cells × genomic-position heatmap with a
+  chromosome ideogram bar on top (alternating black/grey rectangles).
+* :func:`cnv_summary` — per-bin mean CN as a step plot, gain (red)
+  filled above zero and loss (blue) filled below.
+* :func:`cnv_umap` — thin wrapper around :func:`omicverse.pl.embedding`
+  that reads ``adata.obs['cnv_prediction']`` / ``adata.obs['cnv_score']``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Optional, Union
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from anndata import AnnData
+from matplotlib.axes import Axes
+from matplotlib.colors import LinearSegmentedColormap, Normalize
+from matplotlib.figure import Figure
+from matplotlib.patches import Rectangle
+
+from .._registry import register_function
+
+
+# ----------------------------------------------------------------------
+# colour / ordering helpers
+# ----------------------------------------------------------------------
+
+
+_CNV_CMAP = LinearSegmentedColormap.from_list(
+    "ov_cnv", ["#3a5fcd", "#88aedd", "#ffffff", "#e89090", "#cd3a3a"], N=256
+)
+
+
+def _natural_chrom_key(c: str) -> tuple[int, str]:
+    """Sort chromosomes 1, 2, ..., 22, X, Y, M naturally."""
+    s = str(c).replace("chr", "")
+    try:
+        return (int(s), "")
+    except ValueError:
+        order = {"X": 100, "Y": 101, "M": 102, "MT": 102}
+        return (order.get(s.upper(), 200), s)
+
+
+_STANDARD_CHROMS = {f"chr{i}" for i in range(1, 23)} | {"chrX", "chrY", "chrM"}
+_STANDARD_CHROMS |= {f"{i}" for i in range(1, 23)} | {"X", "Y", "M"}
+
+
+def _is_standard_chromosome(name: str) -> bool:
+    return str(name) in _STANDARD_CHROMS
+
+
+def _get_cnv_data(adata: AnnData) -> tuple[np.ndarray, dict[str, int], dict]:
+    """Read X_cnv + chr_pos from the agreed-upon adata slots."""
+    if "X_cnv" not in adata.obsm:
+        raise KeyError(
+            "adata.obsm['X_cnv'] not found — run ov.single.CNV(...).run() first."
+        )
+    uns = adata.uns.get("cnv", {})
+    chr_pos = uns.get("chr_pos")
+    if chr_pos is None or len(chr_pos) == 0:
+        raise KeyError(
+            "adata.uns['cnv']['chr_pos'] not found — run ov.single.CNV(...).run() first."
+        )
+    X = np.asarray(adata.obsm["X_cnv"])
+    return X, dict(chr_pos), dict(uns)
+
+
+def _build_chr_segments(
+    chr_pos: dict[str, int],
+    n_bins: int,
+    *,
+    standard_only: bool = True,
+) -> tuple[list[tuple[str, int, int]], slice]:
+    """Sorted [(chrom, start_bin, end_bin), ...] covering the plotted bin range.
+
+    When ``standard_only`` is True (default), unplaced scaffolds / alt contigs
+    are dropped from the ideogram — they otherwise crowd the right edge of the
+    plot with thin segments labelled e.g. ``GL000220.1``. The second return
+    is the slice over X_cnv columns to render, aligned with the kept
+    chromosomes (contiguous if the kept set is contiguous in chr_pos, else a
+    boolean mask is used instead by the caller).
+    """
+    pairs = sorted(chr_pos.items(), key=lambda kv: kv[1])
+    raw: list[tuple[str, int, int]] = []
+    for i, (chrom, start) in enumerate(pairs):
+        end = pairs[i + 1][1] if i + 1 < len(pairs) else n_bins
+        raw.append((str(chrom), int(start), int(end)))
+
+    if not standard_only:
+        return raw, slice(0, n_bins)
+
+    kept = [seg for seg in raw if _is_standard_chromosome(seg[0])]
+    if not kept:
+        return raw, slice(0, n_bins)
+
+    # If the kept chromosomes are a contiguous prefix/run in raw (typical case
+    # — scaffolds come last), we can render the heatmap with a clean slice.
+    starts = [s for _, s, _ in kept]
+    ends = [e for _, _, e in kept]
+    contig_lo = min(starts)
+    contig_hi = max(ends)
+    contiguous = all(
+        seg[1] >= contig_lo and seg[2] <= contig_hi for seg in kept
+    )
+    if contiguous:
+        # Re-base segment positions to 0 so the heatmap axes start at 0.
+        rebased = [(c, s - contig_lo, e - contig_lo) for c, s, e in kept]
+        return rebased, slice(contig_lo, contig_hi)
+    # Non-contiguous (rare): caller will need to build a mask externally.
+    return kept, slice(0, n_bins)
+
+
+def _draw_ideogram(
+    ax: Axes,
+    segments: Sequence[tuple[str, int, int]],
+    *,
+    height: float = 1.0,
+    fontsize: int = 8,
+    label_short: bool = True,
+) -> None:
+    """Render an ideogram-style chromosome bar onto ``ax``."""
+    total_width = segments[-1][2] - segments[0][1]
+    ax.set_xlim(segments[0][1], segments[-1][2])
+    ax.set_ylim(0, height)
+    ax.set_yticks([])
+    ax.set_xticks([])
+    for spine in ax.spines.values():
+        spine.set_visible(False)
+    light = "#d8d8d8"
+    dark = "#444444"
+    # Skip labels on segments narrower than this fraction of the total width —
+    # avoids overlapping "20 21 22" labels at the right edge.
+    min_label_frac = 0.018
+    for i, (chrom, start, end) in enumerate(segments):
+        color = light if i % 2 == 0 else dark
+        ax.add_patch(
+            Rectangle(
+                (start, 0), end - start, height, facecolor=color, edgecolor="none"
+            )
+        )
+        if end - start <= 0:
+            continue
+        if (end - start) / max(total_width, 1) < min_label_frac:
+            continue
+        label = chrom.replace("chr", "") if label_short else chrom
+        ax.text(
+            (start + end) / 2,
+            height / 2,
+            label,
+            ha="center",
+            va="center",
+            fontsize=fontsize,
+            color="white" if i % 2 else "black",
+        )
+
+
+def _order_rows_by_group(
+    adata: AnnData, groupby: Optional[str]
+) -> tuple[np.ndarray, list[tuple[str, int, int]]]:
+    """Permutation that buckets rows by groupby (preserving within-bucket order).
+
+    Returns ``(row_order, group_segments)`` where ``group_segments`` is a list
+    of ``(label, row_start, row_end)`` triples (for drawing group separators).
+    """
+    if groupby is None or groupby not in adata.obs:
+        order = np.arange(adata.n_obs)
+        return order, [("", 0, adata.n_obs)]
+    series = adata.obs[groupby]
+    # Stable groupby preserves NaN at the end.
+    cats = pd.Categorical(series).categories.tolist()
+    order: list[int] = []
+    segs: list[tuple[str, int, int]] = []
+    for c in cats:
+        idx = np.where(series.values == c)[0]
+        if idx.size == 0:
+            continue
+        start = len(order)
+        order.extend(idx.tolist())
+        segs.append((str(c), start, start + idx.size))
+    # Any cells with NaN groupby value go last
+    nan_idx = np.where(series.isna().values)[0]
+    if nan_idx.size:
+        start = len(order)
+        order.extend(nan_idx.tolist())
+        segs.append(("NA", start, start + nan_idx.size))
+    return np.asarray(order, dtype=int), segs
+
+
+# ----------------------------------------------------------------------
+# cnv_heatmap
+# ----------------------------------------------------------------------
+
+
+@register_function(
+    aliases=["拷贝数热图", "cnv_heatmap", "chromosome_heatmap"],
+    category="pl",
+    description=(
+        "Genome-wide CNV heatmap: cells × ordered genomic bins, gain in red "
+        "and loss in blue, with an alternating chromosome ideogram bar on top "
+        "and optional row grouping by adata.obs['cnv_prediction'] / cell_type."
+    ),
+    examples=[
+        "ov.pl.cnv_heatmap(adata)",
+        "ov.pl.cnv_heatmap(adata, groupby='cnv_prediction')",
+        "ov.pl.cnv_heatmap(adata, groupby='cell_type', max_value=0.6)",
+    ],
+    related=["pl.cnv_summary", "pl.cnv_umap", "single.CNV"],
+)
+def cnv_heatmap(
+    adata: AnnData,
+    *,
+    groupby: Optional[str] = None,
+    max_value: Optional[float] = None,
+    figsize: tuple[float, float] = (8.0, 4.5),
+    cmap=_CNV_CMAP,
+    show_group_labels: bool = True,
+    standard_chromosomes_only: bool = True,
+    ax: Optional[Axes] = None,
+    title: Optional[str] = None,
+) -> tuple[Figure, dict[str, Axes]]:
+    r"""Plot the genome-wide CNV heatmap.
+
+    Parameters
+    ----------
+    adata : AnnData
+        Must contain ``adata.obsm['X_cnv']`` and ``adata.uns['cnv']`` —
+        populated by :class:`omicverse.single.CNV`.
+    groupby : str or None
+        Column in ``adata.obs`` used to sort and visually separate cell rows
+        (e.g. ``'cnv_prediction'`` to show aneuploid vs. diploid cells in
+        separate bands, or ``'cell_type'``).
+    max_value : float or None
+        Symmetric colour limit. If ``None``, set to the 99th percentile of
+        ``|X_cnv|`` so a handful of extreme bins don't wash out the figure.
+    figsize : tuple
+        Figure size in inches. Ignored when ``ax`` is passed.
+    cmap : matplotlib Colormap
+        Diverging colormap. Default is a blue/white/red palette aligned with
+        the figures in Gao et al. 2021 / inferCNV publications.
+    show_group_labels : bool
+        Whether to draw the group names as left-side annotations.
+    ax : matplotlib Axes or None
+        Pre-allocated heatmap axes. If ``None``, a new figure with the
+        ideogram subplot is created.
+    title : str or None
+        Optional figure title.
+
+    Returns
+    -------
+    fig : matplotlib.figure.Figure
+    axes : dict
+        ``{'heatmap': Axes, 'ideogram': Axes}`` — handles for further tuning.
+
+    Examples
+    --------
+    >>> import omicverse as ov
+    >>> cnv = ov.single.CNV(adata, method='copykat').run()
+    >>> ov.pl.cnv_heatmap(adata, groupby='cnv_prediction')
+    """
+    X, chr_pos, _ = _get_cnv_data(adata)
+    n_cells, n_bins_total = X.shape
+    segments, col_slice = _build_chr_segments(
+        chr_pos, n_bins_total, standard_only=standard_chromosomes_only
+    )
+    X = X[:, col_slice]
+    n_bins = X.shape[1]
+
+    row_order, group_segs = _order_rows_by_group(adata, groupby)
+    X_ord = X[row_order]
+
+    if max_value is None:
+        max_value = float(np.nanpercentile(np.abs(X_ord), 99))
+        if max_value <= 0:
+            max_value = 1.0
+
+    if ax is None:
+        fig = plt.figure(figsize=figsize)
+        gs = fig.add_gridspec(
+            2, 1, height_ratios=(0.5, 9.5), hspace=0.05, top=0.92, bottom=0.10
+        )
+        ideo_ax = fig.add_subplot(gs[0, 0])
+        hm_ax = fig.add_subplot(gs[1, 0], sharex=ideo_ax)
+    else:
+        hm_ax = ax
+        fig = hm_ax.figure
+        # Carve a thin axes above the heatmap axes for the ideogram.
+        bbox = hm_ax.get_position()
+        ideo_ax = fig.add_axes(
+            [bbox.x0, bbox.y1 + 0.005, bbox.width, bbox.height * 0.05]
+        )
+
+    _draw_ideogram(ideo_ax, segments)
+
+    norm = Normalize(vmin=-max_value, vmax=max_value)
+    hm_ax.imshow(
+        X_ord,
+        aspect="auto",
+        cmap=cmap,
+        norm=norm,
+        interpolation="nearest",
+        extent=(0, n_bins, n_cells, 0),
+    )
+
+    # Chromosome dividers — thin grey vertical lines at each segment break.
+    for _, _, end in segments[:-1]:
+        hm_ax.axvline(end, color="white", linewidth=0.4, alpha=0.7)
+
+    # Group dividers — horizontal black lines + optional left-side labels.
+    if groupby is not None and len(group_segs) > 1:
+        for _, _, row_end in group_segs[:-1]:
+            hm_ax.axhline(row_end, color="black", linewidth=0.8)
+        if show_group_labels:
+            for label, row_start, row_end in group_segs:
+                hm_ax.text(
+                    -n_bins * 0.01,
+                    (row_start + row_end) / 2,
+                    label,
+                    ha="right",
+                    va="center",
+                    fontsize=9,
+                    rotation=0,
+                )
+
+    hm_ax.set_xticks([])
+    hm_ax.set_yticks([])
+    hm_ax.set_xlabel("Ordered genomic positions")
+    hm_ax.set_ylabel(f"{n_cells:,} cells")
+    for spine in hm_ax.spines.values():
+        spine.set_visible(True)
+        spine.set_linewidth(0.5)
+
+    if title:
+        fig.suptitle(title, fontsize=11, y=0.96)
+
+    # Colour bar on the right.
+    cax = fig.add_axes(
+        [hm_ax.get_position().x1 + 0.01, hm_ax.get_position().y0,
+         0.012, hm_ax.get_position().height * 0.4]
+    )
+    fig.colorbar(
+        plt.cm.ScalarMappable(norm=norm, cmap=cmap), cax=cax, label="CN (log ratio)"
+    )
+
+    return fig, {"heatmap": hm_ax, "ideogram": ideo_ax, "cbar": cax}
+
+
+# ----------------------------------------------------------------------
+# cnv_summary
+# ----------------------------------------------------------------------
+
+
+@register_function(
+    aliases=["拷贝数概览", "cnv_summary", "chromosome_heatmap_summary"],
+    category="pl",
+    description=(
+        "Per-bin mean CN as a step plot — gain (red, above zero) and loss "
+        "(blue, below zero) filled to baseline; companion to cnv_heatmap. "
+        "Use groupby='cnv_prediction' to plot the aneuploid mean."
+    ),
+    examples=[
+        "ov.pl.cnv_summary(adata)",
+        "ov.pl.cnv_summary(adata, groupby='cnv_prediction', subset='aneuploid')",
+    ],
+    related=["pl.cnv_heatmap", "pl.cnv_umap"],
+)
+def cnv_summary(
+    adata: AnnData,
+    *,
+    groupby: Optional[str] = None,
+    subset: Union[str, Sequence[str], None] = None,
+    figsize: tuple[float, float] = (8.0, 2.5),
+    gain_color: str = "#cd3a3a",
+    loss_color: str = "#3a5fcd",
+    ylim: Optional[tuple[float, float]] = None,
+    standard_chromosomes_only: bool = True,
+    ax: Optional[Axes] = None,
+    title: Optional[str] = None,
+) -> tuple[Figure, dict[str, Axes]]:
+    r"""Plot mean CN per genomic bin as a filled step plot.
+
+    Parameters
+    ----------
+    adata : AnnData
+        Output of :class:`omicverse.single.CNV`.
+    groupby : str or None
+        ``adata.obs`` column. If given, cells are filtered to ``subset``.
+    subset : str or list of str or None
+        Category value(s) in ``adata.obs[groupby]`` to restrict to (e.g.
+        ``'aneuploid'``). If ``None``, the mean is over all cells.
+    figsize : tuple
+        Figure size in inches.
+    gain_color / loss_color : str
+        Fill colours for above/below zero deviations.
+    ylim : tuple or None
+        Y-axis limits. Defaults to symmetric around the largest |mean|.
+    ax : matplotlib Axes or None
+        Pre-allocated axes. If ``None``, a new figure is created.
+    title : str or None
+        Optional title.
+
+    Returns
+    -------
+    fig, axes
+    """
+    X, chr_pos, _ = _get_cnv_data(adata)
+    n_bins_total = X.shape[1]
+    segments, col_slice = _build_chr_segments(
+        chr_pos, n_bins_total, standard_only=standard_chromosomes_only
+    )
+    X = X[:, col_slice]
+    n_bins = X.shape[1]
+
+    rows = np.arange(adata.n_obs)
+    if groupby is not None and subset is not None:
+        if groupby not in adata.obs:
+            raise KeyError(f"adata.obs[{groupby!r}] not found")
+        target = {subset} if isinstance(subset, str) else set(subset)
+        rows = np.where(adata.obs[groupby].astype(str).isin(target).values)[0]
+        if rows.size == 0:
+            raise ValueError(f"no cells with {groupby}={subset}")
+
+    mean_cn = np.nanmean(X[rows, :], axis=0)
+
+    if ax is None:
+        fig = plt.figure(figsize=figsize)
+        gs = fig.add_gridspec(
+            2, 1, height_ratios=(0.5, 9.5), hspace=0.05, top=0.90, bottom=0.18
+        )
+        ideo_ax = fig.add_subplot(gs[0, 0])
+        line_ax = fig.add_subplot(gs[1, 0], sharex=ideo_ax)
+    else:
+        line_ax = ax
+        fig = line_ax.figure
+        bbox = line_ax.get_position()
+        ideo_ax = fig.add_axes(
+            [bbox.x0, bbox.y1 + 0.005, bbox.width, bbox.height * 0.07]
+        )
+
+    _draw_ideogram(ideo_ax, segments)
+
+    x = np.arange(n_bins)
+    pos = np.maximum(mean_cn, 0)
+    neg = np.minimum(mean_cn, 0)
+    line_ax.fill_between(x, 0, pos, step="post", color=gain_color, alpha=0.85, linewidth=0)
+    line_ax.fill_between(x, 0, neg, step="post", color=loss_color, alpha=0.85, linewidth=0)
+    line_ax.step(x, mean_cn, where="post", color="black", linewidth=0.4)
+    line_ax.axhline(0, color="black", linewidth=0.5)
+
+    # Chromosome dividers.
+    for _, _, end in segments[:-1]:
+        line_ax.axvline(end, color="grey", linewidth=0.3, alpha=0.5)
+
+    if ylim is None:
+        m = float(np.nanmax(np.abs(mean_cn))) or 1.0
+        ylim = (-m * 1.15, m * 1.15)
+    line_ax.set_ylim(*ylim)
+    line_ax.set_xlim(0, n_bins)
+    line_ax.set_xticks([])
+    line_ax.set_xlabel("Ordered genomic positions")
+    line_ax.set_ylabel("Mean CN (log ratio)")
+    for spine_name in ("top", "right"):
+        line_ax.spines[spine_name].set_visible(False)
+    line_ax.spines["left"].set_linewidth(0.5)
+    line_ax.spines["bottom"].set_linewidth(0.5)
+
+    if title:
+        fig.suptitle(title, fontsize=11, y=0.97)
+
+    return fig, {"line": line_ax, "ideogram": ideo_ax}
+
+
+# ----------------------------------------------------------------------
+# cnv_umap
+# ----------------------------------------------------------------------
+
+
+@register_function(
+    aliases=["拷贝数umap", "cnv_umap"],
+    category="pl",
+    description=(
+        "UMAP coloured by CNV outputs — convenience wrapper around "
+        "ov.pl.embedding that defaults to colouring by ['cnv_prediction', "
+        "'cnv_score'] (the two columns ov.single.CNV writes)."
+    ),
+    examples=[
+        "ov.pl.cnv_umap(adata)",
+        "ov.pl.cnv_umap(adata, color='cnv_score', cmap='Purples')",
+    ],
+    related=["pl.cnv_heatmap", "pl.cnv_summary", "single.CNV", "pl.embedding"],
+)
+def cnv_umap(
+    adata: AnnData,
+    *,
+    color: Union[str, Sequence[str], None] = None,
+    basis: str = "X_umap",
+    cmap: str = "Purples",
+    **kwargs,
+):
+    r"""UMAP coloured by CNV outputs.
+
+    Defaults to side-by-side panels of ``cnv_prediction`` (tumour vs normal
+    classification, when present) and ``cnv_score`` (per-cell mean |CN|).
+    Forwards everything else to :func:`omicverse.pl.embedding`.
+
+    Parameters
+    ----------
+    adata : AnnData
+        Must contain ``adata.obsm[basis]`` (default ``X_umap``) and any
+        of ``cnv_prediction`` / ``cnv_score`` in ``adata.obs``.
+    color : str, list of str, or None
+        Override the default colouring (``['cnv_prediction', 'cnv_score']``
+        when both are present, else whichever exists).
+    basis : str
+        Embedding key (``adata.obsm`` key). Default ``'X_umap'``.
+    cmap : str
+        Colormap for continuous (``cnv_score``) panels.
+    **kwargs
+        Forwarded to :func:`omicverse.pl.embedding`.
+
+    Returns
+    -------
+    Whatever :func:`omicverse.pl.embedding` returns (``(fig, ax)`` or ``ax``,
+    depending on its current signature).
+    """
+    from ._single import embedding
+
+    if color is None:
+        candidates = []
+        if "cnv_prediction" in adata.obs and not adata.obs["cnv_prediction"].isna().all():
+            candidates.append("cnv_prediction")
+        if "cnv_score" in adata.obs:
+            candidates.append("cnv_score")
+        if not candidates:
+            raise KeyError(
+                "neither 'cnv_prediction' nor 'cnv_score' found in adata.obs — "
+                "run ov.single.CNV(...).run() first."
+            )
+        color = candidates if len(candidates) > 1 else candidates[0]
+
+    kwargs.setdefault("cmap", cmap)
+    return embedding(adata, basis=basis, color=color, **kwargs)

--- a/omicverse/single/__init__.py
+++ b/omicverse/single/__init__.py
@@ -98,6 +98,11 @@ from ._lazy_checkpoint import lazy_checkpoint, resume_from_checkpoint, list_chec
 # Monocle2-style trajectory analysis (pure Python re-implementation).
 # Usage: mono = ov.single.Monocle(adata); mono.preprocess(); ...
 from ._monocle import Monocle
+
+# Single-cell CNV inference — pure-Python CopyKAT / inferCNV wrappers.
+# Usage: cnv = ov.single.CNV(adata, method='copykat'); cnv.run()
+from ._cnv import CNV
+
 from ._lazy_step_by_step import (
     lazy_step_qc, lazy_step_preprocess, lazy_step_scale, lazy_step_pca,
     lazy_step_cell_cycle, lazy_step_harmony, lazy_step_scvi, 
@@ -354,7 +359,10 @@ __all__ = [
     'MetaCell',
     'plot_metacells',
     'get_obs_value',
-    
+
+    # Single-cell CNV
+    'CNV',
+
     # Differential expression
     'DCT',
     'DEG',

--- a/omicverse/single/_cnv.py
+++ b/omicverse/single/_cnv.py
@@ -1,0 +1,354 @@
+r"""Single-cell copy-number variation inference (CopyKAT / inferCNV).
+
+Wraps `pycopykat <https://github.com/omicverse/py-CopyKAT>`_ and
+`pyinfercnv <https://github.com/omicverse/py-inferCNV>`_ behind a single
+:class:`CNV` class with ``method='copykat' | 'infercnv'`` dispatch.
+
+Both backends share a unified output schema:
+
+* ``adata.obsm['X_cnv']``      — cells × genomic-bin CN matrix
+* ``adata.uns['cnv']``         — ``dict`` with ``chr_pos`` (chromosome →
+  start-bin index), ``method`` and any backend-specific metadata
+* ``adata.obs['cnv_score']``   — per-cell mean |CN|
+* ``adata.obs['cnv_prediction']`` — categorical (CopyKAT: ``'aneuploid' /
+  'diploid'``; inferCNV: NaN by default since the kernel does not
+  classify cells without a downstream threshold)
+
+so the plotting helpers in :mod:`omicverse.pl` work with either backend.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional, Sequence, Union
+
+import numpy as np
+import pandas as pd
+from anndata import AnnData
+
+from .._registry import register_function
+
+
+def _check_dep(backend: str) -> None:
+    """Lazy-import gate. Raises a clean ImportError pointing at the GitHub repo."""
+    if backend == "copykat":
+        try:
+            import pycopykat  # noqa: F401
+        except ImportError as e:
+            raise ImportError(
+                "pycopykat is required for method='copykat'. Install via:\n"
+                "  pip install git+https://github.com/omicverse/py-CopyKAT.git"
+            ) from e
+    elif backend == "infercnv":
+        try:
+            import pyinfercnv  # noqa: F401
+        except ImportError as e:
+            raise ImportError(
+                "pyinfercnv is required for method='infercnv'. Install via:\n"
+                "  pip install git+https://github.com/omicverse/py-inferCNV.git"
+            ) from e
+    else:
+        raise ValueError(f"unknown CNV backend {backend!r} (expected 'copykat' or 'infercnv')")
+
+
+@register_function(
+    aliases=["拷贝数变异", "CNV", "copy_number", "拷贝数", "CNA", "copykat", "infercnv"],
+    category="single",
+    description=(
+        "Single-cell copy-number variation inference. Wraps the pure-Python "
+        "CopyKAT and inferCNV implementations behind a unified API; results "
+        "land in adata.obsm['X_cnv'] / adata.uns['cnv'] / adata.obs['cnv_*'] "
+        "and feed the ov.pl.cnv_heatmap / cnv_summary / cnv_umap plots."
+    ),
+    requires={
+        "var": [
+            "gene symbols matching the reference genome",
+            "chromosome / start / end coordinates (inferCNV only)",
+        ],
+    },
+    produces={
+        "obsm": ["X_cnv"],
+        "obs": ["cnv_prediction", "cnv_score"],
+        "uns": ["cnv"],
+    },
+    auto_fix="none",
+    examples=[
+        "# CopyKAT — unsupervised aneuploid / diploid classification",
+        "cnv = ov.single.CNV(adata, method='copykat', genome='hg20')",
+        "cnv.run()",
+        "ov.pl.cnv_heatmap(adata)",
+        "",
+        "# inferCNV — reference-anchored CN matrix (uses non-tumour cells)",
+        "cnv = ov.single.CNV(adata, method='infercnv')",
+        "cnv.run(reference_key='cell_type', reference_cat=['T cell CD4', 'Macrophage'])",
+        "ov.pl.cnv_heatmap(adata, groupby='cnv_prediction')",
+    ],
+    related=["pl.cnv_heatmap", "pl.cnv_summary", "pl.cnv_umap"],
+)
+class CNV:
+    """Single-cell CNV inference dispatcher.
+
+    Parameters
+    ----------
+    adata : AnnData
+        Single-cell expression data. For ``method='copykat'`` should contain
+        raw or near-raw counts. For ``method='infercnv'`` should contain
+        chromosome coordinates in ``adata.var`` (``chromosome``, ``start``,
+        ``end`` columns) and a cell-type annotation column referenced by
+        ``reference_key`` in :meth:`run`.
+    method : {'copykat', 'infercnv'}
+        Which backend to run.
+    genome : str, default ``'hg20'``
+        Reference genome. ``'hg20'`` (CopyKAT human GRCh38) or ``'mm10'`` for
+        CopyKAT; for inferCNV the chromosome/start/end metadata in
+        ``adata.var`` is authoritative.
+    layer : str or None, default None
+        Layer to score against (instead of ``adata.X``).
+    raw : bool, default False
+        Use ``adata.raw.X`` instead of ``adata.X`` (CopyKAT only — inferCNV
+        always uses ``layer`` or ``.X``).
+    """
+
+    def __init__(
+        self,
+        adata: AnnData,
+        method: str = "copykat",
+        *,
+        genome: str = "hg20",
+        layer: Optional[str] = None,
+        raw: bool = False,
+    ) -> None:
+        if method not in {"copykat", "infercnv"}:
+            raise ValueError(f"method must be 'copykat' or 'infercnv', got {method!r}")
+        _check_dep(method)
+        self.adata = adata
+        self.method = method
+        self.genome = genome
+        self.layer = layer
+        self.raw = raw
+        # Populated by .run()
+        self.result: Any = None
+
+    # ------------------------------------------------------------------ #
+    # public                                                              #
+    # ------------------------------------------------------------------ #
+
+    def run(
+        self,
+        *,
+        reference_key: Optional[str] = None,
+        reference_cat: Union[str, Sequence[str], None] = None,
+        exclude_chromosomes: Optional[Sequence[str]] = ("chrX", "chrY", "chrM"),
+        n_jobs: int = 1,
+        verbose: bool = False,
+        **kwargs: Any,
+    ) -> "CNV":
+        r"""Execute the chosen backend and write results into ``self.adata``.
+
+        Parameters
+        ----------
+        reference_key : str or None
+            Column in ``adata.obs`` that identifies reference (normal) cells
+            for inferCNV. Required for ``method='infercnv'`` when you want
+            a reference-anchored CN matrix; CopyKAT ignores this (it
+            classifies unsupervised).
+        reference_cat : str or list of str
+            Value(s) in ``adata.obs[reference_key]`` that mark reference cells.
+        exclude_chromosomes : sequence of str
+            Chromosomes to drop before CNV inference. Default skips sex +
+            mitochondrial chromosomes, which carry biological signal that
+            confounds the deviation from the genome-wide diploid baseline.
+        n_jobs : int
+            Parallel workers (CopyKAT only).
+        verbose : bool
+            Stream progress logs from the underlying backend.
+        **kwargs
+            Forwarded to the backend (``CopykatConfig`` or ``InferCNVConfig``).
+
+        Returns
+        -------
+        self
+            ``CNV`` instance with ``.result`` populated. Side-effects:
+            writes ``adata.obsm['X_cnv']``, ``adata.uns['cnv']``,
+            ``adata.obs['cnv_score']`` and (CopyKAT only) ``adata.obs['cnv_prediction']``.
+        """
+        if self.method == "copykat":
+            return self._run_copykat(
+                exclude_chromosomes=exclude_chromosomes,
+                n_jobs=n_jobs,
+                verbose=verbose,
+                **kwargs,
+            )
+        return self._run_infercnv(
+            reference_key=reference_key,
+            reference_cat=reference_cat,
+            exclude_chromosomes=exclude_chromosomes,
+            verbose=verbose,
+            **kwargs,
+        )
+
+    # ------------------------------------------------------------------ #
+    # backends                                                            #
+    # ------------------------------------------------------------------ #
+
+    def _run_copykat(
+        self,
+        *,
+        exclude_chromosomes: Optional[Sequence[str]],
+        n_jobs: int,
+        verbose: bool,
+        **kwargs: Any,
+    ) -> "CNV":
+        import logging
+        from pycopykat import CopykatConfig, copykat
+
+        if verbose:
+            logging.getLogger("pycopykat").setLevel(logging.INFO)
+
+        # CopyKAT wants a (genes × cells) DataFrame with gene names in the index.
+        mat = self._extract_counts_df()
+
+        cfg = CopykatConfig(
+            id_type=kwargs.pop("id_type", "Symbol"),
+            genome=kwargs.pop("genome", self.genome),
+            n_jobs=n_jobs,
+            **kwargs,
+        )
+        result = copykat(mat, config=cfg)
+
+        # cna_mat: bins (MultiIndex chrom/start/end) × cells. Transpose to cells × bins
+        # and align ordering with adata.obs_names so the obsm assignment is safe.
+        cna = result.cna_mat
+        cell_to_col = {c: i for i, c in enumerate(cna.columns)}
+        # Some upstream cells get filtered by stage-1 chrom coverage; we right-pad
+        # those rows with NaN so the obsm matrix still has shape (n_obs, n_bins).
+        n_bins = cna.shape[0]
+        X_cnv = np.full((self.adata.n_obs, n_bins), np.nan, dtype=np.float32)
+        for i, name in enumerate(self.adata.obs_names):
+            col = cell_to_col.get(name)
+            if col is not None:
+                X_cnv[i] = cna.iloc[:, col].to_numpy(dtype=np.float32)
+
+        chr_pos = _chr_pos_from_bin_index(cna.index)
+        bin_meta = pd.DataFrame(cna.index.to_frame(index=False))
+
+        # Prediction (aneuploid / diploid). Missing for cells filtered out.
+        pred_col = "copykat.pred" if "copykat.pred" in result.prediction.columns else result.prediction.columns[-1]
+        pred = result.prediction.set_index("cell")[pred_col].reindex(self.adata.obs_names)
+
+        self.adata.obsm["X_cnv"] = X_cnv
+        self.adata.obs["cnv_prediction"] = pd.Categorical(pred)
+        self.adata.obs["cnv_score"] = np.nanmean(np.abs(X_cnv), axis=1).astype(np.float32)
+        self.adata.uns["cnv"] = {
+            "method": "copykat",
+            "chr_pos": chr_pos,
+            "bin_meta": bin_meta,
+            "exclude_chromosomes": list(exclude_chromosomes or []),
+        }
+        self.result = result
+        return self
+
+    def _run_infercnv(
+        self,
+        *,
+        reference_key: Optional[str],
+        reference_cat: Union[str, Sequence[str], None],
+        exclude_chromosomes: Optional[Sequence[str]],
+        verbose: bool,
+        **kwargs: Any,
+    ) -> "CNV":
+        import logging
+        from pyinfercnv import InferCNVConfig, infercnv
+
+        if verbose:
+            logging.getLogger("pyinfercnv").setLevel(logging.INFO)
+
+        # inferCNV needs chromosome / start / end in adata.var.
+        for col in ("chromosome", "start", "end"):
+            if col not in self.adata.var.columns:
+                raise ValueError(
+                    f"adata.var must contain {col!r} for method='infercnv'. "
+                    "Annotate gene coordinates first (see pyinfercnv.io.genome.load_gene_positions)."
+                )
+
+        cfg = InferCNVConfig(
+            counts_layer=self.layer,
+            **kwargs,
+        )
+        # write_to_anndata(key_added='cnv') is called internally when inplace=True
+        result = infercnv(
+            self.adata,
+            config=cfg,
+            reference_key=reference_key,
+            reference_cat=reference_cat,
+            exclude_chromosomes=exclude_chromosomes,
+            key_added="cnv",
+            inplace=True,
+        )
+
+        # Per-cell mean |CN| as a portable "tumour-ness" score. inferCNV does
+        # not classify cells; downstream users can threshold this.
+        X_cnv = self.adata.obsm["X_cnv"]
+        score = np.asarray(np.abs(X_cnv).mean(axis=1)).reshape(-1).astype(np.float32)
+        self.adata.obs["cnv_score"] = score
+        # Tag method + carry chr_pos for the plot layer
+        uns = dict(self.adata.uns.get("cnv", {}))
+        uns["method"] = "infercnv"
+        # Build a chromosome-bin lookup if not present (pyinfercnv writes chr_pos already)
+        uns.setdefault("chr_pos", _chr_pos_from_obsm_var(self.adata))
+        self.adata.uns["cnv"] = uns
+        # No prediction column from inferCNV — leave it unset so plotting code
+        # falls back to cnv_score / cell-type colouring.
+        if "cnv_prediction" not in self.adata.obs:
+            self.adata.obs["cnv_prediction"] = pd.Categorical(
+                pd.Series([pd.NA] * self.adata.n_obs, index=self.adata.obs_names)
+            )
+        self.result = result
+        return self
+
+    # ------------------------------------------------------------------ #
+    # helpers                                                             #
+    # ------------------------------------------------------------------ #
+
+    def _extract_counts_df(self) -> pd.DataFrame:
+        """Materialise a (genes × cells) DataFrame for CopyKAT."""
+        if self.raw and self.adata.raw is not None:
+            X = self.adata.raw.X
+            var_names = self.adata.raw.var_names
+        elif self.layer is not None:
+            X = self.adata.layers[self.layer]
+            var_names = self.adata.var_names
+        else:
+            X = self.adata.X
+            var_names = self.adata.var_names
+
+        if hasattr(X, "toarray"):
+            X = X.toarray()
+        X = np.asarray(X)
+        # AnnData is cells × genes — CopyKAT wants genes × cells.
+        return pd.DataFrame(X.T, index=var_names, columns=self.adata.obs_names)
+
+
+# ------------------------------------------------------------------ #
+# small utilities                                                     #
+# ------------------------------------------------------------------ #
+
+
+def _chr_pos_from_bin_index(idx: pd.MultiIndex) -> dict[str, int]:
+    """Map chromosome → start-bin index from a CopyKAT bin MultiIndex."""
+    df = idx.to_frame(index=False)
+    chrom_col = df.columns[0]
+    out: dict[str, int] = {}
+    for i, c in enumerate(df[chrom_col].astype(str)):
+        out.setdefault(str(c), i)
+    return out
+
+
+def _chr_pos_from_obsm_var(adata: AnnData) -> dict[str, int]:
+    """Fallback chr_pos from adata.var (used if pyinfercnv didn't write one)."""
+    if "chromosome" not in adata.var:
+        return {}
+    chrom = adata.var["chromosome"].astype(str)
+    out: dict[str, int] = {}
+    for i, c in enumerate(chrom):
+        out.setdefault(c, i)
+    return out


### PR DESCRIPTION
## Summary

Adds a unified entry point for single-cell CNV inference plus three plotting helpers, paired with two tutorial notebooks in [omicverse-tutorials#42](https://github.com/omicverse/omicverse-tutorials/pull/42).

### `ov.single.CNV`

```python
cnv = ov.single.CNV(adata, method='copykat'|'infercnv')
cnv.run(reference_key='cell_type', reference_cat=['T cell', 'Macrophage'])
```

Both backends write the same schema:

| slot | content |
|---|---|
| `adata.obsm['X_cnv']`         | cells × genomic-bin log-CN matrix |
| `adata.uns['cnv']['chr_pos']` | chromosome → starting-bin index |
| `adata.obs['cnv_score']`      | per-cell mean abs(log-CN) |
| `adata.obs['cnv_prediction']` | `aneuploid` / `diploid` / NaN (CopyKAT) |

Lazy imports of [py-CopyKAT](https://github.com/omicverse/py-CopyKAT) and [py-inferCNV](https://github.com/omicverse/py-inferCNV) — neither is a hard dependency; the wrapper raises a clean `ImportError` pointing at the upstream repo if the requested method's package is missing.

### `ov.pl.cnv_heatmap` / `cnv_summary` / `cnv_umap`

- `cnv_heatmap`: cells × bins heatmap with chromosome ideogram bar on top, gain (red) / loss (blue), optional row grouping (`groupby='cnv_prediction'` or `'cell_type'`).
- `cnv_summary`: mean CN per bin as a step plot, gain / loss filled to baseline.
- `cnv_umap`: thin `ov.pl.embedding` wrapper that defaults to the two CNV columns.

Same plot calls work for both backends since the underlying schema is shared.

### Validation

Smoke-tested on `maynard2020_3k.h5ad` (3000 cells × 55 556 genes, lung adenocarcinoma):

- CopyKAT: ~20 s on CPU for 600 cells → 92 aneuploid / 506 diploid / 2 filtered; aneuploid cluster overlaps the Epithelial-cell annotation on UMAP.
- inferCNV: ~15 s on CPU for 600 cells with T cells + Macrophages + B cells as references; `cnv_score` peaks at the Epithelial cluster.

## Test plan

- [x] `import omicverse as ov` clean
- [x] `ov.single.CNV(adata, method='copykat').run()` end-to-end on maynard2020 subset (600 cells)
- [x] `ov.single.CNV(adata, method='infercnv').run(reference_key=..., reference_cat=...)` end-to-end on maynard2020 subset
- [x] All 3 plotting helpers render expected figures
- [x] Tutorial notebooks `t_copykat.ipynb` / `t_infercnv.ipynb` re-execute cleanly (`jupyter nbconvert --execute`, 0 errors, 3-4 PNG outputs each)

## Note for follow-up

`py-CopyKAT` has a known packaging issue where the bundled `data/` directory resolves to the wrong path under a wheel install (`Path(__file__).resolve().parents[2]` lands at `site-packages/` rather than the package root). Worked around in this session by copying the data dir; should be fixed upstream by switching to `importlib.resources` or a `data/` subdirectory inside `pycopykat/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)