### PR TITLE
Bulk-analysis robustness: WGCNA soft-threshold, geneset auto-download, continuous-trait DE

### DIFF
--- a/omicverse/bulk/_Deseq2.py
+++ b/omicverse/bulk/_Deseq2.py
@@ -888,3 +888,130 @@ class pyDEG(object):
 
         else:  # This is where the "method" check (not pydeseq2 version check) ends
             raise ValueError('The method is not supported.')
+
+    def continuous_deg(self, trait, covariates=None, alpha: float = 0.05,
+                       multipletests_method: str = 'fdr_bh') -> pd.DataFrame:
+        r"""Differential expression against a CONTINUOUS sample-level trait.
+
+        Where :meth:`deg_analysis` compares two groups, this models each
+        gene's expression as a linear function of a **continuous**
+        predictor — disease duration, age, dose, a severity score — via
+        limma-voom + eBayes (the vendored pure-Python
+        ``omicverse.external.pylimma``). It is the first-class tool for
+        "which genes are associated with / track / correlate with a
+        continuous variable": ``eBayes`` moderation borrows variance
+        across genes (a per-gene Spearman/Pearson scan has none, and is
+        noisiest in the tails that hold the top hits), and ``voom``
+        models the count mean-variance trend.
+
+        Arguments:
+            trait: Per-sample value of the continuous trait — a
+                ``pandas.Series`` indexed by sample, a ``dict``
+                ``{sample: value}``, or an array aligned to the count
+                columns. Samples with a missing (NaN) trait are dropped.
+            covariates: Optional ``pandas.DataFrame`` (samples × columns)
+                of nuisance variables to hold fixed — RIN, age, sex,
+                batch, sequencing platform. Numeric columns enter the
+                design directly; non-numeric columns are one-hot encoded.
+            alpha: FDR threshold for the ``sig`` column (default 0.05).
+            multipletests_method: ``statsmodels`` multiple-testing
+                method for the q-value (default ``'fdr_bh'``).
+
+        Returns:
+            A genes × stats DataFrame (also stored on ``self.result``):
+            ``log2FC`` here is the **slope** — log2 expression change
+            per unit of the trait, covariates held fixed — plus
+            ``pvalue``, ``qvalue``, ``t``, ``AveExpr`` and ``sig``
+            (``up`` / ``down`` / ``normal`` by ``qvalue < alpha`` and
+            slope sign). Column names match :meth:`deg_analysis` so
+            ``foldchange_set`` / ``plot_volcano`` work unchanged.
+        """
+        from ..external import pylimma as _limma
+        from statsmodels.stats.multitest import multipletests
+        print("⏰ Start continuous-trait limma-voom pipeline (pylimma)...")
+
+        samples = list(self.data.columns)
+
+        # --- align the trait to the count-matrix columns --------------
+        if isinstance(trait, dict):
+            trait = pd.Series(trait)
+        if isinstance(trait, pd.Series):
+            trait_s = trait.reindex(samples).astype(float)
+        else:
+            trait_arr = np.asarray(trait, dtype=float).ravel()
+            if len(trait_arr) != len(samples):
+                raise ValueError(
+                    f"trait has {len(trait_arr)} values but the count "
+                    f"matrix has {len(samples)} samples; pass a Series "
+                    f"indexed by sample to align unambiguously.")
+            trait_s = pd.Series(trait_arr, index=samples)
+
+        use_samples = [s for s in samples if pd.notna(trait_s.get(s))]
+        if len(use_samples) < 3:
+            raise ValueError(
+                f"Only {len(use_samples)} samples have a non-missing trait "
+                f"value — too few for a linear model.")
+        trait_s = trait_s.loc[use_samples]
+
+        # --- design matrix: Intercept + covariates + trait (trait last) -
+        design = pd.DataFrame({'Intercept': 1.0}, index=use_samples)
+        if covariates is not None:
+            cov = covariates.reindex(use_samples)
+            for col in cov.columns:
+                series = cov[col]
+                if pd.api.types.is_numeric_dtype(series):
+                    design[col] = series.astype(float)
+                else:  # one-hot encode a categorical covariate
+                    dummies = pd.get_dummies(series.astype('category'),
+                                             prefix=str(col), drop_first=True)
+                    for d in dummies.columns:
+                        design[d] = dummies[d].astype(float)
+        trait_col = 'trait'
+        while trait_col in design.columns:
+            trait_col += '_'
+        design[trait_col] = trait_s.astype(float)
+
+        if bool(design.isnull().any().any()):
+            bad = design.columns[design.isnull().any()].tolist()
+            raise ValueError(
+                f"design matrix has missing values in {bad} — covariate "
+                f"values must be present for every used sample.")
+
+        counts = self.data[use_samples]
+
+        # --- limma-voom + eBayes --------------------------------------
+        v = _limma.voom(counts, design.values)
+        fit = _limma.lmFit(v.E, design.values, weights=v.weights)
+        print("⏰ Start to adjust pvalue...")
+        fit = _limma.eBayes(fit)
+
+        trait_idx = list(design.columns).index(trait_col)
+        log2FC = np.asarray(fit.coefficients)[:, trait_idx]
+        pvalue = np.asarray(fit.p_value)[:, trait_idx]
+        tstat = np.asarray(fit.t)[:, trait_idx]
+        print("⏰ Start to calculate qvalue...")
+        qvalue = multipletests(np.nan_to_num(np.asarray(pvalue, dtype=float), nan=1.0),
+                               alpha=alpha, method=multipletests_method,
+                               is_sorted=False, returnsorted=False)[1]
+
+        base_mean = self.data[use_samples].mean(axis=1)
+        result = pd.DataFrame({'pvalue': pvalue, 'qvalue': qvalue},
+                              index=self.data.index)
+        result['log2FC'] = log2FC          # slope: log2 change per unit trait
+        result['abs(log2FC)'] = result['log2FC'].abs()
+        result['BaseMean'] = base_mean
+        result['MaxBaseMean'] = base_mean  # no two groups; kept for column parity
+        result['log2(BaseMean)'] = np.log2(base_mean + 1)
+        result['AveExpr'] = np.asarray(fit.Amean)
+        result['t'] = tstat
+        result['size'] = result['abs(log2FC)'] / 10
+        result = result.loc[~result['pvalue'].isnull()]
+        result['-log(pvalue)'] = -np.log10(result['pvalue'])
+        result['-log(qvalue)'] = -np.log10(result['qvalue'])
+        result['sig'] = 'normal'
+        result.loc[(result['qvalue'] < alpha) & (result['log2FC'] > 0), 'sig'] = 'up'
+        result.loc[(result['qvalue'] < alpha) & (result['log2FC'] < 0), 'sig'] = 'down'
+        self.result = result
+        print(f"✅ Continuous-trait DE complete: {len(use_samples)} samples, "
+              f"{int((result['sig'] != 'normal').sum())} genes at q<{alpha}.")
+        return result

