### PR TITLE
test(architecture): fix stale metacell fixtures breaking master CI

### DIFF
--- a/tests/architecture/test_lazy_backend_wiring.py
+++ b/tests/architecture/test_lazy_backend_wiring.py
@@ -37,7 +37,11 @@ def test_modified_backend_helpers_are_wired_to_call_sites():
     expected_helper_calls = {
         "omicverse/bulk/_Gene_module.py": {"_get_pywgcna_backend"},
         "omicverse/single/_cefcon.py": {"_get_cefcon_backend"},
-        "omicverse/single/_metacell.py": {"_get_seacells_backend"},
+        # NOTE: omicverse/single/_metacell.py was refactored into a backend
+        # dispatcher (PR #729). SEACells is now lazy-loaded inside
+        # _metacell_backends/seacells_backend.py via a direct
+        # `from ...external.SEACells.core import SEACells` in fit(), so the
+        # old `_get_seacells_backend` helper no longer exists.
         "omicverse/single/_mofa.py": {"_get_mofa_entry_point"},
         "omicverse/single/_tosica.py": {"_get_tosica_backend"},
         "omicverse/single/_traj.py": {"_get_palantir_backend"},

--- a/tests/architecture/test_optional_torch_dependencies.py
+++ b/tests/architecture/test_optional_torch_dependencies.py
@@ -230,6 +230,8 @@ def _install_single_dependency_stubs():
             "MetaCell": object(),
             "plot_metacells": object(),
             "get_obs_value": object(),
+            "optimize_granularity": object(),
+            "compare_metacell_backends": object(),
         },
         "omicverse.single._mdic3": {"pyMDIC3": object()},
         "omicverse.single._gptcelltype": {


### PR DESCRIPTION
## Summary

PR #729 (unified MetaCell dispatcher) turned master CI red — `2 failed, 4584 passed` on py3.10 / 3.11 / 3.12. Both failures are **stale architecture-test fixtures** that hard-coded the *old* `omicverse/single/_metacell.py` API. No production code is wrong; the fixtures simply lagged the new API surface.

## The two failures

### 1. `test_lazy_backend_wiring.py::test_modified_backend_helpers_are_wired_to_call_sites`

```
AssertionError: omicverse/single/_metacell.py defines _get_seacells_backend but does not call it
```

The `expected_helper_calls` map asserted `_metacell.py` must call a `_get_seacells_backend` lazy-loader helper. PR #729 removed that helper — SEACells lazy-loading moved into `_metacell_backends/seacells_backend.py`, which imports SEACells directly inside `fit()` (`from ...external.SEACells.core import SEACells`). **Fix:** drop the stale `_metacell.py` entry from the map.

### 2. `test_optional_torch_dependencies.py::test_single_imports_without_torch_and_fails_on_torch_features`

```
ImportError: cannot import name 'optimize_granularity' from 'omicverse.single._metacell' (unknown location)
```

`_install_single_dependency_stubs()` installs a fake `omicverse.single._metacell` module exposing only the **old 3** exports (`MetaCell`, `plot_metacells`, `get_obs_value`). PR #729 made `single/__init__.py` also import `optimize_granularity` and `compare_metacell_backends` from `_metacell`, so `from ._metacell import (...)` resolved against the stub and couldn't find the two new names (the `(unknown location)` is the `types.ModuleType` stub having no `__file__`). **Fix:** add the two new names to the stub.

## Changes

- `tests/architecture/test_lazy_backend_wiring.py` — remove the `_metacell.py` → `_get_seacells_backend` expectation (+ explanatory comment).
- `tests/architecture/test_optional_torch_dependencies.py` — add `optimize_granularity` + `compare_metacell_backends` to the `_metacell` stub.

`2 files changed, 7 insertions(+), 1 deletion(-)` — test fixtures only.

## Test plan

- [x] `pytest tests/architecture/test_lazy_backend_wiring.py` — 3 passed.
- [x] `test_single_imports_without_torch...` no longer raises `cannot import name 'optimize_granularity'` (the stub now carries all 5 `_metacell` exports).
- [x] Root-caused against CI run 26136130053: exactly these 2 tests failed, `4584 passed` — no other breakage.
- [ ] CI on this PR should go fully green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)