### PR TITLE
feat(llm): per-gene downstream-shift analysis for Geneformer perturbation

### DIFF
--- a/omicverse/llm/geneformer_model.py
+++ b/omicverse/llm/geneformer_model.py
@@ -1391,7 +1391,7 @@ class GeneformerModel(SCLLMBase):
                 raise RuntimeError(f"Tokenized dataset not produced at {ds_path}")
             base_dataset = load_from_disk(ds_path)
 
-        # 4) load Geneformer + helpers; one forward pass for baseline -------------
+        # 4) load Geneformer + helpers ---------------------------------------------
         from .geneformer import perturber_utils as pu
         from .geneformer.emb_extractor import get_embs
 
@@ -1403,11 +1403,13 @@ class GeneformerModel(SCLLMBase):
         layer_to_quant = pu.quant_layers(model) + (-1)
         pad_token_id = gene_token_dict.get("<pad>", 0)
 
-        def _embed(dataset):
+        compute_gene_shifts: bool = bool(kwargs.get("compute_gene_shifts", True))
+
+        def _embed(dataset, *, mode: str):
             embs = get_embs(
                 model=model,
                 filtered_input_data=dataset,
-                emb_mode="cell",
+                emb_mode=mode,
                 layer_to_quant=layer_to_quant,
                 pad_token_id=pad_token_id,
                 forward_batch_size=forward_batch_size,
@@ -1417,8 +1419,57 @@ class GeneformerModel(SCLLMBase):
             arr = embs.cpu().numpy() if hasattr(embs, "cpu") else np.asarray(embs)
             return arr
 
+        def _cell_from_gene_embs(gene_embs: np.ndarray, lengths: np.ndarray) -> np.ndarray:
+            """Mean-pool per-token gene embeddings into per-cell embeddings, masking pads."""
+            n_cells, max_len, d = gene_embs.shape
+            # mask: (n_cells, max_len) — 1 for real tokens, 0 for padding
+            ar = np.arange(max_len)[None, :]
+            mask = (ar < lengths[:, None]).astype(gene_embs.dtype)
+            summed = (gene_embs * mask[..., None]).sum(axis=1)
+            denom = mask.sum(axis=1, keepdims=True)
+            return summed / np.maximum(denom, 1)
+
         SCLLMOutput.status(f"Baseline forward pass...", "info", indent=1)
-        original_embeddings = _embed(base_dataset)
+        if compute_gene_shifts:
+            orig_gene_embs = _embed(base_dataset, mode="gene")  # (n_cells, max_len, d)
+            orig_lengths = np.asarray([len(r) for r in base_dataset["input_ids"]])
+            original_embeddings = _cell_from_gene_embs(orig_gene_embs, orig_lengths)
+            orig_input_ids = list(base_dataset["input_ids"])
+        else:
+            original_embeddings = _embed(base_dataset, mode="cell")
+            orig_gene_embs = None
+            orig_lengths = None
+            orig_input_ids = None
+
+        # ENSG → symbol lookup. `gene_mapping_file` is `symbol → ENSG` (many
+        # symbols can alias to the same ENSG) — for human-readable downstream-
+        # gene labels we use the input `adata.var`'s annotations, which the
+        # user controls. Two layouts handled: (a) gene_name + ensembl_id
+        # columns side by side, (b) gene symbols as var_names + ENSG in a
+        # gene_id column.
+        ens_to_sym: Dict[str, str] = {}
+        if isinstance(adata.var, pd.DataFrame):
+            ens_col = next(
+                (c for c in ("ensembl_id", "ensg", "gene_id", "ensembl") if c in adata.var.columns),
+                None,
+            )
+            sym_col = next(
+                (c for c in ("gene_name", "gene_names", "symbol", "feature_name") if c in adata.var.columns),
+                None,
+            )
+            if ens_col is not None and sym_col is not None:
+                ens_to_sym.update(
+                    dict(zip(adata.var[ens_col].astype(str), adata.var[sym_col].astype(str)))
+                )
+            elif ens_col is not None:
+                # var_names are likely the symbols.
+                ens_to_sym.update(
+                    dict(zip(adata.var[ens_col].astype(str), adata.var_names.astype(str)))
+                )
+        # Fall back: invert sym_to_ens (first symbol wins).
+        for sym, ens in sym_to_ens.items():
+            ens_to_sym.setdefault(str(ens), str(sym))
+        token_to_ens = {tok: ens for ens, tok in gene_token_dict.items()}
 
         # 5) per-gene perturbed pass ---------------------------------------------
         def _delete_token(row, tok):
@@ -1437,6 +1488,7 @@ class GeneformerModel(SCLLMBase):
 
         perturbed_embeddings: Dict[str, np.ndarray] = {}
         cos_sims: Dict[str, np.ndarray] = {}
+        gene_shifts_per_target: Dict[str, pd.DataFrame] = {}
         stats_rows = []
         for label, ens, token in resolved:
             SCLLMOutput.status(f"Perturbing {label} ({ens}, token {token})", "info", indent=1)
@@ -1447,18 +1499,83 @@ class GeneformerModel(SCLLMBase):
                 [token in set(r) for r in base_dataset["input_ids"]],
                 dtype=bool,
             )