--- a/omicverse/bulk/_wgcna.py
+++ b/omicverse/bulk/_wgcna.py
@@ -197,7 +197,7 @@ class pyWGCNA:
         name="WGCNA",
         TPMcutoff=1,
         powers=None,
-        RsquaredCut=0.9,
+        RsquaredCut=0.85,
         MeanCut=100,
         networkType="signed hybrid",
         TOMType="signed",

--- a/omicverse/external/PyWGCNA/wgcna.py
+++ b/omicverse/external/PyWGCNA/wgcna.py
@@ -173,7 +173,7 @@ class pyWGCNA(GeneExp):
 
     def __init__(self, name='WGCNA',
                  TPMcutoff=1,
-                 powers=None, RsquaredCut=0.9, MeanCut=100,
+                 powers=None, RsquaredCut=0.85, MeanCut=100,
                  networkType="signed hybrid", TOMType="signed",
                  minModuleSize=50, naColor="grey", cut=float('inf'),
                  MEDissThres=0.2,
@@ -1396,7 +1396,7 @@ class pyWGCNA(GeneExp):
 
     # Call the network topology analysis function
     @staticmethod
-    def pickSoftThreshold(data, dataIsExpr=True, weights=None, RsquaredCut=0.9, MeanCut=100, powerVector=None,
+    def pickSoftThreshold(data, dataIsExpr=True, weights=None, RsquaredCut=0.85, MeanCut=100, powerVector=None,
                           nBreaks=10,
                           blockSize=None, corOptions=None, networkType="unsigned", moreNetworkConcepts=False,
                           gcInterval=None):
@@ -1564,16 +1564,46 @@ class pyWGCNA(GeneExp):
 
         print(datout)
 
-        # detect threshold more than 0.9 by default
-        ind = np.logical_and(datout['SFT.R.sq'] > RsquaredCut, datout['mean(k)'] <= MeanCut)
+        # Scale-free topology selection must use the SIGNED fit index,
+        # -sign(slope) * R^2 — not the raw R^2. A scale-free degree
+        # distribution has a NEGATIVE slope; at power 1-2 the fit often
+        # has a POSITIVE slope (not scale-free at all) yet a high raw
+        # R^2. Selecting on raw R^2 therefore collapses to power 1, a
+        # degenerate network where most genes fall into one giant
+        # 'hairball' module.
+        sft_r2 = datout['SFT.R.sq'].astype(float).to_numpy()
+        slope = datout['slope'].astype(float).to_numpy()
+        meanK = datout['mean(k)'].astype(float).to_numpy()
+        signedR2 = -np.sign(slope) * sft_r2
+        powerArr = np.asarray(powerVector)
+
+        ind = np.logical_and(signedR2 >= RsquaredCut, meanK <= MeanCut)
         if np.sum(ind) > 0:
-            powerEstimate = np.min(powerVector[ind])
+            powerEstimate = int(np.min(powerArr[ind]))
             print(f"{OKGREEN}Selected power to have scale free network is {str(powerEstimate)}.{ENDC}")
         else:
-            ind = np.argsort(datout['SFT.R.sq']).tolist()
-            powerEstimate = powerVector[ind[-1]]
-            print(f"{OKGREEN}No power detected to have scale free network!\nFound the best given power which is "
-                  f"{str(powerEstimate)}.{ENDC}")
+            # No power reaches the scale-free fit cut. Do NOT fall back
+            # to the raw-R^2 argmax — that routinely returns power 1-2
+            # and a degenerate hairball. Use the Langfelder sample-size
+            # default (WGCNA FAQ "Choosing the soft-thresholding
+            # power"), the recommended power when the fit cut is unmet.
+            nSamples = data.shape[0]
+            signed = str(networkType).lower() in ("signed", "signed hybrid")
+            if signed:
+                _default = 18 if nSamples < 20 else 16 if nSamples < 30 else 14 if nSamples < 40 else 12
+            else:
+                _default = 9 if nSamples < 20 else 8 if nSamples < 30 else 7 if nSamples < 40 else 6
+            powerEstimate = int(min(max(_default, int(powerArr.min())), int(powerArr.max())))
+            try:
+                _best = float(np.nanmax(signedR2))
+            except ValueError:
+                _best = float('nan')
+            print(f"{WARNING}No soft-threshold power reached the scale-free "
+                  f"fit cut (best signed R^2 = {_best:.2f} < {RsquaredCut}). "
+                  f"Falling back to the sample-size default power = "
+                  f"{powerEstimate} ({networkType}, n={nSamples}). A weak "
+                  f"scale-free fit usually means residual batch effect or "
+                  f"heterogeneous samples in the expression matrix.{ENDC}")
 
         return powerEstimate, datout
 

--- a/omicverse/utils/_data.py
+++ b/omicverse/utils/_data.py
@@ -494,6 +494,56 @@ def download_tosica_gmt():
     ],
     related=["bulk.geneset_enrichment", "utils.download_tosica_gmt", "single.pathway_enrichment"]
 )
