### PR TITLE
fix(pp): drop private scanpy-internal imports (closes #736)

### DIFF
--- a/omicverse/llm/scgpt/preprocess.py
+++ b/omicverse/llm/scgpt/preprocess.py
@@ -4,7 +4,7 @@ import numpy as np
 import torch
 from scipy.sparse import issparse
 import scanpy as sc
-from scanpy.get import _get_obs_rep, _set_obs_rep
+from ...pp._scale import _get_obs_rep, _set_obs_rep
 from anndata import AnnData
 
 #from scgpt import logger

--- a/omicverse/pp/_compat.py
+++ b/omicverse/pp/_compat.py
@@ -21,9 +21,11 @@ __all__ = [
     "DaskArray",
     "SpBase",
     "ZappyArray",
+    "_choose_graph",
     "_numba_threading_layer",
     "deprecated",
     "fullname",
+    "get_init_pos_from_paga",
     "njit",
     "old_positionals",
     "pkg_metadata",
@@ -168,6 +170,68 @@ def _is_in_unsafe_thread_pool() -> bool:
         current_thread.name.startswith("ThreadPoolExecutor")
         and _numba_threading_layer() not in LAYERS["threadsafe"]
     )
+
+
+def _choose_graph(adata, obsp: str | None, neighbors_key: str | None):
+    """Choose connectivities from neighbors or another obsp entry.
+
+    Vendored from ``scanpy.tools._utils._choose_graph`` so omicverse does not
+    depend on scanpy's private API.
+    """
+    if obsp is not None and neighbors_key is not None:
+        msg = "You can't specify both obsp, neighbors_key. Please select only one."
+        raise ValueError(msg)
+
+    if obsp is not None:
+        return adata.obsp[obsp]
+
+    from ._neighbors import NeighborsView
+
+    neighbors = NeighborsView(adata, neighbors_key)
+    if "connectivities" not in neighbors:
+        msg = "You need to run `pp.neighbors` first to compute a neighborhood graph."
+        raise ValueError(msg)
+    return neighbors["connectivities"]
+
+
+def get_init_pos_from_paga(
+    adata,
+    adjacency=None,
+    random_state=0,
+    neighbors_key: str | None = None,
+    obsp: str | None = None,
+):
+    """Compute UMAP init positions from a precomputed PAGA layout.
+
+    Vendored from ``scanpy.tools._utils.get_init_pos_from_paga`` so omicverse
+    does not depend on scanpy's private API.
+    """
+    import numpy as np
+
+    np.random.seed(random_state)
+    if adjacency is None:
+        adjacency = _choose_graph(adata, obsp, neighbors_key)
+    if "pos" not in adata.uns.get("paga", {}):
+        msg = "Plot PAGA first, so that `adata.uns['paga']['pos']` exists."
+        raise ValueError(msg)
+
+    groups = adata.obs[adata.uns["paga"]["groups"]]
+    pos = adata.uns["paga"]["pos"]
+    connectivities_coarse = adata.uns["paga"]["connectivities"]
+    init_pos = np.ones((adjacency.shape[0], 2))
+    for i, group_pos in enumerate(pos):
+        subset = (groups == groups.cat.categories[i]).values
+        neighbors = connectivities_coarse[i].nonzero()
+        if len(neighbors[1]) > 0:
+            connectivities = connectivities_coarse[i][neighbors]
+            nearest_neighbor = neighbors[1][np.argmax(connectivities)]
+            noise = np.random.random((len(subset[subset]), 2))
+            dist = group_pos - pos[nearest_neighbor]
+            noise = noise * dist
+            init_pos[subset] = group_pos - 0.5 * dist + noise
+        else:
+            init_pos[subset] = group_pos
+    return init_pos
 
 
 @cache

--- a/omicverse/pp/_tsne.py
+++ b/omicverse/pp/_tsne.py
@@ -6,18 +6,16 @@ from datetime import datetime
 
 from packaging.version import Version
 
-from scanpy import logging as logg
+from scanpy import settings
 from ._compat import old_positionals
-from scanpy._settings import settings
-from scanpy._utils import _doc_params, raise_not_implemented_error_if_backed_type
-from scanpy.neighbors._doc import doc_n_pcs, doc_use_rep
-from scanpy.tools._utils import _choose_representation
+from ._scale import raise_not_implemented_error_if_backed_type
+from ._neighbors import _choose_representation, _doc_params, doc_n_pcs, doc_use_rep
 from .._settings import EMOJI, Colors, settings as ov_settings
 
 if TYPE_CHECKING:
     from anndata import AnnData
 
-    from scanpy._utils.random import _LegacyRandom
+    from ._neighbors import _LegacyRandom
 
 
 @old_positionals(

--- a/omicverse/pp/_umap.py
+++ b/omicverse/pp/_umap.py
@@ -7,11 +7,9 @@ from datetime import datetime
 import numpy as np
 from sklearn.utils import check_array, check_random_state
 
-from scanpy import logging as logg
-from ._compat import old_positionals
-from scanpy._settings import settings
-from scanpy._utils import NeighborsView
-from scanpy.tools._utils import _choose_representation, get_init_pos_from_paga
+from scanpy import settings
+from ._compat import old_positionals, get_init_pos_from_paga
+from ._neighbors import NeighborsView, _choose_representation
 from .._settings import EMOJI, Colors, settings as ov_settings
 
 if TYPE_CHECKING:
@@ -19,7 +17,7 @@ if TYPE_CHECKING:
 
     from anndata import AnnData
 
-    from scanpy._utils.random import _LegacyRandom
+    from ._neighbors import _LegacyRandom
 
     _InitPos = Literal["paga", "spectral", "random"]
 
@@ -143,7 +141,6 @@ def umap(  # noqa: PLR0913, PLR0915
         adata,
         use_rep=neigh_params.get("use_rep", None),
         n_pcs=neigh_params.get("n_pcs", None),
-        silent=True,
     )
     if method == "umap":
         print(f"   {Colors.GREEN}{EMOJI['start']} Computing UMAP embedding (classic method)...{Colors.ENDC}")

--- a/omicverse/pp/experimental/_highly_variable_genes.py
+++ b/omicverse/pp/experimental/_highly_variable_genes.py
@@ -11,16 +11,14 @@ import pandas as pd
 import scipy.sparse as sp_sparse
 from anndata import AnnData
 
-from scanpy import logging as logg
-from scanpy._compat import njit
-from scanpy._settings import Verbosity, settings
-from scanpy._utils import check_nonnegative_integers, view_to_actual
+from numba import njit
 
 from ..._settings import EMOJI, Colors
 
-from scanpy.get import _get_obs_rep
-from scanpy.preprocessing._distributed import materialize_as_ndarray
-from scanpy.preprocessing._utils import _get_mean_var
+from .._highly_variable_genes import check_nonnegative_integers
+from .._scale import _get_obs_rep, view_to_actual
+from .._distributed import materialize_as_ndarray
+from .._utils import _get_mean_var
 
 from .._qc import _is_rust_backend
 
@@ -181,8 +179,7 @@ def _highly_variable_pearson_residuals(
         if is_rust:
             X_batch_prefilter = X_batch_prefilter[:]
         # Filter out zero genes
-        with settings.verbosity.override(Verbosity.error):
-            nonzero_genes = np.ravel(X_batch_prefilter.sum(axis=0)) != 0
+        nonzero_genes = np.ravel(X_batch_prefilter.sum(axis=0)) != 0
         adata_subset = adata_subset_prefilter[:, nonzero_genes]
         X_batch = _get_obs_rep(adata_subset, layer=layer)
         if is_rust:

--- a/omicverse/pp/experimental/_normalization.py
+++ b/omicverse/pp/experimental/_normalization.py
@@ -8,23 +8,16 @@ import numpy as np
 from anndata import AnnData
 from scipy.sparse import issparse
 
-from scanpy import logging as logg
 from ..._settings import EMOJI, Colors
-from scanpy._utils import (
-    _empty,
-    check_nonnegative_integers,
-    view_to_actual,
-)
-
-from scanpy.get import _get_obs_rep, _set_obs_rep
-from scanpy.preprocessing._docs import doc_mask_var_hvg
-from scanpy.preprocessing._pca import _handle_mask_var, pca
+from .._highly_variable_genes import check_nonnegative_integers
+from .._scale import _get_obs_rep, _set_obs_rep, view_to_actual
+from .._pca import _empty, _handle_mask_var, pca
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
     from typing import Any
 
-    from ..._utils import Empty
+    from .._pca import Empty
 
 
 def _pearson_residuals(X, theta, clip, check_values, *, copy: bool = False):
@@ -132,9 +125,6 @@ def normalize_pearson_residuals(
     else:
         print(f"   {Colors.CYAN}Clipping: {Colors.BOLD}sqrt(n_obs){Colors.ENDC}")
     
-    msg = f"computing analytic Pearson residuals on {computed_on}"
-    start = logg.info(msg)
-
     residuals = _pearson_residuals(X, theta, clip, check_values, copy=not inplace)
     settings_dict = dict(theta=theta, clip=clip, computed_on=computed_on)
 
@@ -148,8 +138,6 @@ def normalize_pearson_residuals(
     print(f"   {Colors.GREEN}✓ Processed: {Colors.BOLD}{residuals.shape[0]:,}{Colors.ENDC}{Colors.GREEN} cells × {Colors.BOLD}{residuals.shape[1]:,}{Colors.ENDC}{Colors.GREEN} genes{Colors.ENDC}")
     if inplace:
         print(f"   {Colors.CYAN}• Added normalization settings to adata.uns['pearson_residuals_normalization']{Colors.ENDC}")
-    
-    logg.info("    finished ({time_passed})", time=start)
 
     if copy:
         return adata

--- a/omicverse/single/_sccaf.py
+++ b/omicverse/single/_sccaf.py
@@ -30,7 +30,32 @@ import seaborn as sns
 #import patsy
 
 from scanpy import settings as sett
-from scanpy import logging as logg
+
+import logging as _logging
+
+
+class _SccafLogger:
+    """Lightweight logger replacing scanpy's private logging API."""
+
+    _logger = _logging.getLogger("omicverse.sccaf")
+
+    def info(self, msg, *args, **kwargs):
+        self._logger.info(msg)
+
+    def warning(self, msg, *args, **kwargs):
+        self._logger.warning(msg)
+
+    def hint(self, msg, *args, **kwargs):
+        self._logger.info(msg)
+
+    def debug(self, msg, *args, **kwargs):
+        self._logger.debug(msg)
+
+    def error(self, msg, *args, **kwargs):
+        self._logger.error(msg)
+
+
+logg = _SccafLogger()
 
 import scanpy as sc
 # for color

--- a/omicverse/utils/_compat.py
+++ b/omicverse/utils/_compat.py
@@ -1,0 +1,158 @@
+"""Vendored compatibility helpers.
+
+This module reimplements small pieces of scanpy's private API so omicverse
+does not break when scanpy changes its internals. Keep these copies faithful
+to the upstream behaviour they replace.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import scipy as sp
+from scipy.sparse.csgraph import minimum_spanning_tree
+
+__all__ = ["PAGA"]
+
+_AVAIL_MODELS = {"v1.0", "v1.2"}
+
+
+def _get_igraph_from_adjacency(adjacency, *, directed: bool = False):
+    """Build an igraph graph from a (sparse) adjacency matrix.
+
+    Vendored from ``scanpy._utils.get_igraph_from_adjacency``.
+    """
+    import igraph as ig
+
+    sources, targets = adjacency.nonzero()
+    weights = adjacency[sources, targets]
+    if isinstance(weights, np.matrix):
+        weights = weights.A1
+    g = ig.Graph(directed=directed)
+    g.add_vertices(adjacency.shape[0])
+    g.add_edges(list(zip(sources, targets)))
+    try:
+        g.es["weight"] = weights
+    except KeyError:
+        pass
+    if g.vcount() != adjacency.shape[0]:
+        print(
+            f"The constructed graph has only {g.vcount()} nodes. "
+            "Your adjacency matrix contained redundant nodes."
+        )
+    return g
+
+
+class PAGA:
+    """Partition-based graph abstraction.
+
+    Vendored from ``scanpy.tools._paga.PAGA`` so omicverse does not depend on
+    scanpy's private ``scanpy.tools._paga`` module. Uses omicverse's own
+    :class:`~omicverse.pp._neighbors.Neighbors` for the neighbor graph.
+    """
+
+    def __init__(self, adata, groups, model: str = "v1.2", neighbors_key=None):
+        assert groups in adata.obs.columns
+        from ..pp._neighbors import Neighbors
+
+        self._adata = adata
+        self._neighbors = Neighbors(adata, neighbors_key=neighbors_key)
+        self._model = model
+        self._groups_key = groups
+
+    def compute_connectivities(self):
+        if self._model == "v1.2":
+            return self._compute_connectivities_v1_2()
+        elif self._model == "v1.0":
+            return self._compute_connectivities_v1_0()
+        else:
+            msg = f"`model` {self._model} needs to be one of {_AVAIL_MODELS}."
+            raise ValueError(msg)
+
+    def _compute_connectivities_v1_2(self):
+        import igraph
+
+        ones = self._neighbors.distances.copy()
+        ones.data = np.ones(len(ones.data))
+        # should be directed if we deal with distances
+        g = _get_igraph_from_adjacency(ones, directed=True)
+        vc = igraph.VertexClustering(
+            g, membership=self._adata.obs[self._groups_key].cat.codes.values
+        )
+        ns = vc.sizes()
+        n = sum(ns)
+        es_inner_cluster = [vc.subgraph(i).ecount() for i in range(len(ns))]
+        cg = vc.cluster_graph(combine_edges="sum")
+        inter_es = cg.get_adjacency_sparse(attribute="weight")
+        es = np.array(es_inner_cluster) + inter_es.sum(axis=1).A1
+        inter_es = inter_es + inter_es.T  # \epsilon_i + \epsilon_j
+        connectivities = inter_es.copy()
+        expected_n_edges = inter_es.copy()
+        inter_es = inter_es.tocoo()
+        for i, j, v in zip(inter_es.row, inter_es.col, inter_es.data):
+            expected_random_null = (es[i] * ns[j] + es[j] * ns[i]) / (n - 1)
+            scaled_value = v / expected_random_null if expected_random_null != 0 else 1
+            scaled_value = min(scaled_value, 1)
+            connectivities[i, j] = scaled_value
+            expected_n_edges[i, j] = expected_random_null
+        # set attributes
+        self.ns = ns
+        self.expected_n_edges_random = expected_n_edges
+        self.connectivities = connectivities
+        self.connectivities_tree = self._get_connectivities_tree_v1_2()
+        return inter_es.tocsr(), connectivities
+
+    def _compute_connectivities_v1_0(self):
+        import igraph
+
+        ones = self._neighbors.connectivities.copy()
+        ones.data = np.ones(len(ones.data))
+        g = _get_igraph_from_adjacency(ones)
+        vc = igraph.VertexClustering(
+            g, membership=self._adata.obs[self._groups_key].cat.codes.values
+        )
+        ns = vc.sizes()
+        cg = vc.cluster_graph(combine_edges="sum")
+        inter_es = cg.get_adjacency_sparse(attribute="weight") / 2
+        connectivities = inter_es.copy()
+        inter_es = inter_es.tocoo()
+        n_neighbors_sq = self._neighbors.n_neighbors**2
+        for i, j, v in zip(inter_es.row, inter_es.col, inter_es.data):
+            # have n_neighbors**2 inside sqrt for backwards compat
+            geom_mean_approx_knn = np.sqrt(n_neighbors_sq * ns[i] * ns[j])
+            scaled_value = v / geom_mean_approx_knn if geom_mean_approx_knn != 0 else 1
+            connectivities[i, j] = scaled_value
+        # set attributes
+        self.ns = ns
+        self.connectivities = connectivities
+        self.connectivities_tree = self._get_connectivities_tree_v1_0(inter_es)
+        return inter_es.tocsr(), connectivities
+
+    def _get_connectivities_tree_v1_2(self):
+        inverse_connectivities = self.connectivities.copy()
+        inverse_connectivities.data = 1.0 / inverse_connectivities.data
+        connectivities_tree = minimum_spanning_tree(inverse_connectivities)
+        connectivities_tree_indices = [
+            connectivities_tree[i].nonzero()[1]
+            for i in range(connectivities_tree.shape[0])
+        ]
+        connectivities_tree = sp.sparse.lil_matrix(
+            self.connectivities.shape, dtype=float
+        )
+        for i, neighbors in enumerate(connectivities_tree_indices):
+            if len(neighbors) > 0:
+                connectivities_tree[i, neighbors] = self.connectivities[i, neighbors]
+        return connectivities_tree.tocsr()
+
+    def _get_connectivities_tree_v1_0(self, inter_es):
+        inverse_inter_es = inter_es.copy()
+        inverse_inter_es.data = 1.0 / inverse_inter_es.data
+        connectivities_tree = minimum_spanning_tree(inverse_inter_es)
+        connectivities_tree_indices = [
+            connectivities_tree[i].nonzero()[1]
+            for i in range(connectivities_tree.shape[0])
+        ]
+        connectivities_tree = sp.sparse.lil_matrix(inter_es.shape, dtype=float)
+        for i, neighbors in enumerate(connectivities_tree_indices):
+            if len(neighbors) > 0:
+                connectivities_tree[i, neighbors] = self.connectivities[i, neighbors]
+        return connectivities_tree.tocsr()

--- a/omicverse/utils/_paga.py
+++ b/omicverse/utils/_paga.py
@@ -3,7 +3,7 @@ import pandas as pd
 from scipy.sparse import csr_matrix
 from scipy.sparse import coo_matrix, issparse
 
-from scanpy.tools._paga import PAGA
+from ._compat import PAGA
 from .._registry import register_function
 
 # TODO: Add docstrings


### PR DESCRIPTION
## Summary

Fixes #736 — `ImportError: cannot import name 'njit' from 'scanpy._compat'` when running `ov.pp.preprocess(mode='shiftlog|pearson')`.

omicverse's own preprocessing code imported **private scanpy internals** (`scanpy._compat`, `scanpy._utils`, `scanpy._settings`, `scanpy.get`, `scanpy.preprocessing._*`, `scanpy.tools._*`). Those are unstable APIs — scanpy 1.12 removed `njit` from `scanpy._compat`, breaking the experimental HVG path. omicverse already has its own copies of every one of these helpers, so the fix re-wires the imports to omicverse's own modules.

### Files fixed (omicverse's own code only — `external/` untouched)

| file | private scanpy import → replacement |
|---|---|
| `pp/experimental/_highly_variable_genes.py` | `njit`→numba; `_get_mean_var`/`_get_obs_rep`/`view_to_actual`/`check_nonnegative_integers`/`materialize_as_ndarray`→`pp/_utils`,`pp/_scale`,`pp/_distributed`,`pp/_highly_variable_genes`; dropped `scanpy._settings` verbosity wrapper |
| `pp/experimental/_normalization.py` | `_get_obs_rep`/`_set_obs_rep`/`view_to_actual`/`check_nonnegative_integers`/`_empty`/`_handle_mask_var`/`pca`→omicverse `pp/_scale`,`pp/_pca`,`pp/_highly_variable_genes` |
| `pp/_umap.py`, `pp/_tsne.py` | `scanpy._settings`→public `scanpy`; `NeighborsView`/`_choose_representation`/etc.→`pp/_neighbors`,`pp/_scale` |
| `utils/_paga.py` | `scanpy.tools._paga.PAGA`→vendored `utils/_compat.py` |
| `llm/scgpt/preprocess.py` | `scanpy.get`→`pp/_scale` |
| `single/_sccaf.py` | `from scanpy import logging`→stdlib logging wrapper |

Two helpers omicverse lacked (`get_init_pos_from_paga`/`_choose_graph`, `PAGA`) are faithfully vendored into `pp/_compat.py` / `utils/_compat.py`. After the fix, **`grep "from scanpy._*"` outside `external/` returns nothing**.

## Test plan

- [x] #736 reproduced (ImportError) → after fix `ov.pp.preprocess(mode='shiftlog|pearson')` completes, HVGs selected
- [x] `mode='pearson|pearson'`, experimental `highly_variable_genes` + `normalize_pearson_residuals` all work
- [x] pp/preprocess/hvg test suite green (249 passed)
- [x] zero private scanpy imports outside `external/`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)