-            pert_emb = _embed(perturbed_ds)
+
+            if compute_gene_shifts:
+                pert_gene_embs = _embed(perturbed_ds, mode="gene")
+                pert_lengths = np.asarray([len(r) for r in perturbed_ds["input_ids"]])
+                pert_input_ids = list(perturbed_ds["input_ids"])
+                pert_emb = _cell_from_gene_embs(pert_gene_embs, pert_lengths)
+            else:
+                pert_emb = _embed(perturbed_ds, mode="cell")
+
             perturbed_embeddings[label] = pert_emb
-            # cosine sim per cell
+            # cell-level cosine sim per cell
             a = original_embeddings
             b = pert_emb
             denom = np.linalg.norm(a, axis=1) * np.linalg.norm(b, axis=1) + 1e-12
             cs = np.sum(a * b, axis=1) / denom
-            # Cells where the gene was absent should show ~1.0 cos sim (no-op); set them
-            # to nan so the user can summarise over only the truly-perturbed cells.
             cs = np.where(has_gene, cs, np.nan)
             cos_sims[label] = cs.astype(np.float32)
             valid = cs[~np.isnan(cs)]
+
+            # ---------- per-gene downstream-shift table ----------
+            if compute_gene_shifts:
+                # For each cell with the gene present, look up each non-target
+                # token's position in both original and perturbed sequences,
+                # and compute 1 - cos(orig_emb, pert_emb).
+                #
+                # Aggregate across cells → mean shift per downstream gene.
+                tok_shift_sum: Dict[int, float] = {}
+                tok_shift_count: Dict[int, int] = {}
+                for ci in np.where(has_gene)[0]:
+                    orig_ids = orig_input_ids[ci]
+                    pert_ids = pert_input_ids[ci]
+                    pert_pos = {t: j for j, t in enumerate(pert_ids)}
+                    for j, t in enumerate(orig_ids):
+                        if t == token or t == pad_token_id:
+                            continue
+                        jp = pert_pos.get(t)
+                        if jp is None:
+                            continue
+                        e_orig = orig_gene_embs[ci, j]
+                        e_pert = pert_gene_embs[ci, jp]
+                        n1 = np.linalg.norm(e_orig) + 1e-12
+                        n2 = np.linalg.norm(e_pert) + 1e-12
+                        cs_g = float(np.dot(e_orig, e_pert) / (n1 * n2))
+                        tok_shift_sum[t] = tok_shift_sum.get(t, 0.0) + (1.0 - cs_g)
+                        tok_shift_count[t] = tok_shift_count.get(t, 0) + 1
+                # Threshold the minimum number of cells per downstream gene at
+                # 2 (lower => more noise; the plot helpers filter further by
+                # min_cells parameter).
+                min_n = 2
+                rows = []
+                for t, ssum in tok_shift_sum.items():
+                    n = tok_shift_count[t]
+                    if n < min_n:
+                        continue
+                    ens_t = token_to_ens.get(t, str(t))
+                    sym_t = ens_to_sym.get(ens_t, ens_t)
+                    rows.append({
+                        "gene": sym_t,
+                        "ensembl_id": ens_t,
+                        "token_id": int(t),
+                        "n_cells": int(n),
+                        "mean_shift": ssum / n,  # = 1 - mean(cos sim)
+                    })
+                if rows:
+                    gene_shifts_df = (
+                        pd.DataFrame(rows)
+                        .sort_values("mean_shift", ascending=False)
+                        .reset_index(drop=True)
+                    )
+                else:
+                    gene_shifts_df = pd.DataFrame(
+                        columns=["gene", "ensembl_id", "token_id", "n_cells", "mean_shift"]
+                    )
+                gene_shifts_per_target[label] = gene_shifts_df
+                # Free the per-target gene-embedding tensor.
+                del pert_gene_embs
+
             stats_rows.append({
                 "gene": label,
                 "ensembl_id": ens,
@@ -1468,6 +1585,7 @@ class GeneformerModel(SCLLMBase):
                 "cosine_mean": float(np.nan if valid.size == 0 else valid.mean()),
                 "cosine_std": float(np.nan if valid.size == 0 else valid.std()),
                 "cosine_min": float(np.nan if valid.size == 0 else valid.min()),
+                "n_downstream_genes_scored": int(len(gene_shifts_per_target.get(label, pd.DataFrame()))),
             })
 
         # 6) build return ---------------------------------------------------------