+def _download_enrichr_library(name, dir='./genesets'):
+    r"""Fetch a gene-set library from Enrichr by name, cache it, return its path.
+
+    Enrichr hosts ~200 curated gene-set libraries — MSigDB Hallmark, KEGG,
+    GO, Reactome, WikiPathways, cell-type and TF/kinase sets — listed at
+    https://maayanlab.cloud/Enrichr/#libraries . This lets
+    :func:`geneset_prepare` resolve any of them on demand instead of
+    failing when the local file is absent.
+
+    Parameters
+    ----------
+    name : str
+        Enrichr library name, e.g. ``"MSigDB_Hallmark_2020"``,
+        ``"KEGG_2021_Human"``, ``"GO_Biological_Process_2021"``.
+    dir : str, default='./genesets'
+        Directory to cache the downloaded ``.gmt`` into.
+
+    Returns
+    -------
+    str or None
+        Local path to the cached library, or ``None`` if the name is
+        unknown to Enrichr or the download fails (e.g. offline).
+    """
+    import requests
+    os.makedirs(dir, exist_ok=True)
+    out = os.path.join(dir, f'{name}.gmt')
+    if os.path.exists(out):
+        return out
+    url = ('https://maayanlab.cloud/Enrichr/geneSetLibrary'
+           f'?mode=text&libraryName={name}')
+    try:
+        print(f"   - Geneset '{name}' missing locally; fetching from Enrichr ...")
+        resp = requests.get(url, timeout=120)
+        resp.raise_for_status()
+        text = resp.text
+        # Enrichr returns an empty body / an HTML page for an unknown name.
+        if (not text.strip()) or text.lstrip()[:1] == '<' or '\t' not in text:
+            print(f"   - Enrichr has no library named '{name}'.")
+            return None
+        with open(out, 'w', encoding='utf-8') as fh:
+            fh.write(text)
+        n_terms = sum(1 for ln in text.splitlines() if ln.strip())
+        print(f"   - Downloaded Enrichr library '{name}' "
+              f"({n_terms} gene sets) -> {out}")
+        return out
+    except Exception as exc:  # network error, bad name, etc.
+        print(f"   - Enrichr download failed for '{name}': {exc}")
+        return None
+
+
 def geneset_prepare(geneset_path,organism='Human',auto_download=True):
     r"""Load and prepare gene sets from GMT/TXT files for enrichment analysis.
 
@@ -524,6 +574,7 @@ def geneset_prepare(geneset_path,organism='Human',auto_download=True):
             'WikiPathways_2019_Mouse', 'Reactome_2022',
         }
         stem = os.path.splitext(os.path.basename(file_path))[0]
+        resolved = None
         if stem in known:
             print(f"   - Geneset '{stem}' missing locally; auto-downloading "
                   f"via ov.utils.download_pathway_database()...")
@@ -531,7 +582,25 @@ def geneset_prepare(geneset_path,organism='Human',auto_download=True):
             # download_pathway_database writes to ./genesets/
             cand = os.path.join('./genesets', f'{stem}.txt')
             if os.path.exists(cand):
-                file_path = cand
+                resolved = cand
+        if resolved is None:
+            # Any other name is treated as an Enrichr gene-set library and
+            # fetched on demand — MSigDB_Hallmark_2020, KEGG_2021_Human,
+            # Reactome_2022, and ~200 more. The caller never has to
+            # pre-stage a database file or have internet arranged manually.
+            resolved = _download_enrichr_library(stem)
+        if resolved is not None and os.path.exists(resolved):
+            file_path = resolved
+
+    if not os.path.exists(file_path):
+        raise FileNotFoundError(
+            f"geneset_prepare: '{geneset_path}' not found locally and could "
+            f"not be auto-downloaded. Pass a path to a .gmt/.txt file, or an "
+            f"Enrichr library name such as 'MSigDB_Hallmark_2020' or "
+            f"'KEGG_2021_Human' — browse names at "
+            f"https://maayanlab.cloud/Enrichr/#libraries"
+        )
+
     with open(file_path, 'r', encoding='utf-8') as file:
         for idx,line in enumerate(file):
             line = line.strip()


### PR DESCRIPTION
## Summary

Three independent robustness improvements to the bulk-analysis stack, each fixing a real gap surfaced while running omicverse end-to-end on process-level bioinformatics tasks.

### 1. `fix(WGCNA)` — signed scale-free fit index + sample-size fallback in `pickSoftThreshold`
`pickSoftThreshold` selected the soft-threshold power on the **raw** R² of the scale-free fit. At power 1–2 a non-scale-free (positive-slope) degree distribution can still have a high raw R², so when no power met the cut the raw-R² argmax fallback routinely returned power 1–2 — a degenerate network where most genes collapse into one giant module.
- Select on the **signed** fit index `-sign(slope) · R²` (a scale-free distribution has a negative slope), matching R's WGCNA.
- When no power reaches the cut, fall back to the **Langfelder sample-size default** power (WGCNA FAQ) instead of the raw-R² argmax, and warn that a weak fit usually indicates a batch effect.
- `RsquaredCut` default `0.9 → 0.85`, matching R WGCNA's `pickSoftThreshold`.

### 2. `feat(utils)` — `geneset_prepare` auto-downloads any Enrichr library on demand
`geneset_prepare`'s `auto_download` only covered 6 hard-coded omicverse pathway files; MSigDB Hallmark, KEGG, and the ~200 other Enrichr libraries would `FileNotFoundError` when the local file was absent. Added `_download_enrichr_library()`: any name that is not a local file and not one of the 6 known datasets is fetched from `https://maayanlab.cloud/Enrichr/geneSetLibrary` and cached under `./genesets/`. `geneset_prepare('MSigDB_Hallmark_2020')` / `'KEGG_2021_Human'` now resolve with no pre-staging; a genuinely unknown name raises a clear error pointing at the Enrichr library list.

### 3. `feat(bulk)` — `pyDEG.continuous_deg`: first-class DE against a continuous trait
`pyDEG.deg_analysis` only compares two groups (the limma path hard-codes a `[-1, 1]` contrast). "Which genes track a continuous variable — disease duration, age, dose" had no one-call API. Added `pyDEG.continuous_deg(trait, covariates=None)`: aligns the trait to the count columns, builds an `Intercept + covariates + trait` design (categorical covariates one-hot encoded), runs limma-voom + eBayes, and returns the trait coefficient as a `deg_analysis`-shaped result (`log2FC` = slope, `pvalue`/`qvalue`/`t`/`sig`) so `foldchange_set` / `plot_volcano` work unchanged.

## Testing
- WGCNA: `pickSoftThreshold` verified on structured and noise data — signed-criterion selection no longer collapses to power 1; sample-size fallback returns 12/16/18 (signed) and 6–9 (unsigned) by n.
- geneset: `geneset_prepare('MSigDB_Hallmark_2020')` auto-fetches 50 gene sets from Enrichr; unknown names raise cleanly.
- continuous_deg: on synthetic data with planted trait-tracking genes, the top hits by `|t|` are exactly the planted genes; result columns match `deg_analysis`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)