### PR TITLE
feat(registry): add I/O contract to metacell @register_function decorators

### DIFF
--- a/omicverse/single/_metacell.py
+++ b/omicverse/single/_metacell.py
@@ -65,8 +65,26 @@ def _legacy_seacells_kwargs(kwargs: dict) -> dict:
     category="single",
     description=(
         "Construct metacells from single-cell data. 7 backends: seacells, "
-        "metaq, mc2, supercell, kmeans, random, geosketch."
+        "metaq, mc2, supercell, kmeans, random, geosketch. Writes a unified "
+        "schema (obs['metacell_id'], uns['metacell']) consumed by all "
+        "downstream tools."
     ),
+    requires={
+        "obsm": [
+            "low-dim embedding via use_rep, e.g. X_pca "
+            "(graph backends: seacells / supercell / kmeans / geosketch)",
+        ],
+        "layers": [
+            "raw counts via layer, e.g. counts "
+            "(deep backends: metaq / mc2)",
+        ],
+    },
+    produces={
+        "obs": ["metacell_id", "metacell_conf"],
+        "obsm": ["X_metacell", "metacell_soft"],
+        "uns": ["metacell"],
+    },
+    auto_fix="none",
     examples=[
         "# SEACells (legacy default)",
         "mc = ov.single.MetaCell(adata, use_rep='X_pca', n_metacells=200).fit()",
@@ -616,7 +634,17 @@ class MetaCell(object):
 @register_function(
     aliases=["选择最优粒度", "optimize_metacell_granularity", "γ优化", "granularity_optimize"],
     category="single",
-    description="Sweep n_metacells values and pick the best via mcRigor's Score.",
+    description=(
+        "Sweep n_metacells values and pick the best granularity via mcRigor's "
+        "Score (dubious-rate / zero-rate trade-off). Returns (best_n, sweep)."
+    ),
+    requires={
+        "obsm": ["low-dim embedding via use_rep, e.g. X_pca"],
+        "layers": ["log-normalised expression via layer_lognorm (optional; "
+                   "defaults to adata.X)"],
+    },
+    produces={},
+    auto_fix="none",
     examples=[
         "best_n, sweep = ov.single.optimize_granularity(adata, method='metaq',",
         "    n_metacells_grid=[50, 100, 200, 500, 1000], weight=0.5)",
@@ -670,8 +698,16 @@ def optimize_granularity(
     category="single",
     description=(
         "Honest baseline comparison: run multiple metacell backends on the "
-        "same adata and report runtime + rigor + purity side-by-side."
+        "same adata and report runtime + rigor + purity side-by-side. "
+        "Returns a per-backend benchmark DataFrame (adata is not modified)."
     ),
+    requires={
+        "obsm": ["low-dim embedding via use_rep, e.g. X_pca"],
+        "layers": ["raw counts via layer (e.g. counts)",
+                   "log-normalised expression via layer_lognorm"],
+    },
+    produces={},
+    auto_fix="none",
     examples=[
         "df = ov.single.compare_metacell_backends(",
         "    adata, backends=['seacells', 'metaq', 'kmeans', 'random', 'geosketch'],",


### PR DESCRIPTION
## Summary

The metacell functions added in #729 were registered with the **basic** `@register_function` fields (`aliases` / `category` / `description` / `examples` / `related`) but were missing the **structured I/O contract** — `requires` / `produces` / `auto_fix` — that newer registered functions (`ov.single.CNV`, `ov.single.batch_correction`) carry.

Those fields let `ov.Agent` do prerequisite checking and know what each call reads from / writes to the AnnData. This PR brings the metacell functions to parity.

## Changes

Filled `requires` / `produces` / `auto_fix` for the three substantive metacell entry points:

| function | `requires` | `produces` |
|---|---|---|
| `MetaCell` | `obsm` (embedding via `use_rep`, graph backends) **or** `layers` (raw counts, metaq/mc2) | `obs['metacell_id','metacell_conf']`, `obsm['X_metacell','metacell_soft']`, `uns['metacell']` |
| `optimize_granularity` | `obsm` + log-normalised layer | — (returns `best_n, sweep`) |
| `compare_metacell_backends` | `obsm` + `counts`/`lognorm` layers | — (returns a benchmark DataFrame; adata untouched) |

`plot_metacells` / `get_obs_value` intentionally keep only the basic fields — they're legacy plotting / obs-transfer helpers, not adata-schema-producing pipeline steps.

The 5 `ov.pl.metacell_*` helpers (in `pl/_metacell.py`) also keep the basic fields: they take a fitted `MetaCell` object, not an AnnData, so an `obsm`/`obs`/`uns` contract doesn't apply.

## Notes

- **Decorator metadata only — no behaviour change.** 1 file, `+39 / −3`.
- Verified all 3 decorators now expose `['aliases','auto_fix','category','description','examples','produces','related','requires']` and `import omicverse` still registers `ov.single.MetaCell`.

## Test plan

- [x] AST audit confirms the 3 decorators carry the full field set.
- [x] `import omicverse` succeeds; `ov.single.MetaCell` registered.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)