### PR TITLE
release: v2.2.0 + bump to 2.2.1rc1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "omicverse"
-version = "2.1.3rc1"
+version = "2.2.0"
 description = "OmicVerse: A single pipeline for exploring the entire transcriptome universe"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "omicverse"
-version = "2.2.0"
+version = "2.2.1rc1"
 description = "OmicVerse: A single pipeline for exploring the entire transcriptome universe"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary

Cuts the **v2.2.0** release.

- `103287c7` — `release: v2.2.0 + bump omicverse_guide submodule`
  - `pyproject.toml` bumped: `2.1.3rc1` → **`2.2.0`**.
  - `omicverse_guide` submodule bumped: `636b233` → **`70924b2`** (omicverse-tutorials PR #46 merge tip) to pick up the v2.2.0 release-notes section.
- `415e08ba` — `chore: bump version to 2.2.1rc1 (post-2.2.0 release)`
  - Standard post-release dev-version bump so subsequent commits don't collide with the released 2.2.0 metadata.

## Already done outside this PR

- ✅ **PyPI**: `omicverse-2.2.0.tar.gz` + `omicverse-2.2.0-py3-none-any.whl` uploaded — https://pypi.org/project/omicverse/2.2.0/
- ✅ **Tag**: `v2.2.0` pushed, pointing at `103287c7` (release commit, NOT the post-release bump). https://github.com/omicverse/omicverse/releases/tag/v2.2.0
- ✅ **Tutorials**: omicverse-tutorials PR #46 merged → main `70924b2` (release-notes section with inline tutorial links for each new feature).

## Release scope (208 commits since v2.1.2 — PR range #652 → #727)

See [`omicverse_guide/docs/Release_notes.md` § v 2.2.0](https://github.com/omicverse/omicverse-tutorials/blob/main/docs/Release_notes.md#v-220) for the full per-module breakdown with tutorial links. Headline themes:

1. **New analysis modules** — `ov.es` (vendored decoupler kernels with GPU acceleration), `ov.single.NMF` (Rust-backed), `ov.single.CNV` (copykat / infercnv) + marsilea `cnv_*`, Geneformer in-silico perturbation, `ov.pp.champ`, `ov.report` (one-call HTML pipeline report from AnnData provenance), `ov.space.RCTD`, `ov.space.nmf_tissue_zones`.
2. **GPU-first preprocessing** — pure-PyTorch Leiden 74×, full-GPU parametric UMAP 21×, GPU KNN by default in `pp.neighbors`, native torch t-SNE, plus a 10-method GPU sweep in `ov.es` (gsva 23–28×, mdt/udt 83–158×, viper 20×, gsea 13–16×, ora 48×).
3. **v2.1.x maturation** — Atera (WTA Preview) reader, Xenium V2 / Prime morphology fix (#708), paired microbe↔metabolite + cross-cohort 16S meta-analysis in `ov.micro`, MTBLS1 case study in `ov.metabol`, Seurat CCA in `single.batch_correction`, scMulan / MetaTiME / TOSICA in `single.Annotation`, CellVote consensus, plot1cell.
4. **Removed** — `ov.fm` namespace (use `SCLLMManager`), xgboost CPU path for `mdt`/`udt`, hardcoded user-path fallback lists.

## Test plan

- [x] PyPI page renders the long-description (twine check PASSED for both sdist and wheel).
- [x] `omicverse 2.2.0` installable from PyPI (verified via `pip index versions omicverse` post-upload).
- [x] Submodule pointer matches the merged tutorials main tip (`70924b2`).
- [x] Tag `v2.2.0` points at the release commit, **not** the post-release dev-bump commit.
- [ ] Merge this PR with **Merge commit** (preserves the tag's relationship to `103287c7`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)