### PR TITLE
feat(protein): add ov.protein bulk-proteomics module

### DIFF
--- a/omicverse/__init__.py
+++ b/omicverse/__init__.py
@@ -86,6 +86,7 @@ _LAZY_MODULES = {
     'mcp',
     'metabol',
     'micro',
+    'protein',
     'report',
 }
 
@@ -367,6 +368,7 @@ __all__ = [
     "space",
     "pl",
     "metabol",
+    "protein",
     "datasets",
     "external",
     "llm",

--- a/omicverse/_registry.py
+++ b/omicverse/_registry.py
@@ -1074,6 +1074,7 @@ def _hydrate_registry_for_export() -> None:
         "omicverse.single",
         "omicverse.space",
         "omicverse.metabol",
+        "omicverse.protein",
     )
     for module_name in module_names:
         try:
@@ -1089,6 +1090,13 @@ def _hydrate_registry_for_export() -> None:
         import omicverse.metabol as _metabol  # noqa: F401
 
         _metabol._hydrate_registry()
+    except Exception:
+        pass
+    # Same drill for ov.protein — its __init__ is lazy too.
+    try:
+        import omicverse.protein as _protein  # noqa: F401
+
+        _protein._hydrate_registry()
     except Exception:
         pass
 

--- a/omicverse/datasets/__init__.py
+++ b/omicverse/datasets/__init__.py
@@ -101,6 +101,7 @@ from ._datasets import (
 from ._protein import (
     # Real proteomics datasets for the ov.protein tutorials
     protein_pxd000022,
+    protein_pxd000279,
     protein_pxd000438,
     protein_dda_spikein,
     protein_dia,

--- a/omicverse/datasets/__init__.py
+++ b/omicverse/datasets/__init__.py
@@ -98,4 +98,12 @@ from ._datasets import (
     pbmc8k,
     seqfish,
 )
+from ._protein import (
+    # Real proteomics datasets for the ov.protein tutorials
+    protein_pxd000022,
+    protein_pxd000438,
+    protein_dda_spikein,
+    protein_dia,
+    protein_olink,
+)
 from ._signatures import load_signatures_from_file, predefined_signatures

--- a/omicverse/datasets/_protein.py
+++ b/omicverse/datasets/_protein.py
@@ -1,0 +1,126 @@
+"""Real published proteomics datasets for the ``ov.protein`` tutorials.
+
+Each loader downloads a dataset asset from the ``omicverse-data`` GitHub
+release (``proteomics-v1``) on first use, caches it under ``dir``, and
+returns it ready for the ``ov.protein`` workflow.
+
+| Loader | Returns | Source |
+|---|---|---|
+| :func:`protein_pxd000022` | AnnData (samples × proteins) | ProteomeXchange PXD000022 |
+| :func:`protein_pxd000438` | AnnData (samples × proteins) | ProteomeXchange PXD000438 |
+| :func:`protein_dda_spikein` | DataFrame (MSstats long) | MSstats ``DDARawData`` |
+| :func:`protein_dia` | DataFrame (MSstats long) | MSstats ``DIARawData`` |
+| :func:`protein_olink` | DataFrame (long NPX) | OlinkAnalyze ``npx_data1`` |
+
+All datasets are real, published proteomics data redistributed from the
+open-source Bioconductor / CRAN packages imputeLCMD, MSstats and
+OlinkAnalyze.
+"""
+from __future__ import annotations
+
+import gzip
+import os
+from typing import TYPE_CHECKING
+
+import pandas as pd
+
+from .._registry import register_function
+from ._datasets import download_data
+
+if TYPE_CHECKING:  # pragma: no cover
+    from anndata import AnnData
+
+_RELEASE = (
+    "https://github.com/omicverse/omicverse-data/releases/download/proteomics-v1"
+)
+
+
+def _fetch(asset: str, dir: str) -> str:
+    """Download ``asset`` from the proteomics-v1 release; return local path."""
+    return download_data(f"{_RELEASE}/{asset}", file_path=asset, dir=dir)
+
+
+@register_function(
+    aliases=["protein_pxd000022", "pxd000022", "蛋白组数据PXD000022"],
+    category="datasets",
+    description=(
+        "Real label-free LC-MS/MS proteomics dataset ProteomeXchange "
+        "PXD000022 — 660 proteins × 6 samples, two groups (MB vs MT, "
+        "3 replicates each), ~40% left-censored (MNAR) missing values. "
+        "Returned as an AnnData (samples × proteins, raw intensities, "
+        "NaN = missing) ready for the ``ov.protein`` bulk-LFQ pipeline."
+    ),
+    examples=["adata = ov.datasets.protein_pxd000022()"],
+)
+def protein_pxd000022(dir: str = "./data") -> "AnnData":
+    """Load the PXD000022 label-free proteomics dataset (real, 2-group)."""
+    import anndata as ad
+    return ad.read_h5ad(_fetch("protein_pxd000022.h5ad", dir))
+
+
+@register_function(
+    aliases=["protein_pxd000438", "pxd000438", "蛋白组数据PXD000438"],
+    category="datasets",
+    description=(
+        "Real label-free LC-MS/MS proteomics dataset ProteomeXchange "
+        "PXD000438 — 3709 proteins × 12 samples, four groups (3 "
+        "replicates each), ~41% left-censored missing values. A larger, "
+        "missingness-rich dataset for the imputation deep-dive. Returned "
+        "as an AnnData (samples × proteins, raw intensities, NaN = "
+        "missing)."
+    ),
+    examples=["adata = ov.datasets.protein_pxd000438()"],
+)
+def protein_pxd000438(dir: str = "./data") -> "AnnData":
+    """Load the PXD000438 label-free proteomics dataset (real, 4-group)."""
+    import anndata as ad
+    return ad.read_h5ad(_fetch("protein_pxd000438.h5ad", dir))
+
+
+@register_function(
+    aliases=["protein_dda_spikein", "msstats_dda", "蛋白组DDA数据"],
+    category="datasets",
+    description=(
+        "Real controlled spike-in label-free DDA dataset (MSstats "
+        "``DDARawData``) — feature/peptide-level intensities in MSstats "
+        "long format (ProteinName / PeptideSequence / Run / Condition / "
+        "Intensity …). Returned as a pandas DataFrame; feed to "
+        "``ov.protein`` peptide→protein summarization or ``pymsstats``."
+    ),
+    examples=["df = ov.datasets.protein_dda_spikein()"],
+)
+def protein_dda_spikein(dir: str = "./data") -> pd.DataFrame:
+    """Load the MSstats DDA spike-in dataset (real, MSstats long format)."""
+    return pd.read_csv(_fetch("protein_msstats_dda.csv.gz", dir))
+
+
+@register_function(
+    aliases=["protein_dia", "msstats_dia", "蛋白组DIA数据"],
+    category="datasets",
+    description=(
+        "Real label-free DIA dataset (MSstats ``DIARawData``) — a "
+        "S. Pyogenes group comparison (Strep 0% vs 10%), feature-level "
+        "MSstats long format. Returned as a pandas DataFrame."
+    ),
+    examples=["df = ov.datasets.protein_dia()"],
+)
+def protein_dia(dir: str = "./data") -> pd.DataFrame:
+    """Load the MSstats DIA dataset (real, MSstats long format)."""
+    return pd.read_csv(_fetch("protein_msstats_dia.csv.gz", dir))
+
+
+@register_function(
+    aliases=["protein_olink", "olink_npx_data", "蛋白组Olink数据"],
+    category="datasets",
+    description=(
+        "Real Olink Explore NPX dataset (OlinkAnalyze ``npx_data1``) — "
+        "long-format NPX with SampleID / OlinkID / Assay / NPX / "
+        "Treatment / Site / Subject, a real bridging study. Returned as "
+        "a pandas DataFrame; load into an AnnData with "
+        "``ov.protein.read_olink_npx`` or analyse with ``pyolinkanalyze``."
+    ),
+    examples=["df = ov.datasets.protein_olink()"],
+)
+def protein_olink(dir: str = "./data") -> pd.DataFrame:
+    """Load the OlinkAnalyze NPX dataset (real Olink Explore data)."""
+    return pd.read_csv(_fetch("protein_olink_npx.csv.gz", dir))

--- a/omicverse/datasets/_protein.py
+++ b/omicverse/datasets/_protein.py
@@ -7,6 +7,7 @@ returns it ready for the ``ov.protein`` workflow.
 | Loader | Returns | Source |
 |---|---|---|
 | :func:`protein_pxd000022` | AnnData (samples × proteins) | ProteomeXchange PXD000022 |
+| :func:`protein_pxd000279` | AnnData (samples × proteins) | ProteomeXchange PXD000279 (MaxQuant) |
 | :func:`protein_pxd000438` | AnnData (samples × proteins) | ProteomeXchange PXD000438 |
 | :func:`protein_dda_spikein` | DataFrame (MSstats long) | MSstats ``DDARawData`` |
 | :func:`protein_dia` | DataFrame (MSstats long) | MSstats ``DIARawData`` |
@@ -56,6 +57,28 @@ def protein_pxd000022(dir: str = "./data") -> "AnnData":
     """Load the PXD000022 label-free proteomics dataset (real, 2-group)."""
     import anndata as ad
     return ad.read_h5ad(_fetch("protein_pxd000022.h5ad", dir))
+
+
+@register_function(
+    aliases=["protein_pxd000279", "pxd000279", "蛋白组benchmark数据"],
+    category="datasets",
+    description=(
+        "Real label-free MaxQuant proteomics benchmark ProteomeXchange "
+        "PXD000279 — the spike-in dataset used by the DEqMS vignette. "
+        "6507 proteins × 6 samples, two groups H vs L (HeLa background "
+        "constant, E. coli spiked at a 3:1 ratio, 3 replicates each). "
+        "``var['peptides']`` holds the real per-protein peptide count "
+        "(needed by DEqMS); ``var['species']`` / ``var['is_spikein']`` "
+        "give the ground truth — E. coli proteins are truly "
+        "differential, human proteins are not. Returned as an AnnData "
+        "(samples × proteins, raw LFQ intensities, NaN = missing)."
+    ),
+    examples=["adata = ov.datasets.protein_pxd000279()"],
+)
+def protein_pxd000279(dir: str = "./data") -> "AnnData":
+    """Load the PXD000279 MaxQuant label-free benchmark (real, spike-in truth)."""
+    import anndata as ad
+    return ad.read_h5ad(_fetch("protein_pxd000279.h5ad", dir))
 
 
 @register_function(

--- a/omicverse/protein/__init__.py
+++ b/omicverse/protein/__init__.py
@@ -1,0 +1,148 @@
+"""
+Proteomics analysis for omicverse — AnnData-native bulk LC-MS/MS &
+Olink workflows.
+
+``ov.protein`` is the analogue of ``ov.metabol`` for protein-level
+quantitative proteomics: it consumes search-engine output
+(MaxQuant ``proteinGroups.txt``, DIA-NN ``report.pg_matrix.tsv``,
+FragPipe ``combined_protein.tsv``, Olink long NPX) and produces an
+``AnnData`` with ``obs = samples``, ``var = proteins`` — the standard
+omicverse convention. Downstream operations (impute, normalize,
+differential expression, enrichment) are all dispatcher functions
+that take ``method=`` as the algorithm selector.
+
+The actual statistical machinery lives in the **standalone packages**
+that omicverse ships as separate releases:
+
+* :mod:`pyimputelcmd` — MinDet / MinProb / QRILC imputation (Lazar 2016)
+* :mod:`pydeqms`       — peptide-count-aware moderated t (Zhu 2020)
+* :mod:`pyproda`       — MNAR probabilistic DE (Ahlmann-Eltze 2020)
+* :mod:`pyolinkanalyze`— Olink NPX QC + LMM
+* :mod:`pymsstats`     — MaxQuant / DIA-NN DDA / DIA pipeline (Choi 2014)
+
+Each is a thin sidecar package; ``ov.protein`` wraps them behind a
+unified ``method=`` argument so users don't have to learn five
+different APIs.
+
+Quick-start
+-----------
+>>> import omicverse as ov
+>>> adata = ov.protein.read_maxquant("proteinGroups.txt", sample_pattern=r"LFQ\\.intensity\\.(.+)")
+>>> adata.obs["group"] = ["control"] * 6 + ["treated"] * 6
+>>> ov.protein.qc_filter(adata, min_peptides=2)
+>>> ov.protein.normalize(adata, method="median", log2=True)
+>>> ov.protein.impute(adata, method="qrilc", seed=0)
+>>> res = ov.protein.de(adata, group="group",
+...                     method="deqms",
+...                     count_var="peptides")
+>>> ov.protein.volcano(res)
+
+Pipeline stages
+---------------
+I/O                       ``read_maxquant``, ``read_diann``,
+                          ``read_fragpipe``, ``read_olink_npx``
+QC                        ``qc_filter`` (min peptides / valid values)
+Imputation                ``impute`` (mindet / minprob / qrilc /
+                          half_min / knn / zero)
+Normalization             ``normalize`` (median / quantile / log2-only)
+Differential expression   ``de`` (deqms / limma / proda / wilcoxon /
+                          welch_t / olink_lmer / msstats)
+Enrichment                ``enrich`` (forwards to ``ov.es``: ulm /
+                          mlm / aucell / ora / gsea / …)
+Plotting                  ``volcano``, ``missing_pattern_plot``,
+                          ``abundance_rank_plot``
+
+All algorithm-specific imports (``pyimputelcmd``, ``pydeqms`` …) are
+deferred to call-time — ``import omicverse.protein`` does no heavy
+work.
+"""
+from __future__ import annotations
+
+import importlib as _importlib
+
+
+# Lazy public surface — single source of truth for what's exposed.
+_LAZY_ATTRS: dict[str, tuple[str, str]] = {
+    # I/O
+    "read_maxquant":          (".io", "read_maxquant"),
+    "read_diann":             (".io", "read_diann"),
+    "read_fragpipe":          (".io", "read_fragpipe"),
+    "read_olink_npx":         (".io", "read_olink_npx"),
+    "read_wide":              (".io", "read_wide"),
+    # Synthetic data (tutorials / tests)
+    "simulate_lfq":           ("._simulate", "simulate_lfq"),
+    # QC
+    "qc_filter":              ("._qc", "qc_filter"),
+    "missing_pattern":        ("._qc", "missing_pattern"),
+    "model_selector":         ("._qc", "model_selector"),
+    # Normalize
+    "normalize":              ("._norm", "normalize"),
+    # Peptide → protein summarization
+    "summarize":              ("._summarize", "summarize"),
+    # Imputation
+    "impute":                 ("._impute", "impute"),
+    # Study design / power
+    "sample_size":            ("._design", "sample_size"),
+    "contrast_matrix":        ("._design", "contrast_matrix"),
+    # Differential expression
+    "de":                     ("._de", "de"),
+    # Enrichment (thin forwarder to ov.es)
+    "enrich":                 ("._enrich", "enrich"),
+    # Plotting
+    "volcano":                (".plotting", "volcano"),
+    "missing_pattern_plot":   (".plotting", "missing_pattern_plot"),
+    "abundance_rank_plot":    (".plotting", "abundance_rank_plot"),
+}
+
+_LAZY_SUBMODULES = {"plotting"}
+
+_REGISTRY_SUBMODULES = (
+    ".io",
+    "._simulate",
+    "._qc",
+    "._norm",
+    "._summarize",
+    "._impute",
+    "._design",
+    "._de",
+    "._enrich",
+    ".plotting",
+)
+
+
+def _hydrate_registry() -> None:
+    """Force-import every @register_function-bearing submodule so the global
+    registry sees ov.protein at export time. Called from
+    :mod:`omicverse._registry._hydrate_registry_for_export`."""
+    for mod in _REGISTRY_SUBMODULES:
+        try:
+            _importlib.import_module(mod, __name__)
+        except Exception:
+            # Optional backends (pydeqms, pyproda, statsmodels) may be missing —
+            # register whatever loads cleanly.
+            continue
+
+
+def __getattr__(name: str):
+    if name in _LAZY_ATTRS:
+        module_path, attr_name = _LAZY_ATTRS[name]
+        module = _importlib.import_module(module_path, __name__)
+        value = getattr(module, attr_name)
+        globals()[name] = value
+        return value
+    if name in _LAZY_SUBMODULES:
+        module = _importlib.import_module(f".{name}", __name__)
+        globals()[name] = module
+        return module
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    return sorted(set(list(globals().keys())
+                      + list(_LAZY_ATTRS.keys())
+                      + list(_LAZY_SUBMODULES)))
+
+
+__version__ = "0.1.0"
+
+__all__ = list(_LAZY_ATTRS.keys()) + list(_LAZY_SUBMODULES)

--- a/omicverse/protein/__init__.py
+++ b/omicverse/protein/__init__.py
@@ -92,6 +92,9 @@ _LAZY_ATTRS: dict[str, tuple[str, str]] = {
     "volcano":                (".plotting", "volcano"),
     "missing_pattern_plot":   (".plotting", "missing_pattern_plot"),
     "abundance_rank_plot":    (".plotting", "abundance_rank_plot"),
+    "pca_plot":               (".plotting", "pca_plot"),
+    "heatmap":                (".plotting", "heatmap"),
+    "boxplot":                (".plotting", "boxplot"),
 }
 
 _LAZY_SUBMODULES = {"plotting"}

--- a/omicverse/protein/_de.py
+++ b/omicverse/protein/_de.py
@@ -1,0 +1,497 @@
+"""Differential-expression dispatcher for ``ov.protein``.
+
+Exposes ``ov.protein.de(adata, group, method=...)`` with one of six
+backends:
+
+* ``'deqms'`` — peptide-count-aware moderated t (via :mod:`pydeqms`)
+* ``'limma'`` — Smyth 2004 empirical-Bayes moderated t
+  (:func:`pydeqms.ebayes`, no count adjustment)
+* ``'proda'`` — MNAR probabilistic DE (via :mod:`pyproda`, optional)
+* ``'wilcoxon'`` — Mann-Whitney U (NaN-tolerant per-protein)
+* ``'welch_t'`` — Welch t-test (unequal variances, NaN-tolerant)
+* ``'olink_lmer'`` — Olink-style per-protein LMM via statsmodels
+  (optional)
+
+Returns a tidy ``pandas.DataFrame`` with columns
+``gene``, ``logFC``, ``AveExpr``, ``t``, ``P.Value``, ``adj.P.Val``
+(plus ``count``, ``sca.*`` for DEqMS; ``rho``, ``zeta`` for proDA).
+"""
+from __future__ import annotations
+
+from typing import Optional, Union
+
+import numpy as np
+import pandas as pd
+
+from .._registry import register_function
+
+
+_VALID_METHODS = {
+    "deqms", "limma", "proda",
+    "wilcoxon", "welch_t", "ttest", "t-test",
+    "olink_lmer",
+    "anova", "kruskal",        # multi-group (>2)
+}
+_MULTIGROUP_METHODS = {"anova", "kruskal"}
+
+
+@register_function(
+    aliases=["protein_de", "de", "蛋白差异分析", "蛋白DE"],
+    category="analysis",
+    description=(
+        "Differential-expression dispatcher for proteomics AnnData. "
+        "``method`` selects: ``'deqms'`` (peptide-count moderated t, "
+        "via pydeqms), ``'limma'`` (Smyth 2004 moderated t, no count), "
+        "``'proda'`` (MNAR probabilistic DE, via pyproda), "
+        "``'wilcoxon'`` / ``'welch_t'`` (per-protein non-parametric / "
+        "parametric two-group test), ``'olink_lmer'`` (per-protein "
+        "linear mixed model via statsmodels), or the multi-group omnibus "
+        "tests ``'anova'`` / ``'kruskal'`` (>2 groups). The first "
+        "argument after ``adata`` is ``group`` — either a column in "
+        "``adata.obs`` (string) or an explicit (n_samples,) labels array."
+    ),
+    requires={"obs": ["group"]},
+    produces={"uns": ["protein_de"]},
+    auto_fix="none",
+    examples=[
+        "ov.protein.de(adata, group='treatment', method='deqms', count_var='peptides')",
+        "ov.protein.de(adata, group='treatment', method='limma')",
+        "ov.protein.de(adata, group='treatment', method='wilcoxon')",
+        "ov.protein.de(adata, group='treatment', method='proda')",
+    ],
+)
+def de(
+    adata,
+    group: Union[str, np.ndarray, pd.Series],
+    *,
+    method: str = "deqms",
+    reference: Optional[str] = None,
+    count_var: str = "peptides",
+    fit_method: str = "loess",
+    **kwargs,
+) -> pd.DataFrame:
+    """Differential-expression dispatch.
+
+    Parameters
+    ----------
+    adata
+        ``ov.protein`` AnnData (samples × proteins). ``X`` should be on
+        log2 scale (call ``ov.protein.normalize(adata, log2=True)`` first).
+    group
+        Sample-group assignment. Either a column name in ``adata.obs`` or
+        an explicit (n_samples,) array of labels.
+    method
+        Algorithm selector — one of the seven above. ``'ttest'`` and
+        ``'t-test'`` are aliases for ``'welch_t'``.
+    reference
+        Optional reference group name; the test reports ``other - reference``
+        log2 fold-change. Defaults to the first sorted unique group.
+    count_var
+        For ``method='deqms'``: the column in ``adata.var`` holding the
+        per-protein peptide / PSM count. Falls back to 1 (no count
+        weighting) if the column is missing.
+    fit_method
+        For ``method='deqms'``: ``'loess'`` | ``'nls'`` | ``'spline'``.
+    **kwargs
+        Forwarded to the backend.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Result table, columns vary by ``method``; always includes
+        ``gene``, ``logFC``, ``P.Value``, ``adj.P.Val``.
+    """
+    key = method.lower().strip()
+    if key in ("t-test", "ttest"):
+        key = "welch_t"
+    if key not in _VALID_METHODS:
+        raise ValueError(
+            f"method must be one of {sorted(_VALID_METHODS)}, got {method!r}"
+        )
+
+    labels, groups = _resolve_groups(adata, group, reference)
+
+    X = adata.X.astype(float)
+    n_samples, n_proteins = X.shape
+    gene_names = list(adata.var_names.astype(str))
+
+    if key in _MULTIGROUP_METHODS:
+        res = _de_multigroup(X, gene_names, labels, groups, key)
+        adata.uns.setdefault("protein", {})["de_method"] = key
+        adata.uns["protein_de"] = res
+        return res
+
+    # Pairwise tests below need exactly two groups.
+    if len(groups) != 2:
+        raise ValueError(
+            f"method={key!r} is a two-group test but got {len(groups)} "
+            f"groups: {groups}. Use method='anova' or 'kruskal' for "
+            f"multi-group designs, or pass reference= to pick a baseline."
+        )
+
+    if key == "deqms":
+        res = _de_deqms(adata, labels, groups, count_var, fit_method, **kwargs)
+    elif key == "limma":
+        res = _de_limma(adata, labels, groups, **kwargs)
+    elif key == "proda":
+        res = _de_proda(adata, labels, groups, **kwargs)
+    elif key == "wilcoxon":
+        res = _de_wilcoxon(X, gene_names, labels, groups, **kwargs)
+    elif key == "welch_t":
+        res = _de_welch_t(X, gene_names, labels, groups, **kwargs)
+    elif key == "olink_lmer":
+        res = _de_olink_lmer(adata, labels, groups, **kwargs)
+    else:  # pragma: no cover
+        raise ValueError(key)
+
+    adata.uns.setdefault("protein", {})["de_method"] = key
+    adata.uns["protein_de"] = res
+    return res
+
+
+# --------------------------------------------------------------------------- #
+# Helpers                                                                      #
+# --------------------------------------------------------------------------- #
+
+def _resolve_groups(adata, group, reference):
+    if isinstance(group, str):
+        if group not in adata.obs.columns:
+            raise KeyError(f"group {group!r} not in adata.obs columns: "
+                           f"{list(adata.obs.columns)}")
+        labels = adata.obs[group].astype(str).to_numpy()
+    else:
+        labels = np.asarray(group)
+        if labels.size != adata.n_obs:
+            raise ValueError(f"group array has length {labels.size}, expected {adata.n_obs}")
+    groups = list(pd.unique(labels))
+    if reference is not None:
+        if reference not in groups:
+            raise ValueError(f"reference {reference!r} not among groups {groups}")
+        groups = [reference] + [g for g in groups if g != reference]
+    else:
+        groups = sorted(groups)
+    return labels, groups
+
+
+def _build_design(labels, groups):
+    n = labels.size
+    design = np.zeros((n, len(groups)), dtype=float)
+    for j, g in enumerate(groups):
+        design[labels == g, j] = 1.0
+    return design
+
+
+def _bh_adjust(p: np.ndarray) -> np.ndarray:
+    from scipy import stats as _st
+    return _st.false_discovery_control(np.clip(p, 0.0, 1.0), method="bh")
+
+
+# --------------------------------------------------------------------------- #
+# DEqMS                                                                       #
+# --------------------------------------------------------------------------- #
+def _de_deqms(adata, labels, groups, count_var, fit_method, **kwargs):
+    try:
+        from pydeqms import deqms as _deqms_fn
+    except ImportError as exc:
+        raise ImportError(
+            "method='deqms' requires pydeqms: `pip install pydeqms`. "
+            "Fall back to method='limma' for no-count moderated t."
+        ) from exc
+
+    X = adata.X.astype(float)
+    # pydeqms expects proteins × samples.
+    M = pd.DataFrame(
+        X.T, index=adata.var_names.astype(str), columns=adata.obs_names.astype(str),
+    )
+    design = pd.DataFrame(
+        _build_design(labels, groups),
+        index=adata.obs_names.astype(str),
+        columns=[f"group_{g}" for g in groups],
+    )
+    if count_var in adata.var.columns:
+        count = (
+            pd.to_numeric(adata.var[count_var], errors="coerce")
+              .fillna(1.0).astype(float).to_numpy()
+        )
+    else:
+        count = np.ones(adata.n_vars, dtype=float)
+    # Contrast: group1 - group0 (matches sorted groups ordering).
+    contrast = np.array([-1.0, 1.0], dtype=float)
+    # The DEqMS variance prior regresses log(s^2) on log2(count) — when
+    # the peptide count has few distinct values the loess local fits go
+    # singular ("svddc failed in l2fit"). Fall back loess → nls → spline
+    # so ``method='deqms'`` is robust regardless of the count spread.
+    fit_methods = [fit_method] + [
+        m for m in ("nls", "spline") if m != fit_method
+    ]
+    result = None
+    last_exc: Exception | None = None
+    for fm in fit_methods:
+        try:
+            result = _deqms_fn(
+                M, design, count=count,
+                contrast=contrast, fit_method=fm, **kwargs,
+            )
+            break
+        except (ValueError, np.linalg.LinAlgError, RuntimeError) as exc:
+            last_exc = exc
+            continue
+    if result is None:
+        raise RuntimeError(
+            "DEqMS variance fit failed for every fit_method "
+            f"({fit_methods}); the peptide count column may be degenerate. "
+            "Use method='limma' for a count-free moderated t."
+        ) from last_exc
+    # Drop the limma P.Value/adj columns to avoid duplicate column names
+    # after the sca.* rename — the DEqMS-adjusted statistics are the
+    # ``ov.protein.de(method='deqms')`` answer; limma's are available via
+    # ``method='limma'``.
+    result = result.drop(columns=["P.Value", "adj.P.Val"], errors="ignore")
+    result = result.rename(columns={
+        "sca.P.Value": "P.Value",
+        "sca.adj.pval": "adj.P.Val",
+    })
+    # Keep the limma t around but rename to sca.t to mark it's the
+    # DEqMS-adjusted statistic.
+    if "sca.t" in result.columns:
+        result = result.drop(columns=["t"], errors="ignore")
+        result = result.rename(columns={"sca.t": "t"})
+    return result
+
+
+# --------------------------------------------------------------------------- #
+# limma (Smyth 2004 moderated t, no count weighting)                          #
+# --------------------------------------------------------------------------- #
+def _de_limma(adata, labels, groups, **kwargs):
+    try:
+        from pydeqms import lm_fit, ebayes
+        from pydeqms.pipeline import _resolve_contrast
+    except ImportError as exc:
+        raise ImportError(
+            "method='limma' requires pydeqms (vendored limma.eBayes): "
+            "`pip install pydeqms`."
+        ) from exc
+
+    X = adata.X.astype(float)
+    M = pd.DataFrame(
+        X.T, index=adata.var_names.astype(str), columns=adata.obs_names.astype(str),
+    )
+    design = pd.DataFrame(
+        _build_design(labels, groups),
+        index=adata.obs_names.astype(str),
+        columns=[f"group_{g}" for g in groups],
+    )
+    fit = lm_fit(M, design)
+    fit, _ = _resolve_contrast(fit, np.array([-1.0, 1.0]))
+    ebayes(fit)
+    res = pd.DataFrame({
+        "gene":      fit.protein_names,
+        "logFC":     fit.coefficients[:, 0],
+        "AveExpr":   fit.Amean,
+        "t":         fit.t[:, 0],
+        "P.Value":   fit.p_value[:, 0],
+        "adj.P.Val": _bh_adjust(fit.p_value[:, 0]),
+    }).sort_values("P.Value").reset_index(drop=True)
+    return res
+
+
+# --------------------------------------------------------------------------- #
+# proDA (optional)                                                            #
+# --------------------------------------------------------------------------- #
+def _de_proda(adata, labels, groups, **kwargs):
+    try:
+        from pyproda import proda as _proda_fn, test_diff as _test_diff
+    except ImportError as exc:
+        raise ImportError(
+            "method='proda' requires pyproda: `pip install pyproda`."
+        ) from exc
+
+    M = pd.DataFrame(
+        adata.X.astype(float).T,
+        index=adata.var_names.astype(str),
+        columns=adata.obs_names.astype(str),
+    )
+    design = pd.DataFrame(
+        _build_design(labels, groups),
+        index=adata.obs_names.astype(str),
+        columns=[f"group_{g}" for g in groups],
+    )
+    fit = _proda_fn(M, design=design, **kwargs)
+    result = _test_diff(fit, contrast=np.array([-1.0, 1.0]))
+    # Canonicalise pyproda's column names to the ov.protein DE schema.
+    rename = {
+        "name": "gene", "protein": "gene", "feature": "gene",
+        "pval": "P.Value", "p.value": "P.Value", "pvalue": "P.Value",
+        "adj.pval": "adj.P.Val", "adj_pval": "adj.P.Val",
+        "padj": "adj.P.Val", "qvalue": "adj.P.Val",
+        "estimate": "logFC", "diff": "logFC",
+        "t_statistic": "t", "t.statistic": "t",
+        "avg_abundance": "AveExpr",
+    }
+    result = result.rename(columns={k: v for k, v in rename.items() if k in result.columns})
+    if "gene" not in result.columns:
+        # Fall back to the index if no explicit name column survived.
+        result = result.reset_index().rename(columns={"index": "gene"})
+    if "adj.P.Val" not in result.columns and "P.Value" in result.columns:
+        result["adj.P.Val"] = _bh_adjust(result["P.Value"].to_numpy())
+    if "P.Value" in result.columns:
+        result = result.sort_values("P.Value").reset_index(drop=True)
+    return result
+
+
+# --------------------------------------------------------------------------- #
+# Wilcoxon                                                                    #
+# --------------------------------------------------------------------------- #
+def _de_wilcoxon(X, gene_names, labels, groups, **kwargs):
+    from scipy import stats
+    g0, g1 = groups
+    idx0 = labels == g0
+    idx1 = labels == g1
+    n = X.shape[1]
+    logfc = np.full(n, np.nan)
+    pv = np.full(n, np.nan)
+    for j in range(n):
+        a = X[idx0, j]; b = X[idx1, j]
+        a = a[~np.isnan(a)]; b = b[~np.isnan(b)]
+        if a.size < 2 or b.size < 2:
+            continue
+        logfc[j] = float(np.mean(b) - np.mean(a))
+        try:
+            res = stats.mannwhitneyu(a, b, alternative="two-sided",
+                                      use_continuity=True)
+            pv[j] = float(res.pvalue)
+        except ValueError:
+            continue
+    return pd.DataFrame({
+        "gene":      gene_names,
+        "logFC":     logfc,
+        "AveExpr":   np.nanmean(X, axis=0),
+        "P.Value":   pv,
+        "adj.P.Val": _bh_adjust(pv),
+    }).sort_values("P.Value").reset_index(drop=True)
+
+
+def _de_welch_t(X, gene_names, labels, groups, **kwargs):
+    from scipy import stats
+    g0, g1 = groups
+    idx0 = labels == g0
+    idx1 = labels == g1
+    n = X.shape[1]
+    logfc = np.full(n, np.nan)
+    tval = np.full(n, np.nan)
+    pv = np.full(n, np.nan)
+    for j in range(n):
+        a = X[idx0, j]; b = X[idx1, j]
+        a = a[~np.isnan(a)]; b = b[~np.isnan(b)]
+        if a.size < 2 or b.size < 2:
+            continue
+        logfc[j] = float(np.mean(b) - np.mean(a))
+        try:
+            res = stats.ttest_ind(b, a, equal_var=False, nan_policy="omit")
+            tval[j] = float(res.statistic)
+            pv[j] = float(res.pvalue)
+        except ValueError:
+            continue
+    return pd.DataFrame({
+        "gene":      gene_names,
+        "logFC":     logfc,
+        "AveExpr":   np.nanmean(X, axis=0),
+        "t":         tval,
+        "P.Value":   pv,
+        "adj.P.Val": _bh_adjust(pv),
+    }).sort_values("P.Value").reset_index(drop=True)
+
+
+# --------------------------------------------------------------------------- #
+# Multi-group: one-way ANOVA / Kruskal-Wallis                                 #
+# --------------------------------------------------------------------------- #
+def _de_multigroup(X, gene_names, labels, groups, key):
+    """Per-protein omnibus test across >=2 groups (ANOVA or Kruskal-Wallis)."""
+    from scipy import stats
+    group_idx = [labels == g for g in groups]
+    n = X.shape[1]
+    stat = np.full(n, np.nan)
+    pv = np.full(n, np.nan)
+    for j in range(n):
+        samples = []
+        for idx in group_idx:
+            v = X[idx, j]
+            v = v[~np.isnan(v)]
+            if v.size >= 2:
+                samples.append(v)
+        if len(samples) < 2:
+            continue
+        try:
+            if key == "anova":
+                res = stats.f_oneway(*samples)
+            else:  # kruskal
+                res = stats.kruskal(*samples)
+            stat[j] = float(res.statistic)
+            pv[j] = float(res.pvalue)
+        except ValueError:
+            continue
+    stat_name = "F" if key == "anova" else "H"
+    return pd.DataFrame({
+        "gene":      gene_names,
+        stat_name:   stat,
+        "AveExpr":   np.nanmean(X, axis=0),
+        "P.Value":   pv,
+        "adj.P.Val": _bh_adjust(pv),
+    }).sort_values("P.Value").reset_index(drop=True)
+
+
+# --------------------------------------------------------------------------- #
+# Olink-style per-protein LMM                                                 #
+# --------------------------------------------------------------------------- #
+def _de_olink_lmer(adata, labels, groups, **kwargs):
+    """Per-protein LMM ``NPX ~ group + (1|subject)`` via statsmodels.
+
+    Used for paired / repeated-measures Olink designs. Falls back to
+    fixed-effects OLS when ``subject_var`` is not supplied.
+    """
+    try:
+        import statsmodels.formula.api as smf
+    except ImportError as exc:
+        raise ImportError(
+            "method='olink_lmer' requires statsmodels: "
+            "`pip install statsmodels`."
+        ) from exc
+    subject_var = kwargs.get("subject_var")
+
+    rows = []
+    for j, gene in enumerate(adata.var_names.astype(str)):
+        y = adata.X[:, j].astype(float)
+        keep = ~np.isnan(y)
+        if keep.sum() < 4:
+            rows.append({"gene": gene, "logFC": np.nan, "P.Value": np.nan})
+            continue
+        df = pd.DataFrame({
+            "y": y[keep],
+            "group": pd.Categorical(labels[keep], categories=groups),
+        })
+        if subject_var is not None:
+            df["subject"] = adata.obs[subject_var].to_numpy()[keep]
+            try:
+                m = smf.mixedlm("y ~ group", df, groups=df["subject"]).fit(disp=False)
+            except Exception:
+                rows.append({"gene": gene, "logFC": np.nan, "P.Value": np.nan})
+                continue
+        else:
+            try:
+                m = smf.ols("y ~ group", df).fit()
+            except Exception:
+                rows.append({"gene": gene, "logFC": np.nan, "P.Value": np.nan})
+                continue
+        # Pick the group1 coefficient.
+        target = next((k for k in m.params.index if k.startswith("group[T.")), None)
+        if target is None:
+            rows.append({"gene": gene, "logFC": np.nan, "P.Value": np.nan})
+            continue
+        rows.append({
+            "gene":    gene,
+            "logFC":   float(m.params[target]),
+            "P.Value": float(m.pvalues[target]),
+        })
+    out = pd.DataFrame(rows)
+    out["adj.P.Val"] = _bh_adjust(out["P.Value"].to_numpy())
+    return out.sort_values("P.Value").reset_index(drop=True)

--- a/omicverse/protein/_design.py
+++ b/omicverse/protein/_design.py
@@ -1,0 +1,141 @@
+"""Study-design helpers for ``ov.protein`` — sample-size / power
+calculation and contrast-matrix construction, wrapping :mod:`pymsstats`.
+"""
+from __future__ import annotations
+
+from typing import Optional, Sequence, Union
+
+import numpy as np
+import pandas as pd
+
+from .._registry import register_function
+
+
+@register_function(
+    aliases=["protein_sample_size", "sample_size", "样本量计算", "功效分析"],
+    category="analysis",
+    description=(
+        "Sample-size / statistical-power calculation for a proteomics "
+        "experiment, wrapping ``pymsstats.design_sample_size`` "
+        "(MSstats ``designSampleSize``). Given a processed protein-level "
+        "AnnData (post-summarization), returns the minimum number of "
+        "biological replicates per group needed to detect a panel of "
+        "desired fold-changes at the requested FDR and power."
+    ),
+    requires={},
+    produces={"uns": ["protein_sample_size"]},
+    auto_fix="none",
+    examples=[
+        "tbl = ov.protein.sample_size(adata, group='treatment', desired_fc=(1.25, 2.0))",
+    ],
+)
+def sample_size(
+    adata,
+    group: Union[str, np.ndarray],
+    *,
+    desired_fc: Sequence[float] = (1.25, 1.5, 1.75, 2.0),
+    fdr: float = 0.05,
+    power: float = 0.8,
+    **kwargs,
+) -> pd.DataFrame:
+    """Minimum replicates per group for a target fold-change panel.
+
+    Parameters
+    ----------
+    adata
+        Protein-level AnnData (post-``summarize`` / log2-normalized).
+    group
+        Sample-group column in ``adata.obs`` (or a labels array).
+    desired_fc
+        Fold-changes to power for. R default range is ``(1.25, …, 2.0)``.
+    fdr
+        Target false-discovery rate.
+    power
+        Target statistical power.
+    **kwargs
+        Forwarded to ``pymsstats.design_sample_size``.
+
+    Returns
+    -------
+    pandas.DataFrame
+        One row per desired fold-change with the minimum N.
+    """
+    try:
+        import pymsstats
+    except ImportError as exc:
+        raise ImportError(
+            "ov.protein.sample_size requires pymsstats: `pip install pymsstats`."
+        ) from exc
+
+    if isinstance(group, str):
+        labels = adata.obs[group].astype(str).to_numpy()
+    else:
+        labels = np.asarray(group)
+
+    # Build the MSstats-style processed long table the function expects.
+    long_rows = pd.DataFrame(
+        adata.X.astype(float),
+        index=adata.obs_names.astype(str),
+        columns=adata.var_names.astype(str),
+    )
+    long_rows["__group__"] = labels
+    melted = long_rows.melt(
+        id_vars="__group__", var_name="PROTEIN", value_name="LogIntensities",
+        ignore_index=False,
+    ).rename(columns={"__group__": "GROUP"})
+    melted["RUN"] = melted.index.astype(str)
+    melted["SUBJECT"] = melted.index.astype(str)
+
+    result = pymsstats.design_sample_size(
+        melted, desired_fc=tuple(desired_fc), fdr=fdr, power=power,
+        protein_col="PROTEIN", group_col="GROUP",
+        abundance_col="LogIntensities", subject_col="SUBJECT",
+        **kwargs,
+    )
+    adata.uns.setdefault("protein", {})["sample_size"] = result
+    return result
+
+
+@register_function(
+    aliases=["protein_contrast_matrix", "contrast_matrix"],
+    category="analysis",
+    description=(
+        "Build a contrast matrix for a multi-group proteomics design, "
+        "wrapping ``pymsstats.msstats_contrast_matrix`` "
+        "(MSstats ``MSstatsContrastMatrix``). Accepts a string spec "
+        "(``'groupB-groupA'``), ``'pairwise'``, a list of pairs, or a "
+        "ready-made ndarray."
+    ),
+    examples=[
+        "C = ov.protein.contrast_matrix('treated-control', ['control','treated'])",
+        "C = ov.protein.contrast_matrix('pairwise', ['A','B','C'])",
+    ],
+)
+def contrast_matrix(
+    contrasts: Union[str, Sequence, np.ndarray],
+    conditions: Sequence[str],
+) -> pd.DataFrame:
+    """Construct an MSstats-style contrast matrix.
+
+    Parameters
+    ----------
+    contrasts
+        Contrast spec — ``'groupB-groupA'``, ``'pairwise'``, a list of
+        ``(a, b)`` pairs, or an ndarray (returned as-is).
+    conditions
+        Ordered list of condition / group names (the columns of the
+        contrast matrix).
+
+    Returns
+    -------
+    pandas.DataFrame
+        Contrast matrix, rows = contrasts, columns = conditions.
+    """
+    try:
+        import pymsstats
+    except ImportError as exc:
+        raise ImportError(
+            "ov.protein.contrast_matrix requires pymsstats: "
+            "`pip install pymsstats`."
+        ) from exc
+    return pymsstats.msstats_contrast_matrix(contrasts, list(conditions))

--- a/omicverse/protein/_enrich.py
+++ b/omicverse/protein/_enrich.py
@@ -1,0 +1,100 @@
+"""Enrichment dispatcher for ``ov.protein`` — thin wrapper over ``ov.es``.
+
+For protein-level analysis the canonical input to ``ov.es`` is either:
+
+* the AnnData itself (per-sample scoring), or
+* a ranked statistic vector from ``ov.protein.de`` (one-shot GSEA / ORA).
+
+This module re-exposes the relevant ``ov.es`` functions under a single
+``ov.protein.enrich`` entry point with the same ``method=`` selector
+the user is familiar with from imputation / DE.
+"""
+from __future__ import annotations
+
+from typing import Optional, Union
+
+import numpy as np
+import pandas as pd
+
+from .._registry import register_function
+
+
+@register_function(
+    aliases=["protein_enrich", "enrich", "蛋白富集"],
+    category="enrichment",
+    description=(
+        "Run an ``ov.es`` enrichment kernel on a proteomics AnnData "
+        "(per-sample scoring) or on a DE result table (one-shot ORA / "
+        "GSEA). ``method`` is forwarded to ``ov.es.decoupler`` — one "
+        "of ``aucell``, ``gsea``, ``gsva``, ``ora``, ``ulm``, ``mlm``, "
+        "``waggr``, ``zscore``, ``viper``, ``mdt``, ``udt``."
+    ),
+    requires={},
+    produces={"obsm": ["score_<method>"]},
+    auto_fix="none",
+    examples=[
+        "ov.protein.enrich(adata, signatures=msigdb, method='ulm')",
+        "ov.protein.enrich(de_table, signatures=msigdb, method='gsea')",
+    ],
+)
+def enrich(
+    data: Union["AnnData", pd.DataFrame],
+    signatures: Optional[dict] = None,
+    *,
+    net: Optional[pd.DataFrame] = None,
+    method: str = "ulm",
+    engine: str = "auto",
+    **kwargs,
+):
+    """Enrichment on protein-level data (AnnData) or DE result (DataFrame).
+
+    Parameters
+    ----------
+    data
+        ``AnnData`` (samples × proteins) or a DE result ``DataFrame``
+        with at least ``gene`` and one of ``t``, ``logFC``, ``P.Value``.
+    signatures
+        Dict mapping ``signature_name → list[gene] | dict[gene, weight]``
+        (omicverse convention). Mutually exclusive with ``net``.
+    net
+        Long-format ``source / target / weight`` DataFrame (decoupler
+        convention). Power-user escape hatch.
+    method
+        Which kernel to run (forwarded to ``ov.es.decoupler``).
+    engine
+        ``'auto'`` | ``'cpu'`` | ``'gpu'``.
+    **kwargs
+        Forwarded to the chosen kernel.
+
+    Returns
+    -------
+    AnnData | (DataFrame, DataFrame)
+        Same return shape as the underlying ``ov.es`` function.
+    """
+    from .. import es as _es
+
+    # If user passes a DE table, transpose into a 1-row "pseudo-sample"
+    # for the t-statistic ranking. ``ov.es.gsea`` etc. consume this fine.
+    if isinstance(data, pd.DataFrame) and "gene" in data.columns:
+        rank_col = next(
+            (c for c in ("t", "logFC", "stat", "log2FoldChange") if c in data.columns),
+            None,
+        )
+        if rank_col is None:
+            raise ValueError(
+                "DE-table input must contain a rank column (one of t, "
+                "logFC, stat, log2FoldChange)."
+            )
+        # Build a 1-row AnnData-like DataFrame.
+        score = (
+            data[["gene", rank_col]]
+            .dropna()
+            .set_index("gene")
+            .T
+        )
+        score.index = ["de_query"]
+        data = score
+    return _es.decoupler(
+        data, signatures=signatures, net=net,
+        method=method, engine=engine, **kwargs,
+    )

--- a/omicverse/protein/_impute.py
+++ b/omicverse/protein/_impute.py
@@ -1,0 +1,136 @@
+"""Imputation dispatcher for ``ov.protein``.
+
+Wraps the full :mod:`pyimputelcmd` imputer suite (MinDet / MinProb /
+QRILC / ZERO / MLE / KNN / SVD / MAR / MAR-MNAR) plus the two
+commonest non-LCMD fallbacks (``half_min`` and ``min``). The single
+:func:`impute` function takes ``method=...`` and writes the imputed
+matrix to ``adata.X``, stashing the pre-imputation copy in
+``adata.layers['pre_impute']``.
+
+The ``'auto'`` method runs :func:`pyimputelcmd.model_selector` to
+classify each protein as MCAR or MNAR, then applies an MAR imputer
+(KNN) to the MCAR proteins and an MNAR imputer (QRILC) to the rest —
+the recommended strategy from Lazar 2016.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+import numpy as np
+
+from .._registry import register_function
+
+
+_VALID_METHODS = {
+    "mindet", "minprob", "qrilc",       # imputeLCMD left-censored
+    "zero", "mle", "knn", "svd",        # imputeLCMD MAR-family
+    "mar", "mar_mnar", "auto",          # imputeLCMD model-selector driven
+    "half_min", "min",                  # non-LCMD fallbacks
+}
+
+
+@register_function(
+    aliases=["protein_impute", "impute", "蛋白缺失值填补"],
+    category="preprocessing",
+    description=(
+        "Impute missing values in a proteomics AnnData. ``method`` "
+        "dispatches to the full imputeLCMD suite (via ``pyimputelcmd``): "
+        "left-censored MNAR imputers ``'mindet'`` / ``'minprob'`` / "
+        "``'qrilc'``; MAR-family ``'zero'`` / ``'mle'`` / ``'knn'`` / "
+        "``'svd'``; model-selector-driven ``'mar'`` / ``'mar_mnar'`` / "
+        "``'auto'`` (classify each protein MCAR vs MNAR then route); plus "
+        "the non-LCMD fallbacks ``'half_min'`` and ``'min'``. All methods "
+        "are NaN-aware and operate per-sample (column) on the proteins × "
+        "samples layout that R uses; the wrapper transposes ``adata.X`` "
+        "internally and back."
+    ),
+    requires={},
+    produces={"layers": ["pre_impute"]},
+    auto_fix="none",
+    examples=[
+        "ov.protein.impute(adata, method='qrilc', seed=0)",
+        "ov.protein.impute(adata, method='mindet')",
+        "ov.protein.impute(adata, method='knn', n_neighbors=5)",
+        "ov.protein.impute(adata, method='auto')  # MCAR/MNAR-aware",
+    ],
+)
+def impute(
+    adata,
+    *,
+    method: str = "qrilc",
+    seed: Optional[int] = 0,
+    stash: bool = True,
+    **kwargs,
+) -> None:
+    """Impute ``adata.X`` in place using the requested ``method``.
+
+    Parameters
+    ----------
+    adata
+        AnnData with ``X`` = samples × proteins (omicverse layout). NaN
+        marks missing.
+    method
+        Selector — see the function description.
+    seed
+        Optional seed for stochastic imputers (``minprob`` / ``qrilc``).
+    stash
+        Save the pre-imputation matrix to ``adata.layers['pre_impute']``
+        (default ``True``).
+    **kwargs
+        Forwarded to the chosen imputer (e.g. ``q=0.01``,
+        ``tune_sigma=1.0``, ``n_neighbors=5``).
+    """
+    key = method.lower().strip()
+    if key not in _VALID_METHODS:
+        raise ValueError(
+            f"method must be one of {sorted(_VALID_METHODS)}, got {method!r}"
+        )
+    X = adata.X.astype(float, copy=True)  # samples × proteins
+    if stash and "pre_impute" not in adata.layers:
+        adata.layers["pre_impute"] = X.copy()
+
+    # Transpose to proteins × samples for the R-convention imputers.
+    XT = X.T
+
+    if key in ("half_min", "min"):
+        imputed = XT.copy()
+        # Per-sample (column) minimum.
+        col_min = np.nanmin(imputed, axis=0, keepdims=True)
+        fill = col_min if key == "min" else col_min / 2.0
+        # Where col_min itself is NaN (all-NaN column), fall back to global min.
+        global_min = np.nanmin(imputed)
+        fill = np.where(np.isnan(fill), global_min, fill)
+        mask = np.isnan(imputed)
+        imputed[mask] = np.broadcast_to(fill, imputed.shape)[mask]
+    else:
+        # Everything else is a pyimputelcmd backend.
+        try:
+            import pyimputelcmd as pyi
+        except ImportError as exc:
+            raise ImportError(
+                f"method={key!r} requires ``pyimputelcmd``: "
+                "`pip install pyimputelcmd`."
+            ) from exc
+        if key in ("minprob", "qrilc", "minprob"):
+            kwargs.setdefault("seed", seed)
+        if key in ("mar", "mar_mnar", "auto"):
+            # Model-selector-driven imputation: classify MCAR vs MNAR,
+            # then route each protein to the appropriate imputer.
+            mcar_mask, _thr = pyi.model_selector(XT)
+            if key == "mar":
+                imputed = pyi.impute_mar(
+                    XT, mcar_mask, method=kwargs.pop("mar_method", "mle"),
+                )
+            else:  # 'mar_mnar' / 'auto'
+                imputed = pyi.impute_mar_mnar(
+                    XT, mcar_mask,
+                    method_mar=kwargs.pop("method_mar", "knn"),
+                    method_mnar=kwargs.pop("method_mnar", "qrilc"),
+                    **kwargs,
+                )
+        else:
+            # Single-method imputers — dispatch through pyimputelcmd.impute.
+            imputed = pyi.impute(XT, method=key, **kwargs)
+
+    adata.X = np.asarray(imputed).T  # back to samples × proteins
+    adata.uns.setdefault("protein", {})["impute_method"] = key

--- a/omicverse/protein/_norm.py
+++ b/omicverse/protein/_norm.py
@@ -1,0 +1,146 @@
+"""Per-sample normalization for proteomics AnnData.
+
+``ov.protein.normalize(adata, method=...)`` is the unified dispatcher
+that picks between median centering, quantile normalization, and a
+``log2-only`` no-op (for already-normalised inputs like Olink NPX).
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+import numpy as np
+
+from .._registry import register_function
+
+
+@register_function(
+    aliases=["protein_normalize", "normalize", "蛋白归一化"],
+    category="preprocessing",
+    description=(
+        "Per-sample normalize a proteomics intensity matrix. ``method`` "
+        "selects one of: ``'median'`` (subtract sample-median from each "
+        "column after log2 — the standard LFQ default), "
+        "``'equalize_medians'`` (DEqMS/MSstats column-median equalisation "
+        "via the pydeqms backend), ``'quantile'`` (rank-based quantile "
+        "equalisation), or ``'log2'`` (log2-only, no centering). NaN-safe "
+        "in every case. Mutates ``adata.X``; stashes the pre-normalised "
+        "copy in ``adata.layers['raw']``."
+    ),
+    requires={},
+    produces={"layers": ["raw", "log2"]},
+    auto_fix="none",
+    examples=[
+        "ov.protein.normalize(adata, method='median', log2=True)",
+        "ov.protein.normalize(adata, method='quantile', log2=True)",
+    ],
+)
+def normalize(
+    adata,
+    *,
+    method: str = "median",
+    log2: bool = True,
+    stash_raw: bool = True,
+) -> None:
+    """Per-sample normalize ``adata.X`` in place.
+
+    Parameters
+    ----------
+    method
+        ``'median'`` | ``'quantile'`` | ``'log2'``.
+    log2
+        Apply ``log2(X + 1)`` before normalization. Set ``False`` if the
+        matrix is already on log scale (Olink NPX, post-VSN).
+    stash_raw
+        Save the unmodified ``X`` to ``adata.layers['raw']``. Default ``True``.
+    """
+    method = method.lower().strip()
+    valid = {"median", "equalize_medians", "quantile", "log2"}
+    if method not in valid:
+        raise ValueError(f"method must be one of {sorted(valid)}, got {method!r}")
+    X = adata.X.astype(float, copy=True)
+
+    if stash_raw and "raw" not in adata.layers:
+        adata.layers["raw"] = X.copy()
+
+    if log2:
+        # log2(X+1) preserves zero / missing semantics (0 → 0).
+        with np.errstate(invalid="ignore", divide="ignore"):
+            X = np.log2(X + 1.0)
+            # Negative inputs (Olink NPX is already log) become NaN here —
+            # callers should pass log2=False for NPX.
+        adata.layers["log2"] = X.copy()
+
+    if method == "log2":
+        # log2-only — no centering / quantile.
+        adata.X = X
+        return
+
+    if method == "median":
+        sample_medians = np.nanmedian(X, axis=1, keepdims=True)
+        # Reference: overall median across samples.
+        overall = np.nanmedian(sample_medians)
+        X = X - sample_medians + overall
+    elif method == "equalize_medians":
+        try:
+            from pydeqms import equal_median_normalization
+        except ImportError as exc:
+            raise ImportError(
+                "method='equalize_medians' requires pydeqms: "
+                "`pip install pydeqms`."
+            ) from exc
+        # pydeqms works on proteins × samples — transpose in and back.
+        X = np.asarray(equal_median_normalization(X.T)).T
+    elif method == "quantile":
+        X = _quantile_normalize(X)
+
+    adata.X = X
+
+
+def _quantile_normalize(X: np.ndarray) -> np.ndarray:
+    """Rank-based quantile normalization, NaN-tolerant.
+
+    Mirrors ``limma::normalizeBetweenArrays(method='quantile')``: each
+    sample's distribution is mapped to the average across samples after
+    ranking. NaNs preserve their position (do not contribute to the rank
+    average).
+    """
+    Y = X.copy()
+    n_samples, n_proteins = Y.shape
+    ranks = np.full_like(Y, np.nan, dtype=float)
+    sorted_vals = []
+    for i in range(n_samples):
+        row = Y[i]
+        finite = ~np.isnan(row)
+        if not finite.any():
+            sorted_vals.append(np.array([]))
+            continue
+        idx = np.where(finite)[0]
+        order = idx[np.argsort(row[idx])]
+        ranks_row = np.empty(idx.size)
+        ranks_row[np.argsort(row[idx])] = np.linspace(0.0, 1.0, idx.size)
+        ranks[i, idx] = ranks_row
+        sorted_vals.append(np.sort(row[idx]))
+
+    # Average reference distribution at fractional ranks 0..1.
+    common_grid = np.linspace(0.0, 1.0, n_proteins)
+    ref = np.zeros(n_proteins)
+    cnt = np.zeros(n_proteins)
+    for arr in sorted_vals:
+        if arr.size == 0:
+            continue
+        # Interpolate each sample to the common grid.
+        sample_grid = np.linspace(0.0, 1.0, arr.size)
+        interp = np.interp(common_grid, sample_grid, arr)
+        ref += interp
+        cnt += 1.0
+    ref = ref / np.maximum(cnt, 1.0)
+
+    # Map each sample's NaN-aware ranks back to ref values.
+    out = np.full_like(Y, np.nan, dtype=float)
+    for i in range(n_samples):
+        finite = ~np.isnan(Y[i])
+        if not finite.any():
+            continue
+        r = ranks[i, finite]
+        out[i, finite] = np.interp(r, common_grid, ref)
+    return out

--- a/omicverse/protein/_qc.py
+++ b/omicverse/protein/_qc.py
@@ -1,0 +1,157 @@
+"""QC for proteomics AnnData: peptide-count / valid-value filtering and
+missing-pattern statistics. ``ov.protein`` follows the omicverse
+convention of mutating ``adata`` in place — same as ``ov.metabol.cv_filter``."""
+from __future__ import annotations
+
+from typing import Optional
+
+import numpy as np
+import pandas as pd
+
+from .._registry import register_function
+
+
+@register_function(
+    aliases=["protein_qc_filter", "qc_filter", "蛋白质控"],
+    category="preprocessing",
+    description=(
+        "Drop low-quality proteins from a proteomics AnnData. Two filters: "
+        "(1) peptide-count threshold (``min_peptides``) on a per-protein "
+        "metadata column; (2) per-protein minimum number of valid (non-NaN) "
+        "samples (``min_valid``). Both default to keeping proteins with "
+        "≥2 peptides and ≥50% valid samples — the MaxQuant default."
+    ),
+    requires={"var": []},
+    produces={"obs": ["n_valid_proteins"], "var": ["n_valid_samples"]},
+    auto_fix="none",
+    examples=[
+        "ov.protein.qc_filter(adata, min_peptides=2, min_valid=0.5)",
+        "ov.protein.qc_filter(adata, min_peptides=2, peptides_col='Combined.Total.Peptides')",
+    ],
+)
+def qc_filter(
+    adata,
+    *,
+    min_peptides: int = 2,
+    peptides_col: str = "peptides",
+    min_valid: float = 0.5,
+    inplace: bool = True,
+) -> "AnnData | None":
+    """Subset ``adata`` to proteins passing peptide-count and missingness QC.
+
+    Parameters
+    ----------
+    adata
+        ``AnnData`` from ``ov.protein.read_*``.
+    min_peptides
+        Minimum count in ``adata.var[peptides_col]``. Set to 0 to skip.
+        Silently skipped if the column does not exist.
+    peptides_col
+        Column in ``adata.var`` holding the peptide count.
+    min_valid
+        Per-protein minimum fraction of samples with a valid (non-NaN)
+        intensity. If ≥1, treated as an integer count instead of a
+        fraction.
+    inplace
+        Modify ``adata`` in place (default) or return a new object.
+
+    Returns
+    -------
+    None | AnnData
+        ``None`` when ``inplace=True``; the filtered ``AnnData`` otherwise.
+    """
+    X = adata.X
+    n_samples = X.shape[0]
+    n_valid_per_var = np.sum(~np.isnan(X), axis=0)
+
+    keep = np.ones(adata.n_vars, dtype=bool)
+
+    if min_peptides > 0 and peptides_col in adata.var.columns:
+        peptides = pd.to_numeric(adata.var[peptides_col], errors="coerce")
+        keep &= (peptides.fillna(0).to_numpy() >= min_peptides)
+
+    if min_valid > 0:
+        thresh = (min_valid if min_valid >= 1 else min_valid * n_samples)
+        keep &= n_valid_per_var >= thresh
+
+    # Persist QC metrics.
+    adata.var["n_valid_samples"] = n_valid_per_var
+    if inplace:
+        kept_idx = np.flatnonzero(keep)
+        # AnnData's slice copies. Replace contents.
+        new = adata[:, kept_idx].copy()
+        adata._init_as_actual(
+            X=new.X, obs=new.obs, var=new.var,
+            obsm=dict(new.obsm), varm=dict(new.varm),
+            uns=dict(new.uns), layers=dict(new.layers),
+        )
+        # Per-sample valid-protein count (after filtering).
+        adata.obs["n_valid_proteins"] = np.sum(~np.isnan(adata.X), axis=1)
+        return None
+    out = adata[:, keep].copy()
+    out.obs["n_valid_proteins"] = np.sum(~np.isnan(out.X), axis=1)
+    return out
+
+
+@register_function(
+    aliases=["protein_model_selector", "model_selector", "缺失机制分类"],
+    category="preprocessing",
+    description=(
+        "Classify each protein's missingness as MCAR (missing completely "
+        "at random) or MNAR (missing not at random, i.e. left-censored) "
+        "using the imputeLCMD ``model.Selector`` algorithm (via "
+        "``pyimputelcmd``). Writes a boolean ``adata.var['is_mcar']`` "
+        "column (True = MCAR/MAR) and returns the per-protein mask plus "
+        "the estimated censoring threshold. Use it to decide between "
+        "MAR imputers (KNN/MLE) and MNAR imputers (QRILC)."
+    ),
+    requires={},
+    produces={"var": ["is_mcar"]},
+    auto_fix="none",
+    examples=["mask, thr = ov.protein.model_selector(adata)"],
+)
+def model_selector(adata):
+    """Classify proteins as MCAR vs MNAR (imputeLCMD model.Selector).
+
+    Returns
+    -------
+    (np.ndarray[bool], float)
+        Per-protein MCAR mask (True = MCAR/MAR) and the estimated
+        censoring threshold. Also written to ``adata.var['is_mcar']``.
+    """
+    try:
+        import pyimputelcmd as pyi
+    except ImportError as exc:
+        raise ImportError(
+            "model_selector requires pyimputelcmd: `pip install pyimputelcmd`."
+        ) from exc
+    # pyimputelcmd works on proteins × samples.
+    mask, threshold = pyi.model_selector(adata.X.T.astype(float))
+    adata.var["is_mcar"] = np.asarray(mask, dtype=bool)
+    adata.uns.setdefault("protein", {})["mnar_threshold"] = float(threshold)
+    return mask, float(threshold)
+
+
+@register_function(
+    aliases=["protein_missing_pattern", "missing_pattern"],
+    category="preprocessing",
+    description=(
+        "Tabulate the per-protein and per-sample missingness pattern. "
+        "Returns a dict with ``protein_missing_frac`` (Series), "
+        "``sample_missing_frac`` (Series), and ``overall`` (float)."
+    ),
+    examples=["stats = ov.protein.missing_pattern(adata)"],
+)
+def missing_pattern(adata) -> dict:
+    """Per-protein / per-sample / overall missing fraction for a proteomics AnnData."""
+    X = adata.X
+    miss = np.isnan(X)
+    return {
+        "protein_missing_frac": pd.Series(
+            miss.mean(axis=0), index=adata.var_names, name="missing_frac",
+        ),
+        "sample_missing_frac": pd.Series(
+            miss.mean(axis=1), index=adata.obs_names, name="missing_frac",
+        ),
+        "overall": float(miss.mean()),
+    }

--- a/omicverse/protein/_simulate.py
+++ b/omicverse/protein/_simulate.py
@@ -1,0 +1,162 @@
+"""Synthetic bulk-proteomics data generator for ``ov.protein`` tutorials
+and tests. Produces a realistic MaxQuant-style AnnData with planted
+differential proteins, count-correlated variance, and MNAR dropouts.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+import numpy as np
+import pandas as pd
+
+from .._registry import register_function
+
+
+@register_function(
+    aliases=["protein_simulate_lfq", "simulate_lfq", "蛋白模拟数据"],
+    category="datasets",
+    description=(
+        "Simulate a bulk label-free proteomics dataset as an AnnData "
+        "(samples × proteins, raw intensities in ``X``). Plants a known "
+        "set of differential proteins, gives each protein a peptide "
+        "count with count-correlated variance (so DEqMS has signal to "
+        "exploit), and injects MNAR left-censored dropouts. The "
+        "ground-truth DE flag is stored in ``adata.var['is_de_true']``."
+    ),
+    produces={"obs": ["group"], "var": ["peptides", "is_de_true"]},
+    auto_fix="none",
+    examples=[
+        "adata = ov.protein.simulate_lfq(seed=0)",
+        "adata = ov.protein.simulate_lfq(n_proteins=3000, n_per_group=8)",
+    ],
+)
+def simulate_lfq(
+    *,
+    n_proteins: int = 2000,
+    n_per_group: int = 6,
+    n_groups: int = 2,
+    prop_de: float = 0.12,
+    effect_size: float = 1.0,
+    missing_frac: float = 0.12,
+    platform: str = "lfq",
+    peptide_level: bool = False,
+    n_peptides_per_protein: int = 4,
+    seed: Optional[int] = 0,
+):
+    """Simulate a bulk proteomics AnnData.
+
+    Parameters
+    ----------
+    n_proteins
+        Number of proteins (``var``).
+    n_per_group
+        Biological replicates per group.
+    n_groups
+        Number of groups (the first two are the test contrast).
+    prop_de
+        Fraction of proteins that are truly differential.
+    effect_size
+        Log2 fold-change magnitude for the planted DE proteins.
+    missing_frac
+        Target overall fraction of MNAR (left-censored) missing values.
+        Ignored when ``platform='olink'`` (NPX has negligible dropout).
+    platform
+        ``'lfq'`` (default) — raw linear intensities, MNAR dropout, a
+        per-protein peptide count. ``'olink'`` — NPX-style values
+        (already log2 scale, no dropout, no peptide count).
+    peptide_level
+        If ``True``, return a **peptide-level** AnnData
+        (samples × peptides) with a ``var['Protein']`` column mapping
+        each peptide to its parent protein — feed this to
+        :func:`omicverse.protein.summarize`.
+    n_peptides_per_protein
+        Peptides per protein when ``peptide_level=True``.
+    seed
+        RNG seed.
+
+    Returns
+    -------
+    AnnData
+        ``obs['group']`` = group labels; ``var['is_de_true']`` =
+        ground-truth DE flag. For ``platform='lfq'`` protein-level,
+        ``var['peptides']`` holds the peptide count; ``X`` is raw
+        intensities (NaN = missing). For ``platform='olink'`` ``X`` is
+        NPX (log2). For ``peptide_level=True`` ``var['Protein']`` maps
+        peptides → proteins.
+    """
+    from anndata import AnnData
+
+    rng = np.random.default_rng(seed)
+    n_samples = n_per_group * n_groups
+    is_olink = platform.lower() == "olink"
+
+    base_mean, base_sd = (0.0, 2.0) if is_olink else (20.0, 1.6)
+    base = rng.normal(base_mean, base_sd, n_proteins)
+    count = rng.integers(1, 25, n_proteins).astype(float)
+    sigma = (0.3 + 0.4 * rng.uniform(size=n_proteins)) if is_olink \
+        else (0.35 + 0.9 / np.sqrt(count))
+
+    is_de = rng.uniform(size=n_proteins) < prop_de
+    delta = np.zeros(n_proteins)
+    delta[is_de] = rng.choice([-1, 1], size=int(is_de.sum())) * effect_size
+
+    group_labels = np.repeat([f"group{g}" for g in range(n_groups)], n_per_group)
+
+    def _draw_block(means_per_protein):
+        """Draw an (n_samples × n_proteins) block from the group means."""
+        block = np.zeros((n_samples, n_proteins))
+        for g in range(n_groups):
+            mean_g = base + means_per_protein + (delta if g == 1 else 0.0)
+            block[g * n_per_group:(g + 1) * n_per_group, :] = rng.normal(
+                mean_g[None, :], sigma[None, :], (n_per_group, n_proteins),
+            )
+        return block
+
+    obs = pd.DataFrame({"group": group_labels},
+                       index=[f"S{i:02d}" for i in range(n_samples)])
+
+    if peptide_level:
+        # Each peptide is its parent protein's signal + a peptide offset.
+        # Per-protein peptide count varies in [1, n_peptides_per_protein]
+        # so a count-aware DE method (DEqMS) has real signal to model.
+        per_protein_n = rng.integers(
+            1, max(n_peptides_per_protein, 2) + 1, n_proteins,
+        )
+        cols, proteins, pep_de = [], [], []
+        for p in range(n_proteins):
+            for k in range(int(per_protein_n[p])):
+                offset = rng.normal(0.0, 0.5)
+                pep_signal = _draw_block(np.full(n_proteins, 0.0))[:, p] + offset
+                cols.append(pep_signal)
+                proteins.append(f"prot_{p:04d}")
+                pep_de.append(bool(is_de[p]))
+        Xp = np.column_stack(cols)
+        if not is_olink:
+            Xp = 2.0 ** Xp
+        var = pd.DataFrame(
+            {"Protein": proteins, "is_de_true": pep_de},
+            index=[f"pep_{i:05d}" for i in range(Xp.shape[1])],
+        )
+        adata = AnnData(X=Xp, obs=obs, var=var)
+        adata.uns["source"] = f"simulate_lfq[{platform},peptide]"
+        return adata
+
+    X = _draw_block(np.zeros(n_proteins))
+    if not is_olink:
+        X = 2.0 ** X
+        if missing_frac > 0:
+            thr = np.quantile(X, min(missing_frac * 1.6, 0.5))
+            p_miss = np.clip(np.exp(-(X / thr) ** 2), 0.0, 1.0)
+            X[rng.uniform(size=X.shape) < p_miss] = np.nan
+
+    var_cols = {
+        "Gene_names": [f"GENE{i:04d}" for i in range(n_proteins)],
+        "is_de_true": is_de,
+    }
+    if not is_olink:
+        var_cols["peptides"] = count.astype(int)
+    var = pd.DataFrame(var_cols,
+                       index=[f"prot_{i:04d}" for i in range(n_proteins)])
+    adata = AnnData(X=X, obs=obs, var=var)
+    adata.uns["source"] = f"simulate_lfq[{platform}]"
+    return adata

--- a/omicverse/protein/_summarize.py
+++ b/omicverse/protein/_summarize.py
@@ -1,0 +1,195 @@
+"""Peptide → protein summarization for ``ov.protein``.
+
+Bulk LC-MS/MS search engines often report **peptide / PSM-level**
+intensities; the downstream DE machinery (DEqMS, proDA, MSstats) works
+on **protein-level** matrices. :func:`summarize` collapses a
+peptide-level AnnData into a protein-level one, dispatching to the
+canonical summarization algorithms from the standalone backends:
+
+* ``'median'``          — per-protein median across peptides (``pydeqms.median_summary``)
+* ``'median_sweeping'`` — TMT median sweeping (``pydeqms.median_sweeping``)
+* ``'medpolish'``       — Tukey median polish (``pydeqms.medpolish_summary``)
+* ``'tmp'``             — MSstats Tukey-median-polish (``pymsstats.msstats_summarize``)
+* ``'linear'``          — MSstats linear-model summarization (``pymsstats.linear_summarize``)
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+import numpy as np
+import pandas as pd
+
+from .._registry import register_function
+
+
+_VALID_METHODS = {"median", "median_sweeping", "medpolish", "tmp", "linear"}
+
+
+@register_function(
+    aliases=["protein_summarize", "summarize", "肽段汇总", "蛋白汇总"],
+    category="preprocessing",
+    description=(
+        "Collapse a peptide / PSM-level proteomics AnnData into a "
+        "protein-level AnnData. ``method`` selects the summarization "
+        "algorithm: ``'median'`` / ``'median_sweeping'`` / ``'medpolish'`` "
+        "(DEqMS ports via pydeqms) or ``'tmp'`` / ``'linear'`` (MSstats "
+        "ports via pymsstats). The peptide→protein map is read from "
+        "``adata.var[protein_col]``."
+    ),
+    requires={"var": ["protein_col"]},
+    produces={"uns": ["protein_summarize"]},
+    auto_fix="none",
+    examples=[
+        "prot_adata = ov.protein.summarize(pep_adata, protein_col='Protein', method='medpolish')",
+        "prot_adata = ov.protein.summarize(pep_adata, protein_col='Protein', method='tmp')",
+    ],
+)
+def summarize(
+    adata,
+    *,
+    protein_col: str = "Protein",
+    method: str = "medpolish",
+    log2: bool = True,
+    **kwargs,
+):
+    """Summarize a peptide-level AnnData to protein level.
+
+    Parameters
+    ----------
+    adata
+        Peptide-level AnnData — ``X`` = samples × peptides, with a
+        ``adata.var[protein_col]`` column mapping each peptide to its
+        parent protein.
+    protein_col
+        Column in ``adata.var`` holding the parent-protein ID.
+    method
+        Summarization algorithm — see the function description.
+    log2
+        If ``True`` (default) the input is raw linear intensity and is
+        log2-transformed before summarization — all summarizers (DEqMS
+        and MSstats) collapse on the log scale. Set ``False`` when the
+        matrix is already on log scale (e.g. Olink NPX).
+    **kwargs
+        Forwarded to the backend summarizer.
+
+    Returns
+    -------
+    AnnData
+        Protein-level AnnData — ``X`` = samples × proteins. ``obs`` is
+        copied from the input; ``var`` is the unique protein index.
+    """
+    from anndata import AnnData
+
+    key = method.lower().strip()
+    if key not in _VALID_METHODS:
+        raise ValueError(
+            f"method must be one of {sorted(_VALID_METHODS)}, got {method!r}"
+        )
+    if protein_col not in adata.var.columns:
+        raise KeyError(
+            f"protein_col {protein_col!r} not in adata.var columns: "
+            f"{list(adata.var.columns)}"
+        )
+
+    # peptide × sample matrix (R convention for the backends).
+    pep_by_sample = pd.DataFrame(
+        adata.X.T.astype(float),
+        index=adata.var_names.astype(str),
+        columns=adata.obs_names.astype(str),
+    )
+    # All summarizers (DEqMS and MSstats) collapse on the LOG2 scale —
+    # summarising raw linear intensities inflates the protein-level
+    # variance by orders of magnitude. ``log2=True`` (default) means the
+    # input is raw intensity and should be logged first; ``log2=False``
+    # means the matrix is already on log scale (e.g. Olink NPX).
+    if log2:
+        with np.errstate(invalid="ignore", divide="ignore"):
+            pep_by_sample = np.log2(pep_by_sample)
+    proteins = adata.var[protein_col].astype(str).to_numpy()
+
+    if key in ("median", "median_sweeping", "medpolish"):
+        try:
+            import pydeqms
+        except ImportError as exc:
+            raise ImportError(
+                f"method={key!r} requires pydeqms: `pip install pydeqms`."
+            ) from exc
+        # pydeqms summarizers take a peptide DataFrame with a protein
+        # column + sample columns.
+        pep_df = pep_by_sample.copy()
+        pep_df.insert(0, protein_col, proteins)
+        fn = {
+            "median":          pydeqms.median_summary,
+            "median_sweeping": pydeqms.median_sweeping,
+            "medpolish":       pydeqms.medpolish_summary,
+        }[key]
+        prot_df = fn(pep_df, protein_col=protein_col,
+                     sample_cols=list(pep_by_sample.columns), **kwargs)
+        # ``medpolish`` / ``median_sweeping`` collapse to *column effects*
+        # — for a single-peptide protein those effects are identically
+        # zero (faithful to R DEqMS, which assumes ≥2-peptide filtering
+        # upstream). Replace such degenerate rows with the plain median
+        # summary so they carry real signal instead of a zero vector.
+        if key in ("medpolish", "median_sweeping"):
+            pep_per_protein = pd.Series(proteins).value_counts()
+            singletons = pep_per_protein[pep_per_protein < 2].index
+            singletons = [p for p in singletons if p in prot_df.index]
+            if singletons:
+                med = pydeqms.median_summary(
+                    pep_df, protein_col=protein_col,
+                    sample_cols=list(pep_by_sample.columns),
+                )
+                prot_df.loc[singletons, :] = med.reindex(
+                    index=singletons, columns=prot_df.columns,
+                )
+    elif key in ("tmp", "linear"):
+        try:
+            import pymsstats
+        except ImportError as exc:
+            raise ImportError(
+                f"method={key!r} requires pymsstats: `pip install pymsstats`."
+            ) from exc
+        # pymsstats summarizers consume a long-format DataFrame:
+        # PROTEIN / RUN / FEATURE / ABUNDANCE.
+        long_rows = pep_by_sample.copy()
+        long_rows.insert(0, "FEATURE", long_rows.index.astype(str))
+        long_rows.insert(0, "PROTEIN", proteins)
+        # pep_by_sample is already log2 (handled at the top).
+        long_df = long_rows.melt(
+            id_vars=["PROTEIN", "FEATURE"],
+            var_name="RUN", value_name="ABUNDANCE",
+        )
+        fn = (pymsstats.msstats_summarize if key == "tmp"
+              else pymsstats.linear_summarize)
+        summ = fn(long_df, **kwargs)
+        # pymsstats returns long Protein / RUN / LogIntensities — pivot wide.
+        prot_key = next(
+            (c for c in ("Protein", "PROTEIN", "ProteinName")
+             if c in summ.columns),
+            summ.columns[0],
+        )
+        run_key = next(
+            (c for c in ("RUN", "Run", "run") if c in summ.columns), "RUN",
+        )
+        val_col = next(
+            (c for c in ("LogIntensities", "ABUNDANCE", "Abundance")
+             if c in summ.columns),
+            summ.columns[2],
+        )
+        prot_df = summ.pivot_table(
+            index=prot_key, columns=run_key, values=val_col, aggfunc="first",
+        )
+    else:  # pragma: no cover
+        raise ValueError(key)
+
+    # prot_df is proteins × samples. Back to samples × proteins for AnnData.
+    prot_df = prot_df.reindex(columns=pep_by_sample.columns)
+    X = prot_df.to_numpy(dtype=float).T
+    out = AnnData(
+        X=X,
+        obs=adata.obs.copy(),
+        var=pd.DataFrame(index=pd.Index(prot_df.index.astype(str), name="protein")),
+    )
+    out.uns["protein_summarize"] = {"method": key, "n_peptides_in": adata.n_vars}
+    out.uns["source"] = adata.uns.get("source", "unknown")
+    return out

--- a/omicverse/protein/io.py
+++ b/omicverse/protein/io.py
@@ -1,0 +1,389 @@
+"""Readers for the four bulk-proteomics file formats omicverse supports
+out of the box: MaxQuant ``proteinGroups.txt``, DIA-NN
+``report.pg_matrix.tsv``, FragPipe ``combined_protein.tsv``, and Olink
+long NPX TSV/CSV.
+
+Every reader returns an ``AnnData`` with the omicverse convention:
+``obs = samples`` (rows), ``var = proteins`` (columns), and ``X``
+populated with **raw intensities** (NOT log-transformed). Downstream
+``ov.protein.normalize(..., log2=True)`` is responsible for the
+transform.
+
+Per-protein metadata (peptide count, sequence coverage, gene names,
+UniProt IDs, …) lands in ``adata.var`` so DEqMS / proDA / MSstats can
+read it directly via ``count_var=`` etc.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Optional, Union
+
+import numpy as np
+import pandas as pd
+
+try:
+    from anndata import AnnData
+except ImportError:  # pragma: no cover
+    AnnData = None  # type: ignore
+
+from .._registry import register_function
+
+
+PathLike = Union[str, Path]
+
+
+def _require_anndata() -> None:
+    if AnnData is None:
+        raise ImportError(
+            "anndata is required for omicverse.protein.io — "
+            "`pip install anndata`."
+        )
+
+
+def _intensity_columns(
+    df: pd.DataFrame,
+    pattern: str,
+) -> tuple[list[str], list[str]]:
+    """Return (column names, sample names) where columns match ``pattern``.
+
+    The sample name is captured by group(1) of the regex.
+    """
+    cre = re.compile(pattern)
+    keep_cols, sample_names = [], []
+    for col in df.columns:
+        m = cre.fullmatch(str(col))
+        if m is not None:
+            keep_cols.append(col)
+            sample_names.append(m.group(1) if m.groups() else str(col))
+    return keep_cols, sample_names
+
+
+# --------------------------------------------------------------------------- #
+# MaxQuant                                                                    #
+# --------------------------------------------------------------------------- #
+
+@register_function(
+    aliases=["read_maxquant", "maxquant", "蛋白组maxquant", "蛋白MaxQuant"],
+    category="io",
+    description=(
+        "Read a MaxQuant ``proteinGroups.txt`` file into an AnnData "
+        "(samples × proteins). ``sample_pattern`` selects which intensity "
+        "columns become samples (default = ``LFQ intensity <sample>``). "
+        "Reverse / contaminant / only-identified-by-site rows are dropped. "
+        "Per-protein metadata (peptides, sequence coverage, gene names, "
+        "Majority protein IDs) lands in ``adata.var``."
+    ),
+    produces={"obs": ["sample"], "var": ["peptides", "Gene_names", "Protein_IDs"]},
+    auto_fix="none",
+    examples=[
+        "adata = ov.protein.read_maxquant('proteinGroups.txt')",
+        "adata = ov.protein.read_maxquant('pG.txt', sample_pattern=r'Intensity (.+)')",
+    ],
+)
+def read_maxquant(
+    path: PathLike,
+    *,
+    sample_pattern: str = r"LFQ intensity (.+)",
+    protein_id_col: str = "Majority protein IDs",
+    drop_contaminants: bool = True,
+    drop_reverse: bool = True,
+    drop_only_by_site: bool = True,
+    peptides_col: str = "Peptides",
+    gene_names_col: str = "Gene names",
+) -> "AnnData":
+    """Load MaxQuant ``proteinGroups.txt`` into AnnData."""
+    _require_anndata()
+    df = pd.read_csv(path, sep="\t", low_memory=False)
+
+    # Standard MaxQuant junk-row filters.
+    mask = pd.Series(True, index=df.index)
+    if drop_reverse and "Reverse" in df.columns:
+        mask &= df["Reverse"].fillna("") != "+"
+    if drop_contaminants:
+        col = "Potential contaminant" if "Potential contaminant" in df.columns else "Contaminant"
+        if col in df.columns:
+            mask &= df[col].fillna("") != "+"
+    if drop_only_by_site and "Only identified by site" in df.columns:
+        mask &= df["Only identified by site"].fillna("") != "+"
+    df = df[mask].reset_index(drop=True)
+
+    cols, sample_names = _intensity_columns(df, sample_pattern)
+    if not cols:
+        raise ValueError(
+            f"No columns match {sample_pattern!r}. Available columns: "
+            f"{list(df.columns)[:20]}…"
+        )
+    # X is samples × proteins.
+    X = df[cols].to_numpy(dtype=float).T
+    # 0 → NaN: MaxQuant uses 0 for missing in LFQ intensities.
+    X[X == 0] = np.nan
+
+    var_cols = {}
+    if protein_id_col in df.columns:
+        var_cols["Protein_IDs"] = df[protein_id_col].astype(str).values
+    if peptides_col in df.columns:
+        var_cols["peptides"] = pd.to_numeric(df[peptides_col], errors="coerce").values
+    if gene_names_col in df.columns:
+        var_cols["Gene_names"] = df[gene_names_col].astype(str).values
+    if "Sequence coverage [%]" in df.columns:
+        var_cols["seq_coverage"] = pd.to_numeric(
+            df["Sequence coverage [%]"], errors="coerce",
+        ).values
+    if "id" in df.columns:
+        var_cols["mq_id"] = df["id"].astype(str).values
+
+    var_index = (
+        var_cols["Gene_names"] if "Gene_names" in var_cols else df.index.astype(str).values
+    )
+    # Disambiguate duplicate gene names.
+    var_index = pd.Index(var_index).astype(str)
+    if var_index.duplicated().any():
+        seen: dict[str, int] = {}
+        new = []
+        for v in var_index:
+            seen[v] = seen.get(v, 0) + 1
+            new.append(f"{v}_{seen[v]}" if seen[v] > 1 else v)
+        var_index = pd.Index(new)
+    var = pd.DataFrame(var_cols, index=var_index)
+
+    obs = pd.DataFrame(index=pd.Index(sample_names, name="sample"))
+    adata = AnnData(X=X, obs=obs, var=var)
+    adata.uns["source"] = "MaxQuant"
+    adata.uns["source_path"] = str(path)
+    return adata
+
+
+# --------------------------------------------------------------------------- #
+# DIA-NN                                                                      #
+# --------------------------------------------------------------------------- #
+
+@register_function(
+    aliases=["read_diann", "diann", "DIA-NN"],
+    category="io",
+    description=(
+        "Read a DIA-NN ``report.pg_matrix.tsv`` (or main ``report.tsv``) "
+        "into an AnnData (samples × proteins). For pg_matrix the wide "
+        "format is parsed directly; for the long ``report.tsv`` the "
+        "matrix is pivoted on ``Protein.Group`` × ``File.Name`` using "
+        "``PG.MaxLFQ``."
+    ),
+    produces={"obs": ["sample"], "var": ["Protein_Group", "Gene_names"]},
+    auto_fix="none",
+    examples=[
+        "adata = ov.protein.read_diann('report.pg_matrix.tsv')",
+        "adata = ov.protein.read_diann('report.tsv', quant_col='PG.MaxLFQ')",
+    ],
+)
+def read_diann(
+    path: PathLike,
+    *,
+    quant_col: str = "PG.MaxLFQ",
+    protein_col: str = "Protein.Group",
+    sample_col: str = "File.Name",
+) -> "AnnData":
+    """Load a DIA-NN report into AnnData."""
+    _require_anndata()
+    df = pd.read_csv(path, sep="\t", low_memory=False)
+
+    # Long vs wide detection: pg_matrix is wide (one column per sample).
+    if {protein_col, quant_col, sample_col}.issubset(df.columns):
+        wide = df.pivot_table(
+            index=protein_col, columns=sample_col, values=quant_col,
+            aggfunc="first",
+        )
+        protein_ids = wide.index.astype(str)
+        sample_names = wide.columns.astype(str)
+        X = wide.to_numpy(dtype=float).T
+        var_cols = {"Protein_Group": protein_ids.values}
+    else:
+        # Wide pg_matrix: protein ID(s) in first ~5 columns, then sample columns.
+        meta_cols = [c for c in df.columns
+                     if c in ("Protein.Group", "Protein.Ids", "Protein.Names",
+                              "Genes", "First.Protein.Description")]
+        sample_cols = [c for c in df.columns if c not in meta_cols]
+        if not sample_cols:
+            raise ValueError(
+                f"Could not determine sample columns in {path}; "
+                f"columns={list(df.columns)[:10]}…"
+            )
+        protein_ids = df.get("Protein.Group", df[meta_cols[0]]).astype(str).values
+        X = df[sample_cols].to_numpy(dtype=float).T
+        sample_names = sample_cols
+        var_cols = {"Protein_Group": protein_ids}
+        if "Genes" in df.columns:
+            var_cols["Gene_names"] = df["Genes"].astype(str).values
+        if "First.Protein.Description" in df.columns:
+            var_cols["protein_desc"] = df["First.Protein.Description"].astype(str).values
+
+    # DIA-NN already drops 0s but emit NaN-safe just in case.
+    X[X == 0] = np.nan
+
+    var_index = (
+        var_cols.get("Gene_names")
+        if "Gene_names" in var_cols
+        else var_cols["Protein_Group"]
+    )
+    var_index = pd.Index(pd.Series(var_index).astype(str))
+    if var_index.duplicated().any():
+        seen: dict[str, int] = {}
+        new = []
+        for v in var_index:
+            seen[v] = seen.get(v, 0) + 1
+            new.append(f"{v}_{seen[v]}" if seen[v] > 1 else v)
+        var_index = pd.Index(new)
+    var = pd.DataFrame(var_cols, index=var_index)
+    obs = pd.DataFrame(index=pd.Index([str(s) for s in sample_names], name="sample"))
+    adata = AnnData(X=X, obs=obs, var=var)
+    adata.uns["source"] = "DIA-NN"
+    adata.uns["source_path"] = str(path)
+    return adata
+
+
+# --------------------------------------------------------------------------- #
+# FragPipe                                                                    #
+# --------------------------------------------------------------------------- #
+
+@register_function(
+    aliases=["read_fragpipe", "fragpipe", "MSFragger"],
+    category="io",
+    description=(
+        "Read a FragPipe ``combined_protein.tsv`` into an AnnData "
+        "(samples × proteins). Intensity columns are taken from "
+        "``<sample> Intensity`` by default."
+    ),
+    produces={"obs": ["sample"], "var": ["Protein", "Gene", "Combined.Total.Peptides"]},
+    auto_fix="none",
+    examples=["adata = ov.protein.read_fragpipe('combined_protein.tsv')"],
+)
+def read_fragpipe(
+    path: PathLike,
+    *,
+    sample_pattern: str = r"(.+) Intensity",
+) -> "AnnData":
+    """Load FragPipe ``combined_protein.tsv`` into AnnData."""
+    _require_anndata()
+    df = pd.read_csv(path, sep="\t", low_memory=False)
+    cols, sample_names = _intensity_columns(df, sample_pattern)
+    if not cols:
+        raise ValueError(
+            f"No FragPipe Intensity columns match {sample_pattern!r}."
+        )
+    X = df[cols].to_numpy(dtype=float).T
+    X[X == 0] = np.nan
+    var_cols: dict[str, np.ndarray] = {}
+    for key in ("Protein", "Protein ID", "Entry Name", "Gene",
+                "Combined Total Peptides", "Description"):
+        if key in df.columns:
+            var_cols[key.replace(" ", "_")] = df[key].astype(str).values
+    var_index = (
+        var_cols.get("Gene") if "Gene" in var_cols else df.index.astype(str).values
+    )
+    var_index = pd.Index(pd.Series(var_index).astype(str))
+    var = pd.DataFrame(var_cols, index=var_index)
+    obs = pd.DataFrame(index=pd.Index(sample_names, name="sample"))
+    adata = AnnData(X=X, obs=obs, var=var)
+    adata.uns["source"] = "FragPipe"
+    adata.uns["source_path"] = str(path)
+    return adata
+
+
+# --------------------------------------------------------------------------- #
+# Olink NPX (long-format TSV / CSV)                                           #
+# --------------------------------------------------------------------------- #
+
+@register_function(
+    aliases=["read_olink_npx", "olink", "NPX"],
+    category="io",
+    description=(
+        "Read an Olink NPX TSV / CSV (long-format with columns "
+        "``SampleID``, ``OlinkID`` (or ``Assay``), ``NPX``) into an "
+        "AnnData (samples × proteins). NPX values are kept on the "
+        "original log2 scale; no further transform needed."
+    ),
+    produces={"obs": ["sample"], "var": ["OlinkID", "Assay", "Panel", "UniProt"]},
+    auto_fix="none",
+    examples=[
+        "adata = ov.protein.read_olink_npx('olink_npx.csv')",
+    ],
+)
+def read_olink_npx(
+    path: PathLike,
+    *,
+    sample_col: str = "SampleID",
+    protein_col: str = "OlinkID",
+    value_col: str = "NPX",
+    sep: Optional[str] = None,
+) -> "AnnData":
+    """Load Olink long-format NPX file into AnnData."""
+    _require_anndata()
+    sep = sep or ("\t" if str(path).lower().endswith(".tsv") else ",")
+    df = pd.read_csv(path, sep=sep, low_memory=False)
+
+    if protein_col not in df.columns and "Assay" in df.columns:
+        protein_col = "Assay"
+    for c in (sample_col, protein_col, value_col):
+        if c not in df.columns:
+            raise ValueError(
+                f"Column {c!r} missing from {path}. Found: {list(df.columns)[:10]}…"
+            )
+
+    wide = df.pivot_table(
+        index=sample_col, columns=protein_col, values=value_col,
+        aggfunc="mean",
+    )
+    X = wide.to_numpy(dtype=float)
+
+    # Per-protein metadata: take the first non-null row per protein.
+    var_keys = [c for c in ("Assay", "UniProt", "Panel", "LOD", "OlinkID")
+                if c in df.columns]
+    var = (
+        df.drop_duplicates(subset=protein_col)
+          .set_index(protein_col)[var_keys]
+          .reindex(wide.columns)
+    )
+    var.index = pd.Index(var.index.astype(str), name="protein")
+    obs = pd.DataFrame(index=pd.Index(wide.index.astype(str), name="sample"))
+    adata = AnnData(X=X, obs=obs, var=var)
+    adata.uns["source"] = "Olink_NPX"
+    adata.uns["source_path"] = str(path)
+    return adata
+
+
+# --------------------------------------------------------------------------- #
+# Generic wide-table reader                                                   #
+# --------------------------------------------------------------------------- #
+
+@register_function(
+    aliases=["read_wide", "protein_read_wide"],
+    category="io",
+    description=(
+        "Read a generic wide protein × sample TSV / CSV into AnnData. "
+        "Use this for already-processed matrices (e.g. supplementary "
+        "tables) that don't come from a known vendor format."
+    ),
+    auto_fix="none",
+    examples=["adata = ov.protein.read_wide('matrix.tsv', protein_col='gene')"],
+)
+def read_wide(
+    path: PathLike,
+    *,
+    protein_col: Optional[str] = None,
+    sep: Optional[str] = None,
+    na_values: Optional[list[str]] = None,
+) -> "AnnData":
+    """Generic protein × sample table → AnnData (samples × proteins)."""
+    _require_anndata()
+    sep = sep or ("\t" if str(path).lower().endswith((".tsv", ".txt")) else ",")
+    df = pd.read_csv(path, sep=sep, na_values=na_values or ["NA", ""])
+    if protein_col is None:
+        # Assume first column holds protein IDs.
+        protein_col = df.columns[0]
+    df = df.set_index(protein_col)
+    X = df.to_numpy(dtype=float).T  # samples × proteins
+    obs = pd.DataFrame(index=pd.Index(df.columns.astype(str), name="sample"))
+    var = pd.DataFrame(index=pd.Index(df.index.astype(str), name="protein"))
+    adata = AnnData(X=X, obs=obs, var=var)
+    adata.uns["source"] = "wide_table"
+    adata.uns["source_path"] = str(path)
+    return adata

--- a/omicverse/protein/plotting.py
+++ b/omicverse/protein/plotting.py
@@ -1,0 +1,185 @@
+"""Minimal plotting for ``ov.protein``.
+
+Three convenience plots:
+
+* :func:`volcano` — log2FC × -log10(adj.P) scatter for a DE result.
+* :func:`missing_pattern_plot` — heatmap of per-protein × per-sample
+  missingness (white = observed, dark = missing).
+* :func:`abundance_rank_plot` — per-sample rank-vs-intensity diagnostic
+  (mirrors the MaxQuant ``QC_plot``).
+"""
+from __future__ import annotations
+
+from typing import Optional, Sequence
+
+import numpy as np
+import pandas as pd
+
+from .._registry import register_function
+
+
+@register_function(
+    aliases=["protein_volcano", "volcano", "蛋白火山图"],
+    category="visualization",
+    description=(
+        "Volcano plot for a DE result table from ``ov.protein.de``. "
+        "Highlights proteins passing ``adj_p_threshold`` (FDR) and "
+        "``logfc_threshold`` (absolute log2FC). Returns the matplotlib "
+        "axes for further annotation."
+    ),
+    examples=[
+        "ov.protein.volcano(res, fc_col='logFC', p_col='adj.P.Val')",
+    ],
+)
+def volcano(
+    de_table: pd.DataFrame,
+    *,
+    fc_col: str = "logFC",
+    p_col: str = "adj.P.Val",
+    raw_p_col: str = "P.Value",
+    logfc_threshold: float = 1.0,
+    adj_p_threshold: float = 0.05,
+    label_top: int = 10,
+    gene_col: str = "gene",
+    ax: Optional["matplotlib.axes.Axes"] = None,
+    figsize: tuple[float, float] = (5.0, 4.5),
+    s: float = 8.0,
+    up_color: str = "#d62728",
+    down_color: str = "#1f77b4",
+    nochange_color: str = "#cccccc",
+    title: Optional[str] = None,
+):
+    """Standard volcano: x = logFC, y = -log10(p). Highlights significant proteins."""
+    import matplotlib.pyplot as plt
+
+    if ax is None:
+        _, ax = plt.subplots(figsize=figsize)
+
+    df = de_table.copy()
+    pcol_used = p_col if p_col in df.columns else raw_p_col
+    p = df[pcol_used].to_numpy(dtype=float)
+    fc = df[fc_col].to_numpy(dtype=float)
+    valid = np.isfinite(p) & np.isfinite(fc)
+    df = df.loc[valid].reset_index(drop=True)
+    p = p[valid]; fc = fc[valid]
+    nlogp = -np.log10(np.clip(p, 1e-300, 1.0))
+
+    up_mask = (fc >= logfc_threshold) & (p <= adj_p_threshold)
+    down_mask = (fc <= -logfc_threshold) & (p <= adj_p_threshold)
+    other_mask = ~(up_mask | down_mask)
+
+    ax.scatter(fc[other_mask], nlogp[other_mask], s=s, c=nochange_color,
+               edgecolor="none", alpha=0.7, label=None)
+    ax.scatter(fc[up_mask], nlogp[up_mask], s=s, c=up_color,
+               edgecolor="none", alpha=0.9,
+               label=f"Up ({int(up_mask.sum())})")
+    ax.scatter(fc[down_mask], nlogp[down_mask], s=s, c=down_color,
+               edgecolor="none", alpha=0.9,
+               label=f"Down ({int(down_mask.sum())})")
+
+    ax.axhline(-np.log10(adj_p_threshold), color="black", lw=0.6, ls="--")
+    ax.axvline(logfc_threshold, color="black", lw=0.6, ls="--")
+    ax.axvline(-logfc_threshold, color="black", lw=0.6, ls="--")
+
+    ax.set_xlabel(fc_col)
+    ax.set_ylabel(f"-log10({pcol_used})")
+    ax.legend(loc="best", fontsize=8, frameon=False)
+    if title:
+        ax.set_title(title)
+
+    if label_top and gene_col in df.columns:
+        # Label top-N most-significant proteins among the highlighted set.
+        sig_idx = np.where(up_mask | down_mask)[0]
+        if sig_idx.size:
+            top = sig_idx[np.argsort(p[sig_idx])][:label_top]
+            for i in top:
+                ax.annotate(
+                    str(df[gene_col].iloc[i]),
+                    (fc[i], nlogp[i]),
+                    fontsize=7, alpha=0.85,
+                    xytext=(3, 3), textcoords="offset points",
+                )
+
+    return ax
+
+
+@register_function(
+    aliases=["protein_missing_pattern_plot", "missing_pattern_plot"],
+    category="visualization",
+    description=(
+        "Heatmap of the proteomics missingness pattern. Rows are "
+        "proteins (sorted by overall missingness), columns are samples. "
+        "Useful for diagnosing MNAR vs MCAR before imputation."
+    ),
+    examples=["ov.protein.missing_pattern_plot(adata)"],
+)
+def missing_pattern_plot(
+    adata,
+    *,
+    ax: Optional["matplotlib.axes.Axes"] = None,
+    figsize: tuple[float, float] = (8.0, 5.0),
+    cmap: str = "Greys",
+    max_proteins: int = 1000,
+):
+    """Heatmap of per-protein × per-sample missingness — diagnose MNAR vs MCAR."""
+    import matplotlib.pyplot as plt
+    miss = np.isnan(adata.X).T.astype(float)  # proteins × samples
+    order = np.argsort(-miss.mean(axis=1))
+    miss = miss[order][:max_proteins]
+    if ax is None:
+        _, ax = plt.subplots(figsize=figsize)
+    im = ax.imshow(miss, aspect="auto", cmap=cmap, interpolation="nearest")
+    ax.set_xlabel("samples"); ax.set_ylabel(f"proteins (top {max_proteins} missing)")
+    ax.set_xticks(np.arange(adata.n_obs))
+    ax.set_xticklabels(adata.obs_names, rotation=90, fontsize=6)
+    ax.set_yticks([])
+    plt.colorbar(im, ax=ax, label="missing")
+    return ax
+
+
+@register_function(
+    aliases=["protein_abundance_rank_plot", "abundance_rank_plot"],
+    category="visualization",
+    description=(
+        "Per-sample rank-vs-log-intensity diagnostic — one line per "
+        "sample, sorted by descending abundance. Use to spot under-/"
+        "over-loaded samples before normalization."
+    ),
+    examples=["ov.protein.abundance_rank_plot(adata)"],
+)
+def abundance_rank_plot(
+    adata,
+    *,
+    ax: Optional["matplotlib.axes.Axes"] = None,
+    figsize: tuple[float, float] = (6.0, 4.0),
+    log: bool = True,
+    color_by: Optional[str] = None,
+):
+    """Per-sample rank-vs-log-intensity diagnostic; spots under/over-loaded samples."""
+    import matplotlib.pyplot as plt
+    X = adata.X.astype(float)
+    if log:
+        X = np.log2(np.where(X > 0, X, np.nan))
+    if ax is None:
+        _, ax = plt.subplots(figsize=figsize)
+    palette = None
+    if color_by and color_by in adata.obs.columns:
+        groups = adata.obs[color_by].astype(str)
+        unique = pd.unique(groups)
+        palette = {g: c for g, c in zip(
+            unique, plt.cm.tab10.colors[: len(unique)]  # type: ignore[attr-defined]
+        )}
+    for i, sample in enumerate(adata.obs_names):
+        row = X[i]
+        row = row[~np.isnan(row)]
+        row = np.sort(row)[::-1]
+        if row.size == 0:
+            continue
+        color = palette[str(adata.obs[color_by].iloc[i])] if palette else None
+        ax.plot(np.arange(row.size), row, lw=0.6, alpha=0.7,
+                color=color, label=sample if not palette else None)
+    ax.set_xlabel("rank (sorted high → low)")
+    ax.set_ylabel("log2 intensity" if log else "intensity")
+    if not palette and adata.n_obs <= 20:
+        ax.legend(fontsize=6, ncol=2)
+    return ax

--- a/omicverse/protein/plotting.py
+++ b/omicverse/protein/plotting.py
@@ -1,12 +1,15 @@
-"""Minimal plotting for ``ov.protein``.
+"""Plotting for ``ov.protein``.
 
-Three convenience plots:
+Diagnostic + result plots for the bulk-proteomics workflow:
 
 * :func:`volcano` — log2FC × -log10(adj.P) scatter for a DE result.
 * :func:`missing_pattern_plot` — heatmap of per-protein × per-sample
   missingness (white = observed, dark = missing).
 * :func:`abundance_rank_plot` — per-sample rank-vs-intensity diagnostic
   (mirrors the MaxQuant ``QC_plot``).
+* :func:`pca_plot` — sample PCA scatter, coloured by a metadata column.
+* :func:`heatmap` — z-scored expression heatmap of the top DE proteins.
+* :func:`boxplot` — per-sample intensity boxplots (normalization QC).
 """
 from __future__ import annotations
 
@@ -182,4 +185,175 @@ def abundance_rank_plot(
     ax.set_ylabel("log2 intensity" if log else "intensity")
     if not palette and adata.n_obs <= 20:
         ax.legend(fontsize=6, ncol=2)
+    return ax
+
+
+@register_function(
+    aliases=["protein_pca_plot", "pca_plot", "蛋白PCA图"],
+    category="visualization",
+    description=(
+        "Sample-level PCA scatter for a proteomics AnnData — points are "
+        "samples, coloured by an ``adata.obs`` column. Use it as a QC "
+        "step after normalization / imputation to spot batch effects "
+        "and outlier samples and to confirm the groups separate."
+    ),
+    examples=["ov.protein.pca_plot(adata, color='group')"],
+)
+def pca_plot(
+    adata,
+    *,
+    color: Optional[str] = None,
+    n_comps: int = 2,
+    ax: Optional["matplotlib.axes.Axes"] = None,
+    figsize: tuple[float, float] = (4.8, 4.2),
+    s: float = 60.0,
+    label_samples: bool = False,
+):
+    """PCA of samples (rows of ``adata.X``); colour by ``adata.obs[color]``."""
+    import matplotlib.pyplot as plt
+    from sklearn.decomposition import PCA
+
+    X = adata.X.astype(float)
+    # PCA needs complete data — mean-impute any residual NaNs for the projection.
+    if np.isnan(X).any():
+        col_mean = np.nanmean(X, axis=0, keepdims=True)
+        X = np.where(np.isnan(X), col_mean, X)
+    X = X - X.mean(axis=0, keepdims=True)
+    pca = PCA(n_components=min(n_comps, *X.shape))
+    scores = pca.fit_transform(X)
+    var = pca.explained_variance_ratio_ * 100.0
+
+    if ax is None:
+        _, ax = plt.subplots(figsize=figsize)
+    if color and color in adata.obs.columns:
+        groups = adata.obs[color].astype(str)
+        for g in pd.unique(groups):
+            m = (groups == g).to_numpy()
+            ax.scatter(scores[m, 0], scores[m, 1], s=s, label=str(g),
+                       edgecolor="white", linewidth=0.5, alpha=0.9)
+        ax.legend(title=color, fontsize=8, frameon=False)
+    else:
+        ax.scatter(scores[:, 0], scores[:, 1], s=s,
+                   edgecolor="white", linewidth=0.5, alpha=0.9)
+    if label_samples:
+        for i, name in enumerate(adata.obs_names):
+            ax.annotate(str(name), (scores[i, 0], scores[i, 1]),
+                        fontsize=6, xytext=(3, 3), textcoords="offset points")
+    ax.set_xlabel(f"PC1 ({var[0]:.1f}%)")
+    ax.set_ylabel(f"PC2 ({var[1]:.1f}%)" if var.size > 1 else "PC2")
+    ax.set_title("Sample PCA")
+    ax.axhline(0, color="grey", lw=0.5, ls="--")
+    ax.axvline(0, color="grey", lw=0.5, ls="--")
+    return ax
+
+
+@register_function(
+    aliases=["protein_heatmap", "heatmap", "蛋白热图"],
+    category="visualization",
+    description=(
+        "Z-scored expression heatmap of the top differentially-expressed "
+        "proteins. Rows = proteins (top ``n_top`` by ascending p-value "
+        "from an ``ov.protein.de`` result), columns = samples grouped / "
+        "annotated by ``group``. Each row is z-scored across samples."
+    ),
+    examples=[
+        "ov.protein.heatmap(adata, de_table=res, group='group', n_top=40)",
+    ],
+)
+def heatmap(
+    adata,
+    de_table: pd.DataFrame,
+    *,
+    group: Optional[str] = None,
+    n_top: int = 40,
+    gene_col: str = "gene",
+    p_col: str = "adj.P.Val",
+    ax: Optional["matplotlib.axes.Axes"] = None,
+    figsize: tuple[float, float] = (7.0, 8.0),
+    cmap: str = "RdBu_r",
+):
+    """Z-scored heatmap of the top-``n_top`` DE proteins across samples."""
+    import matplotlib.pyplot as plt
+
+    ranked = de_table.sort_values(p_col) if p_col in de_table.columns else de_table
+    top_genes = [g for g in ranked[gene_col].astype(str).tolist()
+                 if g in set(adata.var_names.astype(str))][:n_top]
+    if not top_genes:
+        raise ValueError("none of the DE-table genes are in adata.var_names")
+
+    sub = adata[:, top_genes]
+    M = sub.X.astype(float).T  # proteins × samples
+    # Per-protein z-score across samples.
+    mu = np.nanmean(M, axis=1, keepdims=True)
+    sd = np.nanstd(M, axis=1, keepdims=True)
+    Z = (M - mu) / np.where(sd == 0, 1.0, sd)
+
+    # Order samples by group for a block-structured heatmap.
+    sample_order = np.arange(adata.n_obs)
+    col_labels = list(adata.obs_names.astype(str))
+    if group and group in adata.obs.columns:
+        g = adata.obs[group].astype(str).to_numpy()
+        sample_order = np.argsort(g, kind="stable")
+        Z = Z[:, sample_order]
+        col_labels = [f"{adata.obs_names[i]}" for i in sample_order]
+        group_sorted = g[sample_order]
+    else:
+        group_sorted = None
+
+    if ax is None:
+        _, ax = plt.subplots(figsize=figsize)
+    vmax = float(np.nanpercentile(np.abs(Z), 98)) or 1.0
+    im = ax.imshow(Z, aspect="auto", cmap=cmap, vmin=-vmax, vmax=vmax,
+                   interpolation="nearest")
+    ax.set_yticks(np.arange(len(top_genes)))
+    ax.set_yticklabels(top_genes, fontsize=6)
+    ax.set_xticks(np.arange(len(col_labels)))
+    ax.set_xticklabels(col_labels, rotation=90, fontsize=6)
+    # Group separators.
+    if group_sorted is not None:
+        bounds = np.where(group_sorted[:-1] != group_sorted[1:])[0] + 0.5
+        for b in bounds:
+            ax.axvline(b, color="black", lw=1.0)
+    ax.set_title(f"Top {len(top_genes)} DE proteins (z-scored)")
+    plt.colorbar(im, ax=ax, label="z-score", fraction=0.03, pad=0.02)
+    return ax
+
+
+@register_function(
+    aliases=["protein_boxplot", "boxplot"],
+    category="visualization",
+    description=(
+        "Per-sample intensity boxplots — a normalization QC plot. Run it "
+        "before and after ``ov.protein.normalize`` to confirm the "
+        "sample medians have been equalised."
+    ),
+    examples=["ov.protein.boxplot(adata, color_by='group')"],
+)
+def boxplot(
+    adata,
+    *,
+    color_by: Optional[str] = None,
+    ax: Optional["matplotlib.axes.Axes"] = None,
+    figsize: tuple[float, float] = (7.0, 3.6),
+):
+    """Per-sample intensity boxplots (normalization QC)."""
+    import matplotlib.pyplot as plt
+
+    X = adata.X.astype(float)
+    data = [row[~np.isnan(row)] for row in X]
+    if ax is None:
+        _, ax = plt.subplots(figsize=figsize)
+    bp = ax.boxplot(data, showfliers=False, patch_artist=True,
+                    medianprops=dict(color="black"))
+    if color_by and color_by in adata.obs.columns:
+        groups = adata.obs[color_by].astype(str)
+        uniq = list(pd.unique(groups))
+        palette = {g: c for g, c in zip(uniq, plt.cm.tab10.colors)}  # type: ignore[attr-defined]
+        for patch, samp in zip(bp["boxes"], adata.obs_names):
+            patch.set_facecolor(palette[str(adata.obs[color_by].loc[samp])])
+            patch.set_alpha(0.7)
+    ax.set_xticks(np.arange(1, adata.n_obs + 1))
+    ax.set_xticklabels(adata.obs_names, rotation=90, fontsize=6)
+    ax.set_ylabel("intensity")
+    ax.set_title("Per-sample intensity distribution")
     return ax

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -181,6 +181,23 @@ mcp = [
   "mcp>=1.0; python_version >= '3.10'",
 ]
 
+# Proteomics backends for ``ov.protein`` — pure-Python ports of the
+# canonical Bioconductor / CRAN proteomics R packages. Install via:
+#   pip install omicverse[protein]
+# Enables the full bulk LC-MS/MS + Olink workflow: imputation
+# (imputeLCMD), peptide-count-aware DE (DEqMS), MNAR probabilistic DE
+# (proDA), DDA/DIA pipeline (MSstats), and Olink NPX analysis
+# (OlinkAnalyze).
+protein = [
+  "pyimputelcmd>=0.1.1",   # Bioconductor imputeLCMD — left-censored imputation
+  "pydeqms>=0.1.1",        # Bioconductor DEqMS — peptide-count moderated t
+  "pyproda>=0.1.1",        # Bioconductor proDA — MNAR probabilistic DE
+  "pymsstats>=0.3.0",      # Bioconductor MSstats — DDA/DIA pipeline
+  "pyolinkanalyze>=0.2.1", # CRAN OlinkAnalyze — Olink NPX analysis
+  "scikit-misc>=0.3",      # R-faithful loess (DEqMS variance prior)
+  "statsmodels>=0.14",     # LMM / ANOVA / ordinal regression backends
+]
+
 
 [project.urls]
 Github = 'https://github.com/Starlitnightly/omicverse'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,6 +175,14 @@ tests = [
   "scikit-bio>=0.6",
   "ete3",
   "pydeseq2>=0.4.1",
+  # ov.protein test dependencies — the standalone proteomics backends
+  # exercised by tests/test_protein.py.
+  "pyimputelcmd>=0.1.1",
+  "pydeqms>=0.1.1",
+  "pyproda>=0.1.1",
+  "pymsstats>=0.3.0",
+  "pyolinkanalyze>=0.2.1",
+  "scikit-misc>=0.3",
 ]
 
 mcp = [

--- a/tests/test_protein.py
+++ b/tests/test_protein.py
@@ -1,0 +1,327 @@
+"""Integration tests for the ``ov.protein`` module.
+
+Covers:
+- Lazy import + module surface (read_*, qc_filter, normalize, impute, de, enrich, volcano)
+- Synthetic MaxQuant-like AnnData → full pipeline (qc → normalize → impute → de)
+- Each ``de(method=...)`` branch runs (deqms / limma / wilcoxon / welch_t)
+- Each ``impute(method=...)`` branch runs (mindet / minprob / qrilc / half_min / zero)
+- @register_function metadata visible in ov.find_function / list_functions
+
+These are smoke tests that don't require R — algorithmic correctness is
+covered by the standalone py-imputeLCMD / py-DEqMS test suites.
+"""
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+import pandas as pd
+import pytest
+
+# Quiet expected DeqMS / scipy warnings during synthetic test runs.
+warnings.filterwarnings("ignore", category=DeprecationWarning)
+warnings.filterwarnings("ignore", category=RuntimeWarning)
+
+
+def _make_anndata(seed: int = 0, n_proteins: int = 200, n_per_group: int = 6):
+    """Synthetic 12-sample LFQ-style AnnData with NaN dropouts and DE."""
+    from anndata import AnnData
+
+    rng = np.random.default_rng(seed)
+    n_samples = 2 * n_per_group
+    base = rng.normal(20.0, 1.5, n_proteins)
+    count = rng.integers(1, 20, n_proteins).astype(float)
+    sigma = 0.5 + 0.5 / np.sqrt(count)
+    is_de = rng.uniform(size=n_proteins) < 0.15
+    delta = np.where(is_de, rng.choice([-1, 1], n_proteins) * 1.0, 0.0)
+
+    X = np.zeros((n_samples, n_proteins))  # samples × proteins
+    for g in [0, 1]:
+        mu = base + (delta if g else 0)
+        X[g * n_per_group:(g + 1) * n_per_group, :] = (
+            rng.normal(mu[None, :], sigma[None, :], (n_per_group, n_proteins))
+        )
+    X = 2.0 ** X  # raw intensities
+    # Inject ~10% MNAR missingness at low intensities.
+    threshold = np.quantile(X, 0.10)
+    p_miss = np.exp(-(X / threshold) ** 2)
+    X[rng.uniform(size=X.shape) < p_miss * 0.5] = np.nan
+    X[X < threshold * 0.5] = np.nan
+
+    obs = pd.DataFrame({
+        "group": ["control"] * n_per_group + ["treated"] * n_per_group,
+    }, index=[f"S{i:02d}" for i in range(n_samples)])
+    var = pd.DataFrame({
+        "peptides":   count,
+        "Gene_names": [f"gene_{i:04d}" for i in range(n_proteins)],
+        "is_de_true": is_de,
+    }, index=[f"prot_{i:04d}" for i in range(n_proteins)])
+    return AnnData(X=X, obs=obs, var=var)
+
+
+# --------------------------------------------------------------------------- #
+# Module surface                                                              #
+# --------------------------------------------------------------------------- #
+
+def test_module_loads_and_exposes_public_api():
+    import omicverse as ov
+    p = ov.protein
+    for sym in (
+        "read_maxquant", "read_diann", "read_fragpipe", "read_olink_npx",
+        "read_wide", "qc_filter", "normalize", "impute", "de", "enrich",
+        "volcano", "missing_pattern_plot", "abundance_rank_plot",
+    ):
+        assert hasattr(p, sym), f"ov.protein.{sym} missing"
+
+
+def test_registry_sees_protein_module():
+    from omicverse._registry import get_registry
+    import omicverse.protein as _p
+    _p._hydrate_registry()
+    reg = get_registry()
+    keys = [e for e in reg._registry.values()
+            if "omicverse.protein" in str(e.get("module", ""))]
+    assert len(keys) > 0, "no ov.protein functions registered"
+
+
+# --------------------------------------------------------------------------- #
+# Pipeline                                                                    #
+# --------------------------------------------------------------------------- #
+
+def test_full_pipeline_qc_normalize_impute_de_deqms():
+    import omicverse as ov
+    adata = _make_anndata(seed=0)
+    # qc_filter (drops low-peptide proteins).
+    ov.protein.qc_filter(adata, min_peptides=2, min_valid=0.3)
+    assert adata.n_vars > 0
+    assert "n_valid_proteins" in adata.obs.columns
+    # normalize (log2 + median centering).
+    ov.protein.normalize(adata, method="median", log2=True)
+    assert "raw" in adata.layers
+    assert "log2" in adata.layers
+    # impute (QRILC).
+    ov.protein.impute(adata, method="qrilc", seed=0)
+    assert not np.isnan(adata.X).any()
+    # DE via DEqMS.
+    res = ov.protein.de(adata, group="group", method="deqms",
+                        count_var="peptides")
+    assert {"gene", "logFC", "P.Value", "adj.P.Val"}.issubset(res.columns)
+    assert res["P.Value"].notna().sum() > 0
+
+
+@pytest.mark.parametrize("imp_method", ["mindet", "minprob", "qrilc",
+                                          "half_min", "min", "zero",
+                                          "knn", "mle", "svd",
+                                          "mar", "mar_mnar", "auto"])
+def test_impute_dispatch_each_method(imp_method):
+    import omicverse as ov
+    adata = _make_anndata(seed=1)
+    ov.protein.qc_filter(adata, min_peptides=2, min_valid=0.3)
+    ov.protein.normalize(adata, method="median", log2=True)
+    ov.protein.impute(adata, method=imp_method, seed=0)
+    assert not np.isnan(adata.X).any()
+
+
+def test_model_selector_classifies_proteins():
+    import omicverse as ov
+    adata = _make_anndata(seed=11)
+    ov.protein.qc_filter(adata, min_peptides=2, min_valid=0.3)
+    ov.protein.normalize(adata, method="median", log2=True)
+    mask, thr = ov.protein.model_selector(adata)
+    assert mask.shape == (adata.n_vars,)
+    assert mask.dtype == bool
+    assert "is_mcar" in adata.var.columns
+    assert np.isfinite(thr)
+
+
+def test_normalize_equalize_medians():
+    import omicverse as ov
+    adata = _make_anndata(seed=12)
+    ov.protein.qc_filter(adata, min_peptides=2, min_valid=0.3)
+    ov.protein.normalize(adata, method="equalize_medians", log2=True)
+    # After column-median equalisation, per-sample medians ~equal.
+    medians = np.nanmedian(adata.X, axis=1)
+    assert np.std(medians) < 0.1
+
+
+def test_summarize_peptide_to_protein():
+    """Peptide-level AnnData → protein-level AnnData via each method."""
+    import omicverse as ov
+    from anndata import AnnData
+    rng = np.random.default_rng(20)
+    n_proteins, n_pep_each, n_samples = 40, 3, 8
+    n_peptides = n_proteins * n_pep_each
+    # Build peptide-level matrix.
+    base = rng.normal(20.0, 1.0, n_proteins)
+    X = np.zeros((n_samples, n_peptides))
+    protein_of = []
+    for p in range(n_proteins):
+        for k in range(n_pep_each):
+            col = p * n_pep_each + k
+            X[:, col] = 2.0 ** rng.normal(base[p] + rng.normal(0, 0.3), 0.3, n_samples)
+            protein_of.append(f"prot_{p:03d}")
+    obs = pd.DataFrame({"group": ["A"] * 4 + ["B"] * 4},
+                       index=[f"S{i}" for i in range(n_samples)])
+    var = pd.DataFrame({"Protein": protein_of},
+                       index=[f"pep_{i:04d}" for i in range(n_peptides)])
+    pep_adata = AnnData(X=X, obs=obs, var=var)
+    for method in ["median", "median_sweeping", "medpolish", "tmp", "linear"]:
+        prot = ov.protein.summarize(pep_adata, protein_col="Protein",
+                                    method=method)
+        assert prot.n_vars == n_proteins, f"{method}: wrong protein count"
+        assert prot.n_obs == n_samples
+        assert list(prot.obs["group"]) == list(pep_adata.obs["group"])
+
+
+def test_contrast_matrix():
+    import omicverse as ov
+    C = ov.protein.contrast_matrix("treated-control", ["control", "treated"])
+    # treated - control → [-1, +1] on [control, treated].
+    arr = C.to_numpy() if hasattr(C, "to_numpy") else np.asarray(C)
+    assert arr.shape[1] == 2
+    row = arr[0]
+    assert row[0] == -1 and row[1] == 1
+
+
+def test_sample_size_runs():
+    import omicverse as ov
+    adata = _make_anndata(seed=21, n_proteins=120, n_per_group=6)
+    ov.protein.qc_filter(adata, min_peptides=2, min_valid=0.4)
+    ov.protein.normalize(adata, method="median", log2=True)
+    ov.protein.impute(adata, method="qrilc", seed=0)
+    tbl = ov.protein.sample_size(adata, group="group",
+                                 desired_fc=(1.5, 2.0))
+    assert len(tbl) >= 1
+
+
+def test_impute_invalid_method_raises():
+    import omicverse as ov
+    adata = _make_anndata(seed=2)
+    with pytest.raises(ValueError, match="method must be one of"):
+        ov.protein.impute(adata, method="nope")
+
+
+@pytest.mark.parametrize("de_method", ["deqms", "limma", "wilcoxon", "welch_t"])
+def test_de_dispatch_each_method(de_method):
+    import omicverse as ov
+    adata = _make_anndata(seed=3)
+    ov.protein.qc_filter(adata, min_peptides=2, min_valid=0.3)
+    ov.protein.normalize(adata, method="median", log2=True)
+    ov.protein.impute(adata, method="qrilc", seed=0)
+    res = ov.protein.de(adata, group="group", method=de_method,
+                        count_var="peptides")
+    assert {"gene", "logFC", "P.Value", "adj.P.Val"}.issubset(res.columns)
+    assert len(res) > 0
+
+
+@pytest.mark.parametrize("mg_method", ["anova", "kruskal"])
+def test_de_multigroup(mg_method):
+    """Three-group omnibus tests run and return a sorted table."""
+    import omicverse as ov
+    from anndata import AnnData
+    rng = np.random.default_rng(30)
+    n_proteins, n_per = 100, 5
+    n_samples = n_per * 3
+    X = np.zeros((n_samples, n_proteins))
+    base = rng.normal(20.0, 1.0, n_proteins)
+    for g in range(3):
+        X[g * n_per:(g + 1) * n_per] = rng.normal(
+            base[None, :] + (g * 0.5), 0.4, (n_per, n_proteins),
+        )
+    obs = pd.DataFrame({"group": (["G0"] * n_per + ["G1"] * n_per
+                                  + ["G2"] * n_per)},
+                       index=[f"S{i}" for i in range(n_samples)])
+    adata = AnnData(X=X, obs=obs,
+                    var=pd.DataFrame(index=[f"p{i}" for i in range(n_proteins)]))
+    res = ov.protein.de(adata, group="group", method=mg_method)
+    assert {"gene", "P.Value", "adj.P.Val"}.issubset(res.columns)
+    assert len(res) == n_proteins
+    pv = res["P.Value"].dropna().to_numpy()
+    assert (np.diff(pv) >= -1e-9).all()
+
+
+def test_de_two_group_method_rejects_three_groups():
+    import omicverse as ov
+    from anndata import AnnData
+    rng = np.random.default_rng(31)
+    X = rng.normal(20, 1, (15, 50))
+    obs = pd.DataFrame({"group": ["A"] * 5 + ["B"] * 5 + ["C"] * 5},
+                       index=[f"S{i}" for i in range(15)])
+    adata = AnnData(X=X, obs=obs,
+                    var=pd.DataFrame(index=[f"p{i}" for i in range(50)]))
+    with pytest.raises(ValueError, match="two-group test"):
+        ov.protein.de(adata, group="group", method="welch_t")
+
+
+def test_de_recovers_planted_de_proteins():
+    """Top-N DE genes should overlap with the planted-true set."""
+    import omicverse as ov
+    adata = _make_anndata(seed=4, n_proteins=300, n_per_group=8)
+    ov.protein.qc_filter(adata, min_peptides=2, min_valid=0.4)
+    ov.protein.normalize(adata, method="median", log2=True)
+    ov.protein.impute(adata, method="qrilc", seed=0)
+    res = ov.protein.de(adata, group="group", method="deqms",
+                        count_var="peptides")
+    n_true = int(adata.var["is_de_true"].sum())
+    if n_true == 0:
+        pytest.skip("no DE proteins planted")
+    top = set(res["gene"].head(n_true).astype(str))
+    true_de_genes = set(adata.var.index[adata.var["is_de_true"]].astype(str))
+    overlap = len(top & true_de_genes) / max(n_true, 1)
+    assert overlap > 0.4, f"only {overlap:.1%} of top-{n_true} are true DE"
+
+
+def test_volcano_returns_axes_and_does_not_crash():
+    import matplotlib
+    matplotlib.use("Agg")
+    import omicverse as ov
+    adata = _make_anndata(seed=5)
+    ov.protein.qc_filter(adata, min_peptides=2, min_valid=0.3)
+    ov.protein.normalize(adata, method="median", log2=True)
+    ov.protein.impute(adata, method="qrilc", seed=0)
+    res = ov.protein.de(adata, group="group", method="limma")
+    ax = ov.protein.volcano(res, label_top=5)
+    assert ax is not None
+
+
+def test_missing_pattern_returns_stats():
+    import omicverse as ov
+    adata = _make_anndata(seed=6)
+    stats = ov.protein.missing_pattern(adata)
+    assert "protein_missing_frac" in stats
+    assert "sample_missing_frac" in stats
+    assert 0.0 <= stats["overall"] <= 1.0
+
+
+def test_normalize_quantile_method():
+    import omicverse as ov
+    adata = _make_anndata(seed=7)
+    ov.protein.qc_filter(adata, min_peptides=2, min_valid=0.3)
+    ov.protein.normalize(adata, method="quantile", log2=True)
+    # After quantile norm, per-sample row medians should be approximately equal.
+    medians = np.nanmedian(adata.X, axis=1)
+    assert np.std(medians) < 0.05
+
+
+def test_olink_npx_pipeline():
+    """Synthetic Olink NPX data goes through the no-log2 path."""
+    import omicverse as ov
+    from anndata import AnnData
+    rng = np.random.default_rng(8)
+    n_proteins = 50
+    n_samples = 16
+    base = rng.normal(0.0, 2.0, n_proteins)
+    delta = rng.choice([-1, 0, 1], n_proteins, p=[0.1, 0.8, 0.1]) * 1.0
+    X = np.zeros((n_samples, n_proteins))
+    for s in range(n_samples):
+        g = 0 if s < 8 else 1
+        X[s] = rng.normal(base + (delta if g else 0), 0.4)
+    obs = pd.DataFrame({"group": ["G0"] * 8 + ["G1"] * 8},
+                       index=[f"S{i:02d}" for i in range(n_samples)])
+    var = pd.DataFrame(index=[f"prot_{i:04d}" for i in range(n_proteins)])
+    adata = AnnData(X=X, obs=obs, var=var)
+    # Olink NPX is already log2 — skip log2 step.
+    ov.protein.normalize(adata, method="median", log2=False)
+    # Olink data doesn't need imputation (no NPX dropouts typically).
+    res = ov.protein.de(adata, group="group", method="welch_t")
+    assert len(res) == n_proteins

--- a/tests/test_protein.py
+++ b/tests/test_protein.py
@@ -12,6 +12,7 @@ covered by the standalone py-imputeLCMD / py-DEqMS test suites.
 """
 from __future__ import annotations
 
+import importlib.util
 import warnings
 
 import numpy as np
@@ -21,6 +22,18 @@ import pytest
 # Quiet expected DeqMS / scipy warnings during synthetic test runs.
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 warnings.filterwarnings("ignore", category=RuntimeWarning)
+
+# ov.protein dispatches to standalone backend packages (pyimputelcmd,
+# pydeqms, pyproda, pymsstats). They are the ``omicverse[protein]`` /
+# ``omicverse[tests]`` optional dependencies — skip this whole file
+# gracefully if they are not installed rather than erroring.
+_BACKENDS = ["pyimputelcmd", "pydeqms", "pyproda", "pymsstats"]
+_MISSING_BACKENDS = [m for m in _BACKENDS
+                     if importlib.util.find_spec(m) is None]
+pytestmark = pytest.mark.skipif(
+    bool(_MISSING_BACKENDS),
+    reason=f"ov.protein backend packages not installed: {_MISSING_BACKENDS}",
+)
 
 
 def _make_anndata(seed: int = 0, n_proteins: int = 200, n_per_group: int = 6):


### PR DESCRIPTION
## Summary

Adds **`ov.protein`** — an AnnData-native downstream framework for **bulk quantitative proteomics**: label-free LC-MS/MS (MaxQuant, DIA-NN, FragPipe) and affinity proteomics (Olink NPX). It mirrors the `ov.es` / `ov.metabol` dispatcher design — every stage is a single function with a `method=` selector.

Single-cell proteomics (SCP) and spatial proteomics (IMC/CODEX) are intentionally **out of scope**.

### `ov.protein` module surface

| Stage | Function | Methods |
|---|---|---|
| I/O | `read_maxquant` / `read_diann` / `read_fragpipe` / `read_olink_npx` / `read_wide` | — |
| Simulate | `simulate_lfq` | bulk / Olink / peptide-level |
| QC | `qc_filter`, `missing_pattern`, `model_selector` | MCAR/MNAR |
| Normalize | `normalize` | median, equalize_medians, quantile, log2 |
| Summarize | `summarize` | median, median_sweeping, medpolish, tmp, linear |
| Impute | `impute` | mindet, minprob, qrilc, zero, mle, knn, svd, mar, mar_mnar, auto, half_min, min |
| DE | `de` | deqms, limma, proda, wilcoxon, welch_t, olink_lmer, anova, kruskal |
| Design | `sample_size`, `contrast_matrix` | — |
| Enrich | `enrich` | forwards to `ov.es` kernels |
| Plot | `volcano`, `heatmap`, `pca_plot`, `boxplot`, `missing_pattern_plot`, `abundance_rank_plot` | — |

All entries `@register_function`-decorated — discoverable via `ov.find_function` (incl. Chinese aliases).

### Backend packages (PyPI)

The statistical engines are five **standalone, R-parity-tested** packages — pure-Python ports of the canonical Bioconductor / CRAN proteomics R packages, published to PyPI and wired in as the `protein` optional-dependency group (`pip install omicverse[protein]`):

| Package | Ports | Coverage |
|---|---|---|
| [`pyimputelcmd`](https://pypi.org/project/pyimputelcmd/) | Bioconductor imputeLCMD | 14/14 functions |
| [`pydeqms`](https://pypi.org/project/pydeqms/) | Bioconductor DEqMS | 10/10 functions |
| [`pyproda`](https://pypi.org/project/pyproda/) | Bioconductor proDA | 18/18 functions |
| [`pymsstats`](https://pypi.org/project/pymsstats/) | Bioconductor MSstats | 50/50 names |
| [`pyolinkanalyze`](https://pypi.org/project/pyolinkanalyze/) | CRAN OlinkAnalyze | full |

### Real datasets via `ov.datasets`

Five real published proteomics datasets, downloaded on demand from the `omicverse-data` GitHub release:

- `protein_pxd000022` / `protein_pxd000438` — ProteomeXchange label-free LC-MS/MS
- `protein_dda_spikein` / `protein_dia` — MSstats DDA / DIA spike-in
- `protein_olink` — OlinkAnalyze Olink Explore NPX

## Changes

- `omicverse/protein/` — new module (io, simulate, qc, norm, summarize, impute, design, de, enrich, plotting)
- `omicverse/datasets/_protein.py` — five real-dataset loaders
- `omicverse/__init__.py` / `_registry.py` — register `protein` module
- `pyproject.toml` — new `[project.optional-dependencies]` `protein` group
- `tests/test_protein.py` — 33 integration tests
- `omicverse_guide` submodule — new **Tutorials-protein** chapter: 5 comprehensive best-practice notebooks, each on a real published dataset (see omicverse/omicverse-tutorials#48)

## Test plan

- [x] `pytest tests/test_protein.py` — 33 passed
- [x] All 5 tutorial notebooks execute end-to-end (0 errors) on real data
- [x] `ov.find_function` discovers all `ov.protein` entries
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)