### PR TITLE
feat(genetics): add the ov.genetics statistical-genetics module

### DIFF
--- a/omicverse/__init__.py
+++ b/omicverse/__init__.py
@@ -87,6 +87,7 @@ _LAZY_MODULES = {
     'metabol',
     'micro',
     'protein',
+    'genetics',
     'report',
 }
 
@@ -369,6 +370,7 @@ __all__ = [
     "pl",
     "metabol",
     "protein",
+    "genetics",
     "datasets",
     "external",
     "llm",

--- a/omicverse/_registry.py
+++ b/omicverse/_registry.py
@@ -1075,6 +1075,7 @@ def _hydrate_registry_for_export() -> None:
         "omicverse.space",
         "omicverse.metabol",
         "omicverse.protein",
+        "omicverse.genetics",
     )
     for module_name in module_names:
         try:
@@ -1097,6 +1098,13 @@ def _hydrate_registry_for_export() -> None:
         import omicverse.protein as _protein  # noqa: F401
 
         _protein._hydrate_registry()
+    except Exception:
+        pass
+    # And ov.genetics — its __init__ is lazy too.
+    try:
+        import omicverse.genetics as _genetics  # noqa: F401
+
+        _genetics._hydrate_registry()
     except Exception:
         pass
 

--- a/omicverse/genetics/__init__.py
+++ b/omicverse/genetics/__init__.py
@@ -1,0 +1,185 @@
+"""
+Statistical genetics for omicverse — a unified post-GWAS analysis suite.
+
+``ov.genetics`` is the analogue of ``ov.protein`` for human statistical
+genetics: it threads the major post-GWAS analyses — eQTL mapping,
+fine-mapping, colocalization, Mendelian randomization, single-cell
+disease-relevance scoring, LD score regression, and TWAS — behind one
+registered, dispatch-based API. Unlike single-cell modules, genetics
+data is heterogeneous: GWAS summary statistics are DataFrames, genotypes
+are matrices, single-cell data is AnnData — so each function takes the
+data type its task naturally uses rather than forcing everything into
+AnnData.
+
+The statistical machinery lives in **seven standalone packages** that
+omicverse ships as separate releases, plus a backend-free GWAS core:
+
+* :mod:`pymatrixeqtl`  — Matrix eQTL: cis / trans eQTL mapping (Shabalin 2012)
+* :mod:`pysusie`       — SuSiE: Bayesian fine-mapping (Wang 2020)
+* :mod:`pycoloc`       — coloc: Bayesian colocalization (Giambartolomei 2014)
+* :mod:`pytwosamplemr` — TwoSampleMR / MendelianRandomization estimators
+* :mod:`pyscdrs`       — scDRS: single-cell disease-relevance scoring (Zhang 2022)
+* :mod:`pyldsc`        — LDSC: LD score regression / SEG (Bulik-Sullivan 2015)
+* :mod:`pytwas`        — (S-)PrediXcan / S-MultiXcan TWAS (Barbeira 2018)
+
+Each is a thin sidecar; ``ov.genetics`` wraps them behind ``method=``
+dispatchers so users learn one API instead of seven. The GWAS core
+(``gwas_qc``, ``gwas_association``, ``genomic_inflation``) is implemented
+directly on numpy / scipy / statsmodels — no backend required.
+
+Install the backends with::
+
+    pip install omicverse[genetics]
+
+Quick-start
+-----------
+>>> import omicverse as ov
+>>> # 1. eQTL mapping
+>>> eq = ov.genetics.eqtl_map(genotype, expression, model='linear')
+>>> # 2. fine-map a locus from summary stats
+>>> fit = ov.genetics.finemap(z=zscores, R=ld, n=10000, method='susie_rss')
+>>> cs = ov.genetics.get_credible_sets(fit, R=ld)
+>>> # 3. colocalize a GWAS with an eQTL
+>>> co = ov.genetics.colocalize(gwas_dataset, eqtl_dataset, method='abf')
+>>> # 4. Mendelian randomization
+>>> mr = ov.genetics.mendelian_randomization(mr_input, method='ivw')
+>>> # 5. single-cell disease relevance
+>>> df = ov.genetics.disease_relevance_score(adata, gene_set=disease_genes)
+>>> # 6. heritability / TWAS
+>>> h2 = ov.genetics.heritability('trait.sumstats', ref_ld='ldsc', w_ld='w')
+>>> tw = ov.genetics.twas('model.db', covariance='cov.txt.gz', gwas=gwas_df)
+
+Pipeline stages
+---------------
+I/O                       ``read_sumstats``, ``read_plink``, ``read_vcf``
+GWAS core (no backend)    ``gwas_qc``, ``gwas_association``,
+                          ``genomic_inflation``
+eQTL mapping              ``eqtl_map`` (linear / anova / linear_cross)
+Fine-mapping              ``finemap`` (susie / susie_rss),
+                          ``get_credible_sets``, ``get_pip``
+Colocalization            ``colocalize`` (abf / susie / signals),
+                          ``finemap_abf``, ``coloc_sensitivity``
+Mendelian randomization   ``mendelian_randomization`` (ivw / egger /
+                          median / mode / maxlik / divw / conmix /
+                          lasso / cml / all), ``harmonize``,
+                          ``mr_steiger``, ``mr_heterogeneity``,
+                          ``mr_pleiotropy``
+Single-cell relevance     ``disease_relevance_score``, ``score_downstream``
+Heritability / LDSC       ``heritability``, ``genetic_correlation``,
+                          ``partitioned_heritability``, ``ldsc_cell_type``,
+                          ``munge_sumstats``
+TWAS                      ``twas`` (spredixcan / smultixcan / predixcan),
+                          ``load_twas_model``
+Plotting                  ``manhattan``, ``qqplot``, ``regional_plot``,
+                          ``coloc_plot``, ``mr_scatter``, ``mr_forest``,
+                          ``finemap_plot``
+
+All backend imports (``pymatrixeqtl``, ``pysusie`` …) are deferred to
+call-time — ``import omicverse.genetics`` does no heavy work and succeeds
+even when some backends are not installed.
+"""
+from __future__ import annotations
+
+import importlib as _importlib
+
+
+# Lazy public surface — single source of truth for what's exposed.
+_LAZY_ATTRS: dict[str, tuple[str, str]] = {
+    # I/O
+    "read_sumstats":             (".io", "read_sumstats"),
+    "read_plink":                (".io", "read_plink"),
+    "read_vcf":                  (".io", "read_vcf"),
+    # GWAS core (backend-free)
+    "gwas_qc":                   ("._gwas", "gwas_qc"),
+    "gwas_association":          ("._gwas", "gwas_association"),
+    "genomic_inflation":         ("._gwas", "genomic_inflation"),
+    # eQTL mapping
+    "eqtl_map":                  ("._eqtl", "eqtl_map"),
+    # Fine-mapping
+    "finemap":                   ("._finemap", "finemap"),
+    "get_credible_sets":         ("._finemap", "get_credible_sets"),
+    "get_pip":                   ("._finemap", "get_pip"),
+    # Colocalization
+    "colocalize":                ("._coloc", "colocalize"),
+    "finemap_abf":               ("._coloc", "finemap_abf"),
+    "coloc_sensitivity":         ("._coloc", "coloc_sensitivity"),
+    # Mendelian randomization
+    "mendelian_randomization":   ("._mr", "mendelian_randomization"),
+    "harmonize":                 ("._mr", "harmonize"),
+    "mr_steiger":                ("._mr", "mr_steiger"),
+    "mr_heterogeneity":          ("._mr", "mr_heterogeneity"),
+    "mr_pleiotropy":             ("._mr", "mr_pleiotropy"),
+    # Single-cell disease relevance
+    "disease_relevance_score":   ("._scdrs", "disease_relevance_score"),
+    "score_downstream":          ("._scdrs", "score_downstream"),
+    # Heritability / LD score regression
+    "heritability":              ("._ldsc", "heritability"),
+    "genetic_correlation":       ("._ldsc", "genetic_correlation"),
+    "partitioned_heritability":  ("._ldsc", "partitioned_heritability"),
+    "ldsc_cell_type":            ("._ldsc", "ldsc_cell_type"),
+    "munge_sumstats":            ("._ldsc", "munge_sumstats"),
+    # TWAS
+    "twas":                      ("._twas", "twas"),
+    "load_twas_model":           ("._twas", "load_twas_model"),
+    # Plotting
+    "manhattan":                 (".plotting", "manhattan"),
+    "qqplot":                    (".plotting", "qqplot"),
+    "regional_plot":             (".plotting", "regional_plot"),
+    "coloc_plot":                (".plotting", "coloc_plot"),
+    "mr_scatter":                (".plotting", "mr_scatter"),
+    "mr_forest":                 (".plotting", "mr_forest"),
+    "finemap_plot":              (".plotting", "finemap_plot"),
+}
+
+_LAZY_SUBMODULES = {"io", "plotting"}
+
+_REGISTRY_SUBMODULES = (
+    ".io",
+    "._gwas",
+    "._eqtl",
+    "._finemap",
+    "._coloc",
+    "._mr",
+    "._scdrs",
+    "._ldsc",
+    "._twas",
+    ".plotting",
+)
+
+
+def _hydrate_registry() -> None:
+    """Force-import every @register_function-bearing submodule so the global
+    registry sees ov.genetics at export time. Called from
+    :mod:`omicverse._registry._hydrate_registry_for_export`."""
+    for mod in _REGISTRY_SUBMODULES:
+        try:
+            _importlib.import_module(mod, __name__)
+        except Exception:
+            # Optional backends (pymatrixeqtl, pysusie, …) may be missing —
+            # register whatever loads cleanly.
+            continue
+
+
+def __getattr__(name: str):
+    if name in _LAZY_ATTRS:
+        module_path, attr_name = _LAZY_ATTRS[name]
+        module = _importlib.import_module(module_path, __name__)
+        value = getattr(module, attr_name)
+        globals()[name] = value
+        return value
+    if name in _LAZY_SUBMODULES:
+        module = _importlib.import_module(f".{name}", __name__)
+        globals()[name] = module
+        return module
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    return sorted(set(list(globals().keys())
+                      + list(_LAZY_ATTRS.keys())
+                      + list(_LAZY_SUBMODULES)))
+
+
+__version__ = "0.1.0"
+
+__all__ = list(_LAZY_ATTRS.keys()) + list(_LAZY_SUBMODULES)