@@ -1479,10 +1597,11 @@ class GeneformerModel(SCLLMBase):
             index=adata.obs_names[cell_idx],
         )
         stats_df = pd.DataFrame(stats_rows).set_index("gene")
-        SCLLMOutput.status(f"Perturbation complete — see stats_df / cosine_similarities", "info", indent=1)
+        SCLLMOutput.status(f"Perturbation complete — see stats / cosine_similarities / gene_shifts", "info", indent=1)
         return {
             "cosine_similarities": cos_df,
             "stats": stats_df,
+            "gene_shifts": gene_shifts_per_target,
             "original_embeddings": original_embeddings,
             "perturbed_embeddings": perturbed_embeddings,
             "perturb_type": perturb_type,

--- a/omicverse/pl/__init__.py
+++ b/omicverse/pl/__init__.py
@@ -155,7 +155,7 @@ from ._flowsig import (
 )
 from ._embedding import embedding_atlas
 from ._cnv import cnv_heatmap, cnv_summary, cnv_umap
-from ._perturbation import perturbation_shift_violin, perturbation_embedding_shift
+from ._perturbation import perturbation_shift_violin, perturbation_embedding_shift, perturbation_top_downstream_genes
 from ._density import add_density_contour, calculate_gene_density
 from ._plot1cell import plot1cell
 from ._cpdbviz import CellChatViz
@@ -401,4 +401,5 @@ __all__ = [
     # @ _perturbation
     "perturbation_shift_violin",
     "perturbation_embedding_shift",
+    "perturbation_top_downstream_genes",
 ]

--- a/omicverse/pl/_perturbation.py
+++ b/omicverse/pl/_perturbation.py
@@ -57,6 +57,8 @@ from .._registry import register_function
 def perturbation_shift_violin(
     result: Dict,
     *,
+    adata: Optional[AnnData] = None,
+    groupby: Optional[str] = None,
     figsize: tuple[float, float] = (6.0, 3.5),
     color: str = "#5B8FF9",
     order: Optional[Sequence[str]] = None,
@@ -71,10 +73,15 @@ def perturbation_shift_violin(
         The dictionary returned by ``manager.perturb_genes(...)``. Must
         contain ``'cosine_similarities'`` — a ``DataFrame`` with one column
         per perturbed gene (cells × genes).
+    adata, groupby : AnnData and str
+        Optional — when both are passed and ``groupby`` is a column in
+        ``adata.obs``, the violin for each gene is split into one violin
+        per category (e.g. ``groupby='cell_type'`` reveals lineage-
+        specific perturbation effects).
     figsize : tuple
         Figure size in inches.
     color : str
-        Violin fill colour.
+        Default violin fill colour when ``groupby`` is not provided.
     order : sequence of str or None
         Gene plot order. ``None`` = sort by mean cosine ascending (strongest
         effect leftmost).
@@ -100,6 +107,91 @@ def perturbation_shift_violin(
     if order is None:
         order = df.mean(axis=0, skipna=True).sort_values().index.tolist()
     df = df[order]
+    # Drop genes that ended up entirely NaN (no cell carried the gene — typical
+    # for narrowly-expressed TFs when max_ncells is small).
+    nonempty = [c for c in df.columns if df[c].notna().any()]
+    skipped = [c for c in df.columns if c not in nonempty]
+    if skipped:
+        import warnings as _warnings
+        _warnings.warn(
+            f"Skipping genes with no perturbed cells: {skipped} "
+            f"(increase max_ncells or pick more broadly-expressed targets)."
+        )
+    df = df[nonempty]
+    order = nonempty
+    if df.empty:
+        raise ValueError("No genes have any perturbed cells to plot.")
+
+    # If a groupby is requested, render one violin per category per gene.
+    if groupby is not None and adata is not None:
+        if groupby not in adata.obs.columns:
+            raise KeyError(f"adata.obs[{groupby!r}] not found")
+        from ._palette import palette_28
+        group = adata.obs[groupby].astype(str)
+        # Align to the cells scored by perturb_genes (which used obs_names index)
+        cell_idx = result.get("cell_indices")
+        if cell_idx is not None:
+            group = group.iloc[cell_idx].reset_index(drop=True)
+            df_aligned = df.reset_index(drop=True)
+        else:
+            df_aligned = df.copy()
+            group = group.loc[df_aligned.index]
+        if ax is None:
+            fig, ax = plt.subplots(figsize=figsize)
+        else:
+            fig = ax.figure
+        cats = sorted(group.unique())
+        pal = list(palette_28)
+        cat_to_color = {c: pal[i % len(pal)] for i, c in enumerate(cats)}
+        n_g = len(order)
+        n_c = len(cats)
+        width = 0.8 / max(n_c, 1)
+        # Cap each gene's group set to top-K most-perturbed categories (by mean
+        # |1-cos| over that gene), so the plot stays readable with many categories.
+        max_groups_per_gene = 6
+        for gi, g in enumerate(order):
+            shifts = (1 - df_aligned[g]).abs()
+            by_cat = shifts.groupby(group).mean().dropna()
+            top_cats = by_cat.sort_values(ascending=False).head(max_groups_per_gene).index.tolist()
+            for ci, c in enumerate(top_cats):
+                vals = df_aligned[g][(group == c) & df_aligned[g].notna()].values
+                if vals.size < 2:
+                    continue
+                pos = gi + (ci - (len(top_cats) - 1) / 2) * width
+                parts = ax.violinplot(
+                    [vals], positions=[pos], widths=width * 0.9,
+                    showmeans=True, showextrema=False,
+                )
+                for body in parts["bodies"]:
+                    body.set_facecolor(cat_to_color[c])
+                    body.set_edgecolor("#333333")
+                    body.set_alpha(0.75)
+                if "cmeans" in parts:
+                    parts["cmeans"].set_color("#222222")
+            # legend (once)
+            if gi == 0:
+                for c in top_cats:
+                    ax.scatter([], [], s=30, c=cat_to_color[c], label=str(c))
+        ax.set_xticks(range(len(order)))
+        ax.set_xticklabels(order)
+        ax.set_xlabel("Perturbed gene")
+        ax.set_ylabel("Cosine similarity\n(original ↔ perturbed)")
+        ax.axhline(1.0, color="#888888", linewidth=0.5, linestyle="--")
+        for spine_name in ("top", "right"):
+            ax.spines[spine_name].set_visible(False)
+        if ax.get_legend_handles_labels()[0]:
+            ax.legend(
+                loc="center left", bbox_to_anchor=(1.02, 0.5),
+                fontsize=7, frameon=False, title=groupby,
+            )
+        if title:
+            ax.set_title(title, fontsize=11)
+        elif result.get("perturb_type"):
+            ax.set_title(
+                f"Geneformer in-silico {result['perturb_type']} — by {groupby}",
+                fontsize=11,
+            )
+        return fig, ax
 
     if ax is None:
         fig, ax = plt.subplots(figsize=figsize)
@@ -130,6 +222,96 @@ def perturbation_shift_violin(
             fontsize=11,
         )
 
+    return fig, ax
+
+
+# --------------------------------------------------------------------------- #
+# downstream genes: bar plot of top-shifted genes                              #
+# --------------------------------------------------------------------------- #
+
+
+@register_function(
+    aliases=["扰动下游基因", "perturbation_top_downstream_genes", "perturbation_top_genes"],
+    category="pl",
+    description=(
+        "Bar plot of the genes whose contextual embedding shifted most after "
+        "in-silico knockout of a target transcription factor — i.e. candidate "
+        "downstream targets ranked by 1 - cos(orig_emb, perturbed_emb)."
+    ),
+    examples=[
+        "result = manager.perturb_genes(adata, ['PAX5'], perturb_type='delete')",
+        "ov.pl.perturbation_top_downstream_genes(result, gene='PAX5', top_n=20)",
+    ],
+    related=["llm.SCLLMManager.perturb_genes", "pl.perturbation_shift_violin"],
+)
+def perturbation_top_downstream_genes(
+    result: Dict,
+    *,
+    gene: str,
+    top_n: int = 20,
+    figsize: tuple[float, float] = (6.5, 5.0),
+    bar_color: str = "#cd3a3a",
+    min_cells: int = 5,
+    title: Optional[str] = None,
+    ax: Optional[Axes] = None,
+):
+    r"""Plot the top-N most-shifted downstream genes after a TF knockout.
+
+    Requires ``manager.perturb_genes(..., compute_gene_shifts=True)`` (the
+    default). The shift metric per downstream gene is
+    ``mean_cells(1 - cos(emb_orig, emb_perturbed))`` — averaged over the
+    cells where both the target and the downstream gene were present in
+    the rank-encoded input. Higher = larger context shift = stronger
+    model-predicted downstream effect.
+
+    Parameters
+    ----------
+    result : dict
+        Output of ``manager.perturb_genes(...)``. Must contain
+        ``'gene_shifts'`` — a dict keyed by target-gene label.
+    gene : str
+        Which target gene's perturbation to summarise.
+    top_n : int
+        Number of downstream genes to display.
+    figsize, bar_color, title, ax
+        Standard matplotlib styling.
+    min_cells : int
+        Minimum number of cells in which a downstream gene must be present
+        for it to enter the ranking. Filters out noise from rare genes.
+
+    Returns
+    -------
+    fig, ax
+    """
+    shifts_by_target = result.get("gene_shifts") or {}
+    if gene not in shifts_by_target:
+        raise KeyError(
+            f"result['gene_shifts'] has no entry for {gene!r} (keys: "
+            f"{list(shifts_by_target.keys())}). Re-run perturb_genes with "
+            f"compute_gene_shifts=True (default)."
+        )
+    df = pd.DataFrame(shifts_by_target[gene])
+    if df.empty:
+        raise ValueError(f"No downstream-gene shifts recorded for {gene!r}.")
+    df = df[df["n_cells"] >= min_cells].sort_values("mean_shift", ascending=False).head(top_n)
+    if df.empty:
+        raise ValueError(f"No downstream genes pass min_cells={min_cells} filter.")
+
+    if ax is None:
+        fig, ax = plt.subplots(figsize=figsize)
+    else:
+        fig = ax.figure
+
+    y_pos = np.arange(len(df))[::-1]  # tallest bar at the top
+    labels = df["gene"].astype(str).tolist()
+    ax.barh(y_pos, df["mean_shift"].values, color=bar_color, alpha=0.8, edgecolor="#333333")
+    ax.set_yticks(y_pos)
+    ax.set_yticklabels(labels, fontsize=9)
+    ax.set_xlabel("Mean 1 − cos(orig, perturbed)\n(higher = more shifted)")
+    ax.set_ylabel("Downstream gene")
+    for spine_name in ("top", "right"):
+        ax.spines[spine_name].set_visible(False)
+    ax.set_title(title or f"Top {len(df)} downstream genes shifted by {result.get('perturb_type', 'perturbation')} of {gene}", fontsize=11)
     return fig, ax
 
 


### PR DESCRIPTION
## Why

After @wujiajin0920's original perturbation request (#509 → #725), I noticed a real UX problem: when you knock out a single gene, the cell-level cosine similarity values sit near 1.0 because deleting one token from a ~2000-token rank-encoded sequence is structurally tiny. The violin plot looks empty even when the perturbation IS working — the biological signal is in the *relative ranking of downstream genes*, which is what the Geneformer papers actually report.

This PR adds that per-gene downstream-shift analysis end-to-end.

## New API

```python
result = manager.model.perturb_genes(
    adata, target_genes=['SPI1', 'PAX5', 'TBX21'],
    perturb_type='delete', max_ncells=2000,
)
result['gene_shifts']['PAX5']        # DataFrame ranked by mean_shift
result['stats']                       # cosine_mean + n_downstream_genes_scored

# Visualise — lineage-grouped violin (NEW: adata + groupby args)
ov.pl.perturbation_shift_violin(result, adata=adata, groupby='cell_type')

# NEW: bar plot of top downstream genes for one perturbed TF
ov.pl.perturbation_top_downstream_genes(result, gene='PAX5', top_n=20)
```

## What changed

### `omicverse/llm/geneformer_model.py`

`GeneformerModel._predict_perturbation` now extracts per-token embeddings during both the baseline and perturbed forward passes (using the existing `get_embs(emb_mode='gene')` path). For each perturbed target it builds a `DataFrame[gene, ensembl_id, token_id, n_cells, mean_shift]` where `mean_shift = mean over cells of (1 - cos(emb_orig, emb_perturbed))` for every co-occurring gene. The per-cell cosine workflow is preserved; cell-level embeddings are now derived by mean-pooling the gene-level tensor (mathematically identical to the previous `emb_mode='cell'` pass).

ENSG→symbol lookup for the downstream table now prefers `adata.var` (gene_name + ensembl_id columns, or var_names + gene_id) over the upstream `gene_mapping_file` pickle — the latter is `symbol → ENSG` direction and doesn't cleanly invert (many aliases per ENSG).

### `omicverse/pl/_perturbation.py`

- `perturbation_shift_violin(result, adata=..., groupby=...)` — splits each gene's violin by an `adata.obs` column. Caps to the 6 most-shifted categories per gene so the legend stays readable on 30-celltype panels.
- **NEW** `perturbation_top_downstream_genes(result, gene='PAX5', top_n=20)` — horizontal bar plot of candidate downstream targets ranked by mean cosine shift.

## Biological sanity-check

On the NeurIPS 2021 bone-marrow dataset (29 cell types):

- **PAX5 (B-cell TF) → top 20 downstream** includes **TBX21 at #3** (the antagonistic T-cell TF; known PAX5↔TBX21 cross-lineage repression), plus erythroid context (HEMGN, SLC4A1) and lymphocyte signaling (LAX1, CASP7, IGSF6).
- **SPI1** hits include KLRC1 / KLRC2 / KLRC4 (NK/T cell markers).
- **TBX21** hits include TIGIT (T-cell exhaustion) and KLRC2.

Tutorial in [omicverse-tutorials#45](https://github.com/omicverse/omicverse-tutorials/pull/45) (already merged at `636b233`); submodule bumped here.

## Test plan

- [x] `import omicverse as ov` clean
- [x] `ov.pl.perturbation_top_downstream_genes` resolves
- [x] End-to-end TF run on NeurIPS bone marrow (~3000 stratified cells): 0 errors, 5 figure PNGs baked into the tutorial
- [x] Downstream gene labels render as symbols (not raw ENSG IDs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)