--- a/omicverse/genetics/_coloc.py
+++ b/omicverse/genetics/_coloc.py
@@ -1,0 +1,196 @@
+"""Colocalization analysis for ``ov.genetics`` — coloc backend.
+
+Wraps the standalone :mod:`pycoloc` package (Giambartolomei *et al.*
+2014; Wallace 2020/2021). :func:`colocalize` tests whether two traits
+(e.g. a GWAS signal and an eQTL) share a causal variant at a locus.
+``method`` dispatches between the single-causal-variant ABF model,
+the SuSiE-based multi-signal model, and the conditional/masking
+``coloc_signals`` model.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+import numpy as np
+
+from .._registry import register_function
+
+
+def _require_coloc():
+    """Import :mod:`pycoloc` with a friendly error if it is missing."""
+    try:
+        import pycoloc  # noqa: F401
+    except ImportError as exc:  # pragma: no cover
+        raise ImportError(
+            "ov.genetics.colocalize requires the pycoloc backend: "
+            "`pip install pycoloc` (or `pip install omicverse[genetics]`)."
+        ) from exc
+    return pycoloc
+
+
+@register_function(
+    aliases=[
+        "colocalize", "coloc", "colocalization", "coloc_abf",
+        "共定位", "共定位分析",
+    ],
+    category="genetics",
+    description=(
+        "Bayesian colocalization of two traits — tests whether a GWAS "
+        "signal and a molecular QTL (eQTL / pQTL) are driven by the same "
+        "causal variant. ``method`` selects the model: ``'abf'`` (default; "
+        "single causal variant per locus, Giambartolomei 2014), "
+        "``'susie'`` (SuSiE fine-mapping allowing multiple causal "
+        "variants, Wallace 2021), or ``'signals'`` "
+        "(conditional/masking iteration over multiple signals). Each "
+        "dataset is a dict of summary statistics (keys such as ``beta``, "
+        "``varbeta``/``MAF``, ``snp``, ``type``, ``N``, ``sdY``). Returns "
+        "posterior probabilities PP.H0..PP.H4 (H4 = shared causal "
+        "variant). Wraps the pycoloc backend."
+    ),
+    examples=[
+        "ov.genetics.colocalize(d1, d2, method='abf')",
+        "ov.genetics.colocalize(d1, d2, method='susie')",
+        "ov.genetics.colocalize(d1, d2, method='signals', p12=1e-6)",
+    ],
+    related=["ov.genetics.finemap", "ov.genetics.finemap_abf",
+             "ov.genetics.coloc_sensitivity", "ov.genetics.coloc_plot"],
+)
+def colocalize(
+    dataset1: dict,
+    dataset2: dict,
+    *,
+    method: str = "abf",
+    MAF: Optional[np.ndarray] = None,
+    p1: float = 1e-4,
+    p2: float = 1e-4,
+    p12: float = 1e-5,
+    **kwargs,
+):
+    """Colocalize two GWAS / QTL traits.
+
+    Parameters
+    ----------
+    dataset1, dataset2
+        Summary-statistics dicts for the two traits. Recognised keys
+        include ``beta``, ``varbeta`` (or ``MAF`` + ``N``), ``snp``,
+        ``position``, ``type`` (``'quant'`` / ``'cc'``), ``N``, ``sdY``,
+        and ``LD`` (required for ``method='susie'``).
+    method
+        ``'abf'`` (single causal variant), ``'susie'`` (multiple causal
+        variants via SuSiE), or ``'signals'`` (conditional/masking).
+    MAF
+        Optional minor-allele-frequency vector attached to datasets that
+        lack ``MAF``.
+    p1, p2, p12
+        Prior probabilities that a SNP associates with trait 1, trait 2,
+        or both.
+    **kwargs
+        Forwarded to the backend coloc function.
+
+    Returns
+    -------
+    object
+        The backend result — for ``'abf'`` a :class:`pycoloc.ColocABF`
+        with a ``summary`` (``PP.H0..PP.H4.abf``) and per-SNP ``results``.
+    """
+    cl = _require_coloc()
+    key = str(method).lower().strip()
+
+    if key == "abf":
+        return cl.coloc_abf(dataset1, dataset2, MAF=MAF,
+                            p1=p1, p2=p2, p12=p12, **kwargs)
+    if key == "susie":
+        p12_susie = kwargs.pop("p12", 5e-6) if p12 == 1e-5 else p12
+        return cl.coloc_susie(dataset1, dataset2,
+                              p1=p1, p2=p2, p12=p12_susie, **kwargs)
+    if key in ("signals", "signal"):
+        return cl.coloc_signals(dataset1, dataset2, MAF=MAF,
+                                p1=p1, p2=p2, p12=p12, **kwargs)
+
+    raise ValueError(
+        f"method must be one of 'abf', 'susie', 'signals', got {method!r}"
+    )
+
+
+@register_function(
+    aliases=["finemap_abf", "abf_finemap", "近似贝叶斯因子精细定位"],
+    category="genetics",
+    description=(
+        "Single-trait fine-mapping with Approximate Bayes Factors "
+        "(Wakefield 2009) — computes a per-SNP posterior probability of "
+        "causality for one GWAS / QTL dataset. Wraps "
+        ":func:`pycoloc.finemap_abf`."
+    ),
+    examples=[
+        "ov.genetics.finemap_abf(dataset)",
+        "ov.genetics.finemap_abf(dataset, p1=1e-4)",
+    ],
+    related=["ov.genetics.colocalize", "ov.genetics.finemap"],
+)
+def finemap_abf(dataset: dict, *, p1: float = 1e-4):
+    """ABF fine-mapping of a single dataset.
+
+    Parameters
+    ----------
+    dataset
+        Summary-statistics dict (as for :func:`colocalize`).
+    p1
+        Prior probability a SNP is causal.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Per-SNP table with the approximate Bayes factor and posterior
+        probability of association.
+    """
+    cl = _require_coloc()
+    return cl.finemap_abf(dataset, p1=p1)
+
+
+@register_function(
+    aliases=["coloc_sensitivity", "sensitivity", "coloc敏感性分析", "共定位敏感性"],
+    category="genetics",
+    description=(
+        "Prior-sensitivity analysis for a colocalization result — shows "
+        "how the posterior probabilities respond to the choice of priors "
+        "p1 / p2 / p12, and whether a colocalization rule (e.g. "
+        "``'H4 > 0.8'``) is robust. Wraps :func:`pycoloc.sensitivity`."
+    ),
+    examples=[
+        "ov.genetics.coloc_sensitivity(res, rule='H4 > 0.5')",
+        "ov.genetics.coloc_sensitivity(res, rule='H4 > 0.8', dataset1=d1, dataset2=d2)",
+    ],
+    related=["ov.genetics.colocalize", "ov.genetics.coloc_plot"],
+)
+def coloc_sensitivity(
+    obj,
+    *,
+    rule: str = "",
+    dataset1: Optional[dict] = None,
+    dataset2: Optional[dict] = None,
+    doplot: bool = True,
+    **kwargs,
+):
+    """Run a prior-sensitivity analysis on a coloc result.
+
+    Parameters
+    ----------
+    obj
+        A result from :func:`colocalize` (``method='abf'``).
+    rule
+        Colocalization rule to evaluate, e.g. ``'H4 > 0.8'``.
+    dataset1, dataset2
+        The original input datasets (needed to redraw Manhattan panels).
+    doplot
+        Whether to draw the sensitivity figure.
+    **kwargs
+        Forwarded to :func:`pycoloc.sensitivity`.
+
+    Returns
+    -------
+    object
+        The backend sensitivity result.
+    """
+    cl = _require_coloc()
+    return cl.sensitivity(obj, rule=rule, dataset1=dataset1,
+                          dataset2=dataset2, doplot=doplot, **kwargs)

--- a/omicverse/genetics/_eqtl.py
+++ b/omicverse/genetics/_eqtl.py
@@ -1,0 +1,146 @@
+"""eQTL mapping for ``ov.genetics`` — Matrix eQTL backend.
+
+Exposes :func:`eqtl_map`, a dispatcher over the linear / ANOVA /
+linear-cross models of `Matrix eQTL <https://github.com/andreyshabalin/MatrixEQTL>`_
+(Shabalin 2012). The heavy lifting lives in the standalone
+:mod:`pymatrixeqtl` package — this module is a thin, registry-aware
+wrapper that translates plain DataFrames / arrays into the backend's
+:class:`SlicedData` containers.
+"""
+from __future__ import annotations
+
+from typing import Optional, Union
+
+import numpy as np
+import pandas as pd
+
+from .._registry import register_function
+
+
+def _require_matrixeqtl():
+    """Import :mod:`pymatrixeqtl` with a friendly error if it is missing."""
+    try:
+        import pymatrixeqtl  # noqa: F401
+    except ImportError as exc:  # pragma: no cover
+        raise ImportError(
+            "ov.genetics.eqtl_map requires the pymatrixeqtl backend: "
+            "`pip install pymatrixeqtl` (or `pip install omicverse[genetics]`)."
+        ) from exc
+    return pymatrixeqtl
+
+
+_MODEL_ALIASES = {
+    "linear": "modelLINEAR",
+    "anova": "modelANOVA",
+    "linear_cross": "modelLINEAR_CROSS",
+    "cross": "modelLINEAR_CROSS",
+}
+
+
+@register_function(
+    aliases=[
+        "eqtl_map", "eqtl", "matrix_eqtl", "eQTL mapping",
+        "表达数量性状位点", "eQTL分析", "eQTL映射",
+    ],
+    category="genetics",
+    description=(
+        "eQTL mapping via Matrix eQTL (Shabalin 2012). Scans every "
+        "SNP-gene pair for a genotype-expression association. ``model`` "
+        "selects the test: ``'linear'`` (additive dosage), ``'anova'`` "
+        "(genotype as a 3-level factor) or ``'linear_cross'`` (genotype x "
+        "covariate interaction). Genotype / expression / covariates are "
+        "given as features x samples DataFrames or numpy arrays; optional "
+        "``snp_pos`` / ``gene_pos`` enable a cis / trans split. Wraps the "
+        "pymatrixeqtl backend; returns a result object whose ``.cis`` / "
+        "``.trans`` / ``.all`` tables hold beta, t-stat, p-value and FDR."
+    ),
+    examples=[
+        "ov.genetics.eqtl_map(geno, expr, model='linear')",
+        "ov.genetics.eqtl_map(geno, expr, covariates=cov, model='anova')",
+        "ov.genetics.eqtl_map(geno, expr, snp_pos=spos, gene_pos=gpos, cis_dist=1e6)",
+    ],
+    related=["ov.genetics.finemap", "ov.genetics.colocalize", "ov.genetics.manhattan"],
+)
+def eqtl_map(
+    genotype: Union[pd.DataFrame, np.ndarray, str],
+    expression: Union[pd.DataFrame, np.ndarray, str],
+    covariates: Optional[Union[pd.DataFrame, np.ndarray, str]] = None,
+    *,
+    snp_pos: Optional[Union[pd.DataFrame, str]] = None,
+    gene_pos: Optional[Union[pd.DataFrame, str]] = None,
+    model: str = "linear",
+    cis_dist: float = 1e6,
+    pv_threshold: float = 1e-5,
+    pv_threshold_cis: float = 0.0,
+    n_anova_groups: int = 3,
+    verbose: bool = False,
+    **kwargs,
+):
+    """Map eQTLs with Matrix eQTL.
+
+    Parameters
+    ----------
+    genotype
+        Genotype dosages — ``SNPs x samples``. A DataFrame (index = SNP
+        IDs, columns = sample IDs), a 2-D numpy array, a TSV path, or a
+        :class:`pymatrixeqtl.SlicedData`.
+    expression
+        Expression matrix — ``genes x samples``, same accepted types.
+    covariates
+        Optional covariate matrix — ``covariates x samples``.
+    snp_pos, gene_pos
+        Optional SNP / gene position tables. When both are supplied the
+        result is split into ``cis`` (within ``cis_dist``) and ``trans``.
+    model
+        ``'linear'`` (additive), ``'anova'`` (3-level genotype factor), or
+        ``'linear_cross'`` (genotype x first-covariate interaction).
+    cis_dist
+        Maximum SNP-gene distance (bp) counted as ``cis``. Default 1e6.
+    pv_threshold
+        p-value cutoff for reported trans (or all) associations.
+    pv_threshold_cis
+        p-value cutoff for reported cis associations; ``0`` disables the
+        cis / trans split unless positions are given.
+    n_anova_groups
+        Number of genotype levels for ``model='anova'``.
+    verbose
+        Print backend progress.
+    **kwargs
+        Forwarded to :func:`pymatrixeqtl.eqtl`.
+
+    Returns
+    -------
+    pymatrixeqtl.MatrixEQTLResult
+        Result object exposing ``.all`` / ``.cis`` / ``.trans`` DataFrames
+        (columns: ``snps``, ``gene``, ``beta``, ``statistic``, ``pvalue``,
+        ``FDR``).
+    """
+    meq = _require_matrixeqtl()
+
+    key = str(model).lower().strip()
+    if key not in _MODEL_ALIASES:
+        raise ValueError(
+            f"model must be one of {sorted(_MODEL_ALIASES)}, got {model!r}"
+        )
+    model_const = getattr(meq, _MODEL_ALIASES[key])
+
+    # Cis/trans split only when both position tables are supplied; otherwise
+    # report a single combined table at ``pv_threshold``.
+    use_cis = snp_pos is not None and gene_pos is not None
+    pv_cis = pv_threshold_cis if (use_cis and pv_threshold_cis > 0) else (
+        pv_threshold if use_cis else 0.0
+    )
+
+    result = meq.eqtl(
+        genotype, expression, covariates,
+        model=model_const,
+        pv_threshold=pv_threshold,
+        pv_threshold_cis=pv_cis,
+        snpspos=snp_pos,
+        genepos=gene_pos,
+        cis_dist=cis_dist,
+        n_anova_groups=n_anova_groups,
+        verbose=verbose,
+        **kwargs,
+    )
+    return result

--- a/omicverse/genetics/_finemap.py
+++ b/omicverse/genetics/_finemap.py
@@ -1,0 +1,224 @@
+"""Statistical fine-mapping for ``ov.genetics`` — SuSiE backend.
+
+Wraps the standalone :mod:`pysusie` package (the Sum of Single Effects
+model, Wang *et al.* 2020). :func:`finemap` dispatches between SuSiE on
+individual-level data (``method='susie'``) and SuSiE-RSS on GWAS
+summary statistics + an LD matrix (``method='susie_rss'``).
+:func:`get_credible_sets` and :func:`get_pip` summarise a fitted model.
+"""
+from __future__ import annotations
+
+from typing import Optional, Union
+
+import numpy as np
+
+from .._registry import register_function
+
+
+def _require_susie():
+    """Import :mod:`pysusie` with a friendly error if it is missing."""
+    try:
+        import pysusie  # noqa: F401
+    except ImportError as exc:  # pragma: no cover
+        raise ImportError(
+            "ov.genetics.finemap requires the pysusie backend: "
+            "`pip install pysusie` (or `pip install omicverse[genetics]`)."
+        ) from exc
+    return pysusie
+
+
+@register_function(
+    aliases=[
+        "finemap", "fine_mapping", "susie", "susie_rss",
+        "精细定位", "精细映射", "因果变异定位",
+    ],
+    category="genetics",
+    description=(
+        "Statistical fine-mapping with SuSiE (Wang 2020) to resolve which "
+        "variants in an associated locus are causal. ``method`` selects the "
+        "backend: ``'susie'`` fits the Sum of Single Effects model on "
+        "individual-level genotype ``X`` and phenotype ``y``; "
+        "``'susie_rss'`` (default) fits from GWAS summary statistics — a "
+        "z-score vector ``z`` (or ``bhat`` / ``shat``) plus an LD "
+        "correlation matrix ``R``. Returns a fitted SuSiE model carrying "
+        "per-variant posterior inclusion probabilities and 95% credible "
+        "sets. Wraps the pysusie backend."
+    ),
+    examples=[
+        "ov.genetics.finemap(z=z, R=ld, n=5000, method='susie_rss')",
+        "ov.genetics.finemap(X=geno, y=pheno, method='susie', L=10)",
+        "fit = ov.genetics.finemap(z=z, R=ld, n=5000); ov.genetics.get_credible_sets(fit, R=ld)",
+    ],
+    related=["ov.genetics.colocalize", "ov.genetics.get_pip",
+             "ov.genetics.get_credible_sets", "ov.genetics.finemap_plot"],
+)
+def finemap(
+    X: Optional[np.ndarray] = None,
+    y: Optional[np.ndarray] = None,
+    *,
+    method: str = "susie_rss",
+    z: Optional[np.ndarray] = None,
+    R: Optional[np.ndarray] = None,
+    n: Optional[int] = None,
+    bhat: Optional[np.ndarray] = None,
+    shat: Optional[np.ndarray] = None,
+    L: int = 10,
+    coverage: float = 0.95,
+    min_abs_corr: float = 0.5,
+    max_iter: int = 100,
+    **kwargs,
+):
+    """Fine-map a locus with SuSiE.
+
+    Parameters
+    ----------
+    X, y
+        For ``method='susie'``: individual-level genotype matrix
+        (``samples x SNPs``) and phenotype vector (``samples``).
+    method
+        ``'susie'`` (individual data) or ``'susie_rss'`` (summary stats).
+    z
+        For ``method='susie_rss'``: SNP z-score vector.
+    R
+        For ``method='susie_rss'``: SNP-SNP LD correlation matrix.
+    n
+        GWAS sample size (recommended for ``susie_rss``).
+    bhat, shat
+        Alternative to ``z`` for ``susie_rss``: marginal effect sizes and
+        their standard errors.
+    L
+        Maximum number of causal effects (single effects) to fit.
+    coverage
+        Target coverage of the credible sets (default 0.95).
+    min_abs_corr
+        Minimum absolute correlation for a "pure" credible set.
+    max_iter
+        Maximum number of IBSS iterations.
+    **kwargs
+        Forwarded to the backend (:func:`pysusie.susie` /
+        :func:`pysusie.susie_rss`).
+
+    Returns
+    -------
+    pysusie.SusieFit
+        Fitted model; use :func:`get_pip` / :func:`get_credible_sets`.
+    """
+    ps = _require_susie()
+    key = str(method).lower().strip()
+
+    if key == "susie":
+        if X is None or y is None:
+            raise ValueError("method='susie' requires individual-level X and y.")
+        return ps.susie(
+            np.asarray(X, dtype=float), np.asarray(y, dtype=float).ravel(),
+            L=L, coverage=coverage, min_abs_corr=min_abs_corr,
+            max_iter=max_iter, **kwargs,
+        )
+
+    if key == "susie_rss":
+        if z is None and (bhat is None or shat is None):
+            raise ValueError(
+                "method='susie_rss' requires either z, or both bhat and shat."
+            )
+        if R is None:
+            raise ValueError("method='susie_rss' requires the LD matrix R.")
+        return ps.susie_rss(
+            z=None if z is None else np.asarray(z, dtype=float).ravel(),
+            R=np.asarray(R, dtype=float),
+            n=n,
+            bhat=None if bhat is None else np.asarray(bhat, dtype=float).ravel(),
+            shat=None if shat is None else np.asarray(shat, dtype=float).ravel(),
+            L=L, coverage=coverage, min_abs_corr=min_abs_corr,
+            max_iter=max_iter, **kwargs,
+        )
+
+    raise ValueError(
+        f"method must be 'susie' or 'susie_rss', got {method!r}"
+    )
+
+
+@register_function(
+    aliases=["get_credible_sets", "credible_sets", "susie_cs", "可信集"],
+    category="genetics",
+    description=(
+        "Extract the 95% credible sets from a fitted SuSiE model — the "
+        "minimal variant groups that jointly capture each causal signal "
+        "at the requested coverage. Wraps :func:`pysusie.susie_get_cs`."
+    ),
+    examples=[
+        "ov.genetics.get_credible_sets(fit, R=ld)",
+        "ov.genetics.get_credible_sets(fit, X=geno, coverage=0.9)",
+    ],
+    related=["ov.genetics.finemap", "ov.genetics.get_pip"],
+)
+def get_credible_sets(
+    fit,
+    *,
+    X: Optional[np.ndarray] = None,
+    R: Optional[np.ndarray] = None,
+    coverage: float = 0.95,
+    min_abs_corr: float = 0.5,
+    **kwargs,
+):
+    """Return the credible sets of a SuSiE fit.
+
+    Parameters
+    ----------
+    fit
+        A :class:`pysusie.SusieFit` returned by :func:`finemap`.
+    X
+        Individual-level genotype matrix used to compute purity (for
+        models fit with ``method='susie'``).
+    R
+        SNP-SNP LD correlation matrix used to compute purity (for
+        ``method='susie_rss'`` models).
+    coverage, min_abs_corr
+        Credible-set coverage and the purity threshold.
+    **kwargs
+        Forwarded to :func:`pysusie.susie_get_cs`.
+
+    Returns
+    -------
+    dict
+        Credible-set summary (``cs``, ``purity``, ``coverage`` ...).
+    """
+    ps = _require_susie()
+    return ps.susie_get_cs(
+        fit, X=X, Xcorr=R, coverage=coverage,
+        min_abs_corr=min_abs_corr, **kwargs,
+    )
+
+
+@register_function(
+    aliases=["get_pip", "pip", "posterior_inclusion_probability", "后验包含概率"],
+    category="genetics",
+    description=(
+        "Extract per-variant posterior inclusion probabilities (PIPs) "
+        "from a fitted SuSiE model — the probability that each variant is "
+        "causal. Wraps :func:`pysusie.susie_get_pip`."
+    ),
+    examples=[
+        "ov.genetics.get_pip(fit)",
+        "ov.genetics.get_pip(fit, prune_by_cs=True)",
+    ],
+    related=["ov.genetics.finemap", "ov.genetics.get_credible_sets"],
+)
+def get_pip(fit, *, prune_by_cs: bool = False, **kwargs) -> np.ndarray:
+    """Return the per-variant PIP vector of a SuSiE fit.
+
+    Parameters
+    ----------
+    fit
+        A :class:`pysusie.SusieFit` returned by :func:`finemap`.
+    prune_by_cs
+        If ``True``, zero out variants not in any credible set.
+    **kwargs
+        Forwarded to :func:`pysusie.susie_get_pip`.
+
+    Returns
+    -------
+    numpy.ndarray
+        Length-``n_snps`` vector of posterior inclusion probabilities.
+    """
+    ps = _require_susie()
+    return ps.susie_get_pip(fit, prune_by_cs=prune_by_cs, **kwargs)

--- a/omicverse/genetics/_gwas.py
+++ b/omicverse/genetics/_gwas.py
@@ -1,0 +1,435 @@
+"""GWAS core for ``ov.genetics`` — pure numpy / scipy / statsmodels.
+
+Unlike the rest of ``ov.genetics`` this module has no external backend:
+the standard genome-wide-association primitives are implemented
+directly. Covers per-SNP / per-sample quality control (:func:`gwas_qc`),
+the per-SNP association scan (:func:`gwas_association`, linear or
+logistic) and the genomic-inflation factor (:func:`genomic_inflation`).
+"""
+from __future__ import annotations
+
+from typing import Optional, Union
+
+import numpy as np
+import pandas as pd
+
+from .._registry import register_function
+
+
+# --------------------------------------------------------------------------- #
+# Hardy-Weinberg exact test                                                    #
+# --------------------------------------------------------------------------- #
+def _hwe_exact_p(n_aa: int, n_ab: int, n_bb: int) -> float:
+    """Wigginton-Cutler-Abecasis (2005) exact HWE test p-value.
+
+    Parameters
+    ----------
+    n_aa, n_ab, n_bb
+        Counts of homozygous-major, heterozygous and homozygous-minor
+        genotypes.
+
+    Returns
+    -------
+    float
+        Two-sided exact-test p-value (1.0 for an empty / degenerate site).
+    """
+    n_aa, n_ab, n_bb = int(n_aa), int(n_ab), int(n_bb)
+    n = n_aa + n_ab + n_bb
+    if n == 0:
+        return 1.0
+    # Minor-allele count.
+    n_a = 2 * min(n_aa, n_bb) + n_ab
+    n_genotypes = n
+    # Probability mass over all heterozygote counts of the same parity.
+    het_probs = np.zeros(n_a + 1)
+    mid = n_a * (2 * n_genotypes - n_a) // (2 * n_genotypes)
+    if mid % 2 != n_a % 2:
+        mid += 1
+    het_probs[mid] = 1.0
+    s = het_probs[mid]
+    # Downward recursion from mid.
+    curr_hets = mid
+    curr_homr = (n_a - mid) // 2
+    curr_homc = n_genotypes - curr_hets - curr_homr
+    while curr_hets > 1:
+        het_probs[curr_hets - 2] = (
+            het_probs[curr_hets] * curr_hets * (curr_hets - 1.0)
+            / (4.0 * (curr_homr + 1.0) * (curr_homc + 1.0))
+        )
+        s += het_probs[curr_hets - 2]
+        curr_homr += 1
+        curr_homc += 1
+        curr_hets -= 2
+    # Upward recursion from mid.
+    curr_hets = mid
+    curr_homr = (n_a - mid) // 2
+    curr_homc = n_genotypes - curr_hets - curr_homr
+    while curr_hets <= n_a - 2:
+        het_probs[curr_hets + 2] = (
+            het_probs[curr_hets] * 4.0 * curr_homr * curr_homc
+            / ((curr_hets + 2.0) * (curr_hets + 1.0))
+        )
+        s += het_probs[curr_hets + 2]
+        curr_homr -= 1
+        curr_homc -= 1
+        curr_hets += 2
+    if s <= 0:
+        return 1.0
+    het_probs /= s
+    obs_hets = n_ab
+    p = het_probs[het_probs <= het_probs[obs_hets] + 1e-12].sum()
+    return float(min(1.0, max(0.0, p)))
+
+
+def _as_genotype_matrix(genotype):
+    """Coerce a genotype input to a (samples, snps) float array + SNP names."""
+    if isinstance(genotype, pd.DataFrame):
+        return genotype.to_numpy(dtype=float), list(genotype.columns.astype(str))
+    arr = np.asarray(genotype, dtype=float)
+    if arr.ndim != 2:
+        raise ValueError("genotype must be a 2-D (samples x SNPs) array.")
+    return arr, [f"snp{i}" for i in range(arr.shape[1])]
+
+
+@register_function(
+    aliases=[
+        "gwas_qc", "genotype_qc", "snp_qc", "gwas_quality_control",
+        "GWAS质控", "基因型质控", "SNP质控",
+    ],
+    category="genetics",
+    description=(
+        "Quality control for a GWAS genotype matrix — applies the "
+        "standard per-SNP and per-sample filters: SNP call rate, minor-"
+        "allele frequency (MAF), the Hardy-Weinberg-equilibrium exact "
+        "test (Wigginton 2005), and per-sample missingness. Operates on "
+        "an AnnData of samples x SNPs (dosage / 0-1-2 genotype in ``.X``) "
+        "and returns a filtered AnnData plus the SNP / sample QC metrics. "
+        "Pure numpy / scipy — no external backend."
+    ),
+    examples=[
+        "ov.genetics.gwas_qc(adata, maf=0.01, call_rate=0.95, hwe=1e-6)",
+        "adata_qc = ov.genetics.gwas_qc(adata, sample_call_rate=0.98)",
+    ],
+    related=["ov.genetics.gwas_association", "ov.genetics.read_plink"],
+)
+def gwas_qc(
+    adata,
+    *,
+    call_rate: float = 0.95,
+    maf: float = 0.01,
+    hwe: float = 1e-6,
+    sample_call_rate: float = 0.95,
+    copy: bool = True,
+):
+    """Quality-control a GWAS genotype AnnData.
+
+    Parameters
+    ----------
+    adata
+        AnnData of ``samples x SNPs``; ``.X`` holds genotype dosages
+        (0 / 1 / 2, with NaN for missing calls).
+    call_rate
+        Minimum per-SNP call rate (fraction of non-missing genotypes).
+    maf
+        Minimum minor-allele frequency.
+    hwe
+        Hardy-Weinberg-equilibrium exact-test p-value cutoff — SNPs below
+        it are dropped.
+    sample_call_rate
+        Minimum per-sample call rate.
+    copy
+        If ``True`` (default) return a filtered copy; if ``False`` filter
+        in place.
+
+    Returns
+    -------
+    AnnData
+        The QC-filtered AnnData. ``.var`` gains ``call_rate``, ``maf``,
+        ``hwe_p``; ``.obs`` gains ``sample_call_rate``.
+    """
+    X = np.asarray(adata.X, dtype=float)
+    if hasattr(adata.X, "toarray"):
+        X = adata.X.toarray().astype(float)
+
+    n_samples, n_snps = X.shape
+    missing = np.isnan(X)
+
+    # Per-SNP metrics.
+    snp_call = 1.0 - missing.mean(axis=0)
+    with np.errstate(invalid="ignore"):
+        allele_freq = np.nanmean(X, axis=0) / 2.0
+    snp_maf = np.minimum(allele_freq, 1.0 - allele_freq)
+
+    hwe_p = np.ones(n_snps)
+    for j in range(n_snps):
+        col = X[:, j]
+        col = col[~np.isnan(col)]
+        if col.size == 0:
+            continue
+        rounded = np.rint(col)
+        n_aa = int(np.sum(rounded == 0))
+        n_ab = int(np.sum(rounded == 1))
+        n_bb = int(np.sum(rounded == 2))
+        hwe_p[j] = _hwe_exact_p(n_aa, n_ab, n_bb)
+
+    # Per-sample metrics.
+    sample_call = 1.0 - missing.mean(axis=1)
+
+    snp_keep = (
+        (snp_call >= call_rate)
+        & (snp_maf >= maf)
+        & (hwe_p >= hwe)
+    )
+    sample_keep = sample_call >= sample_call_rate
+
+    out = adata.copy() if copy else adata
+    out.var["call_rate"] = snp_call
+    out.var["maf"] = snp_maf
+    out.var["hwe_p"] = hwe_p
+    out.obs["sample_call_rate"] = sample_call
+    out = out[sample_keep, snp_keep].copy()
+    out.uns["gwas_qc"] = {
+        "n_snps_in": int(n_snps),
+        "n_snps_kept": int(snp_keep.sum()),
+        "n_samples_in": int(n_samples),
+        "n_samples_kept": int(sample_keep.sum()),
+        "thresholds": {
+            "call_rate": call_rate, "maf": maf, "hwe": hwe,
+            "sample_call_rate": sample_call_rate,
+        },
+    }
+    return out
+
+
+@register_function(
+    aliases=[
+        "gwas_association", "gwas_scan", "association_test", "gwas",
+        "全基因组关联分析", "GWAS关联分析", "关联扫描",
+    ],
+    category="genetics",
+    description=(
+        "Per-SNP genome-wide association scan. Regresses a phenotype on "
+        "each SNP's genotype (with optional covariates): ``model='linear'`` "
+        "uses ordinary least squares for a quantitative trait, "
+        "``model='logistic'`` uses logistic regression for a binary "
+        "(case / control) trait. Returns a tidy per-SNP DataFrame with "
+        "the effect size (beta / log-OR), standard error, test statistic "
+        "and p-value. Pure numpy / scipy / statsmodels — no external "
+        "backend."
+    ),
+    examples=[
+        "ov.genetics.gwas_association(genotype, phenotype, model='linear')",
+        "ov.genetics.gwas_association(genotype, phenotype, covariates=pcs, model='logistic')",
+    ],
+    related=["ov.genetics.gwas_qc", "ov.genetics.genomic_inflation",
+             "ov.genetics.manhattan", "ov.genetics.qqplot"],
+)
+def gwas_association(
+    genotype: Union[pd.DataFrame, np.ndarray],
+    phenotype: Union[pd.Series, np.ndarray],
+    covariates: Optional[Union[pd.DataFrame, np.ndarray]] = None,
+    *,
+    model: str = "linear",
+) -> pd.DataFrame:
+    """Run a per-SNP GWAS association scan.
+
+    Parameters
+    ----------
+    genotype
+        Genotype matrix — ``samples x SNPs`` (DataFrame or array). Values
+        are dosages / 0-1-2 genotypes; NaN entries are dropped per SNP.
+    phenotype
+        Per-sample phenotype — quantitative (``model='linear'``) or binary
+        0/1 (``model='logistic'``).
+    covariates
+        Optional ``samples x covariates`` matrix (e.g. genotype PCs, age,
+        sex) added to every per-SNP regression.
+    model
+        ``'linear'`` (OLS, quantitative trait) or ``'logistic'``
+        (logistic regression, binary trait).
+
+    Returns
+    -------
+    pandas.DataFrame
+        One row per SNP, columns ``snp``, ``beta``, ``se``, ``stat``,
+        ``pvalue``, ``n`` — sorted by p-value.
+    """
+    key = str(model).lower().strip()
+    if key not in ("linear", "logistic"):
+        raise ValueError(f"model must be 'linear' or 'logistic', got {model!r}")
+
+    X, snp_names = _as_genotype_matrix(genotype)
+    y = np.asarray(phenotype, dtype=float).ravel()
+    if y.size != X.shape[0]:
+        raise ValueError(
+            f"phenotype has length {y.size}, expected {X.shape[0]} samples."
+        )
+    if covariates is not None:
+        C = (covariates.to_numpy(dtype=float)
+             if isinstance(covariates, pd.DataFrame)
+             else np.asarray(covariates, dtype=float))
+        if C.ndim == 1:
+            C = C[:, None]
+        if C.shape[0] != X.shape[0]:
+            raise ValueError("covariates must have the same number of samples.")
+    else:
+        C = None
+
+    n_snps = X.shape[1]
+    beta = np.full(n_snps, np.nan)
+    se = np.full(n_snps, np.nan)
+    stat = np.full(n_snps, np.nan)
+    pval = np.full(n_snps, np.nan)
+    n_used = np.zeros(n_snps, dtype=int)
+
+    if key == "linear":
+        from scipy import stats as _st
+        for j in range(n_snps):
+            g = X[:, j]
+            keep = ~np.isnan(g) & ~np.isnan(y)
+            if C is not None:
+                keep &= ~np.isnan(C).any(axis=1)
+            ng = int(keep.sum())
+            if ng < 3 or np.ptp(g[keep]) == 0:
+                continue
+            cols = [np.ones(ng), g[keep]]
+            if C is not None:
+                cols.append(C[keep])
+            design = np.column_stack(cols)
+            yk = y[keep]
+            # OLS via least squares.
+            coef, _, rank, _ = np.linalg.lstsq(design, yk, rcond=None)
+            if rank < design.shape[1]:
+                continue
+            resid = yk - design @ coef
+            dof = ng - design.shape[1]
+            if dof <= 0:
+                continue
+            sigma2 = float(resid @ resid) / dof
+            try:
+                xtx_inv = np.linalg.inv(design.T @ design)
+            except np.linalg.LinAlgError:
+                continue
+            b = coef[1]
+            b_se = float(np.sqrt(sigma2 * xtx_inv[1, 1]))
+            if b_se == 0:
+                continue
+            t = b / b_se
+            beta[j] = b
+            se[j] = b_se
+            stat[j] = t
+            pval[j] = float(2.0 * _st.t.sf(abs(t), dof))
+            n_used[j] = ng
+    else:  # logistic
+        try:
+            import statsmodels.api as sm
+        except ImportError as exc:  # pragma: no cover
+            raise ImportError(
+                "model='logistic' requires statsmodels: "
+                "`pip install statsmodels` (or omicverse[genetics])."
+            ) from exc
+        from scipy import stats as _st
+        for j in range(n_snps):
+            g = X[:, j]
+            keep = ~np.isnan(g) & ~np.isnan(y)
+            if C is not None:
+                keep &= ~np.isnan(C).any(axis=1)
+            ng = int(keep.sum())
+            if ng < 5 or np.ptp(g[keep]) == 0:
+                continue
+            cols = [g[keep]]
+            if C is not None:
+                cols.append(C[keep])
+            design = sm.add_constant(np.column_stack(cols), has_constant="add")
+            yk = y[keep]
+            try:
+                fit = sm.Logit(yk, design).fit(disp=False, maxiter=100)
+            except Exception:
+                continue
+            b = float(fit.params[1])
+            b_se = float(fit.bse[1])
+            if not np.isfinite(b_se) or b_se == 0:
+                continue
+            z = b / b_se
+            beta[j] = b
+            se[j] = b_se
+            stat[j] = z
+            pval[j] = float(2.0 * _st.norm.sf(abs(z)))
+            n_used[j] = ng
+
+    res = pd.DataFrame({
+        "snp": snp_names,
+        "beta": beta,
+        "se": se,
+        "stat": stat,
+        "pvalue": pval,
+        "n": n_used,
+    })
+    return res.sort_values("pvalue", na_position="last").reset_index(drop=True)
+
+
+@register_function(
+    aliases=[
+        "genomic_inflation", "lambda_gc", "inflation_factor",
+        "基因组膨胀因子", "lambdaGC",
+    ],
+    category="genetics",
+    description=(
+        "Genomic-inflation factor (lambda GC) — the ratio of the median "
+        "observed association chi-square to its expected value under the "
+        "null. A value near 1 indicates well-calibrated test statistics; "
+        "values much above 1 flag population stratification or "
+        "cryptic relatedness. Accepts p-values, z-scores or chi-square "
+        "statistics. Pure numpy / scipy."
+    ),
+    examples=[
+        "ov.genetics.genomic_inflation(res['pvalue'])",
+        "ov.genetics.genomic_inflation(zscores, statistic='z')",
+    ],
+    related=["ov.genetics.gwas_association", "ov.genetics.qqplot"],
+)
+def genomic_inflation(
+    values: Union[pd.Series, np.ndarray],
+    *,
+    statistic: str = "pvalue",
+) -> float:
+    """Compute the genomic-inflation factor lambda GC.
+
+    Parameters
+    ----------
+    values
+        Per-SNP association statistics — p-values, z-scores or
+        chi-square values (see ``statistic``).
+    statistic
+        ``'pvalue'`` (default), ``'z'`` (z-scores) or ``'chi2'``
+        (chi-square statistics).
+
+    Returns
+    -------
+    float
+        The genomic-inflation factor (1 df).
+    """
+    from scipy import stats as _st
+
+    v = np.asarray(values, dtype=float).ravel()
+    v = v[np.isfinite(v)]
+    if v.size == 0:
+        return float("nan")
+
+    key = str(statistic).lower().strip()
+    if key == "pvalue":
+        v = np.clip(v, np.finfo(float).tiny, 1.0)
+        chi2 = _st.chi2.isf(v, df=1)
+    elif key == "z":
+        chi2 = v ** 2
+    elif key == "chi2":
+        chi2 = v
+    else:
+        raise ValueError(
+            f"statistic must be 'pvalue', 'z' or 'chi2', got {statistic!r}"
+        )
+
+    chi2 = chi2[np.isfinite(chi2)]
+    if chi2.size == 0:
+        return float("nan")
+    return float(np.median(chi2) / _st.chi2.ppf(0.5, df=1))

--- a/omicverse/genetics/_ldsc.py
+++ b/omicverse/genetics/_ldsc.py
@@ -1,0 +1,349 @@
+"""LD score regression for ``ov.genetics`` — LDSC backend.
+
+Wraps the standalone :mod:`pyldsc` package (Bulik-Sullivan *et al.*
+2015; Finucane *et al.* 2015, 2018). Covers SNP-heritability
+(:func:`heritability`), genetic correlation (:func:`genetic_correlation`),
+partitioned heritability (:func:`partitioned_heritability`), the
+cell-type-specific LDSC-SEG analysis (:func:`ldsc_cell_type`) and
+summary-statistics munging (:func:`munge_sumstats`).
+"""
+from __future__ import annotations
+
+from typing import List, Optional, Sequence, Tuple, Union
+
+from .._registry import register_function
+
+
+def _require_ldsc():
+    """Import :mod:`pyldsc` with a friendly error if it is missing."""
+    try:
+        import pyldsc  # noqa: F401
+    except ImportError as exc:  # pragma: no cover
+        raise ImportError(
+            "ov.genetics.heritability requires the pyldsc backend: "
+            "`pip install pyldsc` (or `pip install omicverse[genetics]`)."
+        ) from exc
+    return pyldsc
+
+
+@register_function(
+    aliases=[
+        "heritability", "ldsc", "estimate_h2", "snp_heritability",
+        "遗传力", "SNP遗传力", "LD得分回归",
+    ],
+    category="genetics",
+    description=(
+        "SNP-heritability estimation by LD score regression (Bulik-"
+        "Sullivan 2015). Regresses GWAS chi-square statistics on LD "
+        "scores to estimate the proportion of phenotypic variance "
+        "explained by common SNPs, while the regression intercept "
+        "separates polygenic signal from confounding / inflation. Takes "
+        "the path to a ``.sumstats`` file plus reference-panel and "
+        "regression-weight LD-score filesets. Wraps "
+        ":func:`pyldsc.estimate_h2`."
+    ),
+    examples=[
+        "ov.genetics.heritability('trait.sumstats', ref_ld='baseline', w_ld='weights')",
+        "ov.genetics.heritability('trait.sumstats', ref_ld='ldsc', w_ld='w', samp_prev=0.5, pop_prev=0.01)",
+    ],
+    related=["ov.genetics.genetic_correlation", "ov.genetics.partitioned_heritability",
+             "ov.genetics.ldsc_cell_type", "ov.genetics.munge_sumstats"],
+)
+def heritability(
+    sumstats: str,
+    ref_ld: str,
+    w_ld: str,
+    *,
+    M: Optional[str] = None,
+    intercept_h2: Optional[float] = None,
+    no_intercept: bool = False,
+    n_blocks: int = 200,
+    chisq_max: Optional[float] = None,
+    samp_prev: Optional[float] = None,
+    pop_prev: Optional[float] = None,
+    **kwargs,
+):
+    """Estimate SNP-heritability with LD score regression.
+
+    Parameters
+    ----------
+    sumstats
+        Path to a ``.sumstats(.gz)`` GWAS summary-statistics file.
+    ref_ld
+        Reference-panel LD-score fileset prefix(es), comma-separated.
+    w_ld
+        Regression-weight LD-score fileset prefix.
+    M
+        Optional override of the SNP count.
+    intercept_h2
+        Constrain the regression intercept (e.g. to 1).
+    no_intercept
+        Equivalent to ``intercept_h2=1``.
+    n_blocks
+        Number of block-jackknife blocks.
+    chisq_max
+        Drop SNPs with chi-square above this value.
+    samp_prev, pop_prev
+        Sample / population prevalence — supplying both converts the
+        observed-scale h2 to the liability scale.
+    **kwargs
+        Forwarded to :func:`pyldsc.estimate_h2`.
+
+    Returns
+    -------
+    pyldsc.regressions.Hsq
+        Fitted heritability object (``.tot``, ``.tot_se``, ``.intercept``,
+        ``.lambda_gc``, ``.mean_chisq`` ...).
+    """
+    ldsc = _require_ldsc()
+    return ldsc.estimate_h2(
+        sumstats, ref_ld, w_ld, M=M, intercept_h2=intercept_h2,
+        no_intercept=no_intercept, n_blocks=n_blocks, chisq_max=chisq_max,
+        samp_prev=samp_prev, pop_prev=pop_prev, log=None, **kwargs,
+    )
+
+
+@register_function(
+    aliases=[
+        "genetic_correlation", "estimate_rg", "rg", "genetic_corr",
+        "遗传相关", "遗传相关性",
+    ],
+    category="genetics",
+    description=(
+        "Genome-wide genetic correlation (rg) between two or more traits "
+        "by cross-trait LD score regression (Bulik-Sullivan 2015) — "
+        "quantifies the shared polygenic architecture of traits. Takes a "
+        "list of ``.sumstats`` paths (the first is the reference trait) "
+        "plus LD-score filesets. Wraps :func:`pyldsc.estimate_rg`."
+    ),
+    examples=[
+        "ov.genetics.genetic_correlation(['t1.sumstats', 't2.sumstats'], ref_ld='ldsc', w_ld='w')",
+    ],
+    related=["ov.genetics.heritability", "ov.genetics.partitioned_heritability"],
+)
+def genetic_correlation(
+    sumstats_list: Sequence[str],
+    ref_ld: str,
+    w_ld: str,
+    *,
+    n_blocks: int = 200,
+    chisq_max: Optional[float] = None,
+    intercept_h2: Optional[float] = None,
+    intercept_gencov: Optional[float] = None,
+    no_intercept: bool = False,
+    **kwargs,
+):
+    """Estimate genetic correlation between traits.
+
+    Parameters
+    ----------
+    sumstats_list
+        Paths to two or more ``.sumstats(.gz)`` files; the first is the
+        reference trait, the rest are each correlated against it.
+    ref_ld, w_ld
+        Reference-panel and regression-weight LD-score fileset prefixes.
+    n_blocks
+        Number of block-jackknife blocks.
+    chisq_max
+        Drop SNPs with chi-square above this value.
+    intercept_h2, intercept_gencov
+        Optionally constrain the h2 / genetic-covariance intercepts.
+    no_intercept
+        Constrain all intercepts (h2 to 1, gencov to 0).
+    **kwargs
+        Forwarded to :func:`pyldsc.estimate_rg`.
+
+    Returns
+    -------
+    list of pyldsc.regressions.RG
+        One genetic-correlation object per trait pair.
+    """
+    ldsc = _require_ldsc()
+    return ldsc.estimate_rg(
+        list(sumstats_list), ref_ld, w_ld, n_blocks=n_blocks,
+        chisq_max=chisq_max, intercept_h2=intercept_h2,
+        intercept_gencov=intercept_gencov, no_intercept=no_intercept,
+        log=None, **kwargs,
+    )
+
+
+@register_function(
+    aliases=[
+        "partitioned_heritability", "partitioned_h2", "stratified_ldsc",
+        "分层遗传力", "分区遗传力",
+    ],
+    category="genetics",
+    description=(
+        "Partitioned (stratified) heritability — splits SNP-heritability "
+        "across functional annotation categories to find which genomic "
+        "features (enhancers, conserved regions, etc.) are enriched for a "
+        "trait's heritability (Finucane 2015). Takes a ``.sumstats`` path "
+        "plus annotation-stratified LD-score filesets. Wraps "
+        ":func:`pyldsc.partitioned_h2`."
+    ),
+    examples=[
+        "ov.genetics.partitioned_heritability('trait.sumstats', ref_ld='baseline', w_ld='w', frqfile='1000G')",
+    ],
+    related=["ov.genetics.heritability", "ov.genetics.ldsc_cell_type"],
+)
+def partitioned_heritability(
+    sumstats: str,
+    ref_ld: str,
+    w_ld: str,
+    *,
+    frqfile: Optional[str] = None,
+    overlap_annot: bool = True,
+    n_blocks: int = 200,
+    chisq_max: Optional[float] = None,
+    **kwargs,
+):
+    """Estimate partitioned (category-stratified) heritability.
+
+    Parameters
+    ----------
+    sumstats
+        Path to a ``.sumstats(.gz)`` file.
+    ref_ld
+        Annotation-stratified reference LD-score fileset prefix(es).
+    w_ld
+        Regression-weight LD-score fileset prefix.
+    frqfile
+        Allele-frequency fileset prefix (used with ``overlap_annot``).
+    overlap_annot
+        Apply the overlapping-category correction.
+    n_blocks
+        Number of block-jackknife blocks.
+    chisq_max
+        Drop SNPs with chi-square above this value.
+    **kwargs
+        Forwarded to :func:`pyldsc.partitioned_h2`.
+
+    Returns
+    -------
+    pyldsc.regressions.Hsq
+        Fitted object with per-category h2, enrichment and coefficients.
+    """
+    ldsc = _require_ldsc()
+    return ldsc.partitioned_h2(
+        sumstats, ref_ld, w_ld, frqfile=frqfile,
+        overlap_annot=overlap_annot, n_blocks=n_blocks,
+        chisq_max=chisq_max, log=None, **kwargs,
+    )
+
+
+@register_function(
+    aliases=[
+        "ldsc_cell_type", "ldsc_seg", "ldsc_cts", "cell_type_ldsc",
+        "细胞类型遗传力富集", "LDSC-SEG", "组织特异性遗传力",
+    ],
+    category="genetics",
+    description=(
+        "LDSC-SEG cell-type / tissue specific heritability enrichment "
+        "(Finucane 2018). For each cell type's specifically-expressed-gene "
+        "LD-score set, fits a heritability regression on top of the "
+        "baseline model and reports the cell-type coefficient with a "
+        "one-sided p-value — ranking which cell types / tissues are most "
+        "relevant to a trait. Wraps :func:`pyldsc.ldsc_seg`."
+    ),
+    examples=[
+        "ov.genetics.ldsc_cell_type('trait.sumstats', ref_ld_cts='tissues.ldcts', ref_ld='baseline', w_ld='w')",
+    ],
+    related=["ov.genetics.partitioned_heritability", "ov.genetics.disease_relevance_score"],
+)
+def ldsc_cell_type(
+    sumstats: str,
+    ref_ld_cts: Union[str, List[Tuple[str, str]]],
+    ref_ld: str,
+    w_ld: str,
+    *,
+    n_blocks: int = 200,
+    chisq_max: Optional[float] = None,
+    **kwargs,
+):
+    """Run the LDSC-SEG cell-type heritability-enrichment analysis.
+
+    Parameters
+    ----------
+    sumstats
+        Path to a ``.sumstats(.gz)`` file.
+    ref_ld_cts
+        Either a path to a ``--ref-ld-chr-cts`` file (two columns: name
+        and LD-score prefix) or a list of ``(name, ld_prefix)`` tuples.
+    ref_ld
+        The baseline-model reference LD-score fileset prefix.
+    w_ld
+        Regression-weight LD-score fileset prefix.
+    n_blocks
+        Number of block-jackknife blocks.
+    chisq_max
+        Drop SNPs with chi-square above this value.
+    **kwargs
+        Forwarded to :func:`pyldsc.ldsc_seg`.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Per-cell-type coefficient, standard error and one-sided p-value.
+    """
+    ldsc = _require_ldsc()
+    return ldsc.ldsc_seg(
+        sumstats, ref_ld_cts, ref_ld, w_ld, n_blocks=n_blocks,
+        chisq_max=chisq_max, log=None, **kwargs,
+    )
+
+
+@register_function(
+    aliases=[
+        "munge_sumstats", "munge", "format_sumstats", "标准化汇总统计",
+        "GWAS汇总统计格式化",
+    ],
+    category="genetics",
+    description=(
+        "Munge a raw GWAS summary-statistics file into the standardised "
+        "``.sumstats`` format used by LD score regression — harmonises "
+        "column names, filters on INFO / MAF / sample size and aligns "
+        "alleles. Wraps :func:`pyldsc.munge_sumstats`."
+    ),
+    examples=[
+        "ov.genetics.munge_sumstats('raw_gwas.txt', out='trait', N=100000)",
+    ],
+    related=["ov.genetics.heritability", "ov.genetics.read_sumstats"],
+)
+def munge_sumstats(
+    sumstats: str,
+    *,
+    out: Optional[str] = None,
+    N: Optional[float] = None,
+    info_min: float = 0.9,
+    maf_min: float = 0.01,
+    write: bool = True,
+    **kwargs,
+):
+    """Munge a raw GWAS file to ``.sumstats`` format.
+
+    Parameters
+    ----------
+    sumstats
+        Path to the raw GWAS file (optionally ``.gz`` / ``.bz2``).
+    out
+        Output prefix; ``out.sumstats.gz`` is written when ``write`` is
+        ``True``.
+    N
+        Sample size (used when the file lacks an ``N`` column).
+    info_min, maf_min
+        Minimum INFO score and minor-allele frequency to keep a SNP.
+    write
+        Whether to write the munged file to disk.
+    **kwargs
+        Forwarded to :func:`pyldsc.munge_sumstats`.
+
+    Returns
+    -------
+    pandas.DataFrame
+        The munged summary-statistics table.
+    """
+    ldsc = _require_ldsc()
+    return ldsc.munge_sumstats(
+        sumstats, out=out, N=N, info_min=info_min,
+        maf_min=maf_min, write=write, log=None, **kwargs,
+    )

--- a/omicverse/genetics/_mr.py
+++ b/omicverse/genetics/_mr.py
@@ -1,0 +1,332 @@
+"""Mendelian randomization for ``ov.genetics`` — TwoSampleMR backend.
+
+Wraps the standalone :mod:`pytwosamplemr` package. :func:`mendelian_randomization`
+is a single dispatcher over the full library of two-sample MR
+estimators (IVW, MR-Egger, weighted median, mode-based, maximum
+likelihood, dIVW, contamination mixture, MR-Lasso, MR-cML).
+:func:`harmonize`, :func:`mr_steiger`, :func:`mr_heterogeneity` and
+:func:`mr_pleiotropy` cover data preparation and sensitivity analyses.
+"""
+from __future__ import annotations
+
+from typing import Optional, Sequence, Union
+
+import numpy as np
+import pandas as pd
+
+from .._registry import register_function
+
+
+def _require_mr():
+    """Import :mod:`pytwosamplemr` with a friendly error if it is missing."""
+    try:
+        import pytwosamplemr  # noqa: F401
+    except ImportError as exc:  # pragma: no cover
+        raise ImportError(
+            "ov.genetics.mendelian_randomization requires the pytwosamplemr "
+            "backend: `pip install pytwosamplemr` "
+            "(or `pip install omicverse[genetics]`)."
+        ) from exc
+    return pytwosamplemr
+
+
+_MR_METHODS = {
+    "ivw": "mr_ivw",
+    "egger": "mr_egger",
+    "median": "mr_median",
+    "mode": "mr_mbe",
+    "mbe": "mr_mbe",
+    "maxlik": "mr_maxlik",
+    "divw": "mr_divw",
+    "conmix": "mr_conmix",
+    "lasso": "mr_lasso",
+    "cml": "mr_cml",
+}
+
+
+def _coerce_input(mr, mr_input_or_dataframes, bx, bxse, by, byse, snps):
+    """Build an :class:`pytwosamplemr.MRInput` from the flexible first arg."""
+    obj = mr_input_or_dataframes
+    # Already an MRInput.
+    if obj is not None and obj.__class__.__name__ == "MRInput":
+        return obj
+    # Harmonised TwoSampleMR-style DataFrame.
+    if isinstance(obj, pd.DataFrame):
+        cols = {c.lower(): c for c in obj.columns}
+        def _col(*cands):
+            for cand in cands:
+                if cand in cols:
+                    return obj[cols[cand]].to_numpy(dtype=float)
+            raise KeyError(
+                f"DataFrame is missing one of {cands}; pass an MRInput or "
+                f"explicit bx/bxse/by/byse instead."
+            )
+        snp_col = next((obj[cols[c]].astype(str).tolist()
+                        for c in ("snp", "snps") if c in cols), None)
+        return mr.mr_input(
+            bx=_col("beta.exposure", "bx", "beta_exposure"),
+            bxse=_col("se.exposure", "bxse", "se_exposure"),
+            by=_col("beta.outcome", "by", "beta_outcome"),
+            byse=_col("se.outcome", "byse", "se_outcome"),
+            snps=snp_col,
+        )
+    # Explicit arrays.
+    if bx is not None and bxse is not None and by is not None and byse is not None:
+        return mr.mr_input(bx=np.asarray(bx, dtype=float),
+                           bxse=np.asarray(bxse, dtype=float),
+                           by=np.asarray(by, dtype=float),
+                           byse=np.asarray(byse, dtype=float),
+                           snps=snps)
+    raise ValueError(
+        "Provide an MRInput, a harmonised DataFrame, or all four of "
+        "bx / bxse / by / byse."
+    )
+
+
+@register_function(
+    aliases=[
+        "mendelian_randomization", "mr", "mendelian randomization",
+        "孟德尔随机化", "MR分析", "因果推断",
+    ],
+    category="genetics",
+    description=(
+        "Two-sample Mendelian randomization to estimate the causal effect "
+        "of an exposure on an outcome from GWAS summary statistics. "
+        "``method`` selects the estimator: ``'ivw'`` (inverse-variance "
+        "weighted, default), ``'egger'`` (MR-Egger, pleiotropy-robust), "
+        "``'median'`` (weighted median), ``'mode'`` (mode-based estimate), "
+        "``'maxlik'`` (maximum likelihood), ``'divw'`` (debiased IVW), "
+        "``'conmix'`` (contamination mixture), ``'lasso'`` (MR-Lasso), "
+        "``'cml'`` (MR-cML), or ``'all'`` to run every estimator and "
+        "return a comparison table. The first argument may be an MRInput, "
+        "a harmonised DataFrame, or explicit bx/bxse/by/byse arrays. "
+        "Wraps the pytwosamplemr backend."
+    ),
+    examples=[
+        "ov.genetics.mendelian_randomization(mr_input, method='ivw')",
+        "ov.genetics.mendelian_randomization(mr_input, method='egger')",
+        "ov.genetics.mendelian_randomization(mr_input, method='all')",
+        "ov.genetics.mendelian_randomization(bx=bx, bxse=bxse, by=by, byse=byse)",
+    ],
+    related=["ov.genetics.harmonize", "ov.genetics.mr_steiger",
+             "ov.genetics.mr_heterogeneity", "ov.genetics.mr_pleiotropy",
+             "ov.genetics.mr_scatter"],
+)
+def mendelian_randomization(
+    mr_input_or_dataframes=None,
+    *,
+    method: str = "ivw",
+    bx: Optional[Sequence[float]] = None,
+    bxse: Optional[Sequence[float]] = None,
+    by: Optional[Sequence[float]] = None,
+    byse: Optional[Sequence[float]] = None,
+    snps: Optional[Sequence[str]] = None,
+    n: Optional[int] = None,
+    **kwargs,
+):
+    """Run two-sample Mendelian randomization.
+
+    Parameters
+    ----------
+    mr_input_or_dataframes
+        An :class:`pytwosamplemr.MRInput`, or a harmonised DataFrame with
+        columns ``beta.exposure`` / ``se.exposure`` / ``beta.outcome`` /
+        ``se.outcome`` (or the ``bx`` / ``bxse`` / ``by`` / ``byse``
+        short forms).
+    method
+        Estimator selector — one of ``'ivw'``, ``'egger'``, ``'median'``,
+        ``'mode'``, ``'maxlik'``, ``'divw'``, ``'conmix'``, ``'lasso'``,
+        ``'cml'``, or ``'all'``.
+    bx, bxse, by, byse
+        Explicit SNP-exposure / SNP-outcome effect sizes and standard
+        errors (an alternative to passing an MRInput / DataFrame).
+    snps
+        Optional SNP identifiers.
+    n
+        Sample size — required for ``method='cml'``.
+    **kwargs
+        Forwarded to the backend estimator.
+
+    Returns
+    -------
+    object or pandas.DataFrame
+        A single MR result object, or — for ``method='all'`` — a tidy
+        DataFrame comparing every estimator.
+    """
+    mr = _require_mr()
+    obj = _coerce_input(mr, mr_input_or_dataframes, bx, bxse, by, byse, snps)
+    key = str(method).lower().strip()
+
+    if key == "all":
+        return mr.mr_allmethods(obj, **kwargs)
+    if key not in _MR_METHODS:
+        raise ValueError(
+            f"method must be 'all' or one of {sorted(_MR_METHODS)}, "
+            f"got {method!r}"
+        )
+    fn = getattr(mr, _MR_METHODS[key])
+    if key == "cml":
+        if n is None:
+            raise ValueError("method='cml' requires the sample size n=.")
+        return fn(obj, n=n, **kwargs)
+    return fn(obj, **kwargs)
+
+
+@register_function(
+    aliases=["harmonize", "harmonise", "harmonise_data", "数据协调", "等位基因协调"],
+    category="genetics",
+    description=(
+        "Harmonise SNP-exposure and SNP-outcome GWAS effects onto the "
+        "same effect allele before Mendelian randomization — resolves "
+        "strand and allele mismatches and flags ambiguous palindromic "
+        "SNPs. Wraps :func:`pytwosamplemr.harmonise_data`."
+    ),
+    examples=[
+        "ov.genetics.harmonize(exposure_df, outcome_df)",
+        "ov.genetics.harmonize(exposure_df, outcome_df, action=2)",
+    ],
+    related=["ov.genetics.mendelian_randomization"],
+)
+def harmonize(
+    exposure: pd.DataFrame,
+    outcome: pd.DataFrame,
+    *,
+    tolerance: float = 0.08,
+    action: int = 2,
+) -> pd.DataFrame:
+    """Harmonise exposure and outcome GWAS effects.
+
+    Parameters
+    ----------
+    exposure, outcome
+        DataFrames with columns ``SNP``, ``beta``, ``se``,
+        ``effect_allele``, ``other_allele`` (``eaf`` optional).
+    tolerance
+        Max allele-frequency difference for palindromic-SNP resolution.
+    action
+        Allele-harmonisation strictness (``1`` / ``2`` / ``3``).
+
+    Returns
+    -------
+    pandas.DataFrame
+        Harmonised SNP table ready for :func:`mendelian_randomization`.
+    """
+    mr = _require_mr()
+    return mr.harmonise_data(exposure, outcome,
+                             tolerance=tolerance, action=action)
+
+
+@register_function(
+    aliases=["mr_steiger", "steiger", "directionality_test", "方向性检验"],
+    category="genetics",
+    description=(
+        "MR-Steiger directionality test — checks that the instrument "
+        "explains more variance in the exposure than in the outcome, "
+        "i.e. that the assumed causal direction is correct. Wraps "
+        ":func:`pytwosamplemr.mr_steiger`."
+    ),
+    examples=[
+        "ov.genetics.mr_steiger(p_exp, p_out, n_exp, n_out)",
+    ],
+    related=["ov.genetics.mendelian_randomization"],
+)
+def mr_steiger(p_exp, p_out, n_exp, n_out, *, r_exp=None, r_out=None) -> dict:
+    """Run the MR-Steiger directionality test.
+
+    Parameters
+    ----------
+    p_exp, p_out
+        SNP-exposure and SNP-outcome association p-values.
+    n_exp, n_out
+        Exposure / outcome GWAS sample sizes.
+    r_exp, r_out
+        Optional pre-computed SNP-trait correlations.
+
+    Returns
+    -------
+    dict
+        Steiger result — correlations, the directionality verdict and its
+        p-value.
+    """
+    mr = _require_mr()
+    return mr.mr_steiger(p_exp, p_out, n_exp, n_out, r_exp=r_exp, r_out=r_out)
+
+
+@register_function(
+    aliases=["mr_heterogeneity", "heterogeneity", "cochran_q", "异质性检验"],
+    category="genetics",
+    description=(
+        "Cochran's Q heterogeneity test for a Mendelian-randomization "
+        "analysis — excess heterogeneity across instruments flags "
+        "pleiotropy or invalid instruments. Wraps "
+        ":func:`pytwosamplemr.mr_heterogeneity`."
+    ),
+    examples=[
+        "ov.genetics.mr_heterogeneity(mr_input)",
+        "ov.genetics.mr_heterogeneity(mr_input, methods=('ivw', 'egger'))",
+    ],
+    related=["ov.genetics.mendelian_randomization", "ov.genetics.mr_pleiotropy"],
+)
+def mr_heterogeneity(
+    dat,
+    *,
+    methods: Sequence[str] = ("ivw", "egger"),
+    bx=None, bxse=None, by=None, byse=None, snps=None,
+) -> pd.DataFrame:
+    """Cochran's Q heterogeneity test.
+
+    Parameters
+    ----------
+    dat
+        An MRInput / harmonised DataFrame (or pass bx/bxse/by/byse).
+    methods
+        Which estimators to compute Q for.
+    bx, bxse, by, byse, snps
+        Explicit arrays, if ``dat`` is not given.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Per-method Q statistic, degrees of freedom and p-value.
+    """
+    mr = _require_mr()
+    obj = _coerce_input(mr, dat, bx, bxse, by, byse, snps)
+    return mr.mr_heterogeneity(obj, methods=tuple(methods))
+
+
+@register_function(
+    aliases=["mr_pleiotropy", "pleiotropy", "egger_intercept", "多效性检验"],
+    category="genetics",
+    description=(
+        "MR-Egger intercept test for directional (horizontal) pleiotropy "
+        "— a non-zero intercept indicates the instruments violate the "
+        "exclusion-restriction assumption. Wraps "
+        ":func:`pytwosamplemr.mr_pleiotropy_test`."
+    ),
+    examples=[
+        "ov.genetics.mr_pleiotropy(mr_input)",
+    ],
+    related=["ov.genetics.mendelian_randomization", "ov.genetics.mr_heterogeneity"],
+)
+def mr_pleiotropy(
+    dat,
+    *,
+    bx=None, bxse=None, by=None, byse=None, snps=None,
+) -> pd.DataFrame:
+    """MR-Egger intercept (pleiotropy) test.
+
+    Parameters
+    ----------
+    dat
+        An MRInput / harmonised DataFrame (or pass bx/bxse/by/byse).
+    bx, bxse, by, byse, snps
+        Explicit arrays, if ``dat`` is not given.
+
+    Returns
+    -------
+    pandas.DataFrame
+        The MR-Egger intercept, its standard error and p-value.
+    """
+    mr = _require_mr()
+    obj = _coerce_input(mr, dat, bx, bxse, by, byse, snps)
+    return mr.mr_pleiotropy_test(obj)

--- a/omicverse/genetics/_scdrs.py
+++ b/omicverse/genetics/_scdrs.py
@@ -1,0 +1,220 @@
+"""Single-cell disease relevance scoring for ``ov.genetics`` — scDRS backend.
+
+Wraps the standalone :mod:`pyscdrs` package (Zhang *et al.* 2022). Given
+an scRNA-seq :class:`~anndata.AnnData` and a GWAS-derived gene set,
+:func:`disease_relevance_score` assigns each cell a disease-relevance
+score (and an empirical p-value). :func:`score_downstream` runs the
+group-level, covariate-correlation and gene-level downstream analyses.
+
+This is the one ``ov.genetics`` task that is genuinely AnnData-native —
+scDRS operates on single-cell expression directly.
+"""
+from __future__ import annotations
+
+from typing import List, Optional, Sequence, Union
+
+import numpy as np
+import pandas as pd
+
+from .._registry import register_function
+
+
+def _require_scdrs():
+    """Import :mod:`pyscdrs` with a friendly error if it is missing."""
+    try:
+        import pyscdrs  # noqa: F401
+    except ImportError as exc:  # pragma: no cover
+        raise ImportError(
+            "ov.genetics.disease_relevance_score requires the pyscdrs "
+            "backend: `pip install pyscdrs` "
+            "(or `pip install omicverse[genetics]`)."
+        ) from exc
+    return pyscdrs
+
+
+@register_function(
+    aliases=[
+        "disease_relevance_score", "scdrs", "scDRS", "disease_score",
+        "单细胞疾病相关性", "疾病相关性打分", "细胞疾病评分",
+    ],
+    category="genetics",
+    description=(
+        "Single-cell disease-relevance scoring with scDRS (Zhang 2022). "
+        "Links a GWAS to single-cell expression: each cell receives a "
+        "normalised disease-relevance score and an empirical p-value "
+        "against Monte-Carlo control gene sets, revealing which cell "
+        "types / states are enriched for a disease's heritability. Takes "
+        "an scRNA-seq AnnData plus a GWAS-derived gene set (a list of "
+        "genes, or a (genes, weights) tuple from a MAGMA ``.gs`` file). "
+        "Runs scDRS preprocessing then control-matched scoring. Wraps the "
+        "pyscdrs backend."
+    ),
+    examples=[
+        "ov.genetics.disease_relevance_score(adata, gene_set=disease_genes)",
+        "ov.genetics.disease_relevance_score(adata, gene_set=(genes, weights), n_ctrl=1000)",
+    ],
+    related=["ov.genetics.score_downstream", "ov.genetics.heritability"],
+)
+def disease_relevance_score(
+    adata,
+    gene_set: Union[Sequence[str], tuple],
+    *,
+    gene_weight: Optional[Sequence[float]] = None,
+    cov: Optional[pd.DataFrame] = None,
+    n_ctrl: int = 1000,
+    weight_opt: str = "vs",
+    ctrl_match_key: str = "mean_var",
+    n_genebin: int = 200,
+    random_seed: int = 0,
+    copy: bool = False,
+    return_raw: bool = False,
+    verbose: bool = False,
+    **kwargs,
+) -> pd.DataFrame:
+    """Score every cell for disease relevance with scDRS.
+
+    Parameters
+    ----------
+    adata
+        Single-cell :class:`~anndata.AnnData` (cells x genes), normalised
+        and log-transformed.
+    gene_set
+        The GWAS-derived gene set — either a list of gene names, or a
+        ``(genes, weights)`` tuple (as returned by :func:`load_gs`).
+    gene_weight
+        Optional per-gene weights (used when ``gene_set`` is a plain list).
+    cov
+        Optional cell-level covariate DataFrame regressed out during
+        preprocessing.
+    n_ctrl
+        Number of Monte-Carlo control gene sets for the empirical null.
+    weight_opt
+        Gene-weighting scheme — ``'vs'`` (variance-stabilised), ``'inv_std'``,
+        ``'od'`` or ``'uniform'``.
+    ctrl_match_key
+        Cell-property key used to match control genes (default
+        ``'mean_var'``).
+    n_genebin
+        Number of expression bins for control-gene matching.
+    random_seed
+        Seed for the Monte-Carlo control draws.
+    copy
+        If ``True``, preprocess a copy and leave ``adata`` untouched.
+    return_raw
+        If ``True``, also return the raw / control scores.
+    verbose
+        Print backend progress.
+    **kwargs
+        Forwarded to :func:`pyscdrs.score_cell`.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Per-cell score table with ``raw_score``, ``norm_score``,
+        ``mc_pval``, ``pval``, ``nlog10_pval`` and ``zscore``.
+    """
+    scdrs = _require_scdrs()
+
+    # Resolve a (genes, weights) tuple vs a plain gene list.
+    if isinstance(gene_set, tuple) and len(gene_set) == 2:
+        genes, weights = gene_set
+        genes = list(genes)
+        weights = None if weights is None else list(weights)
+    else:
+        genes = list(gene_set)
+        weights = None if gene_weight is None else list(gene_weight)
+
+    work = adata.copy() if copy else adata
+    scdrs.preprocess(work, cov=cov, copy=False)
+    df_score = scdrs.score_cell(
+        work, gene_list=genes, gene_weight=weights,
+        ctrl_match_key=ctrl_match_key, n_ctrl=n_ctrl,
+        n_genebin=n_genebin, weight_opt=weight_opt,
+        random_seed=random_seed,
+        return_ctrl_raw_score=return_raw,
+        return_ctrl_norm_score=return_raw,
+        verbose=verbose, **kwargs,
+    )
+    return df_score
+
+
+@register_function(
+    aliases=[
+        "score_downstream", "scdrs_downstream", "disease_score_downstream",
+        "疾病评分下游分析", "scDRS下游分析",
+    ],
+    category="genetics",
+    description=(
+        "Downstream analysis of scDRS disease-relevance scores. "
+        "``analysis`` selects the task: ``'group'`` tests which cell "
+        "groups (e.g. cell types) are disease-enriched and heterogeneous; "
+        "``'corr'`` correlates the score with continuous cell covariates; "
+        "``'gene'`` ranks genes by correlation with the score. Wraps "
+        "pyscdrs' downstream functions."
+    ),
+    examples=[
+        "ov.genetics.score_downstream(adata, df_score, analysis='group', group_cols=['cell_type'])",
+        "ov.genetics.score_downstream(adata, df_score, analysis='corr', var_cols=['gradient'])",
+        "ov.genetics.score_downstream(adata, df_score, analysis='gene')",
+    ],
+    related=["ov.genetics.disease_relevance_score"],
+)
+def score_downstream(
+    adata,
+    df_score: pd.DataFrame,
+    *,
+    analysis: str = "group",
+    group_cols: Optional[List[str]] = None,
+    var_cols: Optional[List[str]] = None,
+    fdr_thresholds: List[float] = [0.05, 0.1, 0.2],
+):
+    """Run a scDRS downstream analysis.
+
+    Parameters
+    ----------
+    adata
+        The AnnData scored by :func:`disease_relevance_score`.
+    df_score
+        The per-cell score DataFrame from :func:`disease_relevance_score`.
+    analysis
+        ``'group'`` (cell-group enrichment / heterogeneity), ``'corr'``
+        (covariate correlation), or ``'gene'`` (gene-level association).
+        ``analysis='group'`` needs a precomputed neighbour graph — run
+        ``sc.pp.neighbors(adata)`` before calling it.
+    group_cols
+        For ``analysis='group'``: the ``adata.obs`` columns defining the
+        cell groups.
+    var_cols
+        For ``analysis='corr'``: the continuous ``adata.obs`` columns to
+        correlate with the score.
+    fdr_thresholds
+        For ``analysis='group'``: FDR cutoffs for the proportion of
+        significant cells.
+
+    Returns
+    -------
+    dict or pandas.DataFrame
+        The backend downstream result.
+    """
+    scdrs = _require_scdrs()
+    key = str(analysis).lower().strip()
+
+    if key == "group":
+        if not group_cols:
+            raise ValueError("analysis='group' requires group_cols=.")
+        return scdrs.downstream_group_analysis(
+            adata, df_score, group_cols=list(group_cols),
+            fdr_thresholds=list(fdr_thresholds),
+        )
+    if key == "corr":
+        if not var_cols:
+            raise ValueError("analysis='corr' requires var_cols=.")
+        return scdrs.downstream_corr_analysis(
+            adata, df_score, var_cols=list(var_cols),
+        )
+    if key == "gene":
+        return scdrs.downstream_gene_analysis(adata, df_score)
+
+    raise ValueError(
+        f"analysis must be 'group', 'corr' or 'gene', got {analysis!r}"
+    )

--- a/omicverse/genetics/_twas.py
+++ b/omicverse/genetics/_twas.py
@@ -1,0 +1,229 @@
+"""Transcriptome-wide association study for ``ov.genetics`` — TWAS backend.
+
+Wraps the standalone :mod:`pytwas` package — the (S-)PrediXcan /
+S-MultiXcan family (Gamazon *et al.* 2015; Barbeira *et al.* 2018, 2019).
+:func:`twas` is a single dispatcher: ``method='spredixcan'`` runs a
+single-tissue summary-statistics TWAS, ``method='smultixcan'`` combines
+tissues, and ``method='predixcan'`` runs the individual-level TWAS.
+"""
+from __future__ import annotations
+
+from typing import Dict, Optional, Union
+
+import numpy as np
+import pandas as pd
+
+from .._registry import register_function
+
+
+def _canonicalize_gwas(
+    df: pd.DataFrame,
+    snp_column, effect_allele_column, non_effect_allele_column,
+    zscore_column, beta_column, se_column, pvalue_column,
+):
+    """Rename a raw GWAS DataFrame to pytwas' canonical schema.
+
+    ``pytwas.spredixcan`` only applies column mapping when it reads from
+    ``gwas_file``; a DataFrame passed via ``gwas=`` must already use the
+    canonical ``snp`` / ``effect_allele`` / ``non_effect_allele`` /
+    ``zscore`` (or ``beta`` / ``se`` / ``pvalue``) names. This helper
+    bridges that gap so users can pass a plain results DataFrame.
+    """
+    canon = {"snp", "effect_allele", "non_effect_allele"}
+    if canon.issubset(set(df.columns)):
+        return df  # already canonical (e.g. from pytwas.load_gwas).
+    rename = {
+        snp_column: "snp",
+        effect_allele_column: "effect_allele",
+        non_effect_allele_column: "non_effect_allele",
+    }
+    if zscore_column:
+        rename[zscore_column] = "zscore"
+    if beta_column:
+        rename[beta_column] = "beta"
+    if se_column:
+        rename[se_column] = "se"
+    if pvalue_column:
+        rename[pvalue_column] = "pvalue"
+    rename = {k: v for k, v in rename.items() if k in df.columns}
+    return df.rename(columns=rename)
+
+
+def _require_twas():
+    """Import :mod:`pytwas` with a friendly error if it is missing."""
+    try:
+        import pytwas  # noqa: F401
+    except ImportError as exc:  # pragma: no cover
+        raise ImportError(
+            "ov.genetics.twas requires the pytwas backend: "
+            "`pip install pytwas` (or `pip install omicverse[genetics]`)."
+        ) from exc
+    return pytwas
+
+
+@register_function(
+    aliases=[
+        "twas", "transcriptome_wide_association", "predixcan", "spredixcan",
+        "smultixcan", "metaxcan",
+        "转录组关联分析", "TWAS分析", "全转录组关联",
+    ],
+    category="genetics",
+    description=(
+        "Transcriptome-wide association study (TWAS) with the PrediXcan / "
+        "MetaXcan family — tests genetically-predicted gene expression for "
+        "association with a trait, nominating candidate effector genes "
+        "from a GWAS. ``method`` selects the algorithm: ``'spredixcan'`` "
+        "(default; single-tissue S-PrediXcan from GWAS summary statistics "
+        "+ a prediction model + a SNP-covariance file), ``'smultixcan'`` "
+        "(S-MultiXcan, aggregates S-PrediXcan results across tissues into "
+        "one chi-square test), or ``'predixcan'`` (individual-level "
+        "PrediXcan from genotype dosages + phenotype). Wraps the pytwas "
+        "backend."
+    ),
+    examples=[
+        "ov.genetics.twas('model.db', covariance='cov.txt.gz', gwas=gwas_df, method='spredixcan')",
+        "ov.genetics.twas(spx_results, models=models, covariance='snp_cov.txt.gz', method='smultixcan')",
+        "ov.genetics.twas('model.db', dosages=dos, phenotype=y, method='predixcan')",
+    ],
+    related=["ov.genetics.load_twas_model", "ov.genetics.heritability",
+             "ov.genetics.manhattan"],
+)
+def twas(
+    gwas=None,
+    model: Optional[Union[str, Dict]] = None,
+    covariance: Optional[Union[str, object]] = None,
+    *,
+    method: str = "spredixcan",
+    gwas_file: Optional[str] = None,
+    models: Optional[Dict] = None,
+    dosages: Optional[pd.DataFrame] = None,
+    phenotype: Optional[np.ndarray] = None,
+    mode: str = "linear",
+    snp_column: str = "SNP",
+    effect_allele_column: str = "A1",
+    non_effect_allele_column: str = "A2",
+    zscore_column: Optional[str] = None,
+    beta_column: Optional[str] = None,
+    se_column: Optional[str] = None,
+    pvalue_column: Optional[str] = None,
+    **kwargs,
+):
+    """Run a transcriptome-wide association study.
+
+    Parameters
+    ----------
+    gwas
+        For ``method='spredixcan'``: a GWAS summary-statistics DataFrame.
+        For ``method='smultixcan'``: a dict ``{tissue: spredixcan_df}``.
+    model
+        Prediction model — a ``.db`` path (PrediXcan / S-PrediXcan) or a
+        loaded :class:`pytwas.PredictionModel`.
+    covariance
+        SNP-covariance file path (or :class:`pytwas.CovarianceDB`).
+    method
+        ``'spredixcan'``, ``'smultixcan'`` or ``'predixcan'``.
+    gwas_file
+        Alternative to ``gwas`` for ``spredixcan`` — a GWAS file path.
+    models
+        For ``method='smultixcan'``: a dict ``{tissue: model}``.
+    dosages
+        For ``method='predixcan'``: a ``samples x SNPs`` dosage DataFrame.
+    phenotype
+        For ``method='predixcan'``: the per-sample phenotype vector.
+    mode
+        For ``method='predixcan'``: ``'linear'`` or ``'logistic'``.
+    snp_column, effect_allele_column, non_effect_allele_column
+        GWAS column names (S-PrediXcan).
+    zscore_column, beta_column, se_column, pvalue_column
+        GWAS effect-size column names — supply whichever your file has.
+    **kwargs
+        Forwarded to the backend function.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Per-gene TWAS table — z-score / chi-square, effect size and
+        p-value.
+    """
+    pytwas = _require_twas()
+    key = str(method).lower().strip()
+
+    if key == "spredixcan":
+        if model is None or covariance is None:
+            raise ValueError(
+                "method='spredixcan' requires a model (.db) and covariance."
+            )
+        if gwas is None and gwas_file is None:
+            raise ValueError(
+                "method='spredixcan' requires gwas= (DataFrame) or gwas_file=."
+            )
+        gwas_df = gwas
+        if isinstance(gwas_df, pd.DataFrame):
+            gwas_df = _canonicalize_gwas(
+                gwas_df, snp_column, effect_allele_column,
+                non_effect_allele_column, zscore_column, beta_column,
+                se_column, pvalue_column,
+            )
+        return pytwas.spredixcan(
+            model, covariance, gwas_file=gwas_file, gwas=gwas_df,
+            snp_column=snp_column,
+            effect_allele_column=effect_allele_column,
+            non_effect_allele_column=non_effect_allele_column,
+            zscore_column=zscore_column, beta_column=beta_column,
+            se_column=se_column, pvalue_column=pvalue_column, **kwargs,
+        )
+
+    if key == "smultixcan":
+        if gwas is None or models is None or covariance is None:
+            raise ValueError(
+                "method='smultixcan' requires gwas= (a {tissue: spredixcan_df} "
+                "dict), models= and covariance=."
+            )
+        return pytwas.smultixcan(gwas, models, covariance, **kwargs)
+
+    if key == "predixcan":
+        if model is None or dosages is None or phenotype is None:
+            raise ValueError(
+                "method='predixcan' requires model, dosages and phenotype."
+            )
+        return pytwas.predixcan(
+            model, dosages, np.asarray(phenotype, dtype=float),
+            mode=mode, **kwargs,
+        )
+
+    raise ValueError(
+        f"method must be 'spredixcan', 'smultixcan' or 'predixcan', "
+        f"got {method!r}"
+    )
+
+
+@register_function(
+    aliases=["load_twas_model", "load_model", "prediction_model", "TWAS模型加载"],
+    category="genetics",
+    description=(
+        "Load a PrediXcan / S-PrediXcan gene-expression prediction model "
+        "from a ``.db`` SQLite file into a :class:`pytwas.PredictionModel`. "
+        "Wraps :func:`pytwas.load_model`."
+    ),
+    examples=[
+        "ov.genetics.load_twas_model('elastic_net_model.db')",
+    ],
+    related=["ov.genetics.twas"],
+)
+def load_twas_model(path: str, *, snp_key: Optional[str] = None):
+    """Load a TWAS prediction model from a ``.db`` file.
+
+    Parameters
+    ----------
+    path
+        Path to the SQLite ``.db`` prediction-model file.
+    snp_key
+        Optional SNP-key column override.
+
+    Returns
+    -------
+    pytwas.PredictionModel
+        The loaded prediction model.
+    """
+    pytwas = _require_twas()
+    return pytwas.load_model(path, snp_key=snp_key)

--- a/omicverse/genetics/io.py
+++ b/omicverse/genetics/io.py
@@ -1,0 +1,321 @@
+"""I/O for ``ov.genetics`` — GWAS summary statistics, PLINK and VCF.
+
+Flexible readers for the heterogeneous file formats of statistical
+genetics: :func:`read_sumstats` parses a GWAS summary-statistics table
+with column-name auto-detection, :func:`read_plink` loads a PLINK
+``.bed`` / ``.bim`` / ``.fam`` triple into a samples x SNPs AnnData,
+and :func:`read_vcf` extracts a genotype dosage matrix from a VCF.
+"""
+from __future__ import annotations
+
+import gzip
+import os
+from typing import Optional
+
+import numpy as np
+import pandas as pd
+
+from .._registry import register_function
+
+
+# Canonical column name -> recognised aliases (lower-case).
+_SUMSTAT_ALIASES = {
+    "SNP": ["snp", "rsid", "rs", "variant", "variant_id", "markername",
+            "id", "snpid"],
+    "CHR": ["chr", "chrom", "chromosome", "#chrom"],
+    "BP": ["bp", "pos", "position", "base_pair_location"],
+    "A1": ["a1", "effect_allele", "allele1", "ea", "alt"],
+    "A2": ["a2", "other_allele", "allele2", "non_effect_allele", "nea", "ref"],
+    "BETA": ["beta", "effect", "b", "effect_size"],
+    "SE": ["se", "stderr", "standard_error", "se_beta"],
+    "OR": ["or", "odds_ratio"],
+    "Z": ["z", "zscore", "z_score", "zstat"],
+    "P": ["p", "pval", "pvalue", "p_value", "p-value", "p.value"],
+    "N": ["n", "samplesize", "n_total", "sample_size"],
+    "EAF": ["eaf", "freq", "maf", "af", "effect_allele_frequency"],
+    "INFO": ["info", "imputation_info", "rsq"],
+}
+
+
+@register_function(
+    aliases=[
+        "read_sumstats", "read_gwas", "load_sumstats", "gwas_reader",
+        "读取GWAS汇总统计", "GWAS数据读取", "汇总统计读取",
+    ],
+    category="genetics",
+    description=(
+        "Flexible reader for a GWAS summary-statistics file. Auto-detects "
+        "the delimiter and the column names (SNP / CHR / BP / A1 / A2 / "
+        "BETA / SE / OR / Z / P / N / EAF / INFO) from a wide set of "
+        "aliases used across GWAS Catalog, PLINK, BOLT-LMM, SAIGE, "
+        "Regenie and consortium releases, and returns a tidy "
+        "DataFrame with canonical column names. Pure pandas."
+    ),
+    examples=[
+        "ov.genetics.read_sumstats('gwas.txt.gz')",
+        "ov.genetics.read_sumstats('gwas.tsv', sep='\\t', rename=False)",
+    ],
+    related=["ov.genetics.munge_sumstats", "ov.genetics.gwas_association",
+             "ov.genetics.manhattan"],
+)
+def read_sumstats(
+    path: str,
+    *,
+    sep: Optional[str] = None,
+    rename: bool = True,
+    nrows: Optional[int] = None,
+    **kwargs,
+) -> pd.DataFrame:
+    """Read a GWAS summary-statistics file.
+
+    Parameters
+    ----------
+    path
+        Path to the summary-statistics file (plain or ``.gz``).
+    sep
+        Field delimiter; ``None`` (default) auto-detects whitespace / TSV
+        / CSV.
+    rename
+        If ``True`` (default), rename detected columns to the canonical
+        names (``SNP``, ``CHR``, ``BP``, ``A1``, ``A2``, ``BETA``, ``SE``,
+        ``OR``, ``Z``, ``P``, ``N``, ``EAF``, ``INFO``).
+    nrows
+        Optionally read only the first ``nrows`` rows.
+    **kwargs
+        Forwarded to :func:`pandas.read_csv`.
+
+    Returns
+    -------
+    pandas.DataFrame
+        The summary-statistics table; ``.attrs['sumstats_columns']`` maps
+        each canonical name to the original column it came from.
+    """
+    if not os.path.exists(path):
+        raise FileNotFoundError(f"sumstats file not found: {path}")
+
+    read_kw = dict(kwargs)
+    if sep is None:
+        read_kw.setdefault("sep", r"\s+|,|\t")
+        read_kw.setdefault("engine", "python")
+    else:
+        read_kw["sep"] = sep
+    if nrows is not None:
+        read_kw["nrows"] = nrows
+
+    df = pd.read_csv(path, **read_kw)
+
+    # Detect canonical columns.
+    lower_map = {c.lower().strip(): c for c in df.columns}
+    detected: dict[str, str] = {}
+    for canon, aliases in _SUMSTAT_ALIASES.items():
+        for alias in aliases:
+            if alias in lower_map:
+                detected[canon] = lower_map[alias]
+                break
+
+    if rename:
+        df = df.rename(columns={orig: canon for canon, orig in detected.items()})
+
+    df.attrs["sumstats_columns"] = detected
+    return df
+
+
+def _read_bim(prefix: str) -> pd.DataFrame:
+    bim = pd.read_csv(
+        prefix + ".bim", sep=r"\s+", header=None,
+        names=["chr", "snp", "cm", "bp", "a1", "a2"],
+        dtype={"snp": str},
+    )
+    return bim
+
+
+def _read_fam(prefix: str) -> pd.DataFrame:
+    fam = pd.read_csv(
+        prefix + ".fam", sep=r"\s+", header=None,
+        names=["fid", "iid", "father", "mother", "sex", "phenotype"],
+        dtype={"fid": str, "iid": str},
+    )
+    return fam
+
+
+def _read_bed(prefix: str, n_samples: int, n_snps: int) -> np.ndarray:
+    """Read a PLINK SNP-major ``.bed`` into a (samples, snps) dosage array."""
+    with open(prefix + ".bed", "rb") as fh:
+        magic = fh.read(3)
+        if magic[:2] != b"\x6c\x1b":
+            raise ValueError(f"{prefix}.bed is not a valid PLINK .bed file.")
+        if magic[2] != 1:
+            raise ValueError(
+                f"{prefix}.bed is not SNP-major; only SNP-major .bed is "
+                "supported."
+            )
+        raw = np.frombuffer(fh.read(), dtype=np.uint8)
+
+    bytes_per_snp = (n_samples + 3) // 4
+    if raw.size != bytes_per_snp * n_snps:
+        raise ValueError(
+            f"{prefix}.bed size mismatch: expected "
+            f"{bytes_per_snp * n_snps} bytes, got {raw.size}."
+        )
+    raw = raw.reshape(n_snps, bytes_per_snp)
+    # Unpack 2 bits per genotype, 4 genotypes per byte (little-endian order).
+    geno_codes = np.zeros((n_snps, bytes_per_snp * 4), dtype=np.uint8)
+    for shift in range(4):
+        geno_codes[:, shift::4] = (raw >> (2 * shift)) & 0b11
+    geno_codes = geno_codes[:, :n_samples]
+    # PLINK 2-bit codes -> dosage of A1 allele:
+    #   00 -> 2 (hom A1), 01 -> NaN (missing), 10 -> 1 (het), 11 -> 0 (hom A2).
+    dosage = np.full(geno_codes.shape, np.nan, dtype=np.float32)
+    dosage[geno_codes == 0] = 2.0
+    dosage[geno_codes == 2] = 1.0
+    dosage[geno_codes == 3] = 0.0
+    # Return (samples, snps).
+    return dosage.T
+
+
+@register_function(
+    aliases=[
+        "read_plink", "load_plink", "plink_reader", "read_bed",
+        "读取PLINK", "PLINK数据读取", "基因型读取",
+    ],
+    category="genetics",
+    description=(
+        "Read a PLINK binary genotype fileset (``.bed`` / ``.bim`` / "
+        "``.fam``) into a samples x SNPs AnnData. ``.X`` holds the A1-"
+        "allele dosage (0 / 1 / 2, NaN for missing), ``.obs`` carries the "
+        "sample table (FID / IID / sex / phenotype) and ``.var`` carries "
+        "the SNP table (chromosome / position / alleles). Pure numpy — "
+        "reads the SNP-major .bed bitstream directly."
+    ),
+    examples=[
+        "ov.genetics.read_plink('cohort')",
+        "adata = ov.genetics.read_plink('/data/study/plink')",
+    ],
+    related=["ov.genetics.gwas_qc", "ov.genetics.gwas_association",
+             "ov.genetics.read_vcf"],
+)
+def read_plink(prefix: str):
+    """Read a PLINK ``.bed`` / ``.bim`` / ``.fam`` fileset.
+
+    Parameters
+    ----------
+    prefix
+        Fileset prefix; ``prefix.bed``, ``prefix.bim`` and ``prefix.fam``
+        must all exist.
+
+    Returns
+    -------
+    AnnData
+        ``samples x SNPs`` AnnData with A1-allele dosages in ``.X``.
+    """
+    import anndata
+
+    # Allow passing the .bed path directly.
+    if prefix.endswith(".bed"):
+        prefix = prefix[:-4]
+    for ext in (".bed", ".bim", ".fam"):
+        if not os.path.exists(prefix + ext):
+            raise FileNotFoundError(f"missing PLINK file: {prefix + ext}")
+
+    bim = _read_bim(prefix)
+    fam = _read_fam(prefix)
+    dosage = _read_bed(prefix, len(fam), len(bim))
+
+    obs = fam.copy()
+    obs.index = obs["iid"].astype(str)
+    var = bim.copy()
+    var.index = var["snp"].astype(str)
+
+    adata = anndata.AnnData(X=dosage, obs=obs, var=var)
+    adata.uns["genetics_source"] = "plink"
+    return adata
+
+
+@register_function(
+    aliases=[
+        "read_vcf", "load_vcf", "vcf_reader", "读取VCF", "VCF数据读取",
+    ],
+    category="genetics",
+    description=(
+        "Read a (small) VCF file into a samples x variants AnnData of "
+        "genotype dosages. Parses the GT field (counting ALT alleles; "
+        "missing calls become NaN), with ``.var`` carrying CHROM / POS / "
+        "REF / ALT. Intended for modest VCFs — for large cohorts use "
+        ":func:`read_plink`. Pure-Python parser."
+    ),
+    examples=[
+        "ov.genetics.read_vcf('variants.vcf')",
+        "ov.genetics.read_vcf('variants.vcf.gz')",
+    ],
+    related=["ov.genetics.read_plink", "ov.genetics.gwas_qc"],
+)
+def read_vcf(path: str, *, max_variants: Optional[int] = None):
+    """Read a VCF into a genotype-dosage AnnData.
+
+    Parameters
+    ----------
+    path
+        Path to the VCF file (plain or ``.gz``).
+    max_variants
+        Optional cap on the number of variants read.
+
+    Returns
+    -------
+    AnnData
+        ``samples x variants`` AnnData of ALT-allele dosages.
+    """
+    import anndata
+
+    if not os.path.exists(path):
+        raise FileNotFoundError(f"VCF file not found: {path}")
+
+    opener = gzip.open if path.endswith(".gz") else open
+    samples: list[str] = []
+    var_rows: list[dict] = []
+    dosage_rows: list[np.ndarray] = []
+
+    with opener(path, "rt") as fh:
+        for line in fh:
+            if line.startswith("##"):
+                continue
+            if line.startswith("#CHROM"):
+                samples = line.rstrip("\n").split("\t")[9:]
+                continue
+            if not samples:
+                raise ValueError("VCF has no #CHROM header line.")
+            fields = line.rstrip("\n").split("\t")
+            if len(fields) < 10:
+                continue
+            chrom, pos, vid, ref, alt = fields[:5]
+            fmt = fields[8].split(":")
+            try:
+                gt_idx = fmt.index("GT")
+            except ValueError:
+                continue
+            dos = np.full(len(samples), np.nan, dtype=np.float32)
+            for k, cell in enumerate(fields[9:]):
+                gt = cell.split(":")[gt_idx]
+                alleles = gt.replace("|", "/").split("/")
+                if any(a in (".", "") for a in alleles):
+                    continue
+                try:
+                    dos[k] = float(sum(int(a) > 0 for a in alleles))
+                except ValueError:
+                    continue
+            var_rows.append({"chr": chrom, "bp": pos, "snp": vid,
+                             "ref": ref, "alt": alt})
+            dosage_rows.append(dos)
+            if max_variants is not None and len(var_rows) >= max_variants:
+                break
+
+    if not var_rows:
+        raise ValueError(f"no variant records parsed from {path}")
+
+    var = pd.DataFrame(var_rows)
+    var.index = [v if v not in (".", "") else f"var{i}"
+                 for i, v in enumerate(var["snp"])]
+    X = np.vstack(dosage_rows).T  # samples x variants
+    obs = pd.DataFrame(index=[str(s) for s in samples])
+    adata = anndata.AnnData(X=X, obs=obs, var=var)
+    adata.uns["genetics_source"] = "vcf"
+    return adata

--- a/omicverse/genetics/plotting.py
+++ b/omicverse/genetics/plotting.py
@@ -1,0 +1,561 @@
+"""Plotting for ``ov.genetics`` — matplotlib visualisations.
+
+Standard statistical-genetics figures: the genome-wide Manhattan plot
+(:func:`manhattan`), the Q-Q plot with genomic inflation
+(:func:`qqplot`), the LocusZoom-style regional association plot
+(:func:`regional_plot`), the colocalization plot (:func:`coloc_plot`),
+the Mendelian-randomization scatter / forest plots
+(:func:`mr_scatter`, :func:`mr_forest`) and the SuSiE fine-mapping plot
+(:func:`finemap_plot`). The MR and fine-mapping plots delegate to the
+backends' own plotting routines.
+"""
+from __future__ import annotations
+
+from typing import Optional, Union
+
+import numpy as np
+import pandas as pd
+
+from .._registry import register_function
+
+
+def _coerce_assoc(data, snp, chrom, pos, pvalue):
+    """Pull SNP / chromosome / position / p-value columns from a DataFrame."""
+    if not isinstance(data, pd.DataFrame):
+        raise TypeError("data must be a pandas DataFrame.")
+    cols = {c.lower(): c for c in data.columns}
+
+    def _pick(explicit, candidates, required=True):
+        if explicit is not None:
+            return explicit
+        for cand in candidates:
+            if cand in cols:
+                return cols[cand]
+        if required:
+            raise KeyError(
+                f"could not find a column among {candidates}; pass it "
+                "explicitly."
+            )
+        return None
+
+    p_col = _pick(pvalue, ["pvalue", "p", "pval", "p.value", "p_value"])
+    snp_col = _pick(snp, ["snp", "snps", "rsid", "variant", "id"], required=False)
+    chr_col = _pick(chrom, ["chr", "chrom", "chromosome"], required=False)
+    pos_col = _pick(pos, ["bp", "pos", "position"], required=False)
+    return snp_col, chr_col, pos_col, p_col
+
+
+@register_function(
+    aliases=[
+        "manhattan", "manhattan_plot", "gwas_plot", "曼哈顿图", "曼哈顿绘图",
+    ],
+    category="genetics",
+    description=(
+        "Genome-wide Manhattan plot of association p-values for GWAS, "
+        "eQTL or TWAS results. Plots -log10(p) against genomic position, "
+        "alternating colours by chromosome, with an optional "
+        "genome-wide-significance line. Accepts any results DataFrame "
+        "with a p-value column (and optional chromosome / position). "
+        "matplotlib."
+    ),
+    examples=[
+        "ov.genetics.manhattan(gwas_res)",
+        "ov.genetics.manhattan(gwas_res, chrom='CHR', pos='BP', pvalue='P')",
+    ],
+    related=["ov.genetics.qqplot", "ov.genetics.regional_plot",
+             "ov.genetics.gwas_association"],
+)
+def manhattan(
+    data: pd.DataFrame,
+    *,
+    snp: Optional[str] = None,
+    chrom: Optional[str] = None,
+    pos: Optional[str] = None,
+    pvalue: Optional[str] = None,
+    sig_line: float = 5e-8,
+    suggestive_line: Optional[float] = 1e-5,
+    ax=None,
+    title: Optional[str] = None,
+    colors=("#3b6fb6", "#9bbce0"),
+):
+    """Draw a Manhattan plot.
+
+    Parameters
+    ----------
+    data
+        Association results — a DataFrame with a p-value column (plus
+        optional chromosome / position columns).
+    snp, chrom, pos, pvalue
+        Column names; auto-detected when not given.
+    sig_line
+        Genome-wide-significance threshold (drawn as a dashed line).
+    suggestive_line
+        Optional suggestive-significance threshold.
+    ax
+        Existing matplotlib Axes; a new one is created if ``None``.
+    title
+        Optional plot title.
+    colors
+        Two alternating chromosome colours.
+
+    Returns
+    -------
+    matplotlib.axes.Axes
+        The plot axes.
+    """
+    import matplotlib.pyplot as plt
+
+    snp_col, chr_col, pos_col, p_col = _coerce_assoc(
+        data, snp, chrom, pos, pvalue
+    )
+    df = data.copy()
+    df = df[np.isfinite(pd.to_numeric(df[p_col], errors="coerce"))]
+    pvals = pd.to_numeric(df[p_col], errors="coerce").to_numpy()
+    pvals = np.clip(pvals, np.finfo(float).tiny, 1.0)
+    logp = -np.log10(pvals)
+
+    if ax is None:
+        _, ax = plt.subplots(figsize=(11, 4))
+
+    if chr_col is not None:
+        df = df.assign(_logp=logp)
+        chrom_vals = df[chr_col].astype(str)
+        # Sort chromosomes numerically where possible.
+        def _chrom_key(c):
+            c = c.replace("chr", "")
+            return (0, int(c)) if c.isdigit() else (1, c)
+        order = sorted(chrom_vals.unique(), key=_chrom_key)
+        x = np.zeros(len(df))
+        offset = 0.0
+        ticks, ticklabels = [], []
+        for i, c in enumerate(order):
+            mask = (chrom_vals == c).to_numpy()
+            n = int(mask.sum())
+            if pos_col is not None:
+                pp = pd.to_numeric(df.loc[mask, pos_col], errors="coerce")
+                pp = pp.fillna(pp.median() if n else 0).to_numpy()
+                pp = pp - pp.min() if n else pp
+            else:
+                pp = np.arange(n, dtype=float)
+            span = (pp.max() - pp.min()) if (n and pp.max() > pp.min()) else max(n, 1)
+            x[mask] = offset + pp
+            ticks.append(offset + span / 2.0)
+            ticklabels.append(c)
+            ax.scatter(x[mask], df["_logp"].to_numpy()[mask], s=8,
+                       c=colors[i % 2], rasterized=True)
+            offset += span * 1.05
+        ax.set_xticks(ticks)
+        ax.set_xticklabels(ticklabels, fontsize=8)
+        ax.set_xlabel("Chromosome")
+    else:
+        x = np.arange(len(logp), dtype=float)
+        ax.scatter(x, logp, s=8, c=colors[0], rasterized=True)
+        ax.set_xlabel("Variant index")
+
+    if sig_line:
+        ax.axhline(-np.log10(sig_line), color="#d62728", ls="--", lw=1,
+                   label=f"genome-wide (p={sig_line:g})")
+    if suggestive_line:
+        ax.axhline(-np.log10(suggestive_line), color="#7f7f7f", ls=":",
+                   lw=1, label=f"suggestive (p={suggestive_line:g})")
+    ax.set_ylabel(r"$-\log_{10}(p)$")
+    if title:
+        ax.set_title(title)
+    ax.legend(fontsize=7, loc="upper right")
+    ax.spines[["top", "right"]].set_visible(False)
+    return ax
+
+
+@register_function(
+    aliases=[
+        "qqplot", "qq_plot", "quantile_quantile_plot", "QQ图", "分位数图",
+    ],
+    category="genetics",
+    description=(
+        "Quantile-quantile (Q-Q) plot of GWAS / eQTL association "
+        "p-values against the uniform null, annotated with the "
+        "genomic-inflation factor lambda GC. Departure of the bulk of "
+        "points from the diagonal indicates inflation; an early "
+        "departure at the tail indicates true signal. matplotlib."
+    ),
+    examples=[
+        "ov.genetics.qqplot(gwas_res['pvalue'])",
+        "ov.genetics.qqplot(gwas_res, pvalue='P')",
+    ],
+    related=["ov.genetics.manhattan", "ov.genetics.genomic_inflation"],
+)
+def qqplot(
+    data: Union[pd.DataFrame, pd.Series, np.ndarray],
+    *,
+    pvalue: Optional[str] = None,
+    ax=None,
+    title: Optional[str] = None,
+    color: str = "#3b6fb6",
+):
+    """Draw a Q-Q plot of association p-values.
+
+    Parameters
+    ----------
+    data
+        A p-value vector, or a DataFrame with a p-value column.
+    pvalue
+        Column name when ``data`` is a DataFrame (auto-detected if
+        ``None``).
+    ax
+        Existing matplotlib Axes; a new one is created if ``None``.
+    title
+        Optional plot title.
+    color
+        Point colour.
+
+    Returns
+    -------
+    matplotlib.axes.Axes
+        The plot axes.
+    """
+    import matplotlib.pyplot as plt
+
+    from ._gwas import genomic_inflation
+
+    if isinstance(data, pd.DataFrame):
+        _, _, _, p_col = _coerce_assoc(data, None, None, None, pvalue)
+        pvals = pd.to_numeric(data[p_col], errors="coerce").to_numpy()
+    else:
+        pvals = np.asarray(data, dtype=float).ravel()
+
+    pvals = pvals[np.isfinite(pvals)]
+    pvals = np.clip(pvals, np.finfo(float).tiny, 1.0)
+    pvals = np.sort(pvals)
+    n = pvals.size
+    if n == 0:
+        raise ValueError("no finite p-values to plot.")
+
+    expected = -np.log10((np.arange(1, n + 1) - 0.5) / n)
+    observed = -np.log10(pvals)
+    lam = genomic_inflation(pvals, statistic="pvalue")
+
+    if ax is None:
+        _, ax = plt.subplots(figsize=(5, 5))
+    lim = max(expected.max(), observed.max()) * 1.05
+    ax.plot([0, lim], [0, lim], color="#d62728", ls="--", lw=1)
+    ax.scatter(expected, observed, s=10, c=color, rasterized=True)
+    ax.set_xlabel(r"Expected $-\log_{10}(p)$")
+    ax.set_ylabel(r"Observed $-\log_{10}(p)$")
+    ax.set_title(title or f"Q-Q plot  ($\\lambda_{{GC}}$ = {lam:.3f})")
+    ax.set_xlim(0, lim)
+    ax.set_ylim(0, lim)
+    ax.spines[["top", "right"]].set_visible(False)
+    return ax
+
+
+@register_function(
+    aliases=[
+        "regional_plot", "locuszoom", "regional_association_plot",
+        "区域关联图", "局部关联图",
+    ],
+    category="genetics",
+    description=(
+        "LocusZoom-style regional association plot — zooms into a single "
+        "locus and plots -log10(p) against base-pair position, optionally "
+        "colouring SNPs by their LD (r^2) with a lead variant. Useful for "
+        "inspecting a GWAS / eQTL peak before fine-mapping. matplotlib."
+    ),
+    examples=[
+        "ov.genetics.regional_plot(gwas_res, chrom='1', start=1e6, end=2e6)",
+        "ov.genetics.regional_plot(gwas_res, lead_snp='rs123', r2=ld_to_lead)",
+    ],
+    related=["ov.genetics.manhattan", "ov.genetics.finemap_plot"],
+)
+def regional_plot(
+    data: pd.DataFrame,
+    *,
+    chrom: Optional[str] = None,
+    pos: Optional[str] = None,
+    pvalue: Optional[str] = None,
+    snp: Optional[str] = None,
+    region_chrom: Optional[str] = None,
+    start: Optional[float] = None,
+    end: Optional[float] = None,
+    lead_snp: Optional[str] = None,
+    r2: Optional[Union[pd.Series, np.ndarray, dict]] = None,
+    ax=None,
+    title: Optional[str] = None,
+):
+    """Draw a regional (LocusZoom-style) association plot.
+
+    Parameters
+    ----------
+    data
+        Association results — must have position and p-value columns.
+    chrom, pos, pvalue, snp
+        Column names; auto-detected when not given.
+    region_chrom, start, end
+        Optional region filter (chromosome + base-pair window).
+    lead_snp
+        Optional lead-variant SNP id (highlighted as a diamond).
+    r2
+        Optional per-SNP LD (r^2) to the lead variant — a Series / array
+        aligned to ``data``, or a ``{snp: r2}`` dict.
+    ax
+        Existing matplotlib Axes.
+    title
+        Optional plot title.
+
+    Returns
+    -------
+    matplotlib.axes.Axes
+        The plot axes.
+    """
+    import matplotlib.pyplot as plt
+
+    snp_col, chr_col, pos_col, p_col = _coerce_assoc(
+        data, snp, chrom, pos, pvalue
+    )
+    if pos_col is None:
+        raise KeyError("regional_plot needs a position column.")
+    df = data.copy()
+    if region_chrom is not None and chr_col is not None:
+        df = df[df[chr_col].astype(str) == str(region_chrom)]
+    bp = pd.to_numeric(df[pos_col], errors="coerce")
+    if start is not None:
+        df = df[bp >= start]
+        bp = pd.to_numeric(df[pos_col], errors="coerce")
+    if end is not None:
+        df = df[bp <= end]
+        bp = pd.to_numeric(df[pos_col], errors="coerce")
+
+    pvals = pd.to_numeric(df[p_col], errors="coerce").to_numpy()
+    pvals = np.clip(pvals, np.finfo(float).tiny, 1.0)
+    logp = -np.log10(pvals)
+    bp = bp.to_numpy()
+
+    if ax is None:
+        _, ax = plt.subplots(figsize=(8, 4))
+
+    if r2 is not None and snp_col is not None:
+        if isinstance(r2, dict):
+            r2_vals = df[snp_col].astype(str).map(r2).to_numpy(dtype=float)
+        else:
+            r2_vals = np.asarray(r2, dtype=float)
+        sc = ax.scatter(bp, logp, c=r2_vals, cmap="YlOrRd", vmin=0, vmax=1,
+                        s=22, edgecolors="grey", linewidths=0.3)
+        cbar = ax.figure.colorbar(sc, ax=ax, fraction=0.04, pad=0.02)
+        cbar.set_label(r"$r^2$ to lead")
+    else:
+        ax.scatter(bp, logp, s=20, c="#3b6fb6", edgecolors="grey",
+                   linewidths=0.3)
+
+    if lead_snp is not None and snp_col is not None:
+        lead = df[df[snp_col].astype(str) == str(lead_snp)]
+        if len(lead):
+            lx = pd.to_numeric(lead[pos_col], errors="coerce").to_numpy()
+            lp = -np.log10(np.clip(
+                pd.to_numeric(lead[p_col], errors="coerce").to_numpy(),
+                np.finfo(float).tiny, 1.0))
+            ax.scatter(lx, lp, marker="D", s=70, c="#8c2d04",
+                       edgecolors="black", zorder=5, label=f"lead: {lead_snp}")
+            ax.legend(fontsize=8)
+
+    ax.set_xlabel("Position (bp)")
+    ax.set_ylabel(r"$-\log_{10}(p)$")
+    if title:
+        ax.set_title(title)
+    ax.spines[["top", "right"]].set_visible(False)
+    return ax
+
+
+@register_function(
+    aliases=[
+        "coloc_plot", "colocalization_plot", "coloc_pp_plot",
+        "共定位图", "共定位绘图",
+    ],
+    category="genetics",
+    description=(
+        "Plot a colocalization result — a bar chart of the five "
+        "posterior probabilities PP.H0..PP.H4 (H4 = a shared causal "
+        "variant). Accepts the result object from "
+        ":func:`ov.genetics.colocalize`. matplotlib."
+    ),
+    examples=[
+        "ov.genetics.coloc_plot(coloc_result)",
+    ],
+    related=["ov.genetics.colocalize", "ov.genetics.coloc_sensitivity"],
+)
+def coloc_plot(result, *, ax=None, title: Optional[str] = None):
+    """Plot the PP.H0..H4 posterior probabilities of a coloc result.
+
+    Parameters
+    ----------
+    result
+        A result from :func:`ov.genetics.colocalize` (``method='abf'``) —
+        anything carrying a ``summary`` with ``PP.H*.abf`` entries.
+    ax
+        Existing matplotlib Axes.
+    title
+        Optional plot title.
+
+    Returns
+    -------
+    matplotlib.axes.Axes
+        The plot axes.
+    """
+    import matplotlib.pyplot as plt
+
+    # pycoloc's ColocABF is a dict subclass — prefer ['summary'], then a
+    # ``.summary`` attribute, else treat the object itself as the summary.
+    if hasattr(result, "keys") and "summary" in result:
+        summary = result["summary"]
+    else:
+        summary = getattr(result, "summary", result)
+    if isinstance(summary, dict):
+        summary = pd.Series(summary)
+    keys = [f"PP.H{i}.abf" for i in range(5)]
+    pp = []
+    for k in keys:
+        if k in summary:
+            pp.append(float(summary[k]))
+        else:
+            alt = k.replace(".abf", "")
+            pp.append(float(summary[alt]) if alt in summary else np.nan)
+    pp = np.asarray(pp)
+
+    if ax is None:
+        _, ax = plt.subplots(figsize=(5, 4))
+    labels = ["H0\nno assoc", "H1\ntrait 1", "H2\ntrait 2",
+              "H3\ndistinct", "H4\nshared"]
+    colors = ["#bdbdbd", "#74a9cf", "#74c476", "#fdae6b", "#d62728"]
+    ax.bar(labels, pp, color=colors, edgecolor="black", linewidth=0.5)
+    for i, v in enumerate(pp):
+        if np.isfinite(v):
+            ax.text(i, v + 0.02, f"{v:.2f}", ha="center", fontsize=8)
+    ax.set_ylabel("Posterior probability")
+    ax.set_ylim(0, 1.1)
+    ax.set_title(title or "Colocalization posterior probabilities")
+    ax.spines[["top", "right"]].set_visible(False)
+    return ax
+
+
+@register_function(
+    aliases=[
+        "mr_scatter", "mr_scatter_plot", "mendelian_randomization_scatter",
+        "MR散点图", "孟德尔随机化散点图",
+    ],
+    category="genetics",
+    description=(
+        "Mendelian-randomization scatter plot — SNP-outcome effects "
+        "against SNP-exposure effects, with the fitted causal-effect "
+        "slope. Delegates to :func:`pytwosamplemr.mr_scatter`."
+    ),
+    examples=[
+        "ov.genetics.mr_scatter(mr_input)",
+    ],
+    related=["ov.genetics.mendelian_randomization", "ov.genetics.mr_forest"],
+)
+def mr_scatter(mr_input, **kwargs):
+    """MR scatter plot (delegates to the pytwosamplemr backend).
+
+    Parameters
+    ----------
+    mr_input
+        An :class:`pytwosamplemr.MRInput`.
+    **kwargs
+        Forwarded to :func:`pytwosamplemr.mr_scatter`.
+
+    Returns
+    -------
+    matplotlib.figure.Figure or matplotlib.axes.Axes
+        The backend figure.
+    """
+    try:
+        import pytwosamplemr
+    except ImportError as exc:  # pragma: no cover
+        raise ImportError(
+            "ov.genetics.mr_scatter requires pytwosamplemr: "
+            "`pip install pytwosamplemr`."
+        ) from exc
+    return pytwosamplemr.mr_scatter(mr_input, **kwargs)
+
+
+@register_function(
+    aliases=[
+        "mr_forest", "mr_forest_plot", "mendelian_randomization_forest",
+        "MR森林图", "孟德尔随机化森林图",
+    ],
+    category="genetics",
+    description=(
+        "Mendelian-randomization forest plot — per-SNP (Wald-ratio) "
+        "causal estimates with confidence intervals, alongside the "
+        "combined estimate. Delegates to :func:`pytwosamplemr.mr_forest`."
+    ),
+    examples=[
+        "ov.genetics.mr_forest(mr_input)",
+    ],
+    related=["ov.genetics.mendelian_randomization", "ov.genetics.mr_scatter"],
+)
+def mr_forest(mr_input, **kwargs):
+    """MR forest plot (delegates to the pytwosamplemr backend).
+
+    Parameters
+    ----------
+    mr_input
+        An :class:`pytwosamplemr.MRInput`.
+    **kwargs
+        Forwarded to :func:`pytwosamplemr.mr_forest`.
+
+    Returns
+    -------
+    matplotlib.figure.Figure or matplotlib.axes.Axes
+        The backend figure.
+    """
+    try:
+        import pytwosamplemr
+    except ImportError as exc:  # pragma: no cover
+        raise ImportError(
+            "ov.genetics.mr_forest requires pytwosamplemr: "
+            "`pip install pytwosamplemr`."
+        ) from exc
+    return pytwosamplemr.mr_forest(mr_input, **kwargs)
+
+
+@register_function(
+    aliases=[
+        "finemap_plot", "susie_plot", "finemapping_plot",
+        "精细定位图", "SuSiE图",
+    ],
+    category="genetics",
+    description=(
+        "Fine-mapping summary plot of a fitted SuSiE model — per-variant "
+        "posterior inclusion probabilities (PIPs), colour-coded by "
+        "credible set. Delegates to :func:`pysusie.susie_plot`."
+    ),
+    examples=[
+        "ov.genetics.finemap_plot(susie_fit)",
+        "ov.genetics.finemap_plot(susie_fit, y='PIP')",
+    ],
+    related=["ov.genetics.finemap", "ov.genetics.get_pip"],
+)
+def finemap_plot(fit, *, y: str = "PIP", **kwargs):
+    """Fine-mapping plot (delegates to the pysusie backend).
+
+    Parameters
+    ----------
+    fit
+        A :class:`pysusie.SusieFit`.
+    y
+        Quantity to plot — ``'PIP'`` (default) or ``'z_original'`` etc.
+    **kwargs
+        Forwarded to :func:`pysusie.susie_plot`.
+
+    Returns
+    -------
+    matplotlib.axes.Axes
+        The backend axes.
+    """
+    try:
+        import pysusie
+    except ImportError as exc:  # pragma: no cover
+        raise ImportError(
+            "ov.genetics.finemap_plot requires pysusie: "
+            "`pip install pysusie`."
+        ) from exc
+    return pysusie.susie_plot(fit, y=y, **kwargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -208,6 +208,24 @@ protein = [
   "statsmodels>=0.14",     # LMM / ANOVA / ordinal regression backends
 ]
 
+# Statistical-genetics backends for ``ov.genetics`` — pure-Python ports
+# of the canonical post-GWAS analysis tools. Install via:
+#   pip install omicverse[genetics]
+# Enables the full post-GWAS workflow: eQTL mapping (Matrix eQTL),
+# fine-mapping (SuSiE), colocalization (coloc), Mendelian randomization
+# (TwoSampleMR), single-cell disease-relevance scoring (scDRS), LD score
+# regression / SEG (LDSC), and TWAS (S-PrediXcan / S-MultiXcan).
+genetics = [
+  "pymatrixeqtl>=0.1.0",   # Matrix eQTL — cis/trans eQTL mapping
+  "pysusie>=0.1.0",        # SuSiE — Bayesian statistical fine-mapping
+  "pycoloc>=0.1.0",        # coloc — Bayesian colocalization
+  "pytwosamplemr>=0.1.0",  # TwoSampleMR — two-sample Mendelian randomization
+  "pyscdrs>=0.1.0",        # scDRS — single-cell disease-relevance scoring
+  "pyldsc>=0.1.0",         # LDSC — LD score regression / partitioned h2 / SEG
+  "pytwas>=0.1.0",         # S-PrediXcan / S-MultiXcan — TWAS
+  "statsmodels>=0.14",     # logistic GWAS association / mixed-model backends
+]
+
 # Lipidomics backend for the lipidomics path of ``ov.metabol`` — a
 # pure-Python port of the Bioconductor lipidr workflow. Install via:
 #   pip install omicverse[lipidomics]


### PR DESCRIPTION
## Summary

Adds **`ov.genetics`** — a unified statistical-genetics framework that links genotype, expression and complex traits. It wraps **seven standalone, R-parity-tested backend packages** behind a `@register_function` registry with `method=` dispatch, modelled on `ov.protein`.

### Backends (all on PyPI + github.com/omicverse/, R-parity bit-exact)

| backend | upstream | role |
|---|---|---|
| `pymatrixeqtl` | MatrixEQTL | cis/trans eQTL mapping |
| `pysusie` | susieR | SuSiE fine-mapping |
| `pycoloc` | coloc | colocalization (abf / susie / signals) |
| `pytwosamplemr` | MendelianRandomization | Mendelian randomization |
| `pyscdrs` | scDRS | single-cell disease-relevance score |
| `pyldsc` | LDSC | LD score regression / LDSC-SEG |
| `pytwas` | MetaXcan | TWAS (S-PrediXcan / S-MultiXcan / PrediXcan) |

### `ov.genetics` — 34 registered functions

`eqtl_map` · `finemap` · `colocalize` · `mendelian_randomization` · `disease_relevance_score` · `heritability` / `genetic_correlation` / `partitioned_heritability` / `ldsc_cell_type` · `twas` · `gwas_qc` / `gwas_association` / `genomic_inflation` · sumstats & PLINK readers · `manhattan` / `qqplot` / `regional_plot` / `coloc_plot` / `mr_scatter` / `mr_forest` / `finemap_plot`.

`method=` dispatchers: `finemap` (susie/susie_rss), `colocalize` (abf/susie/signals), `mendelian_randomization` (ivw/egger/median/mode/maxlik/divw/conmix/lasso/cml/all), `twas` (spredixcan/smultixcan/predixcan), `eqtl_map` (linear/anova/linear_cross).

GWAS core (`_gwas.py`) is backend-free — pure numpy/scipy/statsmodels QC filters, per-SNP association, λGC. Backends lazy-import, so `import omicverse.genetics` works without the optional `[genetics]` extra.

### Tutorial

`t_genetics_01_overview` — end-to-end tour of all seven analyses, executed end-to-end (24 code cells, 0 errors, 5 figures). Registered in the Sphinx nav (`index_genetics`).

## Test plan

- [x] `import omicverse.genetics` works without the `[genetics]` extra
- [x] 34 functions registered under `category='genetics'`, findable via `ov.find_function`
- [x] smoke run of all main functions on the backends' example data
- [x] tutorial notebook executes end-to-end, 0 errors
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)