### PR TITLE
feat(genetics): systematic GWAS best-practice pipeline tutorial + simulate_gwas_study

### DIFF
--- a/omicverse/datasets/__init__.py
+++ b/omicverse/datasets/__init__.py
@@ -114,5 +114,7 @@ from ._genetics import (
     gwas_sumstats,
     gtex_eqtl,
     genetics_scrna,
+    recombination_map,
+    gene_annotation,
 )
 from ._signatures import load_signatures_from_file, predefined_signatures

--- a/omicverse/datasets/__init__.py
+++ b/omicverse/datasets/__init__.py
@@ -107,4 +107,12 @@ from ._protein import (
     protein_dia,
     protein_olink,
 )
+from ._genetics import (
+    # Real genetics datasets for the ov.genetics tutorials
+    geuvadis_genotype,
+    geuvadis_expression,
+    gwas_sumstats,
+    gtex_eqtl,
+    genetics_scrna,
+)
 from ._signatures import load_signatures_from_file, predefined_signatures

--- a/omicverse/datasets/_genetics.py
+++ b/omicverse/datasets/_genetics.py
@@ -1,0 +1,156 @@
+"""Real public genetics datasets for the ``ov.genetics`` GWAS tutorials.
+
+Each loader downloads a dataset asset from the ``omicverse-data`` GitHub
+release (``genetics-v1``) on first use, caches it under ``dir``, and
+returns it ready for the ``ov.genetics`` post-GWAS workflow.
+
+| Loader | Returns | Source |
+|---|---|---|
+| :func:`geuvadis_genotype` | AnnData (individuals × SNPs) | EBI ArrayExpress E-GEUV-1 |
+| :func:`geuvadis_expression` | AnnData (samples × genes) | EBI ArrayExpress E-GEUV-1 |
+| :func:`gwas_sumstats` | DataFrame (GWAS summary stats) | NHGRI-EBI GWAS Catalog GCST004627 |
+| :func:`gtex_eqtl` | DataFrame (cis-eQTL) | GTEx v8 whole blood |
+| :func:`genetics_scrna` | AnnData (cells × genes) | 10x Genomics PBMC 3k |
+
+All datasets are real, published human-genetics data redistributed at
+tutorial scale (one chromosome / a thinned genome-wide set) from the
+EBI ArrayExpress GEUVADIS project, the NHGRI-EBI GWAS Catalog, the GTEx
+Consortium and 10x Genomics — every file retains its original open
+license. The story is biologically coherent: GEUVADIS profiles
+lymphoblastoid cell lines, the GWAS trait is **lymphocyte count**, and
+the single-cell atlas is **PBMCs** — all immune-cell biology.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pandas as pd
+
+from .._registry import register_function
+from ._datasets import download_data
+
+if TYPE_CHECKING:  # pragma: no cover
+    from anndata import AnnData
+
+_RELEASE = (
+    "https://github.com/omicverse/omicverse-data/releases/download/genetics-v1"
+)
+
+
+def _fetch(asset: str, dir: str) -> str:
+    """Download ``asset`` from the genetics-v1 release; return local path."""
+    return download_data(f"{_RELEASE}/{asset}", file_path=asset, dir=dir)
+
+
+@register_function(
+    aliases=["geuvadis_genotype", "geuvadis_geno", "GEUVADIS基因型"],
+    category="datasets",
+    description=(
+        "Real individual-level GEUVADIS genotypes — 462 unrelated "
+        "1000-Genomes individuals from 5 populations (CEU/FIN/GBR/TSI = "
+        "European, YRI = African) × 8000 common biallelic chr22 SNPs. "
+        "Source: EBI ArrayExpress E-GEUV-1, 1000 Genomes phase 1 "
+        "imputed genotypes. Returned as an AnnData (individuals × SNPs); "
+        "``.X`` holds 0/1/2 allele dosages, ``.var`` carries chrom / pos "
+        "/ effect allele A / other allele G / allele frequency, ``.obs`` "
+        "carries the real population label. Anchors the individual-level "
+        "GWAS / eQTL / fine-mapping pipeline."
+    ),
+    examples=["geno = ov.datasets.geuvadis_genotype()"],
+)
+def geuvadis_genotype(dir: str = "./data") -> "AnnData":
+    """Load real GEUVADIS chr22 genotypes (462 individuals, 5 populations)."""
+    import anndata as ad
+    return ad.read_h5ad(_fetch("geuvadis_chr22_genotype.h5ad", dir))
+
+
+@register_function(
+    aliases=["geuvadis_expression", "geuvadis_expr", "GEUVADIS表达"],
+    category="datasets",
+    description=(
+        "Real GEUVADIS lymphoblastoid-cell-line RNA-seq — 462 samples "
+        "(the same individuals as :func:`geuvadis_genotype`) × 633 "
+        "expressed chr22 genes, RPKM quantification. Source: EBI "
+        "ArrayExpress E-GEUV-1 (GD462.GeneQuantRPKM). Returned as an "
+        "AnnData (samples × genes); ``.var`` carries gene symbol / chrom "
+        "/ TSS coordinate, ``.obs`` carries the population label. The "
+        "real molecular phenotype for the cis-eQTL scan."
+    ),
+    examples=["expr = ov.datasets.geuvadis_expression()"],
+)
+def geuvadis_expression(dir: str = "./data") -> "AnnData":
+    """Load real GEUVADIS chr22 lymphoblastoid RNA-seq (462 samples)."""
+    import anndata as ad
+    return ad.read_h5ad(_fetch("geuvadis_chr22_expression.h5ad", dir))
+
+
+@register_function(
+    aliases=["gwas_sumstats", "lymphocyte_gwas", "GWAS统计量"],
+    category="datasets",
+    description=(
+        "Real GWAS summary statistics for blood lymphocyte count "
+        "(Astle et al. 2017, Cell; NHGRI-EBI GWAS Catalog GCST004627, "
+        "PMID 27863252; N≈173,480 Europeans). ``scope='chr22'`` "
+        "(default) returns all ~400k chr22 variants — for "
+        "colocalization and Mendelian randomization against the "
+        "GEUVADIS chr22 eQTLs; ``scope='genomewide'`` returns a thinned "
+        "genome-wide set for LD-score-regression heritability and the "
+        "Manhattan overview. Returned as a DataFrame with canonical "
+        "columns SNP / CHR / BP / A1 / A2 / BETA / SE / P / Z / N / EAF."
+    ),
+    examples=[
+        "ss = ov.datasets.gwas_sumstats(scope='chr22')",
+        "ss = ov.datasets.gwas_sumstats(scope='genomewide')",
+    ],
+)
+def gwas_sumstats(scope: str = "chr22", dir: str = "./data") -> pd.DataFrame:
+    """Load the real lymphocyte-count GWAS summary statistics."""
+    if scope == "chr22":
+        asset = "lymphocyte_count_chr22.tsv.gz"
+    elif scope in ("genomewide", "gw"):
+        asset = "lymphocyte_count_genomewide_thinned.tsv.gz"
+    else:
+        raise ValueError("scope must be 'chr22' or 'genomewide'")
+    return pd.read_csv(_fetch(asset, dir), sep="\t")
+
+
+@register_function(
+    aliases=["gtex_eqtl", "gtex_wholeblood_eqtl", "GTEx_eQTL"],
+    category="datasets",
+    description=(
+        "Real GTEx v8 whole-blood cis-eQTL summary statistics — the "
+        "significant variant-gene pairs on chr22 (~66k pairs, ~398 "
+        "genes). Source: GTEx Consortium v8 single-tissue cis-QTL. "
+        "Whole blood is the GTEx tissue closest to the GEUVADIS "
+        "lymphoblastoid lines, so this provides an independent, "
+        "large-sample eQTL track for colocalization. Returned as a "
+        "DataFrame: variant_id / gene / CHR / BP / A1 / A2 / maf / "
+        "tss_distance / beta / se / pvalue."
+    ),
+    examples=["eqtl = ov.datasets.gtex_eqtl()"],
+)
+def gtex_eqtl(dir: str = "./data") -> pd.DataFrame:
+    """Load real GTEx v8 whole-blood chr22 cis-eQTL summary statistics."""
+    return pd.read_csv(_fetch("gtex_wholeblood_chr22_eqtl.tsv.gz", dir),
+                       sep="\t")
+
+
+@register_function(
+    aliases=["genetics_scrna", "pbmc_immune_atlas", "免疫单细胞图谱"],
+    category="datasets",
+    description=(
+        "Real single-cell RNA-seq immune atlas for scDRS — the 10x "
+        "Genomics PBMC 3k dataset, 2638 quality-controlled peripheral "
+        "blood mononuclear cells × 13,656 genes, raw UMI counts. "
+        "``.obs['cell_type']`` carries the canonical PBMC labels "
+        "(CD4 T / CD8 T / B / NK cells, CD14+ and FCGR3A+ monocytes, "
+        "dendritic cells, megakaryocytes). PBMCs are the cellular "
+        "context of the lymphocyte-count GWAS, so this is the natural "
+        "atlas for single-cell disease-relevance scoring."
+    ),
+    examples=["adata = ov.datasets.genetics_scrna()"],
+)
+def genetics_scrna(dir: str = "./data") -> "AnnData":
+    """Load the real PBMC 3k immune atlas (raw counts) for scDRS."""
+    import anndata as ad
+    return ad.read_h5ad(_fetch("pbmc3k_immune_atlas.h5ad", dir))

--- a/omicverse/datasets/_genetics.py
+++ b/omicverse/datasets/_genetics.py
@@ -11,6 +11,8 @@ returns it ready for the ``ov.genetics`` post-GWAS workflow.
 | :func:`gwas_sumstats` | DataFrame (GWAS summary stats) | NHGRI-EBI GWAS Catalog GCST004627 |
 | :func:`gtex_eqtl` | DataFrame (cis-eQTL) | GTEx v8 whole blood |
 | :func:`genetics_scrna` | AnnData (cells × genes) | 10x Genomics PBMC 3k |
+| :func:`recombination_map` | DataFrame (cM/Mb track) | SHAPEIT4 b37 / 1000 Genomes genetic map |
+| :func:`gene_annotation` | DataFrame (gene models) | GENCODE v19 (GRCh37/hg19) |
 
 All datasets are real, published human-genetics data redistributed at
 tutorial scale (one chromosome / a thinned genome-wide set) from the
@@ -154,3 +156,58 @@ def genetics_scrna(dir: str = "./data") -> "AnnData":
     """Load the real PBMC 3k immune atlas (raw counts) for scDRS."""
     import anndata as ad
     return ad.read_h5ad(_fetch("pbmc3k_immune_atlas.h5ad", dir))
+
+
+@register_function(
+    aliases=["recombination_map", "recomb_map", "genetic_map", "重组图谱"],
+    category="datasets",
+    description=(
+        "Real fine-scale recombination map for the LocusZoom "
+        "recombination-rate track. Source: the SHAPEIT4 b37 genetic map "
+        "(derived from the 1000 Genomes / HapMap recombination maps, "
+        "GRCh37/hg19) — the recombination rate (cM/Mb) is the position "
+        "derivative of the cumulative genetic map. Returned as a "
+        "DataFrame with columns ``position`` (base pairs) and "
+        "``rate_cM_per_Mb``; ``chrom='22'`` (default) covers the whole "
+        "tutorial chromosome (16.05–51.23 Mb). Overlay it on a regional "
+        "association plot with :func:`ov.genetics.regional_plot`."
+    ),
+    examples=[
+        "rmap = ov.datasets.recombination_map()",
+        "rmap = ov.datasets.recombination_map(chrom='22')",
+    ],
+)
+def recombination_map(chrom: str = "22", dir: str = "./data") -> pd.DataFrame:
+    """Load the real chr22 recombination map (cM/Mb) for the LocusZoom track."""
+    if str(chrom) not in ("22",):
+        raise ValueError("recombination_map currently ships chrom='22' only.")
+    df = pd.read_csv(_fetch("recomb_map_chr22.tsv.gz", dir), sep="\t")
+    df["chrom"] = str(chrom)
+    return df
+
+
+@register_function(
+    aliases=["gene_annotation", "gene_models", "gene_track", "基因注释"],
+    category="datasets",
+    description=(
+        "Real chr22 gene models for the LocusZoom gene-track panel. "
+        "Source: GENCODE v19 (GRCh37/hg19) — the canonical hg19 "
+        "annotation, restricted to protein-coding and lincRNA genes "
+        "(579 genes on chr22). Returned as a DataFrame with columns "
+        "``gene`` (symbol), ``chrom``, ``start``, ``end``, ``strand`` "
+        "and ``gene_type``. Pass it to :func:`ov.genetics.regional_plot` "
+        "or :func:`ov.genetics.finemap_locus_plot` to draw the arrowed "
+        "gene boxes beneath a regional association plot."
+    ),
+    examples=[
+        "genes = ov.datasets.gene_annotation()",
+        "genes = ov.datasets.gene_annotation(chrom='22')",
+    ],
+)
+def gene_annotation(chrom: str = "22", dir: str = "./data") -> pd.DataFrame:
+    """Load real GENCODE v19 chr22 gene models for the LocusZoom gene track."""
+    if str(chrom) not in ("22",):
+        raise ValueError("gene_annotation currently ships chrom='22' only.")
+    df = pd.read_csv(_fetch("genes_chr22.tsv.gz", dir), sep="\t",
+                     dtype={"chrom": str})
+    return df

--- a/omicverse/genetics/__init__.py
+++ b/omicverse/genetics/__init__.py
@@ -62,7 +62,8 @@ Pipeline helpers          ``sample_qc_metrics``, ``scan_cis_genes``,
                           ``genotype_pca``, ``clump_loci``, ``grade_loci``,
                           ``prune_by_distance``, ``make_coloc_dataset``,
                           ``coloc_scan``, ``make_eqtl_matrices``,
-                          ``build_twas_model``, ``make_twas_covariance``
+                          ``build_twas_model``, ``compute_ld_to_lead``,
+                          ``make_twas_covariance``
 eQTL mapping              ``eqtl_map`` (linear / anova / linear_cross)
 Fine-mapping              ``finemap`` (susie / susie_rss),
                           ``get_credible_sets``, ``get_pip``
@@ -84,7 +85,7 @@ Plotting                  ``manhattan``, ``qqplot``, ``regional_plot``,
                           ``finemap_plot``, ``sample_qc_plot``,
                           ``pca_structure_plot``, ``finemap_locus_plot``,
                           ``twas_manhattan``, ``scdrs_celltype_plot``,
-                          ``mr_effect_plot``
+                          ``gene_celltype_expression``, ``mr_effect_plot``
 
 All backend imports (``pymatrixeqtl``, ``pysusie`` …) are deferred to
 call-time — ``import omicverse.genetics`` does no heavy work and succeeds
@@ -117,6 +118,7 @@ _LAZY_ATTRS: dict[str, tuple[str, str]] = {
     "coloc_scan":                ("._utils", "coloc_scan"),
     "make_eqtl_matrices":        ("._utils", "make_eqtl_matrices"),
     "build_twas_model":          ("._utils", "build_twas_model"),
+    "compute_ld_to_lead":        ("._utils", "compute_ld_to_lead"),
     # GWAS core (backend-free)
     "gwas_qc":                   ("._gwas", "gwas_qc"),
     "gwas_association":          ("._gwas", "gwas_association"),
@@ -163,6 +165,7 @@ _LAZY_ATTRS: dict[str, tuple[str, str]] = {
     "finemap_locus_plot":        (".plotting", "finemap_locus_plot"),
     "twas_manhattan":            (".plotting", "twas_manhattan"),
     "scdrs_celltype_plot":       (".plotting", "scdrs_celltype_plot"),
+    "gene_celltype_expression":  (".plotting", "gene_celltype_expression"),
     "mr_effect_plot":            (".plotting", "mr_effect_plot"),
 }
 

--- a/omicverse/genetics/__init__.py
+++ b/omicverse/genetics/__init__.py
@@ -58,10 +58,11 @@ Synthetic data            ``simulate_gwas_study`` — one coherent cohort
                           known ground truth, for tutorials / tests
 GWAS core (no backend)    ``gwas_qc``, ``gwas_association``,
                           ``genomic_inflation``
-Pipeline helpers          ``sample_qc_metrics``, ``genotype_pca``,
-                          ``clump_loci``, ``grade_loci``,
-                          ``make_coloc_dataset``, ``make_eqtl_matrices``,
-                          ``build_twas_model``
+Pipeline helpers          ``sample_qc_metrics``, ``scan_cis_genes``,
+                          ``genotype_pca``, ``clump_loci``, ``grade_loci``,
+                          ``prune_by_distance``, ``make_coloc_dataset``,
+                          ``coloc_scan``, ``make_eqtl_matrices``,
+                          ``build_twas_model``, ``make_twas_covariance``
 eQTL mapping              ``eqtl_map`` (linear / anova / linear_cross)
 Fine-mapping              ``finemap`` (susie / susie_rss),
                           ``get_credible_sets``, ``get_pip``
@@ -77,7 +78,7 @@ Heritability / LDSC       ``heritability``, ``genetic_correlation``,
                           ``partitioned_heritability``, ``ldsc_cell_type``,
                           ``munge_sumstats``
 TWAS                      ``twas`` (spredixcan / smultixcan / predixcan),
-                          ``load_twas_model``
+                          ``load_twas_model``, ``make_twas_covariance``
 Plotting                  ``manhattan``, ``qqplot``, ``regional_plot``,
                           ``coloc_plot``, ``mr_scatter``, ``mr_forest``,
                           ``finemap_plot``, ``sample_qc_plot``,
@@ -107,10 +108,13 @@ _LAZY_ATTRS: dict[str, tuple[str, str]] = {
     "GWASStudy":                 ("._simulate", "GWASStudy"),
     # Pipeline data-prep helpers
     "sample_qc_metrics":         ("._utils", "sample_qc_metrics"),
+    "scan_cis_genes":            ("._utils", "scan_cis_genes"),
     "genotype_pca":              ("._utils", "genotype_pca"),
     "clump_loci":                ("._utils", "clump_loci"),
     "grade_loci":                ("._utils", "grade_loci"),
+    "prune_by_distance":         ("._utils", "prune_by_distance"),
     "make_coloc_dataset":        ("._utils", "make_coloc_dataset"),
+    "coloc_scan":                ("._utils", "coloc_scan"),
     "make_eqtl_matrices":        ("._utils", "make_eqtl_matrices"),
     "build_twas_model":          ("._utils", "build_twas_model"),
     # GWAS core (backend-free)
@@ -145,6 +149,7 @@ _LAZY_ATTRS: dict[str, tuple[str, str]] = {
     # TWAS
     "twas":                      ("._twas", "twas"),
     "load_twas_model":           ("._twas", "load_twas_model"),
+    "make_twas_covariance":      ("._twas", "make_twas_covariance"),
     # Plotting
     "manhattan":                 (".plotting", "manhattan"),
     "qqplot":                    (".plotting", "qqplot"),

--- a/omicverse/genetics/__init__.py
+++ b/omicverse/genetics/__init__.py
@@ -52,6 +52,9 @@ Quick-start
 Pipeline stages
 ---------------
 I/O                       ``read_sumstats``, ``read_plink``, ``read_vcf``
+Synthetic data            ``simulate_gwas_study`` — one coherent cohort
+                          (genotype + trait + expression + scRNA) with
+                          known ground truth, for tutorials / tests
 GWAS core (no backend)    ``gwas_qc``, ``gwas_association``,
                           ``genomic_inflation``
 eQTL mapping              ``eqtl_map`` (linear / anova / linear_cross)
@@ -89,6 +92,9 @@ _LAZY_ATTRS: dict[str, tuple[str, str]] = {
     "read_sumstats":             (".io", "read_sumstats"),
     "read_plink":                (".io", "read_plink"),
     "read_vcf":                  (".io", "read_vcf"),
+    # Synthetic data (tutorials / tests)
+    "simulate_gwas_study":       ("._simulate", "simulate_gwas_study"),
+    "GWASStudy":                 ("._simulate", "GWASStudy"),
     # GWAS core (backend-free)
     "gwas_qc":                   ("._gwas", "gwas_qc"),
     "gwas_association":          ("._gwas", "gwas_association"),
@@ -135,6 +141,7 @@ _LAZY_SUBMODULES = {"io", "plotting"}
 
 _REGISTRY_SUBMODULES = (
     ".io",
+    "._simulate",
     "._gwas",
     "._eqtl",
     "._finemap",

--- a/omicverse/genetics/__init__.py
+++ b/omicverse/genetics/__init__.py
@@ -51,12 +51,17 @@ Quick-start
 
 Pipeline stages
 ---------------
-I/O                       ``read_sumstats``, ``read_plink``, ``read_vcf``
+I/O                       ``read_sumstats``, ``read_plink``, ``read_vcf``,
+                          ``write_plink``, ``write_sumstats``
 Synthetic data            ``simulate_gwas_study`` — one coherent cohort
                           (genotype + trait + expression + scRNA) with
                           known ground truth, for tutorials / tests
 GWAS core (no backend)    ``gwas_qc``, ``gwas_association``,
                           ``genomic_inflation``
+Pipeline helpers          ``sample_qc_metrics``, ``genotype_pca``,
+                          ``clump_loci``, ``grade_loci``,
+                          ``make_coloc_dataset``, ``make_eqtl_matrices``,
+                          ``build_twas_model``
 eQTL mapping              ``eqtl_map`` (linear / anova / linear_cross)
 Fine-mapping              ``finemap`` (susie / susie_rss),
                           ``get_credible_sets``, ``get_pip``
@@ -75,7 +80,10 @@ TWAS                      ``twas`` (spredixcan / smultixcan / predixcan),
                           ``load_twas_model``
 Plotting                  ``manhattan``, ``qqplot``, ``regional_plot``,
                           ``coloc_plot``, ``mr_scatter``, ``mr_forest``,
-                          ``finemap_plot``
+                          ``finemap_plot``, ``sample_qc_plot``,
+                          ``pca_structure_plot``, ``finemap_locus_plot``,
+                          ``twas_manhattan``, ``scdrs_celltype_plot``,
+                          ``mr_effect_plot``
 
 All backend imports (``pymatrixeqtl``, ``pysusie`` …) are deferred to
 call-time — ``import omicverse.genetics`` does no heavy work and succeeds
@@ -92,9 +100,19 @@ _LAZY_ATTRS: dict[str, tuple[str, str]] = {
     "read_sumstats":             (".io", "read_sumstats"),
     "read_plink":                (".io", "read_plink"),
     "read_vcf":                  (".io", "read_vcf"),
+    "write_plink":               (".io", "write_plink"),
+    "write_sumstats":            (".io", "write_sumstats"),
     # Synthetic data (tutorials / tests)
     "simulate_gwas_study":       ("._simulate", "simulate_gwas_study"),
     "GWASStudy":                 ("._simulate", "GWASStudy"),
+    # Pipeline data-prep helpers
+    "sample_qc_metrics":         ("._utils", "sample_qc_metrics"),
+    "genotype_pca":              ("._utils", "genotype_pca"),
+    "clump_loci":                ("._utils", "clump_loci"),
+    "grade_loci":                ("._utils", "grade_loci"),
+    "make_coloc_dataset":        ("._utils", "make_coloc_dataset"),
+    "make_eqtl_matrices":        ("._utils", "make_eqtl_matrices"),
+    "build_twas_model":          ("._utils", "build_twas_model"),
     # GWAS core (backend-free)
     "gwas_qc":                   ("._gwas", "gwas_qc"),
     "gwas_association":          ("._gwas", "gwas_association"),
@@ -135,6 +153,12 @@ _LAZY_ATTRS: dict[str, tuple[str, str]] = {
     "mr_scatter":                (".plotting", "mr_scatter"),
     "mr_forest":                 (".plotting", "mr_forest"),
     "finemap_plot":              (".plotting", "finemap_plot"),
+    "sample_qc_plot":            (".plotting", "sample_qc_plot"),
+    "pca_structure_plot":        (".plotting", "pca_structure_plot"),
+    "finemap_locus_plot":        (".plotting", "finemap_locus_plot"),
+    "twas_manhattan":            (".plotting", "twas_manhattan"),
+    "scdrs_celltype_plot":       (".plotting", "scdrs_celltype_plot"),
+    "mr_effect_plot":            (".plotting", "mr_effect_plot"),
 }
 
 _LAZY_SUBMODULES = {"io", "plotting"}
@@ -142,6 +166,7 @@ _LAZY_SUBMODULES = {"io", "plotting"}
 _REGISTRY_SUBMODULES = (
     ".io",
     "._simulate",
+    "._utils",
     "._gwas",
     "._eqtl",
     "._finemap",

--- a/omicverse/genetics/_simulate.py
+++ b/omicverse/genetics/_simulate.py
@@ -1,0 +1,537 @@
+"""Coherent synthetic GWAS cohort for ``ov.genetics`` tutorials and tests.
+
+:func:`simulate_gwas_study` generates ONE internally-consistent study —
+genotypes with realistic LD block structure and population
+substructure, a heritable quantitative trait, a matched bulk-expression
+panel carrying real cis-eQTLs, and a small scRNA-seq atlas — together
+with the planted ground truth. The same causal SNP drives both the
+trait and one gene's expression, so colocalization, TWAS and Mendelian
+randomization all have a real mediated signal to recover, and the
+causal gene is selectively expressed in one cell type so scDRS can
+pinpoint a disease-relevant cell type.
+
+The whole study is deterministic given ``seed`` and is built to run a
+full best-practice GWAS pipeline end to end in a few seconds.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+import numpy as np
+import pandas as pd
+
+from .._registry import register_function
+
+
+@dataclass
+class GWASStudy:
+    """A coherent simulated statistical-genetics study.
+
+    Attributes
+    ----------
+    genotype
+        ``AnnData`` of ``samples x SNPs`` — integer 0/1/2 allele dosages
+        in ``.X``. ``.var`` carries ``chrom``, ``pos``, ``maf``,
+        ``block`` and a boolean ``causal`` flag; ``.obs`` carries a
+        ``population`` label and the quantitative ``phenotype``.
+    phenotype
+        Per-sample quantitative trait (a :class:`pandas.Series` aligned
+        to ``genotype.obs_names``); also stored in ``genotype.obs``.
+    expression
+        ``AnnData`` of ``samples x genes`` — a bulk-expression panel
+        sharing the genotype's samples. ``.var`` carries ``chrom``,
+        ``pos``, an ``eqtl_snp`` column (the cis driver, or ``''``) and
+        an ``is_eqtl_gene`` flag.
+    scrna
+        ``AnnData`` of ``cells x genes`` — a small scRNA-seq atlas with
+        a ``cell_type`` column; the trait's causal gene is selectively
+        over-expressed in one cell type.
+    truth
+        Dict of planted ground truth — see :func:`simulate_gwas_study`.
+    params
+        The simulation parameters used.
+    """
+
+    genotype: "object"
+    phenotype: "pd.Series"
+    expression: "object"
+    scrna: "object"
+    truth: Dict[str, object] = field(default_factory=dict)
+    params: Dict[str, object] = field(default_factory=dict)
+
+    def __repr__(self) -> str:  # pragma: no cover - cosmetic
+        g, e, s = self.genotype, self.expression, self.scrna
+        return (
+            "GWASStudy(\n"
+            f"  genotype  : {g.n_obs} samples x {g.n_vars} SNPs\n"
+            f"  phenotype : quantitative trait, h2 = {self.params.get('h2')}\n"
+            f"  expression: {e.n_obs} samples x {e.n_vars} genes\n"
+            f"  scrna     : {s.n_obs} cells x {s.n_vars} genes\n"
+            f"  truth     : causal_snps={self.truth.get('causal_snps')}, "
+            f"causal_gene={self.truth.get('causal_gene')!r}, "
+            f"cell_type={self.truth.get('relevant_cell_type')!r}\n"
+            ")"
+        )
+
+
+def _make_blocks(n_snps: int, n_blocks: int, rng) -> np.ndarray:
+    """Assign each SNP to an LD block of roughly equal size."""
+    base = n_snps // n_blocks
+    sizes = np.full(n_blocks, base, dtype=int)
+    sizes[: n_snps - base * n_blocks] += 1
+    return np.repeat(np.arange(n_blocks), sizes)
+
+
+@register_function(
+    aliases=[
+        "simulate_gwas_study", "simulate_gwas", "gwas_simulate",
+        "模拟GWAS数据", "GWAS模拟数据", "遗传学模拟",
+    ],
+    category="genetics",
+    description=(
+        "Simulate one coherent, internally-consistent statistical-"
+        "genetics study for tutorials and tests. Returns a genotype "
+        "AnnData with realistic LD-block structure and population "
+        "substructure, a heritable quantitative trait, a matched bulk-"
+        "expression panel carrying true cis-eQTLs, and a small scRNA-seq "
+        "atlas — plus the planted ground truth. Crucially the SAME causal "
+        "SNP drives both the trait and one gene's expression, so "
+        "colocalization, TWAS and Mendelian randomization all recover a "
+        "real mediated signal, and that causal gene is selectively "
+        "expressed in one cell type so scDRS recovers a disease-relevant "
+        "cell type. Deterministic given ``seed``."
+    ),
+    produces={
+        "obs": ["population", "phenotype", "cell_type"],
+        "var": ["chrom", "pos", "maf", "causal", "eqtl_snp", "is_eqtl_gene"],
+    },
+    auto_fix="none",
+    examples=[
+        "study = ov.genetics.simulate_gwas_study(seed=0)",
+        "study = ov.genetics.simulate_gwas_study(n_samples=3000, n_snps=8000)",
+        "geno, pheno = study.genotype, study.phenotype",
+    ],
+    related=[
+        "ov.genetics.gwas_qc", "ov.genetics.gwas_association",
+        "ov.genetics.finemap", "ov.genetics.colocalize",
+    ],
+)
+def simulate_gwas_study(
+    *,
+    n_samples: int = 2000,
+    n_snps: int = 6000,
+    n_blocks: int = 30,
+    n_causal: int = 5,
+    n_genes: int = 200,
+    n_pops: int = 2,
+    n_cells: int = 1500,
+    h2: float = 0.4,
+    seed: int = 0,
+) -> GWASStudy:
+    """Simulate a coherent GWAS study with known ground truth.
+
+    The study is built so every step of a post-GWAS pipeline has a real
+    planted signal to recover:
+
+    * **Genotypes** — ``n_snps`` SNPs spread over ``n_blocks`` LD blocks.
+      Each block is drawn from a correlated latent multivariate normal,
+      then thresholded to 0/1/2 dosages at per-SNP minor-allele
+      frequencies, giving realistic within-block LD. ``n_pops``
+      subpopulations have slightly divergent allele frequencies, so
+      genotype PCA recovers genuine structure.
+    * **Phenotype** — a quantitative trait equal to the additive effect
+      of ``n_causal`` causal SNPs (scaled so they explain a fraction
+      ``h2`` of the variance) **plus** a small population-structure
+      effect **plus** Gaussian noise. The structure effect makes a
+      naive association scan inflated and PC adjustment necessary.
+    * **Expression** — a bulk-expression panel over the same samples;
+      a handful of genes carry true cis-eQTLs. One of the trait's causal
+      SNPs is *also* the cis-eQTL of one designated gene (the *causal
+      gene*) — i.e. the trait signal at that locus is mediated by that
+      gene, so colocalization / TWAS / MR all have a true signal.
+    * **scRNA-seq** — a small single-cell atlas over the same genes; the
+      causal gene is selectively over-expressed in one cell type, so
+      scDRS recovers a disease-relevant cell type.
+
+    Parameters
+    ----------
+    n_samples
+        Number of individuals (rows of the genotype / expression
+        AnnData).
+    n_snps
+        Number of SNPs (columns of the genotype AnnData).
+    n_blocks
+        Number of LD blocks; SNPs within a block are correlated.
+    n_causal
+        Number of SNPs with a true effect on the trait.
+    n_genes
+        Number of genes in the bulk-expression and scRNA-seq panels.
+    n_pops
+        Number of subpopulations with divergent allele frequencies.
+    n_cells
+        Number of cells in the scRNA-seq atlas.
+    h2
+        Narrow-sense heritability — the fraction of trait variance
+        explained by the causal SNPs.
+    seed
+        RNG seed; the whole study is deterministic given this value.
+
+    Returns
+    -------
+    GWASStudy
+        A dataclass with ``.genotype`` (AnnData, samples x SNPs),
+        ``.phenotype`` (Series), ``.expression`` (AnnData, samples x
+        genes), ``.scrna`` (AnnData, cells x genes), ``.truth`` and
+        ``.params``. ``.truth`` carries:
+
+        * ``causal_snps`` — list of trait-causal SNP ids
+        * ``lead_causal_snp`` — the causal SNP that is also the cis-eQTL
+          of the causal gene (the mediated locus)
+        * ``gene_instruments`` — independent eQTLs of the causal gene in
+          other LD blocks (the Mendelian-randomization instruments)
+        * ``causal_gene`` — the gene mediating the trait at that locus
+        * ``causal_block`` — the LD block of the lead causal SNP
+        * ``eqtl_map`` — dict ``{gene: cis_eQTL_snp}`` for all eGenes
+        * ``relevant_cell_type`` — the disease-relevant cell type
+        * ``snp_effects`` — dict ``{snp: trait beta}`` for causal SNPs
+    """
+    from anndata import AnnData
+
+    if n_causal < 1:
+        raise ValueError("n_causal must be at least 1.")
+    if n_genes < 5:
+        raise ValueError("n_genes must be at least 5.")
+    if not 0.0 < h2 < 1.0:
+        raise ValueError("h2 must be in (0, 1).")
+
+    rng = np.random.default_rng(seed)
+
+    # ------------------------------------------------------------------ #
+    # 1. SNP annotation — chromosomes, positions, LD blocks, MAF.        #
+    # ------------------------------------------------------------------ #
+    block = _make_blocks(n_snps, n_blocks, rng)
+    # Map every LD block to a chromosome (a few blocks per chromosome).
+    blocks_per_chr = max(1, n_blocks // 22)
+    chrom_of_block = np.minimum(1 + np.arange(n_blocks) // blocks_per_chr, 22)
+    chrom = chrom_of_block[block]
+    # Genomic position: blocks are ~1 Mb apart, SNPs ~5 kb apart in a block.
+    pos = np.zeros(n_snps, dtype=int)
+    for b in range(n_blocks):
+        idx = np.where(block == b)[0]
+        start = 1_000_000 + (b % blocks_per_chr) * 2_000_000
+        pos[idx] = start + np.arange(idx.size) * 5_000
+    # A baseline MAF per SNP (population-level reference frequency).
+    maf = rng.uniform(0.05, 0.5, n_snps)
+
+    snp_ids = np.array([f"rs{i:06d}" for i in range(n_snps)])
+
+    # ------------------------------------------------------------------ #
+    # 2. Population structure — divergent allele frequencies.            #
+    # ------------------------------------------------------------------ #
+    pop = rng.integers(0, n_pops, n_samples)
+    # Each population shifts every SNP's allele frequency by a small,
+    # SNP-specific amount (Fst-like drift), kept inside [0.02, 0.98].
+    pop_shift = rng.normal(0.0, 0.06, size=(n_pops, n_snps))
+    pop_freq = np.clip(maf[None, :] + pop_shift, 0.02, 0.98)
+
+    # ------------------------------------------------------------------ #
+    # 3. Genotypes — correlated LD blocks thresholded to 0/1/2 dosages.  #
+    # ------------------------------------------------------------------ #
+    geno = np.zeros((n_samples, n_snps), dtype=np.int8)
+    for b in range(n_blocks):
+        idx = np.where(block == b)[0]
+        k = idx.size
+        # A latent within-block correlation: AR(1)-style decay so nearby
+        # SNPs are in tighter LD than distant ones.
+        rho = 0.85
+        d = np.abs(np.subtract.outer(np.arange(k), np.arange(k)))
+        corr = rho ** d
+        chol = np.linalg.cholesky(corr + 1e-6 * np.eye(k))
+        # Two latent haplotype draws per individual -> additive dosage.
+        for hap in range(2):
+            latent = rng.standard_normal((n_samples, k)) @ chol.T
+            # Per-individual threshold from that individual's pop frequency.
+            thr = np.array(
+                [_norm_isf(pop_freq[pop[i], idx]) for i in range(n_samples)]
+            )
+            geno[:, idx] += (latent > thr).astype(np.int8)
+
+    # Realised (in-sample) minor-allele frequency after drawing genotypes.
+    realised_af = geno.mean(axis=0) / 2.0
+    realised_maf = np.minimum(realised_af, 1.0 - realised_af)
+
+    # ------------------------------------------------------------------ #
+    # 4. Causal architecture — designate causal SNPs, the causal gene    #
+    #    and its instruments.                                            #
+    # ------------------------------------------------------------------ #
+    # Pick causal SNPs from common variants in distinct LD blocks. The
+    # FIRST causal SNP is the *lead* — it acts on the trait only through
+    # the causal gene's expression (a true mediated locus); the others
+    # act on the trait directly (independent pleiotropy-free loci).
+    common = np.where(realised_maf > 0.1)[0]
+    rng.shuffle(common)
+    causal_idx: List[int] = []
+    used_blocks: set = set()
+    for j in common:
+        if block[j] not in used_blocks:
+            causal_idx.append(int(j))
+            used_blocks.add(block[j])
+        if len(causal_idx) == n_causal:
+            break
+    causal_idx = np.array(sorted(causal_idx))
+    lead_causal_snp_idx = int(causal_idx[0])
+    causal_block = int(block[lead_causal_snp_idx])
+    # The remaining causal SNPs act on the trait directly.
+    direct_causal_idx = np.array(
+        [j for j in causal_idx if j != lead_causal_snp_idx]
+    )
+
+    gene_ids = np.array([f"GENE{i:04d}" for i in range(n_genes)])
+    causal_gene = gene_ids[0]
+    n_extra_egenes = min(6, n_genes - 1)
+    egene_idx = np.array([0] + list(range(1, 1 + n_extra_egenes)))
+
+    # The causal gene's primary cis driver is the lead trait-causal SNP.
+    eqtl_snp_for_gene: Dict[str, str] = {causal_gene: snp_ids[lead_causal_snp_idx]}
+    eqtl_idx_for_gene: Dict[int, int] = {0: lead_causal_snp_idx}
+    # The causal gene additionally has several independent eQTLs in OTHER
+    # LD blocks. These are valid Mendelian-randomization instruments for
+    # the gene's expression — and, because the gene mediates the trait,
+    # they move the trait only through the gene (no horizontal pleiotropy).
+    n_gene_instruments = 6
+    avail = np.setdiff1d(common, causal_idx)
+    avail = np.array([j for j in avail if block[j] != causal_block])
+    rng.shuffle(avail)
+    extra_instruments: List[int] = []
+    inst_blocks: set = set()
+    for j in avail:
+        if block[j] not in inst_blocks:
+            extra_instruments.append(int(j))
+            inst_blocks.add(block[j])
+        if len(extra_instruments) == n_gene_instruments:
+            break
+    extra_instruments = np.array(extra_instruments, dtype=int)
+    # Other eGenes get their own cis SNPs (from remaining LD blocks).
+    other_pool = np.array(
+        [j for j in avail if j not in set(extra_instruments.tolist())]
+    )
+    other_snps = rng.choice(other_pool, size=n_extra_egenes, replace=False)
+    for g_local, snp_j in zip(egene_idx[1:], other_snps):
+        eqtl_snp_for_gene[gene_ids[g_local]] = snp_ids[snp_j]
+        eqtl_idx_for_gene[int(g_local)] = int(snp_j)
+
+    # ------------------------------------------------------------------ #
+    # 5. Causal-gene expression — driven by its cis SNP + instruments.   #
+    # ------------------------------------------------------------------ #
+    def _std(col):
+        col = col.astype(float)
+        return (col - col.mean()) / (col.std() + 1e-9)
+
+    # The causal gene's "true" expression: the lead cis SNP (much the
+    # largest weight, so it is the dominant cis-eQTL and fine-maps to a
+    # tight credible set) plus several independent eQTL instruments,
+    # plus residual noise. The cis-eQTL h2 of the gene is ~0.7.
+    cg_genetic = 3.0 * _std(geno[:, lead_causal_snp_idx])
+    inst_weights = np.abs(rng.normal(0.0, 1.0, extra_instruments.size)) + 0.6
+    for w, j in zip(inst_weights, extra_instruments):
+        cg_genetic = cg_genetic + w * _std(geno[:, j])
+    cg_genetic = cg_genetic / (cg_genetic.std() + 1e-9)   # var = 1
+    cg_eqtl_h2 = 0.7
+    cg_expr_noise = rng.normal(
+        0.0, np.sqrt(1.0 / cg_eqtl_h2 - 1.0), n_samples,
+    )
+    causal_gene_expr = cg_genetic + cg_expr_noise          # the mediator
+
+    # ------------------------------------------------------------------ #
+    # 6. The heritable quantitative trait.                               #
+    # ------------------------------------------------------------------ #
+    # mediated component : the trait responds to the causal gene's
+    #   expression (so every eQTL of that gene is also a trait locus) —
+    #   weighted to carry most of the genetic signal so the mediated
+    #   locus is the lead genome-wide hit;
+    # direct component   : the other causal SNPs act on the trait
+    #   directly; structure : a small population-mean shift; noise.
+    mediator_effect = 2.2
+    mediated = mediator_effect * (
+        causal_gene_expr - causal_gene_expr.mean()
+    ) / (causal_gene_expr.std() + 1e-9)
+    if direct_causal_idx.size:
+        G_d = np.column_stack([_std(geno[:, j]) for j in direct_causal_idx])
+        d_beta = np.abs(rng.normal(0.0, 1.0, direct_causal_idx.size)) + 0.5
+        d_beta *= rng.choice([-1.0, 1.0], direct_causal_idx.size)
+        direct = G_d @ d_beta
+    else:
+        direct = np.zeros(n_samples)
+    genetic = mediated + direct
+    genetic = genetic / (genetic.std() + 1e-9)            # var = 1
+    # Population-structure effect — a small per-population mean shift.
+    pop_effect_size = 0.45
+    pop_means = rng.normal(0.0, 1.0, n_pops)
+    pop_means -= pop_means.mean()
+    structure = pop_effect_size * pop_means[pop]
+    # Noise scaled so genetic variance / total variance == h2.
+    noise_var = genetic.var() * (1.0 - h2) / h2
+    noise = rng.normal(0.0, np.sqrt(noise_var), n_samples)
+    phenotype_vals = genetic + structure + noise
+
+    # Per-causal-SNP marginal trait effect (additive-coded), for the truth.
+    snp_effects = {}
+    for j in causal_idx:
+        g = geno[:, j].astype(float)
+        snp_effects[snp_ids[j]] = float(
+            np.cov(g, phenotype_vals)[0, 1] / (g.var() + 1e-9)
+        )
+
+    sample_ids = np.array([f"IND{i:05d}" for i in range(n_samples)])
+
+    obs = pd.DataFrame(
+        {
+            "population": pd.Categorical(
+                [f"pop{p}" for p in pop],
+                categories=[f"pop{p}" for p in range(n_pops)],
+            ),
+            "phenotype": phenotype_vals,
+        },
+        index=sample_ids,
+    )
+    causal_flag = np.zeros(n_snps, dtype=bool)
+    causal_flag[causal_idx] = True
+    var = pd.DataFrame(
+        {
+            "chrom": chrom.astype(int),
+            "pos": pos.astype(int),
+            "maf": realised_maf,
+            "block": block.astype(int),
+            "causal": causal_flag,
+        },
+        index=snp_ids,
+    )
+    genotype = AnnData(
+        X=geno.astype(np.float32), obs=obs, var=var,
+    )
+    genotype.uns["genetics_source"] = "simulate_gwas_study"
+
+    # ------------------------------------------------------------------ #
+    # 7. Bulk expression — the causal gene plus other cis-eQTL genes.     #
+    # ------------------------------------------------------------------ #
+    # Place each gene on a chromosome / position.
+    gene_chrom = rng.integers(1, 23, n_genes)
+    gene_pos = rng.integers(1_000_000, 50_000_000, n_genes)
+    # The causal gene's cis SNP defines its locus coordinates.
+    gene_chrom[0] = chrom[lead_causal_snp_idx]
+    gene_pos[0] = pos[lead_causal_snp_idx] + 20_000
+    for g_local, snp_j in eqtl_idx_for_gene.items():
+        if g_local == 0:
+            continue
+        gene_chrom[g_local] = chrom[snp_j]
+        gene_pos[g_local] = pos[snp_j] + 20_000
+
+    # Build the bulk-expression matrix. The causal gene gets the mediator
+    # expression built above (so its eQTLs and the trait truly share the
+    # same drivers); the other eGenes get a single cis-eQTL effect.
+    expr = rng.normal(0.0, 1.0, size=(n_samples, n_genes))
+    expr[:, 0] = causal_gene_expr
+    eqtl_effect = 0.7
+    for g_local, snp_j in eqtl_idx_for_gene.items():
+        if g_local == 0:
+            continue
+        expr[:, g_local] += eqtl_effect * _std(geno[:, snp_j])
+
+    is_eqtl_gene = np.zeros(n_genes, dtype=bool)
+    is_eqtl_gene[egene_idx] = True
+    eqtl_snp_col = np.array(
+        [eqtl_snp_for_gene.get(g, "") for g in gene_ids], dtype=object,
+    )
+    expr_var = pd.DataFrame(
+        {
+            "chrom": gene_chrom.astype(int),
+            "pos": gene_pos.astype(int),
+            "eqtl_snp": eqtl_snp_col,
+            "is_eqtl_gene": is_eqtl_gene,
+        },
+        index=gene_ids,
+    )
+    expression = AnnData(
+        X=expr.astype(np.float32),
+        obs=obs[["population"]].copy(),
+        var=expr_var,
+    )
+    expression.uns["genetics_source"] = "simulate_gwas_study"
+
+    # ------------------------------------------------------------------ #
+    # 8. scRNA-seq atlas — causal gene selective in one cell type.        #
+    # ------------------------------------------------------------------ #
+    cell_types = np.array(["T_cell", "B_cell", "Monocyte", "NK_cell"])
+    n_ct = cell_types.size
+    ct_label = cell_types[rng.integers(0, n_ct, n_cells)]
+    relevant_cell_type = "Monocyte"
+
+    # Poisson counts: a baseline rate per gene, with the causal gene (and
+    # the other eGenes, more weakly) up-regulated in the relevant type.
+    base_rate = rng.uniform(0.5, 3.0, n_genes)
+    counts = rng.poisson(
+        base_rate[None, :], size=(n_cells, n_genes),
+    ).astype(np.float32)
+    in_ct = ct_label == relevant_cell_type
+    # Causal gene: strongly selective in the relevant cell type.
+    counts[in_ct, 0] += rng.poisson(12.0, size=in_ct.sum()).astype(np.float32)
+    # Other eGenes: a weaker selective bump (so the GWAS gene set as a
+    # whole points at the same cell type).
+    for g_local in egene_idx[1:]:
+        counts[in_ct, g_local] += rng.poisson(
+            3.0, size=in_ct.sum(),
+        ).astype(np.float32)
+    # Give each cell type one extra marker gene, for realism.
+    for ci, ct in enumerate(cell_types):
+        marker = n_genes - 1 - ci
+        sel = ct_label == ct
+        counts[sel, marker] += rng.poisson(
+            10.0, size=sel.sum(),
+        ).astype(np.float32)
+
+    sc_obs = pd.DataFrame(
+        {"cell_type": pd.Categorical(ct_label, categories=list(cell_types))},
+        index=[f"CELL{i:05d}" for i in range(n_cells)],
+    )
+    scrna = AnnData(
+        X=counts,
+        obs=sc_obs,
+        var=pd.DataFrame(
+            {"chrom": gene_chrom.astype(int), "pos": gene_pos.astype(int)},
+            index=gene_ids,
+        ),
+    )
+    scrna.uns["genetics_source"] = "simulate_gwas_study"
+
+    # ------------------------------------------------------------------ #
+    # 9. Assemble the study + ground truth.                              #
+    # ------------------------------------------------------------------ #
+    phenotype = pd.Series(phenotype_vals, index=sample_ids, name="phenotype")
+    truth = {
+        "causal_snps": [str(s) for s in snp_ids[causal_idx]],
+        "lead_causal_snp": str(snp_ids[lead_causal_snp_idx]),
+        "gene_instruments": [str(s) for s in snp_ids[extra_instruments]],
+        "causal_gene": str(causal_gene),
+        "causal_block": causal_block,
+        "causal_chrom": int(chrom[lead_causal_snp_idx]),
+        "eqtl_map": {str(k): str(v) for k, v in eqtl_snp_for_gene.items()},
+        "relevant_cell_type": relevant_cell_type,
+        "snp_effects": {str(k): v for k, v in snp_effects.items()},
+    }
+    params = {
+        "n_samples": n_samples, "n_snps": n_snps, "n_blocks": n_blocks,
+        "n_causal": n_causal, "n_genes": n_genes, "n_pops": n_pops,
+        "n_cells": n_cells, "h2": h2, "seed": seed,
+    }
+    return GWASStudy(
+        genotype=genotype, phenotype=phenotype, expression=expression,
+        scrna=scrna, truth=truth, params=params,
+    )
+
+
+def _norm_isf(p):
+    """Inverse survival function of the standard normal (vectorised)."""
+    from scipy.special import ndtri
+
+    return ndtri(1.0 - np.asarray(p, dtype=float))

--- a/omicverse/genetics/_twas.py
+++ b/omicverse/genetics/_twas.py
@@ -61,6 +61,56 @@ def _require_twas():
     return pytwas
 
 
+def _spredixcan_in_memory(
+    pytwas, model, covariance, gwas,
+    snp_column, effect_allele_column, non_effect_allele_column,
+):
+    """Run S-PrediXcan from an in-memory model + covariance.
+
+    ``pytwas.spredixcan`` reads its model and covariance from disk. When a
+    notebook has already built a :class:`pytwas.PredictionModel` (e.g.
+    from :func:`build_twas_model`) and a per-gene SNP covariance, this
+    routes straight through ``pytwas.gene_association`` — no SQLite /
+    text-file round trip — and returns the same per-gene TWAS table.
+    """
+    from scipy import stats as _stats
+
+    if isinstance(covariance, pd.DataFrame):
+        covariance = pytwas.CovarianceDB(covariance)
+
+    weights = model.weights
+    gwas_idx = gwas.set_index(snp_column)
+    rows = []
+    for gene, sub in weights.groupby("gene"):
+        gi = {}
+        for _, w in sub.iterrows():
+            rsid = w["rsid"]
+            if rsid not in gwas_idx.index:
+                continue
+            rec = gwas_idx.loc[rsid]
+            if isinstance(rec, pd.DataFrame):           # duplicate id
+                rec = rec.iloc[0]
+            same = str(rec[effect_allele_column]) == str(w["effect_allele"])
+            sign = 1.0 if same else -1.0
+            z = float(rec["Z"]) if "Z" in rec else float(rec.get("zscore", np.nan))
+            b = (float(rec["BETA"]) if "BETA" in rec
+                 else float(rec.get("beta", np.nan)))
+            gi[rsid] = (sign * z, sign * b)
+        if not gi:
+            continue
+        ga = pytwas.gene_association(gene, model, gi, covariance)
+        rows.append({
+            "gene": gene, "zscore": ga.zscore,
+            "effect_size": ga.effect_size,
+            "n_snps_used": ga.n_snps_used,
+        })
+    res = pd.DataFrame(rows)
+    if not res.empty:
+        res["pvalue"] = 2.0 * _stats.norm.sf(np.abs(res["zscore"].astype(float)))
+        res = res.sort_values("pvalue").reset_index(drop=True)
+    return res
+
+
 @register_function(
     aliases=[
         "twas", "transcriptome_wide_association", "predixcan", "spredixcan",
@@ -157,6 +207,15 @@ def twas(
             raise ValueError(
                 "method='spredixcan' requires gwas= (DataFrame) or gwas_file=."
             )
+        # In-memory route: a PredictionModel + a covariance DataFrame /
+        # CovarianceDB run directly, no .db / .txt files needed. This lets
+        # a notebook build a model from an eQTL table in memory and run
+        # S-PrediXcan without round-tripping through SQLite on disk.
+        if not isinstance(model, str):
+            return _spredixcan_in_memory(
+                pytwas, model, covariance, gwas,
+                snp_column, effect_allele_column, non_effect_allele_column,
+            )
         gwas_df = gwas
         if isinstance(gwas_df, pd.DataFrame):
             gwas_df = _canonicalize_gwas(
@@ -227,3 +286,83 @@ def load_twas_model(path: str, *, snp_key: Optional[str] = None):
     """
     pytwas = _require_twas()
     return pytwas.load_model(path, snp_key=snp_key)
+
+
+@register_function(
+    aliases=[
+        "make_twas_covariance", "twas_covariance", "snp_covariance",
+        "构建TWAS协方差", "SNP协方差矩阵",
+    ],
+    category="genetics",
+    description=(
+        "Build the per-gene SNP-covariance table that S-PrediXcan needs, "
+        "from a TWAS prediction model and a reference genotype AnnData. For "
+        "each gene, the covariance of its model SNPs is computed from the "
+        "reference dosages; SNPs absent from the reference fall back to the "
+        "Hardy-Weinberg variance 2p(1-p) of an allele-frequency table. "
+        "Returns the ``GENE RSID1 RSID2 VALUE`` long-format table that "
+        "``ov.genetics.twas(method='spredixcan')`` accepts in memory. "
+        "Pure numpy / pandas."
+    ),
+    examples=[
+        "cov = ov.genetics.make_twas_covariance(model, geno_qc)",
+        "cov = ov.genetics.make_twas_covariance(model, geno_qc, "
+        "freq=eqtl.set_index('variant')['maf'])",
+    ],
+    related=["ov.genetics.twas", "ov.genetics.build_twas_model"],
+)
+def make_twas_covariance(model, reference=None, *, freq=None):
+    """Build the per-gene SNP-covariance table for S-PrediXcan.
+
+    Parameters
+    ----------
+    model
+        A :class:`pytwas.PredictionModel` (e.g. from
+        :func:`build_twas_model`) whose ``.weights`` lists the SNPs of
+        every gene.
+    reference
+        Optional genotype AnnData (``samples x SNPs``, 0/1/2 dosages) used
+        as the LD reference. SNPs found here get an empirical covariance.
+    freq
+        Optional ``Series`` mapping SNP id -> allele frequency. SNPs not in
+        ``reference`` get the Hardy-Weinberg variance ``2p(1-p)`` from
+        this; off-diagonal covariances of such SNPs are set to 0.
+
+    Returns
+    -------
+    pandas.DataFrame
+        A ``GENE RSID1 RSID2 VALUE`` long-format covariance table.
+    """
+    ref_X = None
+    ref_idx = {}
+    if reference is not None:
+        ref_X = np.asarray(reference.X, dtype=float)
+        if hasattr(reference.X, "toarray"):
+            ref_X = reference.X.toarray().astype(float)
+        ref_idx = {s: i for i, s in enumerate(reference.var_names)}
+    if freq is None:
+        freq = {}
+    else:
+        freq = pd.Series(freq)
+        freq = freq[~freq.index.duplicated()].to_dict()
+
+    rows = []
+    for gene, sub in model.weights.groupby("gene"):
+        snps = list(dict.fromkeys(sub["rsid"]))
+        in_ref = [s for s in snps if s in ref_idx]
+        cov = None
+        if ref_X is not None and len(in_ref) > 0:
+            cols = [ref_idx[s] for s in in_ref]
+            cov = np.atleast_2d(np.cov(ref_X[:, cols], rowvar=False))
+        ref_pos = {s: k for k, s in enumerate(in_ref)}
+        for i, s1 in enumerate(snps):
+            for s2 in snps[i:]:
+                if s1 in ref_pos and s2 in ref_pos and cov is not None:
+                    val = float(cov[ref_pos[s1], ref_pos[s2]])
+                elif s1 == s2:
+                    p = float(freq.get(s1, np.nan))
+                    val = 2.0 * p * (1.0 - p) if not np.isnan(p) else np.nan
+                else:
+                    val = 0.0
+                rows.append((gene, s1, s2, val))
+    return pd.DataFrame(rows, columns=["GENE", "RSID1", "RSID2", "VALUE"])

--- a/omicverse/genetics/_utils.py
+++ b/omicverse/genetics/_utils.py
@@ -1,0 +1,467 @@
+"""Data-prep helpers for ``ov.genetics`` — genetics-specific wrangling.
+
+The post-GWAS pipeline strings together several methods that each want
+their inputs shaped a particular way: genotype PCA needs a scaled
+matrix, locus definition needs LD clumping, colocalization wants a
+summary-statistics dict, TWAS wants a prediction model, eQTL mapping
+wants features x samples matrices. None of that is *analysis* — it is
+plumbing — and it should not be re-typed inline in every tutorial or
+script. This module collects those small, registered helpers so a
+notebook can call one function instead of a dozen lines of reshaping.
+"""
+from __future__ import annotations
+
+from typing import Optional, Union
+
+import numpy as np
+import pandas as pd
+
+from .._registry import register_function
+
+
+# --------------------------------------------------------------------------- #
+# Sample QC                                                                    #
+# --------------------------------------------------------------------------- #
+@register_function(
+    aliases=[
+        "sample_qc_metrics", "per_sample_qc", "individual_qc_metrics",
+        "样本质控指标", "个体质控指标",
+    ],
+    category="genetics",
+    description=(
+        "Compute per-sample (per-individual) GWAS quality-control metrics "
+        "from a genotype AnnData — the call rate (fraction of non-missing "
+        "genotypes) and the mean heterozygosity (fraction of heterozygous "
+        "calls). A low call rate flags a poorly-genotyped DNA sample; a "
+        "heterozygosity outlier (mean +/- 3 SD) flags contamination or "
+        "inbreeding. Returns a tidy per-sample DataFrame and records the "
+        "heterozygosity outlier bounds. Pure numpy."
+    ),
+    examples=[
+        "ov.genetics.sample_qc_metrics(geno)",
+        "qc = ov.genetics.sample_qc_metrics(geno, het_sd=3.0)",
+    ],
+    related=["ov.genetics.gwas_qc", "ov.genetics.sample_qc_plot"],
+)
+def sample_qc_metrics(adata, *, het_sd: float = 3.0) -> pd.DataFrame:
+    """Per-sample call rate and heterozygosity for sample QC.
+
+    Parameters
+    ----------
+    adata
+        Genotype AnnData of ``samples x SNPs`` (0/1/2 dosages in ``.X``).
+    het_sd
+        Number of standard deviations for the heterozygosity outlier
+        bounds (default 3).
+
+    Returns
+    -------
+    pandas.DataFrame
+        One row per sample with columns ``call_rate`` and
+        ``heterozygosity``. ``.attrs['het_bounds']`` holds the
+        ``(low, high)`` heterozygosity outlier bounds.
+    """
+    X = np.asarray(adata.X, dtype=float)
+    if hasattr(adata.X, "toarray"):
+        X = adata.X.toarray().astype(float)
+    call_rate = 1.0 - np.isnan(X).mean(axis=1)
+    het = np.nanmean(X == 1, axis=1)
+    qc = pd.DataFrame(
+        {"call_rate": call_rate, "heterozygosity": het},
+        index=adata.obs_names,
+    )
+    mu, sd = qc["heterozygosity"].mean(), qc["heterozygosity"].std()
+    qc.attrs["het_bounds"] = (float(mu - het_sd * sd), float(mu + het_sd * sd))
+    return qc
+
+
+# --------------------------------------------------------------------------- #
+# Genotype PCA (population structure)                                          #
+# --------------------------------------------------------------------------- #
+@register_function(
+    aliases=[
+        "genotype_pca", "structure_pca", "ancestry_pca",
+        "基因型PCA", "群体结构PCA",
+    ],
+    category="genetics",
+    description=(
+        "Principal-component analysis of a QC'd genotype matrix to capture "
+        "population structure. Scales the genotypes (standard for genotype "
+        "PCA) and runs PCA, returning the sample PC scores and the "
+        "variance explained by each component. The top PCs are then used "
+        "as covariates in ``gwas_association`` to correct for population "
+        "stratification. Wraps scanpy's PCA."
+    ),
+    examples=[
+        "pcs, var_ratio = ov.genetics.genotype_pca(geno_qc, n_comps=10)",
+        "pcs, vr = ov.genetics.genotype_pca(geno_qc, n_comps=20, max_value=10)",
+    ],
+    related=["ov.genetics.gwas_association", "ov.genetics.pca_structure_plot"],
+)
+def genotype_pca(
+    adata,
+    *,
+    n_comps: int = 10,
+    max_value: float = 10.0,
+):
+    """Genotype PCA for population-structure correction.
+
+    Parameters
+    ----------
+    adata
+        QC'd genotype AnnData of ``samples x SNPs``.
+    n_comps
+        Number of principal components to compute.
+    max_value
+        Clip value passed to :func:`scanpy.pp.scale`.
+
+    Returns
+    -------
+    tuple of (numpy.ndarray, numpy.ndarray)
+        ``(pcs, variance_ratio)`` — the ``samples x n_comps`` PC-score
+        matrix and the per-component variance-explained vector.
+    """
+    import scanpy as sc
+
+    work = adata.copy()
+    sc.pp.scale(work, max_value=max_value)
+    sc.tl.pca(work, n_comps=n_comps)
+    pcs = np.asarray(work.obsm["X_pca"])
+    var_ratio = np.asarray(work.uns["pca"]["variance_ratio"])
+    return pcs, var_ratio
+
+
+# --------------------------------------------------------------------------- #
+# Locus definition (LD clumping) and grading                                   #
+# --------------------------------------------------------------------------- #
+@register_function(
+    aliases=[
+        "clump_loci", "define_loci", "ld_clump", "clump",
+        "定义位点", "LD聚类", "位点聚类",
+    ],
+    category="genetics",
+    description=(
+        "Define independent association loci from a GWAS results table by "
+        "LD clumping. Keeps every SNP that reaches genome-wide "
+        "significance, then collapses correlated SNPs to one lead SNP per "
+        "LD block (the block-level clump that stands in for the PLINK "
+        "``--clump`` LD window). Returns one row per independent locus, "
+        "led by its most-significant SNP. Pure pandas."
+    ),
+    examples=[
+        "loci = ov.genetics.clump_loci(res_adj)",
+        "loci = ov.genetics.clump_loci(res_adj, sig=5e-8, block='block')",
+    ],
+    related=["ov.genetics.gwas_association", "ov.genetics.grade_loci",
+             "ov.genetics.manhattan"],
+)
+def clump_loci(
+    results: pd.DataFrame,
+    *,
+    sig: float = 5e-8,
+    block: str = "block",
+    snp: str = "snp",
+    pvalue: str = "pvalue",
+) -> pd.DataFrame:
+    """Define independent loci by LD-block clumping.
+
+    Parameters
+    ----------
+    results
+        GWAS results table — needs SNP, p-value and LD-block columns.
+    sig
+        Genome-wide-significance threshold (default ``5e-8``).
+    block
+        LD-block column used as the clumping unit.
+    snp
+        SNP-id column; renamed to ``lead_snp`` in the output.
+    pvalue
+        p-value column.
+
+    Returns
+    -------
+    pandas.DataFrame
+        One row per independent locus (the lead SNP of each
+        genome-wide-significant LD block), sorted by p-value.
+    """
+    hits = results[results[pvalue] < sig].sort_values(pvalue)
+    loci = (hits.drop_duplicates(block)
+                .rename(columns={snp: "lead_snp"})
+                .reset_index(drop=True))
+    return loci
+
+
+@register_function(
+    aliases=[
+        "grade_loci", "evaluate_loci", "score_loci", "locus_recovery",
+        "位点评估", "位点回收率",
+    ],
+    category="genetics",
+    description=(
+        "Grade discovered GWAS loci against a known ground-truth signal "
+        "set — for simulated cohorts or replication benchmarks. Splits the "
+        "lead SNPs of a clumped locus table into true positives (a planted "
+        "causal SNP or a known instrument) and false positives, and "
+        "reports the counts. Pure-Python set arithmetic."
+    ),
+    examples=[
+        "ov.genetics.grade_loci(loci, causal_snps=truth['causal_snps'])",
+        "ov.genetics.grade_loci(loci, causal_snps=cs, instruments=inst)",
+    ],
+    related=["ov.genetics.clump_loci", "ov.genetics.simulate_gwas_study"],
+)
+def grade_loci(
+    loci: pd.DataFrame,
+    *,
+    causal_snps,
+    instruments=None,
+    lead_col: str = "lead_snp",
+) -> dict:
+    """Grade discovered loci against a ground-truth signal set.
+
+    Parameters
+    ----------
+    loci
+        A clumped locus table (from :func:`clump_loci`).
+    causal_snps
+        The planted / known direct causal SNPs.
+    instruments
+        Optional additional true-signal SNPs (e.g. causal-gene eQTLs that
+        are genuine secondary trait loci).
+    lead_col
+        Column holding each locus' lead SNP.
+
+    Returns
+    -------
+    dict
+        Keys: ``n_loci``, ``recovered_causal`` / ``recovered_instruments``
+        (sorted lists), ``false_positives`` (sorted list), and the matching
+        ``n_*`` counts.
+    """
+    causal = set(causal_snps)
+    inst = set(instruments) if instruments is not None else set()
+    lead = set(loci[lead_col])
+    rec_causal = lead & causal
+    rec_inst = lead & inst
+    false = lead - causal - inst
+    return {
+        "n_loci": int(len(lead)),
+        "recovered_causal": sorted(rec_causal),
+        "n_recovered_causal": int(len(rec_causal)),
+        "recovered_instruments": sorted(rec_inst),
+        "n_recovered_instruments": int(len(rec_inst)),
+        "false_positives": sorted(false),
+        "n_false_positives": int(len(false)),
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Colocalization dataset construction                                          #
+# --------------------------------------------------------------------------- #
+@register_function(
+    aliases=[
+        "make_coloc_dataset", "build_coloc_dataset", "coloc_dataset",
+        "构建共定位数据集", "共定位数据集",
+    ],
+    category="genetics",
+    description=(
+        "Assemble a colocalization input dataset (the dict that "
+        "``ov.genetics.colocalize`` expects) from per-SNP summary "
+        "statistics. Packs the effect sizes, their variances "
+        "(SE squared), SNP ids, minor-allele frequencies and sample size "
+        "into the coloc schema for a quantitative or case/control trait. "
+        "Pure pandas / numpy."
+    ),
+    examples=[
+        "d = ov.genetics.make_coloc_dataset(gwas_locus, beta='BETA', se='SE', "
+        "snps=locus_snps, n=2000, maf=maf)",
+        "d = ov.genetics.make_coloc_dataset(eqtl_locus, n=2000, maf=maf)",
+    ],
+    related=["ov.genetics.colocalize", "ov.genetics.coloc_plot"],
+)
+def make_coloc_dataset(
+    stats: pd.DataFrame,
+    *,
+    snps,
+    n: int,
+    maf,
+    beta: str = "beta",
+    se: str = "se",
+    trait_type: str = "quant",
+    sdY: float = 1.0,
+) -> dict:
+    """Build a coloc summary-statistics dataset dict.
+
+    Parameters
+    ----------
+    stats
+        Per-SNP summary statistics indexed (or alignable) by SNP id.
+    snps
+        SNP ids defining the locus and the row order of the dataset.
+    n
+        Sample size of the study the statistics come from.
+    maf
+        Per-SNP minor-allele frequency vector, aligned to ``snps``.
+    beta, se
+        Effect-size and standard-error column names.
+    trait_type
+        ``'quant'`` (quantitative trait) or ``'cc'`` (case/control).
+    sdY
+        Trait standard deviation (quantitative traits).
+
+    Returns
+    -------
+    dict
+        A coloc dataset with keys ``beta``, ``varbeta``, ``snp``,
+        ``type``, ``N``, ``MAF`` and ``sdY``.
+    """
+    sub = stats.loc[list(snps)]
+    se_vals = sub[se].to_numpy(dtype=float)
+    return {
+        "beta": sub[beta].to_numpy(dtype=float),
+        "varbeta": se_vals ** 2,
+        "snp": list(snps),
+        "type": trait_type,
+        "N": int(n),
+        "MAF": np.asarray(maf, dtype=float),
+        "sdY": float(sdY),
+    }
+
+
+# --------------------------------------------------------------------------- #
+# eQTL input reshaping                                                         #
+# --------------------------------------------------------------------------- #
+@register_function(
+    aliases=[
+        "make_eqtl_matrices", "eqtl_inputs", "prepare_eqtl_inputs",
+        "构建eQTL输入", "eQTL输入矩阵",
+    ],
+    category="genetics",
+    description=(
+        "Reshape a genotype AnnData and an expression AnnData into the "
+        "features x samples matrices (and SNP / gene position tables) that "
+        "``ov.genetics.eqtl_map`` (Matrix eQTL) expects. AnnData is "
+        "samples x features, so this transposes both matrices and builds "
+        "the SNP / gene position tables that drive the cis / trans split. "
+        "Pure pandas."
+    ),
+    examples=[
+        "geno_mat, expr_mat, snp_pos, gene_pos = "
+        "ov.genetics.make_eqtl_matrices(geno_qc, expr)",
+    ],
+    related=["ov.genetics.eqtl_map", "ov.genetics.build_twas_model"],
+)
+def make_eqtl_matrices(geno, expr):
+    """Reshape genotype + expression AnnData for Matrix eQTL.
+
+    Parameters
+    ----------
+    geno
+        Genotype AnnData of ``samples x SNPs`` — ``.var`` must carry
+        ``chrom`` and ``pos``.
+    expr
+        Expression AnnData of ``samples x genes`` — ``.var`` must carry
+        ``chrom`` and ``pos``.
+
+    Returns
+    -------
+    tuple
+        ``(geno_mat, expr_mat, snp_pos, gene_pos)`` — the two
+        ``features x samples`` DataFrames and the SNP / gene position
+        tables (``snp``/``chr``/``pos`` and ``geneid``/``chr``/``left``/
+        ``right``).
+    """
+    geno_mat = pd.DataFrame(
+        np.asarray(geno.X).T, index=geno.var_names, columns=geno.obs_names,
+    )
+    expr_mat = pd.DataFrame(
+        np.asarray(expr.X).T, index=expr.var_names, columns=expr.obs_names,
+    )
+    snp_pos = geno.var[["chrom", "pos"]].reset_index()
+    snp_pos.columns = ["snp", "chr", "pos"]
+    gene_pos = expr.var[["chrom", "pos"]].reset_index()
+    gene_pos.columns = ["geneid", "chr", "left"]
+    gene_pos["right"] = gene_pos["left"] + 1
+    return geno_mat, expr_mat, snp_pos, gene_pos
+
+
+# --------------------------------------------------------------------------- #
+# TWAS prediction-model construction                                           #
+# --------------------------------------------------------------------------- #
+@register_function(
+    aliases=[
+        "build_twas_model", "twas_model_from_eqtl", "make_predixcan_model",
+        "构建TWAS模型", "TWAS预测模型",
+    ],
+    category="genetics",
+    description=(
+        "Build a PrediXcan-style gene-expression prediction model from "
+        "lead cis-eQTLs — a single-SNP-per-gene weight table that "
+        "``ov.genetics.twas`` (``method='predixcan'``) can use directly. "
+        "Each gene's top cis-eQTL becomes its predictor, weighted by the "
+        "eQTL effect size: a realistic minimal elastic-net-style model. "
+        "Wraps the pytwas PredictionModel container."
+    ),
+    examples=[
+        "model = ov.genetics.build_twas_model(lead_eqtl)",
+        "model = ov.genetics.build_twas_model(lead_eqtl, snp_col='snps', "
+        "weight_col='beta')",
+    ],
+    related=["ov.genetics.twas", "ov.genetics.eqtl_map",
+             "ov.genetics.make_eqtl_matrices"],
+)
+def build_twas_model(
+    lead_eqtl: pd.DataFrame,
+    *,
+    snp_col: str = "snps",
+    weight_col: str = "beta",
+    gene_col: Optional[str] = None,
+    effect_allele: str = "A",
+    non_effect_allele: str = "G",
+):
+    """Build a PrediXcan prediction model from lead cis-eQTLs.
+
+    Parameters
+    ----------
+    lead_eqtl
+        Lead-cis-eQTL table — one row per gene. The gene id is taken from
+        the index unless ``gene_col`` is given.
+    snp_col
+        Column holding each gene's lead cis-eQTL SNP id.
+    weight_col
+        Column holding the eQTL effect size (the prediction weight).
+    gene_col
+        Optional explicit gene-id column (otherwise the index is used).
+    effect_allele, non_effect_allele
+        Effect / non-effect alleles for every weight.
+
+    Returns
+    -------
+    pytwas.PredictionModel
+        A single-SNP-per-gene prediction model ready for
+        :func:`ov.genetics.twas` (``method='predixcan'``).
+    """
+    try:
+        import pytwas
+    except ImportError as exc:  # pragma: no cover
+        raise ImportError(
+            "ov.genetics.build_twas_model requires pytwas: "
+            "`pip install pytwas` (or omicverse[genetics])."
+        ) from exc
+
+    genes = (lead_eqtl[gene_col] if gene_col is not None
+             else lead_eqtl.index).astype(str)
+    weights = pd.DataFrame({
+        "rsid": lead_eqtl[snp_col].astype(str).to_numpy(),
+        "gene": genes.to_numpy(),
+        "weight": lead_eqtl[weight_col].astype(float).to_numpy(),
+        "non_effect_allele": non_effect_allele,
+        "effect_allele": effect_allele,
+    })
+    extra = pd.DataFrame({"gene": weights["gene"].unique()})
+    extra["gene_name"] = extra["gene"]
+    return pytwas.PredictionModel(
+        weights=weights[["rsid", "gene", "weight",
+                         "non_effect_allele", "effect_allele"]],
+        extra=extra,
+    )

--- a/omicverse/genetics/_utils.py
+++ b/omicverse/genetics/_utils.py
@@ -76,6 +76,89 @@ def sample_qc_metrics(adata, *, het_sd: float = 3.0) -> pd.DataFrame:
 
 
 # --------------------------------------------------------------------------- #
+# LD to a lead SNP (LocusZoom colouring)                                       #
+# --------------------------------------------------------------------------- #
+@register_function(
+    aliases=[
+        "compute_ld_to_lead", "ld_to_lead", "lead_snp_ld", "locuszoom_ld",
+        "计算LD", "前导SNP连锁不平衡",
+    ],
+    category="genetics",
+    description=(
+        "Compute the LD (r^2) between a lead SNP and every other SNP from "
+        "an individual-level genotype AnnData — the colouring track of a "
+        "publication LocusZoom regional-association plot. r^2 is the "
+        "squared Pearson correlation of the 0/1/2 allele dosages across "
+        "individuals; missing genotypes are mean-imputed per SNP. Pass "
+        "the result straight to :func:`ov.genetics.regional_plot` as its "
+        "``r2=`` argument. Pure numpy."
+    ),
+    examples=[
+        "ld = ov.genetics.compute_ld_to_lead(geno, 'chr22:23456789')",
+        "ld = ov.genetics.compute_ld_to_lead(geno, lead, snps=locus_snps)",
+    ],
+    related=["ov.genetics.regional_plot", "ov.genetics.finemap_locus_plot"],
+)
+def compute_ld_to_lead(genotype, lead_snp, *, snps=None) -> pd.Series:
+    """Compute r^2 between a lead SNP and other SNPs from a genotype AnnData.
+
+    Parameters
+    ----------
+    genotype
+        Genotype AnnData of ``individuals x SNPs`` (0/1/2 allele dosages
+        in ``.X``); ``.var_names`` are the SNP ids.
+    lead_snp
+        SNP id of the lead variant — must be present in
+        ``genotype.var_names``.
+    snps
+        Optional subset / order of SNP ids to score; defaults to every SNP
+        in ``genotype``. SNP ids absent from the genotype are returned as
+        ``NaN``.
+
+    Returns
+    -------
+    pandas.Series
+        Per-SNP LD ``r^2`` to the lead SNP, indexed by SNP id (the lead
+        SNP itself is ``1.0``).
+    """
+    var_names = list(map(str, genotype.var_names))
+    pos = {s: i for i, s in enumerate(var_names)}
+    lead_snp = str(lead_snp)
+    if lead_snp not in pos:
+        raise KeyError(
+            f"lead SNP {lead_snp!r} is not in the genotype's var_names."
+        )
+    X = genotype.X
+    X = X.toarray() if hasattr(X, "toarray") else np.asarray(X)
+    X = X.astype(float)
+    # Mean-impute missing genotypes per SNP.
+    col_mean = np.nanmean(X, axis=0)
+    inds = np.where(np.isnan(X))
+    X[inds] = np.take(col_mean, inds[1])
+
+    target = [lead_snp] if snps is None else list(map(str, snps))
+    lead_vec = X[:, pos[lead_snp]]
+    lead_c = lead_vec - lead_vec.mean()
+    lead_ss = float(np.sqrt(np.sum(lead_c ** 2)))
+
+    out = {}
+    for s in (var_names if snps is None else target):
+        j = pos.get(s)
+        if j is None:
+            out[s] = np.nan
+            continue
+        v = X[:, j]
+        vc = v - v.mean()
+        denom = lead_ss * float(np.sqrt(np.sum(vc ** 2)))
+        if denom == 0.0:
+            out[s] = np.nan
+        else:
+            r = float(np.sum(lead_c * vc) / denom)
+            out[s] = r * r
+    return pd.Series(out, name="r2")
+
+
+# --------------------------------------------------------------------------- #
 # cis-eQTL gene screen                                                         #
 # --------------------------------------------------------------------------- #
 @register_function(

--- a/omicverse/genetics/_utils.py
+++ b/omicverse/genetics/_utils.py
@@ -76,6 +76,106 @@ def sample_qc_metrics(adata, *, het_sd: float = 3.0) -> pd.DataFrame:
 
 
 # --------------------------------------------------------------------------- #
+# cis-eQTL gene screen                                                         #
+# --------------------------------------------------------------------------- #
+@register_function(
+    aliases=[
+        "scan_cis_genes", "cis_gene_screen", "screen_cis_eqtl",
+        "cis基因筛选", "cis-eQTL筛选",
+    ],
+    category="genetics",
+    description=(
+        "Fast cis-eQTL screen across an expression panel — for every gene, "
+        "find the single most strongly associated SNP within a cis window "
+        "of its transcription start site and rank the genes by that best "
+        "p-value. A quick way to pick a gene with a strong regulatory "
+        "signal before a full association scan / fine-mapping. The genotype "
+        "and expression AnnData must share the same individuals; the "
+        "expression ``.var`` must carry a TSS column. Pure numpy / scipy."
+    ),
+    examples=[
+        "screen = ov.genetics.scan_cis_genes(geno_qc, expr)",
+        "screen = ov.genetics.scan_cis_genes(geno_qc, expr, cis_dist=5e5)",
+    ],
+    related=["ov.genetics.gwas_association", "ov.genetics.eqtl_map"],
+)
+def scan_cis_genes(
+    geno,
+    expr,
+    *,
+    cis_dist: float = 1e6,
+    tss_col: str = "tss",
+    pos_col: str = "pos",
+    symbol_col: str = "gene_symbol",
+    min_cis_snps: int = 5,
+):
+    """Screen an expression panel for genes with a strong cis-eQTL.
+
+    Parameters
+    ----------
+    geno
+        Genotype AnnData of ``individuals x SNPs`` (0/1/2 dosages).
+        ``.var`` must carry the SNP base-pair position (``pos_col``).
+    expr
+        Expression AnnData of the **same** individuals x genes. ``.var``
+        must carry the transcription start site (``tss_col``).
+    cis_dist
+        cis window half-width in base pairs (default 1 Mb).
+    tss_col, pos_col
+        Column names of the gene TSS and the SNP position.
+    symbol_col
+        Optional gene-symbol column in ``expr.var`` (used if present).
+    min_cis_snps
+        Skip a gene with fewer than this many SNPs in its cis window.
+
+    Returns
+    -------
+    pandas.DataFrame
+        One row per screened gene — ``gene``, ``symbol``, ``n_cis``,
+        ``best_snp``, ``r`` (the best Pearson r) and ``p`` — sorted by
+        ascending best p-value.
+    """
+    from scipy import stats as _stats
+
+    if not (geno.obs_names == expr.obs_names).all():
+        raise ValueError(
+            "scan_cis_genes: geno and expr must share the same individuals "
+            "in the same order."
+        )
+    X = np.asarray(geno.X, dtype=float)
+    if hasattr(geno.X, "toarray"):
+        X = geno.X.toarray().astype(float)
+    snp_pos = geno.var[pos_col].to_numpy()
+    has_symbol = symbol_col in expr.var.columns
+
+    rows = []
+    for gi, gene in enumerate(expr.var_names):
+        tss = float(expr.var[tss_col].iloc[gi])
+        y = np.asarray(expr[:, gene].X).ravel().astype(float)
+        if y.std() == 0:
+            continue
+        cis = np.where(np.abs(snp_pos - tss) < cis_dist)[0]
+        if len(cis) < min_cis_snps:
+            continue
+        best_p, best_snp, best_r = 1.0, None, 0.0
+        for si in cis:
+            x = X[:, si]
+            if x.std() == 0:
+                continue
+            r, p = _stats.pearsonr(x, y)
+            if p < best_p:
+                best_p, best_snp, best_r = p, geno.var_names[si], r
+        if best_snp is None:
+            continue
+        sym = expr.var[symbol_col].iloc[gi] if has_symbol else gene
+        rows.append((gene, sym, int(len(cis)), best_snp, best_r, best_p))
+    out = pd.DataFrame(
+        rows, columns=["gene", "symbol", "n_cis", "best_snp", "r", "p"],
+    )
+    return out.sort_values("p").reset_index(drop=True)
+
+
+# --------------------------------------------------------------------------- #
 # Genotype PCA (population structure)                                          #
 # --------------------------------------------------------------------------- #
 @register_function(
@@ -329,6 +429,177 @@ def make_coloc_dataset(
 
 
 # --------------------------------------------------------------------------- #
+# Distance-based LD pruning (instrument selection)                             #
+# --------------------------------------------------------------------------- #
+@register_function(
+    aliases=[
+        "prune_by_distance", "distance_prune", "ld_prune_distance",
+        "select_instruments", "距离剪枝", "工具变量筛选",
+    ],
+    category="genetics",
+    description=(
+        "Distance-prune a ranked variant table to an approximately "
+        "independent subset — the standard quick way to choose Mendelian-"
+        "randomization instruments when a full LD matrix is not at hand. "
+        "Walks the table in priority order (e.g. ascending p-value) and "
+        "keeps a variant only if it is at least ``min_dist`` base pairs "
+        "from every variant already kept. Pure pandas."
+    ),
+    examples=[
+        "inst = ov.genetics.prune_by_distance(sig_eqtl, min_dist=1e4)",
+        "inst = ov.genetics.prune_by_distance(hits, pos='BP', min_dist=5e5)",
+    ],
+    related=["ov.genetics.mendelian_randomization", "ov.genetics.clump_loci"],
+)
+def prune_by_distance(
+    variants: pd.DataFrame,
+    *,
+    pos: str = "BP",
+    min_dist: float = 1e4,
+    rank_by: Optional[str] = None,
+    ascending: bool = True,
+) -> pd.DataFrame:
+    """Distance-prune a variant table to a near-independent subset.
+
+    Parameters
+    ----------
+    variants
+        Variant table — one row per variant, with a base-pair position.
+    pos
+        Base-pair position column.
+    min_dist
+        Minimum base-pair separation between any two kept variants.
+    rank_by
+        Optional column to sort by before pruning (e.g. ``'pvalue'``);
+        if ``None`` the table's existing order is used as the priority.
+    ascending
+        Sort direction for ``rank_by``.
+
+    Returns
+    -------
+    pandas.DataFrame
+        The pruned subset, in priority order.
+    """
+    table = variants if rank_by is None else variants.sort_values(
+        rank_by, ascending=ascending)
+    kept, used = [], []
+    for _, row in table.iterrows():
+        bp = float(row[pos])
+        if all(abs(bp - u) > min_dist for u in used):
+            kept.append(row)
+            used.append(bp)
+    return pd.DataFrame(kept).reset_index(drop=True)
+
+
+# --------------------------------------------------------------------------- #
+# Colocalization scan over many genes                                          #
+# --------------------------------------------------------------------------- #
+@register_function(
+    aliases=[
+        "coloc_scan", "scan_colocalization", "colocalize_genes",
+        "共定位扫描", "多基因共定位",
+    ],
+    category="genetics",
+    description=(
+        "Scan a GWAS locus against the cis-eQTLs of many genes and rank "
+        "the genes by colocalization evidence (posterior PP.H4). For every "
+        "eGene with enough variants shared with the GWAS, it builds the two "
+        "coloc datasets and runs ``ov.genetics.colocalize`` — the right way "
+        "to pick the gene a locus acts through (highest PP.H4), instead of "
+        "guessing from proximity. Returns one row per gene with PP.H3 / "
+        "PP.H4 and the shared-variant count, sorted by PP.H4."
+    ),
+    examples=[
+        "tab = ov.genetics.coloc_scan(gwas_locus, eqtl_locus, n_gwas=173000, "
+        "n_eqtl=670)",
+    ],
+    related=["ov.genetics.colocalize", "ov.genetics.make_coloc_dataset",
+             "ov.genetics.coloc_plot"],
+)
+def coloc_scan(
+    gwas: pd.DataFrame,
+    eqtl: pd.DataFrame,
+    *,
+    n_gwas: int,
+    n_eqtl: int,
+    gene_col: str = "gene",
+    variant_col: str = "variant",
+    gwas_beta: str = "BETA",
+    gwas_se: str = "SE",
+    eqtl_beta: str = "beta",
+    eqtl_se: str = "se",
+    gwas_maf: str = "EAF",
+    eqtl_maf: str = "maf",
+    min_shared: int = 20,
+) -> pd.DataFrame:
+    """Scan a GWAS locus against many genes' eQTLs and rank by PP.H4.
+
+    Parameters
+    ----------
+    gwas
+        GWAS summary statistics at the locus — needs the variant id,
+        effect size, standard error and (optionally) allele frequency.
+    eqtl
+        cis-eQTL summary statistics for several genes — needs the gene id,
+        variant id, effect size, standard error and MAF.
+    n_gwas, n_eqtl
+        Sample sizes of the GWAS and the eQTL study.
+    gene_col, variant_col
+        Gene-id and variant-id column names.
+    gwas_beta, gwas_se, eqtl_beta, eqtl_se
+        Effect-size / standard-error column names in each table.
+    gwas_maf, eqtl_maf
+        Allele-frequency columns; the eQTL MAF is used, falling back to
+        ``min(EAF, 1-EAF)`` from the GWAS.
+    min_shared
+        Skip a gene with fewer than this many variants shared with the
+        GWAS.
+
+    Returns
+    -------
+    pandas.DataFrame
+        One row per gene — ``gene``, ``n_shared``, ``PP_H3``, ``PP_H4`` —
+        sorted by descending ``PP_H4``.
+    """
+    from ._coloc import colocalize
+
+    gwas_vars = set(gwas[variant_col])
+    rows = []
+    for gene, sub in eqtl.groupby(gene_col):
+        shared = sorted(set(sub[variant_col]) & gwas_vars)
+        if len(shared) < min_shared:
+            continue
+        merged = gwas.merge(
+            sub, on=variant_col, suffixes=("_gwas", "_eqtl"),
+        ).set_index(variant_col)
+        snps = [s for s in shared if s in merged.index]
+        if len(snps) < min_shared:
+            continue
+        emaf = merged.loc[snps, eqtl_maf].to_numpy(dtype=float)
+        gmaf = np.minimum(merged.loc[snps, gwas_maf],
+                          1.0 - merged.loc[snps, gwas_maf]).to_numpy()
+        maf = np.where(np.isfinite(emaf), emaf, gmaf)
+        d_gwas = make_coloc_dataset(
+            merged, snps=snps, n=int(n_gwas), maf=maf,
+            beta=gwas_beta, se=gwas_se,
+        )
+        d_eqtl = make_coloc_dataset(
+            merged, snps=snps, n=int(n_eqtl), maf=maf,
+            beta=eqtl_beta, se=eqtl_se,
+        )
+        co = colocalize(d_gwas, d_eqtl, method="abf")
+        rows.append({
+            "gene": gene, "n_shared": len(snps),
+            "PP_H3": float(co["summary"]["PP.H3.abf"]),
+            "PP_H4": float(co["summary"]["PP.H4.abf"]),
+        })
+    out = pd.DataFrame(rows)
+    if not out.empty:
+        out = out.sort_values("PP_H4", ascending=False).reset_index(drop=True)
+    return out
+
+
+# --------------------------------------------------------------------------- #
 # eQTL input reshaping                                                         #
 # --------------------------------------------------------------------------- #
 @register_function(
@@ -433,7 +704,10 @@ def build_twas_model(
     gene_col
         Optional explicit gene-id column (otherwise the index is used).
     effect_allele, non_effect_allele
-        Effect / non-effect alleles for every weight.
+        Effect / non-effect alleles for every weight. Each may be a fixed
+        string (one allele for the whole model) **or** the name of a
+        column in ``lead_eqtl`` carrying per-SNP alleles — the latter is
+        what real eQTL tables (GTEx, eQTL Catalogue) provide.
 
     Returns
     -------
@@ -451,12 +725,19 @@ def build_twas_model(
 
     genes = (lead_eqtl[gene_col] if gene_col is not None
              else lead_eqtl.index).astype(str)
+
+    def _allele(spec):
+        # A column name -> per-SNP alleles; otherwise a fixed string.
+        if spec in lead_eqtl.columns:
+            return lead_eqtl[spec].astype(str).to_numpy()
+        return spec
+
     weights = pd.DataFrame({
         "rsid": lead_eqtl[snp_col].astype(str).to_numpy(),
         "gene": genes.to_numpy(),
         "weight": lead_eqtl[weight_col].astype(float).to_numpy(),
-        "non_effect_allele": non_effect_allele,
-        "effect_allele": effect_allele,
+        "non_effect_allele": _allele(non_effect_allele),
+        "effect_allele": _allele(effect_allele),
     })
     extra = pd.DataFrame({"gene": weights["gene"].unique()})
     extra["gene_name"] = extra["gene"]

--- a/omicverse/genetics/io.py
+++ b/omicverse/genetics/io.py
@@ -1,10 +1,14 @@
 """I/O for ``ov.genetics`` — GWAS summary statistics, PLINK and VCF.
 
-Flexible readers for the heterogeneous file formats of statistical
-genetics: :func:`read_sumstats` parses a GWAS summary-statistics table
-with column-name auto-detection, :func:`read_plink` loads a PLINK
-``.bed`` / ``.bim`` / ``.fam`` triple into a samples x SNPs AnnData,
-and :func:`read_vcf` extracts a genotype dosage matrix from a VCF.
+Flexible readers (and writers) for the heterogeneous file formats of
+statistical genetics: :func:`read_sumstats` parses a GWAS
+summary-statistics table with column-name auto-detection,
+:func:`read_plink` loads a PLINK ``.bed`` / ``.bim`` / ``.fam`` triple
+into a samples x SNPs AnnData, :func:`read_vcf` extracts a genotype
+dosage matrix from a VCF, and :func:`write_plink` / :func:`write_sumstats`
+serialise a genotype AnnData / a GWAS results table back out in the
+PLINK and GWAS-summary formats that downstream tools (and these readers)
+consume.
 """
 from __future__ import annotations
 
@@ -319,3 +323,183 @@ def read_vcf(path: str, *, max_variants: Optional[int] = None):
     adata = anndata.AnnData(X=X, obs=obs, var=var)
     adata.uns["genetics_source"] = "vcf"
     return adata
+
+
+@register_function(
+    aliases=[
+        "write_plink", "save_plink", "to_plink", "plink_writer",
+        "写入PLINK", "保存PLINK", "导出PLINK",
+    ],
+    category="genetics",
+    description=(
+        "Write a genotype AnnData out as a PLINK binary fileset "
+        "(``.bed`` / ``.bim`` / ``.fam``) — the round-trip partner of "
+        ":func:`read_plink`. Packs ``.X`` (0/1/2 A1-allele dosages) into "
+        "the SNP-major 2-bit ``.bed`` bitstream and writes the SNP table "
+        "(``.bim``) and sample table (``.fam``). This is the format "
+        "downstream tools such as LDSC and PLINK consume. Pure numpy."
+    ),
+    examples=[
+        "ov.genetics.write_plink(geno_qc, './cohort')",
+        "ov.genetics.write_plink(geno_qc, prefix, a1='A', a2='G')",
+    ],
+    related=["ov.genetics.read_plink", "ov.genetics.heritability",
+             "ov.genetics.write_sumstats"],
+)
+def write_plink(
+    adata,
+    prefix: str,
+    *,
+    chrom: str = "chrom",
+    pos: str = "pos",
+    a1: Union[str, "pd.Series"] = "A",
+    a2: Union[str, "pd.Series"] = "G",
+) -> str:
+    """Write a genotype AnnData as a PLINK ``.bed`` / ``.bim`` / ``.fam``.
+
+    Parameters
+    ----------
+    adata
+        Genotype AnnData of ``samples x SNPs`` — ``.X`` holds 0/1/2
+        A1-allele dosages.
+    prefix
+        Output fileset prefix; ``prefix.bed``, ``.bim``, ``.fam`` are
+        written.
+    chrom, pos
+        ``.var`` columns carrying the SNP chromosome / position.
+    a1, a2
+        A1 (effect) and A2 (other) alleles — a constant string applied to
+        every SNP, or a per-SNP Series aligned to ``.var``.
+
+    Returns
+    -------
+    str
+        The fileset ``prefix``.
+    """
+    parent = os.path.dirname(prefix)
+    if parent:
+        os.makedirs(parent, exist_ok=True)
+
+    X = np.asarray(adata.X, dtype=float)
+    if hasattr(adata.X, "toarray"):
+        X = adata.X.toarray().astype(float)
+    n, m = X.shape
+
+    # .fam — sample table.
+    pd.DataFrame({
+        "fid": adata.obs_names, "iid": adata.obs_names,
+        "pat": 0, "mat": 0, "sex": 0, "phen": -9,
+    }).to_csv(prefix + ".fam", sep=" ", header=False, index=False)
+
+    # .bim — SNP table.
+    a1_col = (adata.var[a1] if isinstance(a1, str) and a1 in adata.var.columns
+              else a1)
+    a2_col = (adata.var[a2] if isinstance(a2, str) and a2 in adata.var.columns
+              else a2)
+    pd.DataFrame({
+        "chr": adata.var[chrom].to_numpy(),
+        "snp": adata.var_names,
+        "cm": 0,
+        "bp": adata.var[pos].to_numpy(),
+        "a1": a1_col,
+        "a2": a2_col,
+    }).to_csv(prefix + ".bim", sep="\t", header=False, index=False)
+
+    # .bed — SNP-major 2-bit bitstream. Dosage->code is the inverse of
+    # _read_bed: 2 (hom A1) -> 00, 1 (het) -> 10, 0 (hom A2) -> 11,
+    # NaN (missing) -> 01.
+    geno = np.rint(X)
+    code = np.full((n, m), 1, dtype=np.uint8)            # default = missing
+    code[geno == 2] = 0
+    code[geno == 1] = 2
+    code[geno == 0] = 3
+    with open(prefix + ".bed", "wb") as fh:
+        fh.write(bytes([0x6c, 0x1b, 0x01]))              # magic + SNP-major
+        for j in range(m):
+            col = code[:, j]
+            buf = bytearray((n + 3) // 4)
+            for i in range(n):
+                buf[i // 4] |= int(col[i]) << (2 * (i % 4))
+            fh.write(bytes(buf))
+    return prefix
+
+
+@register_function(
+    aliases=[
+        "write_sumstats", "save_sumstats", "to_sumstats", "sumstats_writer",
+        "写入GWAS汇总统计", "保存汇总统计", "导出汇总统计",
+    ],
+    category="genetics",
+    description=(
+        "Write a GWAS association results table to disk in the standard "
+        "GWAS-summary format — one row per SNP with canonical column "
+        "names (SNP / CHR / BP / A1 / A2 / BETA / SE / Z / P / N), sorted "
+        "by genomic position. This is the format a study shares publicly "
+        "and the format :func:`read_sumstats` reads back. Pure pandas."
+    ),
+    examples=[
+        "ov.genetics.write_sumstats(res_adj, './gwas_sumstats.tsv')",
+        "ov.genetics.write_sumstats(res, path, chrom='chrom', pos='pos')",
+    ],
+    related=["ov.genetics.read_sumstats", "ov.genetics.gwas_association",
+             "ov.genetics.munge_sumstats"],
+)
+def write_sumstats(
+    results: pd.DataFrame,
+    path: str,
+    *,
+    snp: str = "snp",
+    chrom: str = "chrom",
+    pos: str = "pos",
+    beta: str = "beta",
+    se: str = "se",
+    stat: Optional[str] = "stat",
+    pvalue: str = "pvalue",
+    n: Optional[str] = "n",
+    a1: str = "A",
+    a2: str = "G",
+    sep: str = "\t",
+) -> pd.DataFrame:
+    """Write GWAS summary statistics in the standard sumstats format.
+
+    Parameters
+    ----------
+    results
+        A GWAS association results table (e.g. from
+        :func:`ov.genetics.gwas_association`, merged with SNP annotation).
+    path
+        Output file path (``.tsv`` / ``.txt``; ``.gz`` is gzip-compressed).
+    snp, chrom, pos, beta, se, stat, pvalue, n
+        Source column names; ``stat`` and ``n`` are optional (pass
+        ``None`` to omit).
+    a1, a2
+        Effect (A1) and other (A2) alleles written for every SNP.
+    sep
+        Field delimiter (default tab).
+
+    Returns
+    -------
+    pandas.DataFrame
+        The written sumstats table (canonical columns, position-sorted).
+    """
+    parent = os.path.dirname(path)
+    if parent:
+        os.makedirs(parent, exist_ok=True)
+
+    cols = {snp: "SNP", chrom: "CHR", pos: "BP", beta: "BETA",
+            se: "SE", pvalue: "P"}
+    if stat is not None and stat in results.columns:
+        cols[stat] = "STAT"
+    if n is not None and n in results.columns:
+        cols[n] = "N"
+    out = results[list(cols)].rename(columns=cols).copy()
+    out["A1"] = a1
+    out["A2"] = a2
+    out["Z"] = out["BETA"] / out["SE"]
+    order = [c for c in ["SNP", "CHR", "BP", "A1", "A2", "BETA", "SE",
+                         "STAT", "Z", "P", "N"] if c in out.columns]
+    out = (out[order]
+           .sort_values(["CHR", "BP"])
+           .reset_index(drop=True))
+    out.to_csv(path, sep=sep, index=False)
+    return out

--- a/omicverse/genetics/plotting.py
+++ b/omicverse/genetics/plotting.py
@@ -8,6 +8,16 @@ the Mendelian-randomization scatter / forest plots
 (:func:`mr_scatter`, :func:`mr_forest`) and the SuSiE fine-mapping plot
 (:func:`finemap_plot`). The MR and fine-mapping plots delegate to the
 backends' own plotting routines.
+
+Pipeline composites — multi-panel figures assembled for the GWAS
+follow-up workflow — live here too so that tutorials stay one-liners:
+the sample-QC distributions (:func:`sample_qc_plot`), the genotype-PCA
+structure view (:func:`pca_structure_plot`), the fine-mapping locus view
+(:func:`finemap_locus_plot`), the gene-level TWAS Manhattan
+(:func:`twas_manhattan`) and the scDRS score-by-cell-type panels
+(:func:`scdrs_celltype_plot`), plus the MR exposure-vs-outcome scatter
+(:func:`mr_effect_plot`) for callers who have raw effect arrays rather
+than a backend MRInput.
 """
 from __future__ import annotations
 
@@ -559,3 +569,488 @@ def finemap_plot(fit, *, y: str = "PIP", **kwargs):
             "`pip install pysusie`."
         ) from exc
     return pysusie.susie_plot(fit, y=y, **kwargs)
+
+
+@register_function(
+    aliases=[
+        "sample_qc_plot", "qc_plot", "individual_qc_plot",
+        "样本质控图", "个体质控图",
+    ],
+    category="genetics",
+    description=(
+        "Two-panel sample (per-individual) quality-control figure — a "
+        "histogram of the per-sample call rate with the call-rate "
+        "threshold marked, and a histogram of the per-sample "
+        "heterozygosity with the mean +/- 3 SD outlier bounds marked. "
+        "Accepts the DataFrame from :func:`ov.genetics.sample_qc_metrics`. "
+        "matplotlib."
+    ),
+    examples=[
+        "ov.genetics.sample_qc_plot(qc)",
+        "ov.genetics.sample_qc_plot(qc, call_rate=0.98)",
+    ],
+    related=["ov.genetics.sample_qc_metrics", "ov.genetics.gwas_qc"],
+)
+def sample_qc_plot(
+    qc: pd.DataFrame,
+    *,
+    call_rate: float = 0.98,
+    het_bounds: Optional[tuple] = None,
+    axes=None,
+    title: Optional[str] = "Sample QC distributions",
+):
+    """Two-panel sample-QC distribution plot.
+
+    Parameters
+    ----------
+    qc
+        Per-sample QC table (from :func:`ov.genetics.sample_qc_metrics`) —
+        needs ``call_rate`` and ``heterozygosity`` columns.
+    call_rate
+        Call-rate threshold drawn on the call-rate panel.
+    het_bounds
+        ``(low, high)`` heterozygosity outlier bounds; taken from
+        ``qc.attrs['het_bounds']`` when ``None``.
+    axes
+        Optional pair of existing Axes; a 1x2 grid is created otherwise.
+    title
+        Optional figure suptitle.
+
+    Returns
+    -------
+    numpy.ndarray of matplotlib.axes.Axes
+        The two panel axes.
+    """
+    import matplotlib.pyplot as plt
+
+    if het_bounds is None:
+        het_bounds = qc.attrs.get("het_bounds")
+        if het_bounds is None:
+            mu, sd = qc["heterozygosity"].mean(), qc["heterozygosity"].std()
+            het_bounds = (mu - 3 * sd, mu + 3 * sd)
+    het_lo, het_hi = het_bounds
+
+    if axes is None:
+        _, axes = plt.subplots(1, 2, figsize=(10, 3.6))
+    axes[0].hist(qc["call_rate"], bins=40, color="#3b6fb6")
+    axes[0].axvline(call_rate, color="#d62728", ls="--",
+                    label=f"call-rate {call_rate:g}")
+    axes[0].set(xlabel="per-sample call rate", ylabel="samples")
+    axes[1].hist(qc["heterozygosity"], bins=40, color="#3b6fb6")
+    axes[1].axvline(het_lo, color="#d62728", ls="--")
+    axes[1].axvline(het_hi, color="#d62728", ls="--", label="mean +/- 3 SD")
+    axes[1].set(xlabel="per-sample heterozygosity", ylabel="samples")
+    for ax in axes:
+        ax.legend(fontsize=8)
+    if title:
+        axes[0].figure.suptitle(title)
+    return axes
+
+
+@register_function(
+    aliases=[
+        "pca_structure_plot", "genotype_pca_plot", "structure_plot",
+        "群体结构图", "基因型PCA图",
+    ],
+    category="genetics",
+    description=(
+        "Two-panel genotype-PCA population-structure figure — a scree "
+        "plot of the variance explained by each principal component (to "
+        "choose how many PCs to carry) and a PC1-vs-PC2 scatter, "
+        "optionally coloured by a (sub)population label so that real "
+        "ancestry structure is visible. matplotlib."
+    ),
+    examples=[
+        "ov.genetics.pca_structure_plot(pcs, var_ratio)",
+        "ov.genetics.pca_structure_plot(pcs, var_ratio, labels=pop)",
+    ],
+    related=["ov.genetics.genotype_pca", "ov.genetics.gwas_association"],
+)
+def pca_structure_plot(
+    pcs: np.ndarray,
+    variance_ratio: np.ndarray,
+    *,
+    labels=None,
+    axes=None,
+    title: Optional[str] = None,
+):
+    """Two-panel genotype-PCA structure plot (scree + PC1/PC2 scatter).
+
+    Parameters
+    ----------
+    pcs
+        ``samples x n_comps`` PC-score matrix (from
+        :func:`ov.genetics.genotype_pca`).
+    variance_ratio
+        Per-component variance-explained vector.
+    labels
+        Optional per-sample (sub)population labels colouring the scatter.
+    axes
+        Optional pair of existing Axes; a 1x2 grid is created otherwise.
+    title
+        Optional figure suptitle.
+
+    Returns
+    -------
+    numpy.ndarray of matplotlib.axes.Axes
+        The two panel axes.
+    """
+    import matplotlib.pyplot as plt
+
+    pcs = np.asarray(pcs)
+    vr = np.asarray(variance_ratio)
+    if axes is None:
+        _, axes = plt.subplots(1, 2, figsize=(10, 4))
+
+    axes[0].plot(np.arange(1, len(vr) + 1), vr, "o-", color="#3b6fb6")
+    axes[0].set_xlabel("principal component")
+    axes[0].set_ylabel("variance ratio")
+    axes[0].set_title("Scree plot — choosing the number of PCs")
+
+    if labels is not None:
+        labels = np.asarray(labels).astype(str)
+        for p in sorted(np.unique(labels)):
+            m = labels == p
+            axes[1].scatter(pcs[m, 0], pcs[m, 1], s=8, label=p, alpha=0.6)
+        axes[1].legend(fontsize=8)
+    else:
+        axes[1].scatter(pcs[:, 0], pcs[:, 1], s=8, color="#3b6fb6", alpha=0.6)
+    axes[1].set_xlabel("PC1")
+    axes[1].set_ylabel("PC2")
+    axes[1].set_title("Genotype PCA — PC1 / PC2")
+    for ax in axes:
+        ax.spines[["top", "right"]].set_visible(False)
+    if title:
+        axes[0].figure.suptitle(title)
+    return axes
+
+
+@register_function(
+    aliases=[
+        "finemap_locus_plot", "susie_locus_plot", "finemapping_locus_plot",
+        "精细定位位点图", "SuSiE位点图",
+    ],
+    category="genetics",
+    description=(
+        "Two-panel fine-mapping locus view — the top panel is the regional "
+        "association plot (-log10 p vs position, lead SNP marked) and the "
+        "bottom panel is the SuSiE posterior-inclusion-probability (PIP) "
+        "track, with the 95% credible-set SNPs highlighted. Ties the "
+        "association peak to the fine-mapped credible set in one figure. "
+        "matplotlib."
+    ),
+    examples=[
+        "ov.genetics.finemap_locus_plot(locus, pip, credible)",
+        "ov.genetics.finemap_locus_plot(locus, pip, credible, lead_snp='rs1')",
+    ],
+    related=["ov.genetics.finemap", "ov.genetics.regional_plot",
+             "ov.genetics.get_credible_sets"],
+)
+def finemap_locus_plot(
+    locus: pd.DataFrame,
+    pip: np.ndarray,
+    credible: dict,
+    *,
+    chrom: str = "chrom",
+    pos: str = "pos",
+    pvalue: str = "pvalue",
+    snp: str = "snp",
+    lead_snp: Optional[str] = None,
+    axes=None,
+    title: Optional[str] = None,
+):
+    """Two-panel fine-mapping locus view (regional p-values + SuSiE PIP).
+
+    Parameters
+    ----------
+    locus
+        Per-SNP association table for one locus — needs position and
+        p-value columns; row order must match ``pip``.
+    pip
+        Per-SNP posterior inclusion probabilities (from
+        :func:`ov.genetics.get_pip`), aligned to ``locus``.
+    credible
+        The credible-set object from
+        :func:`ov.genetics.get_credible_sets` — its ``'cs'`` entry lists
+        the within-locus index sets.
+    chrom, pos, pvalue, snp
+        ``locus`` column names.
+    lead_snp
+        Optional lead-SNP id, highlighted on the regional panel.
+    axes
+        Optional pair of existing Axes; a stacked 2x1 grid otherwise.
+    title
+        Optional title for the regional (top) panel.
+
+    Returns
+    -------
+    numpy.ndarray of matplotlib.axes.Axes
+        The two panel axes.
+    """
+    import matplotlib.pyplot as plt
+
+    pip = np.asarray(pip, dtype=float)
+    if axes is None:
+        _, axes = plt.subplots(2, 1, figsize=(9, 6.5), sharex=True)
+
+    regional_plot(
+        locus, chrom=chrom, pos=pos, pvalue=pvalue, snp=snp,
+        lead_snp=lead_snp, ax=axes[0],
+        title=title or "Regional association",
+    )
+
+    bp = pd.to_numeric(locus[pos], errors="coerce").to_numpy()
+    in_cs = np.zeros(len(pip), dtype=bool)
+    for idx in (credible.get("cs") or []):
+        in_cs[list(idx)] = True
+    axes[1].scatter(bp[~in_cs], pip[~in_cs], s=18, c="#bdbdbd",
+                    label="not in credible set")
+    axes[1].scatter(bp[in_cs], pip[in_cs], s=45, c="#d62728",
+                    edgecolors="black", label="95% credible set")
+    axes[1].set_xlabel("position (bp)")
+    axes[1].set_ylabel("PIP")
+    axes[1].set_title("SuSiE fine-mapping — posterior inclusion probability")
+    axes[1].legend(fontsize=8)
+    axes[1].spines[["top", "right"]].set_visible(False)
+    return axes
+
+
+@register_function(
+    aliases=[
+        "twas_manhattan", "twas_plot", "gene_manhattan",
+        "TWAS曼哈顿图", "基因关联图",
+    ],
+    category="genetics",
+    description=(
+        "Gene-level TWAS Manhattan / bar plot — one bar per gene of "
+        "-log10(p) from a transcriptome-wide association study, with the "
+        "gene-level Bonferroni line drawn and an optional gene of "
+        "interest highlighted. Summarises which predicted-expression "
+        "profiles track the trait. matplotlib."
+    ),
+    examples=[
+        "ov.genetics.twas_manhattan(twas_res)",
+        "ov.genetics.twas_manhattan(twas_res, highlight='GENE0007')",
+    ],
+    related=["ov.genetics.twas", "ov.genetics.manhattan"],
+)
+def twas_manhattan(
+    twas_res: pd.DataFrame,
+    *,
+    gene: str = "gene",
+    pvalue: str = "pvalue",
+    highlight: Optional[str] = None,
+    ax=None,
+    title: Optional[str] = "Gene-level TWAS",
+):
+    """Gene-level TWAS Manhattan (bar) plot.
+
+    Parameters
+    ----------
+    twas_res
+        Per-gene TWAS results table (from :func:`ov.genetics.twas`).
+    gene, pvalue
+        Gene-id and p-value column names.
+    highlight
+        Optional gene id drawn in red (e.g. the candidate causal gene).
+    ax
+        Existing matplotlib Axes.
+    title
+        Optional plot title.
+
+    Returns
+    -------
+    tuple of (matplotlib.axes.Axes, float)
+        The plot axes and the Bonferroni threshold used.
+    """
+    import matplotlib.pyplot as plt
+
+    order = (twas_res.sort_values(pvalue, na_position="last")
+                     .reset_index(drop=True))
+    n_tested = int(twas_res[pvalue].notna().sum())
+    threshold = 0.05 / max(n_tested, 1)
+    logp = -np.log10(order[pvalue].clip(lower=1e-300))
+    colors = ["#d62728" if g == highlight else "#3b6fb6"
+              for g in order[gene]]
+
+    if ax is None:
+        _, ax = plt.subplots(figsize=(8, 4))
+    ax.bar(np.arange(len(order)), logp, color=colors, edgecolor="black",
+           linewidth=0.4)
+    ax.axhline(-np.log10(threshold), color="#d62728", ls="--",
+               label=f"Bonferroni (p = {threshold:.1e})")
+    ax.set_xticks(np.arange(len(order)))
+    ax.set_xticklabels(order[gene], rotation=60, ha="right", fontsize=7)
+    ax.set_ylabel(r"$-\log_{10}(p)$")
+    if title:
+        ax.set_title(title)
+    ax.legend(fontsize=8)
+    ax.spines[["top", "right"]].set_visible(False)
+    return ax, threshold
+
+
+@register_function(
+    aliases=[
+        "scdrs_celltype_plot", "scdrs_plot", "disease_score_celltype_plot",
+        "scDRS细胞类型图", "疾病评分细胞类型图",
+    ],
+    category="genetics",
+    description=(
+        "Two-panel single-cell disease-relevance (scDRS) summary by cell "
+        "type — a violin plot of the per-cell disease-relevance score "
+        "across cell types and a bar plot of the fraction of "
+        "significantly disease-associated cells per type. Highlights the "
+        "cell type carrying the trait's genetic signal. matplotlib."
+    ),
+    examples=[
+        "ov.genetics.scdrs_celltype_plot(adata)",
+        "ov.genetics.scdrs_celltype_plot(adata, score='scdrs_score', "
+        "pval='scdrs_pval', cell_type='cell_type')",
+    ],
+    related=["ov.genetics.disease_relevance_score",
+             "ov.genetics.score_downstream"],
+)
+def scdrs_celltype_plot(
+    adata,
+    *,
+    cell_type: str = "cell_type",
+    score: str = "scdrs_score",
+    pval: str = "scdrs_pval",
+    sig: float = 0.05,
+    axes=None,
+    title: Optional[str] = None,
+):
+    """Two-panel scDRS score-by-cell-type figure.
+
+    Parameters
+    ----------
+    adata
+        scRNA-seq AnnData scored by
+        :func:`ov.genetics.disease_relevance_score` — ``.obs`` must carry
+        the cell-type, score and p-value columns.
+    cell_type, score, pval
+        ``.obs`` column names.
+    sig
+        Significance threshold for the per-cell-type significant-fraction
+        panel.
+    axes
+        Optional pair of existing Axes; a 1x2 grid is created otherwise.
+    title
+        Optional figure suptitle.
+
+    Returns
+    -------
+    numpy.ndarray of matplotlib.axes.Axes
+        The two panel axes.
+    """
+    import matplotlib.pyplot as plt
+
+    obs = adata.obs
+    ct = obs[cell_type].astype("category")
+    cats = list(ct.cat.categories)
+    by_ct_mean = (obs.groupby(cell_type, observed=True)[score].mean())
+    top_ct = by_ct_mean.idxmax()
+    ct_colors = ["#d62728" if c == top_ct else "#3b6fb6" for c in cats]
+    score_by_ct = [obs.loc[ct == c, score].to_numpy() for c in cats]
+    sig_frac = (obs.assign(_sig=obs[pval] < sig)
+                   .groupby(cell_type, observed=True)["_sig"].mean()
+                   .reindex(cats))
+
+    if axes is None:
+        _, axes = plt.subplots(1, 2, figsize=(11, 4))
+    parts = axes[0].violinplot(score_by_ct, showmeans=True)
+    for pc, col in zip(parts["bodies"], ct_colors):
+        pc.set_facecolor(col)
+        pc.set_alpha(0.7)
+    axes[0].set_xticks(np.arange(1, len(cats) + 1))
+    axes[0].set_xticklabels(cats, rotation=20)
+    axes[0].set(ylabel="scDRS disease-relevance score",
+                title="Disease-relevance score by cell type")
+
+    axes[1].bar([str(c) for c in cats], sig_frac.to_numpy(),
+                color=ct_colors, edgecolor="black", linewidth=0.4)
+    axes[1].set(ylabel=f"fraction of cells with scDRS p < {sig:g}",
+                title="Significantly disease-associated cells")
+    axes[1].tick_params(axis="x", rotation=20)
+    for ax in axes:
+        ax.spines[["top", "right"]].set_visible(False)
+    if title:
+        axes[0].figure.suptitle(title)
+    return axes
+
+
+@register_function(
+    aliases=[
+        "mr_effect_plot", "mr_effect_scatter", "mr_ivw_scatter",
+        "MR效应散点图", "孟德尔随机化效应图",
+    ],
+    category="genetics",
+    description=(
+        "Mendelian-randomization effect scatter from raw instrument "
+        "arrays — plots each instrument's SNP-outcome effect against its "
+        "SNP-exposure effect (with error bars) and overlays the IVW "
+        "causal-effect slope through the origin. Use this when you have "
+        "the four effect / SE arrays directly; :func:`mr_scatter` is the "
+        "MRInput-based equivalent. matplotlib."
+    ),
+    examples=[
+        "ov.genetics.mr_effect_plot(bx, bxse, by, byse, slope=ivw.estimate)",
+    ],
+    related=["ov.genetics.mendelian_randomization", "ov.genetics.mr_scatter",
+             "ov.genetics.mr_forest"],
+)
+def mr_effect_plot(
+    bx: np.ndarray,
+    bxse: np.ndarray,
+    by: np.ndarray,
+    byse: np.ndarray,
+    *,
+    slope: float,
+    exposure_label: str = "SNP effect on exposure",
+    outcome_label: str = "SNP effect on outcome",
+    ax=None,
+    title: Optional[str] = "Mendelian randomization — exposure vs outcome",
+):
+    """MR exposure-vs-outcome effect scatter with the IVW slope.
+
+    Parameters
+    ----------
+    bx, bxse
+        Per-instrument SNP-exposure effect sizes and standard errors.
+    by, byse
+        Per-instrument SNP-outcome effect sizes and standard errors.
+    slope
+        The IVW causal-effect estimate, drawn as a line through the origin.
+    exposure_label, outcome_label
+        Axis labels for the exposure (x) and outcome (y).
+    ax
+        Existing matplotlib Axes.
+    title
+        Optional plot title.
+
+    Returns
+    -------
+    matplotlib.axes.Axes
+        The plot axes.
+    """
+    import matplotlib.pyplot as plt
+
+    bx = np.asarray(bx, dtype=float)
+    by = np.asarray(by, dtype=float)
+    if ax is None:
+        _, ax = plt.subplots(figsize=(6, 5))
+    ax.errorbar(bx, by, xerr=np.asarray(bxse, dtype=float),
+                yerr=np.asarray(byse, dtype=float), fmt="o", color="#3b6fb6",
+                ecolor="#bdbdbd", capsize=2, label="instruments")
+    xx = np.linspace(min(bx.min(), 0.0), bx.max() * 1.05, 50)
+    ax.plot(xx, slope * xx, color="#d62728", lw=2,
+            label=f"IVW slope = {slope:.3f}")
+    ax.axhline(0, color="grey", lw=0.6)
+    ax.axvline(0, color="grey", lw=0.6)
+    ax.set_xlabel(exposure_label)
+    ax.set_ylabel(outcome_label)
+    if title:
+        ax.set_title(title)
+    ax.legend(fontsize=8)
+    ax.spines[["top", "right"]].set_visible(False)
+    return ax

--- a/omicverse/genetics/plotting.py
+++ b/omicverse/genetics/plotting.py
@@ -258,6 +258,84 @@ def qqplot(
     return ax
 
 
+# --------------------------------------------------------------------------- #
+# LocusZoom helpers — the classic discrete r^2 bins and the gene track.        #
+# --------------------------------------------------------------------------- #
+# The canonical LocusZoom LD-bin colour scheme (lead = purple diamond).
+_LD_BINS = [0.0, 0.2, 0.4, 0.6, 0.8, 1.0]
+_LD_COLORS = ["#1f2f86", "#6fc2ec", "#5cba5c", "#f4a23b", "#e23b30"]
+_LD_LABELS = ["0.0 – 0.2", "0.2 – 0.4", "0.4 – 0.6", "0.6 – 0.8", "0.8 – 1.0"]
+_LD_NA_COLOR = "#9b9b9b"
+
+
+def _ld_bin_color(r2_val):
+    """Map an r^2 value onto its LocusZoom discrete-bin colour."""
+    if r2_val is None or not np.isfinite(r2_val):
+        return _LD_NA_COLOR
+    for i in range(len(_LD_COLORS)):
+        if r2_val <= _LD_BINS[i + 1] or i == len(_LD_COLORS) - 1:
+            return _LD_COLORS[i]
+    return _LD_COLORS[-1]
+
+
+def _draw_gene_track(ax, genes, start, end, *, chrom=None,
+                     gene_col="gene", chrom_col="chrom",
+                     start_col="start", end_col="end", strand_col="strand"):
+    """Draw a LocusZoom gene-model track (arrowed boxes + symbols)."""
+    g = genes.copy()
+    if chrom is not None and chrom_col in g.columns:
+        g = g[g[chrom_col].astype(str) == str(chrom)]
+    gs = pd.to_numeric(g[start_col], errors="coerce")
+    ge = pd.to_numeric(g[end_col], errors="coerce")
+    # Keep any gene overlapping the plotted window.
+    g = g[(ge >= start) & (gs <= end)].copy()
+    g = g.assign(_s=gs[g.index].clip(lower=start),
+                 _e=ge[g.index].clip(upper=end))
+    g = g.sort_values("_s").reset_index(drop=True)
+
+    span = max(end - start, 1.0)
+    rows_end: list = []  # right-edge bp of the last gene placed on each row
+    row_of = []
+    for _, row in g.iterrows():
+        placed = False
+        for ri, redge in enumerate(rows_end):
+            if row["_s"] > redge + 0.04 * span:
+                rows_end[ri] = row["_e"]
+                row_of.append(ri)
+                placed = True
+                break
+        if not placed:
+            rows_end.append(row["_e"])
+            row_of.append(len(rows_end) - 1)
+    n_rows = max(len(rows_end), 1)
+
+    for (_, row), ri in zip(g.iterrows(), row_of):
+        y = n_rows - 1 - ri
+        strand = str(row.get(strand_col, "+"))
+        ax.add_patch(plt_rect((row["_s"], y - 0.18),
+                              row["_e"] - row["_s"], 0.36,
+                              facecolor="#2f6db4", edgecolor="#1b3f6e",
+                              linewidth=0.5))
+        # Strand arrow at the gene's transcription-start side.
+        amark = ">" if strand == "+" else "<"
+        ax_x = row["_e"] if strand == "+" else row["_s"]
+        ax.plot([ax_x], [y], marker=amark, ms=5, color="#1b3f6e")
+        mid = 0.5 * (row["_s"] + row["_e"])
+        ax.text(mid, y + 0.30, str(row[gene_col]), ha="center",
+                va="bottom", fontsize=6.5, style="italic")
+    ax.set_xlim(start, end)
+    ax.set_ylim(-0.7, n_rows - 0.1)
+    ax.set_yticks([])
+    ax.set_ylabel("Genes", fontsize=9)
+    ax.spines[["top", "right", "left"]].set_visible(False)
+
+
+def plt_rect(xy, width, height, **kw):
+    """Thin wrapper around matplotlib's Rectangle (keeps imports local)."""
+    from matplotlib.patches import Rectangle
+    return Rectangle(xy, width, height, **kw)
+
+
 @register_function(
     aliases=[
         "regional_plot", "locuszoom", "regional_association_plot",
@@ -265,16 +343,25 @@ def qqplot(
     ],
     category="genetics",
     description=(
-        "LocusZoom-style regional association plot — zooms into a single "
-        "locus and plots -log10(p) against base-pair position, optionally "
-        "colouring SNPs by their LD (r^2) with a lead variant. Useful for "
-        "inspecting a GWAS / eQTL peak before fine-mapping. matplotlib."
+        "Publication-grade LocusZoom regional-association plot. Zooms into "
+        "a single locus and plots -log10(p) against base-pair position. "
+        "Given an LD vector it colours SNPs by their r^2 to the lead "
+        "variant in the classic five discrete bins (navy -> cyan -> green "
+        "-> orange -> red) with an r^2 legend box and draws the lead SNP "
+        "as a labelled purple diamond. Given a recombination map it "
+        "overlays the recombination-rate (cM/Mb) line on a right-hand "
+        "axis; given a gene table it draws an arrowed gene-model track "
+        "beneath the scatter. All of those inputs are optional — with "
+        "just summary statistics it still draws a plain regional plot. "
+        "matplotlib."
     ),
     examples=[
         "ov.genetics.regional_plot(gwas_res, chrom='1', start=1e6, end=2e6)",
-        "ov.genetics.regional_plot(gwas_res, lead_snp='rs123', r2=ld_to_lead)",
+        "ov.genetics.regional_plot(gwas_res, lead_snp='rs123', r2=ld, "
+        "recomb_map=rmap, genes=gene_models)",
     ],
-    related=["ov.genetics.manhattan", "ov.genetics.finemap_plot"],
+    related=["ov.genetics.manhattan", "ov.genetics.finemap_plot",
+             "ov.genetics.compute_ld_to_lead", "ov.genetics.finemap_locus_plot"],
 )
 def regional_plot(
     data: pd.DataFrame,
@@ -288,10 +375,13 @@ def regional_plot(
     end: Optional[float] = None,
     lead_snp: Optional[str] = None,
     r2: Optional[Union[pd.Series, np.ndarray, dict]] = None,
+    ld: Optional[Union[pd.Series, np.ndarray, dict]] = None,
+    recomb_map: Optional[pd.DataFrame] = None,
+    genes: Optional[pd.DataFrame] = None,
     ax=None,
     title: Optional[str] = None,
 ):
-    """Draw a regional (LocusZoom-style) association plot.
+    """Draw a publication LocusZoom regional-association plot.
 
     Parameters
     ----------
@@ -302,21 +392,37 @@ def regional_plot(
     region_chrom, start, end
         Optional region filter (chromosome + base-pair window).
     lead_snp
-        Optional lead-variant SNP id (highlighted as a diamond).
-    r2
+        Optional lead-variant SNP id (highlighted as a purple diamond
+        labelled with its rsID).
+    r2, ld
         Optional per-SNP LD (r^2) to the lead variant — a Series / array
-        aligned to ``data``, or a ``{snp: r2}`` dict.
+        aligned to ``data``, or a ``{snp: r2}`` dict (e.g. from
+        :func:`ov.genetics.compute_ld_to_lead`). SNPs are then coloured
+        by the classic five discrete r^2 bins. ``ld`` is an alias of
+        ``r2``.
+    recomb_map
+        Optional recombination map — a DataFrame with ``position`` and a
+        rate column (``rate_cM_per_Mb`` / ``rate`` / ``recomb_rate``);
+        drawn as a line on a twin right axis labelled "Recombination
+        rate (cM/Mb)".
+    genes
+        Optional gene-model table (``gene`` / ``chrom`` / ``start`` /
+        ``end`` / ``strand``); drawn as an arrowed gene-track panel
+        beneath the scatter (a 2-row gridspec is created).
     ax
-        Existing matplotlib Axes.
+        Existing matplotlib Axes for the scatter panel. Ignored when
+        ``genes`` is given (a fresh 2-panel figure is built).
     title
         Optional plot title.
 
     Returns
     -------
     matplotlib.axes.Axes
-        The plot axes.
+        The scatter (association) axes.
     """
     import matplotlib.pyplot as plt
+    from matplotlib.lines import Line2D
+    from matplotlib.patches import Patch
 
     snp_col, chr_col, pos_col, p_col = _coerce_assoc(
         data, snp, chrom, pos, pvalue
@@ -338,39 +444,110 @@ def regional_plot(
     pvals = np.clip(pvals, np.finfo(float).tiny, 1.0)
     logp = -np.log10(pvals)
     bp = bp.to_numpy()
+    if bp.size == 0:
+        raise ValueError("regional_plot: no variants in the requested region.")
+    win_lo = float(start) if start is not None else float(np.nanmin(bp))
+    win_hi = float(end) if end is not None else float(np.nanmax(bp))
+    if win_hi <= win_lo:
+        win_hi = win_lo + 1.0
 
-    if ax is None:
-        _, ax = plt.subplots(figsize=(8, 4))
+    r2 = r2 if r2 is not None else ld
+    gene_chrom = region_chrom
+    if gene_chrom is None and chr_col is not None and len(df):
+        gene_chrom = str(df[chr_col].astype(str).iloc[0])
 
+    # Build the figure: a 2-row gridspec when a gene track is requested.
+    gene_ax = None
+    if genes is not None:
+        fig = plt.figure(figsize=(9, 6.2))
+        gs = fig.add_gridspec(2, 1, height_ratios=[3.2, 1.0], hspace=0.12)
+        ax = fig.add_subplot(gs[0])
+        gene_ax = fig.add_subplot(gs[1], sharex=ax)
+    elif ax is None:
+        _, ax = plt.subplots(figsize=(9, 4.4))
+
+    # Recombination-rate line on a twin right axis (drawn first, behind).
+    if recomb_map is not None and len(recomb_map):
+        rate_col = next(
+            (c for c in ("rate_cM_per_Mb", "rate", "recomb_rate",
+                         "cM_per_Mb")
+             if c in recomb_map.columns), None)
+        pos_rc = next(
+            (c for c in ("position", "pos", "bp") if c in recomb_map.columns),
+            None)
+        if rate_col is not None and pos_rc is not None:
+            rm = recomb_map[(recomb_map[pos_rc] >= win_lo)
+                            & (recomb_map[pos_rc] <= win_hi)]
+            rm = rm.sort_values(pos_rc)
+            ax_r = ax.twinx()
+            ax_r.fill_between(rm[pos_rc].to_numpy(),
+                              rm[rate_col].to_numpy(),
+                              color="#9ecae1", alpha=0.35, zorder=0)
+            ax_r.plot(rm[pos_rc].to_numpy(), rm[rate_col].to_numpy(),
+                      color="#4a90d9", lw=0.9, zorder=1)
+            ax_r.set_ylabel("Recombination rate (cM/Mb)", color="#4a90d9")
+            ax_r.tick_params(axis="y", colors="#4a90d9")
+            ax_r.set_ylim(bottom=0)
+            ax_r.spines[["top"]].set_visible(False)
+
+    # Association scatter — discrete LD bins or a flat colour.
     if r2 is not None and snp_col is not None:
-        if isinstance(r2, dict):
-            r2_vals = df[snp_col].astype(str).map(r2).to_numpy(dtype=float)
+        if isinstance(r2, dict) or isinstance(r2, pd.Series):
+            r2_vals = df[snp_col].astype(str).map(dict(r2)).to_numpy(
+                dtype=float)
         else:
             r2_vals = np.asarray(r2, dtype=float)
-        sc = ax.scatter(bp, logp, c=r2_vals, cmap="YlOrRd", vmin=0, vmax=1,
-                        s=22, edgecolors="grey", linewidths=0.3)
-        cbar = ax.figure.colorbar(sc, ax=ax, fraction=0.04, pad=0.02)
-        cbar.set_label(r"$r^2$ to lead")
+        colors = [_ld_bin_color(v) for v in r2_vals]
+        ax.scatter(bp, logp, c=colors, s=34, edgecolors="black",
+                   linewidths=0.35, zorder=3)
+        handles = [Patch(facecolor=c, edgecolor="black", label=l)
+                   for c, l in zip(reversed(_LD_COLORS),
+                                   reversed(_LD_LABELS))]
+        ld_legend = ax.legend(handles=handles, title=r"$r^2$",
+                              fontsize=7, title_fontsize=8,
+                              loc="upper left", framealpha=0.95,
+                              borderpad=0.5, labelspacing=0.25)
+        ax.add_artist(ld_legend)
     else:
-        ax.scatter(bp, logp, s=20, c="#3b6fb6", edgecolors="grey",
-                   linewidths=0.3)
+        ax.scatter(bp, logp, s=24, c="#3b6fb6", edgecolors="grey",
+                   linewidths=0.3, zorder=3)
 
+    # Lead SNP — the classic purple diamond with the rsID label.
     if lead_snp is not None and snp_col is not None:
         lead = df[df[snp_col].astype(str) == str(lead_snp)]
         if len(lead):
-            lx = pd.to_numeric(lead[pos_col], errors="coerce").to_numpy()
-            lp = -np.log10(np.clip(
-                pd.to_numeric(lead[p_col], errors="coerce").to_numpy(),
-                np.finfo(float).tiny, 1.0))
-            ax.scatter(lx, lp, marker="D", s=70, c="#8c2d04",
-                       edgecolors="black", zorder=5, label=f"lead: {lead_snp}")
-            ax.legend(fontsize=8)
+            lx = float(pd.to_numeric(lead[pos_col], errors="coerce").iloc[0])
+            lp = float(-np.log10(np.clip(
+                pd.to_numeric(lead[p_col], errors="coerce").iloc[0],
+                np.finfo(float).tiny, 1.0)))
+            ax.scatter([lx], [lp], marker="D", s=95, c="#7b3fa0",
+                       edgecolors="black", linewidths=0.6, zorder=6)
+            ax.annotate(str(lead_snp), (lx, lp),
+                        textcoords="offset points", xytext=(8, 6),
+                        fontsize=8, fontweight="bold", color="#4a2069")
 
-    ax.set_xlabel("Position (bp)")
+    ax.set_xlim(win_lo, win_hi)
     ax.set_ylabel(r"$-\log_{10}(p)$")
+    ax.set_ylim(bottom=0)
     if title:
         ax.set_title(title)
-    ax.spines[["top", "right"]].set_visible(False)
+    ax.spines[["top"]].set_visible(False)
+
+    if gene_ax is not None:
+        ax.tick_params(labelbottom=False)
+        ax.spines[["bottom"]].set_visible(True)
+        _draw_gene_track(gene_ax, genes, win_lo, win_hi, chrom=gene_chrom)
+        gene_ax.set_xlabel(
+            f"Chromosome {gene_chrom} position (Mb)" if gene_chrom
+            else "Position (Mb)")
+        gene_ax.xaxis.set_major_formatter(
+            plt.FuncFormatter(lambda v, _: f"{v / 1e6:.2f}"))
+    else:
+        ax.set_xlabel(
+            f"Chromosome {gene_chrom} position (Mb)" if gene_chrom
+            else "Position (Mb)")
+        ax.xaxis.set_major_formatter(
+            plt.FuncFormatter(lambda v, _: f"{v / 1e6:.2f}"))
     return ax
 
 
@@ -732,19 +909,23 @@ def pca_structure_plot(
     ],
     category="genetics",
     description=(
-        "Two-panel fine-mapping locus view — the top panel is the regional "
-        "association plot (-log10 p vs position, lead SNP marked) and the "
-        "bottom panel is the SuSiE posterior-inclusion-probability (PIP) "
-        "track, with the 95% credible-set SNPs highlighted. Ties the "
+        "Fine-mapping locus view — the top panel is the publication "
+        "LocusZoom regional association plot (-log10 p vs position, lead "
+        "SNP as a purple diamond, optional LD-binned colouring and "
+        "recombination-rate line) and the bottom panel is the SuSiE "
+        "posterior-inclusion-probability (PIP) track with the 95% "
+        "credible-set SNPs highlighted. When a gene table is supplied a "
+        "gene-model track is inserted between the two. Ties the "
         "association peak to the fine-mapped credible set in one figure. "
         "matplotlib."
     ),
     examples=[
         "ov.genetics.finemap_locus_plot(locus, pip, credible)",
-        "ov.genetics.finemap_locus_plot(locus, pip, credible, lead_snp='rs1')",
+        "ov.genetics.finemap_locus_plot(locus, pip, credible, lead_snp='rs1', "
+        "r2=ld, recomb_map=rmap, genes=gene_models)",
     ],
     related=["ov.genetics.finemap", "ov.genetics.regional_plot",
-             "ov.genetics.get_credible_sets"],
+             "ov.genetics.get_credible_sets", "ov.genetics.compute_ld_to_lead"],
 )
 def finemap_locus_plot(
     locus: pd.DataFrame,
@@ -756,10 +937,14 @@ def finemap_locus_plot(
     pvalue: str = "pvalue",
     snp: str = "snp",
     lead_snp: Optional[str] = None,
+    r2: Optional[Union[pd.Series, np.ndarray, dict]] = None,
+    ld: Optional[Union[pd.Series, np.ndarray, dict]] = None,
+    recomb_map: Optional[pd.DataFrame] = None,
+    genes: Optional[pd.DataFrame] = None,
     axes=None,
     title: Optional[str] = None,
 ):
-    """Two-panel fine-mapping locus view (regional p-values + SuSiE PIP).
+    """Fine-mapping locus view (LocusZoom regional p-values + SuSiE PIP).
 
     Parameters
     ----------
@@ -776,42 +961,92 @@ def finemap_locus_plot(
     chrom, pos, pvalue, snp
         ``locus`` column names.
     lead_snp
-        Optional lead-SNP id, highlighted on the regional panel.
+        Optional lead-SNP id, drawn as a purple diamond on the regional
+        panel.
+    r2, ld
+        Optional per-SNP LD (r^2) to the lead variant, for the LocusZoom
+        discrete-bin colouring (see :func:`regional_plot`).
+    recomb_map
+        Optional recombination map drawn as the cM/Mb track on the
+        regional panel.
+    genes
+        Optional gene-model table; when given an arrowed gene-model track
+        is inserted between the regional and PIP panels.
     axes
-        Optional pair of existing Axes; a stacked 2x1 grid otherwise.
+        Optional pair of existing Axes (regional + PIP); ignored when
+        ``genes`` is supplied (a fresh multi-panel figure is built).
     title
         Optional title for the regional (top) panel.
 
     Returns
     -------
     numpy.ndarray of matplotlib.axes.Axes
-        The two panel axes.
+        The panel axes (regional, PIP — and the gene track when drawn).
+
+    Notes
+    -----
+    Reading a LocusZoom: SNPs near the lead variant share its LD (warm
+    colours, top of the r^2 legend) and cluster at the association peak;
+    a recombination hotspot (a tall cM/Mb spike) marks the boundary of
+    the LD block; the gene track shows which genes the credible set
+    physically falls on.
     """
     import matplotlib.pyplot as plt
 
     pip = np.asarray(pip, dtype=float)
-    if axes is None:
-        _, axes = plt.subplots(2, 1, figsize=(9, 6.5), sharex=True)
-
-    regional_plot(
-        locus, chrom=chrom, pos=pos, pvalue=pvalue, snp=snp,
-        lead_snp=lead_snp, ax=axes[0],
-        title=title or "Regional association",
-    )
-
+    r2 = r2 if r2 is not None else ld
     bp = pd.to_numeric(locus[pos], errors="coerce").to_numpy()
+
+    if genes is not None:
+        # Three-panel layout: LocusZoom scatter / gene track / PIP track.
+        fig = plt.figure(figsize=(9, 9))
+        gs = fig.add_gridspec(3, 1, height_ratios=[3.0, 1.7, 1.6],
+                              hspace=0.28)
+        ax_reg = fig.add_subplot(gs[0])
+        ax_gene = fig.add_subplot(gs[1], sharex=ax_reg)
+        ax_pip = fig.add_subplot(gs[2], sharex=ax_reg)
+        regional_plot(
+            locus, chrom=chrom, pos=pos, pvalue=pvalue, snp=snp,
+            lead_snp=lead_snp, r2=r2, recomb_map=recomb_map, ax=ax_reg,
+            title=title or "Regional association",
+        )
+        ax_reg.tick_params(labelbottom=False)
+        ax_reg.set_xlabel("")
+        win_lo, win_hi = ax_reg.get_xlim()
+        chrom_val = (str(locus[chrom].astype(str).iloc[0])
+                     if chrom in locus.columns and len(locus) else None)
+        _draw_gene_track(ax_gene, genes, win_lo, win_hi, chrom=chrom_val)
+        ax_gene.tick_params(labelbottom=False)
+        ax_gene.set_xlabel("")
+        axes = np.array([ax_reg, ax_pip])
+        gene_track = ax_gene
+    else:
+        if axes is None:
+            _, axes = plt.subplots(2, 1, figsize=(9, 6.8), sharex=True)
+        regional_plot(
+            locus, chrom=chrom, pos=pos, pvalue=pvalue, snp=snp,
+            lead_snp=lead_snp, r2=r2, recomb_map=recomb_map, ax=axes[0],
+            title=title or "Regional association",
+        )
+        gene_track = None
+
     in_cs = np.zeros(len(pip), dtype=bool)
     for idx in (credible.get("cs") or []):
         in_cs[list(idx)] = True
-    axes[1].scatter(bp[~in_cs], pip[~in_cs], s=18, c="#bdbdbd",
-                    label="not in credible set")
-    axes[1].scatter(bp[in_cs], pip[in_cs], s=45, c="#d62728",
-                    edgecolors="black", label="95% credible set")
-    axes[1].set_xlabel("position (bp)")
-    axes[1].set_ylabel("PIP")
-    axes[1].set_title("SuSiE fine-mapping — posterior inclusion probability")
-    axes[1].legend(fontsize=8)
-    axes[1].spines[["top", "right"]].set_visible(False)
+    ax_pip = axes[1]
+    ax_pip.scatter(bp[~in_cs], pip[~in_cs], s=18, c="#bdbdbd",
+                   label="not in credible set")
+    ax_pip.scatter(bp[in_cs], pip[in_cs], s=45, c="#d62728",
+                   edgecolors="black", label="95% credible set")
+    ax_pip.set_xlabel("position (Mb)")
+    ax_pip.set_ylabel("PIP")
+    ax_pip.set_title("SuSiE fine-mapping — posterior inclusion probability")
+    ax_pip.legend(fontsize=8)
+    ax_pip.spines[["top", "right"]].set_visible(False)
+    ax_pip.xaxis.set_major_formatter(
+        plt.FuncFormatter(lambda v, _: f"{v / 1e6:.2f}"))
+    if gene_track is not None:
+        return np.array([axes[0], gene_track, ax_pip], dtype=object)
     return axes
 
 
@@ -977,6 +1212,93 @@ def scdrs_celltype_plot(
     if title:
         axes[0].figure.suptitle(title)
     return axes
+
+
+@register_function(
+    aliases=[
+        "gene_celltype_expression", "gene_celltype_barplot",
+        "gene_expression_by_celltype", "基因细胞类型表达图",
+        "细胞类型基因表达图",
+    ],
+    category="genetics",
+    description=(
+        "Barplot of one gene's mean expression across cell types — the "
+        "panel-c style figure used to show which cell type expresses a "
+        "candidate disease gene (e.g. the top scDRS gene). Given an "
+        "scRNA-seq AnnData, a gene name and a cell-type ``.obs`` column, "
+        "it averages the gene's expression within each cell type and "
+        "draws one bar per type, highlighting the highest-expressing "
+        "cell type. matplotlib."
+    ),
+    examples=[
+        "ov.genetics.gene_celltype_expression(adata, 'CD3D')",
+        "ov.genetics.gene_celltype_expression(adata, gene, "
+        "cell_type='cell_type')",
+    ],
+    related=["ov.genetics.scdrs_celltype_plot",
+             "ov.genetics.disease_relevance_score"],
+)
+def gene_celltype_expression(
+    adata,
+    gene: str,
+    *,
+    cell_type: str = "cell_type",
+    layer: Optional[str] = None,
+    ax=None,
+    title: Optional[str] = None,
+):
+    """Barplot of a gene's mean expression across cell types.
+
+    Parameters
+    ----------
+    adata
+        scRNA-seq AnnData — ``.obs`` must carry the cell-type column and
+        ``gene`` must be one of ``.var_names``.
+    gene
+        Gene name (a ``var_names`` entry) to summarise.
+    cell_type
+        ``.obs`` column holding the cell-type labels.
+    layer
+        Optional ``.layers`` key to read expression from; ``.X`` is used
+        when ``None``.
+    ax
+        Existing matplotlib Axes.
+    title
+        Optional plot title.
+
+    Returns
+    -------
+    matplotlib.axes.Axes
+        The plot axes.
+    """
+    import matplotlib.pyplot as plt
+
+    if gene not in adata.var_names:
+        raise KeyError(f"gene {gene!r} is not in adata.var_names.")
+    if cell_type not in adata.obs.columns:
+        raise KeyError(f"{cell_type!r} is not an .obs column.")
+    sub = adata[:, gene]
+    expr = sub.layers[layer] if layer is not None else sub.X
+    expr = expr.toarray() if hasattr(expr, "toarray") else np.asarray(expr)
+    expr = np.asarray(expr, dtype=float).ravel()
+
+    by_ct = (pd.Series(expr, index=adata.obs[cell_type].to_numpy())
+               .groupby(level=0).mean().sort_values(ascending=False))
+    cats = [str(c) for c in by_ct.index]
+    top = cats[0] if cats else None
+    colors = ["#d62728" if c == top else "#3b6fb6" for c in cats]
+
+    if ax is None:
+        _, ax = plt.subplots(figsize=(max(5, 0.7 * len(cats)), 4))
+    ax.bar(cats, by_ct.to_numpy(), color=colors, edgecolor="black",
+           linewidth=0.4)
+    ax.set_ylabel(f"mean {gene} expression")
+    ax.set_title(title or f"{gene} expression by cell type")
+    ax.tick_params(axis="x", rotation=35)
+    for lbl in ax.get_xticklabels():
+        lbl.set_ha("right")
+    ax.spines[["top", "right"]].set_visible(False)
+    return ax
 
 
 @register_function(


### PR DESCRIPTION
## Summary

Replaces the `ov.genetics` "method tour" tutorial with a **systematic, two-notebook GWAS best-practice pipeline** — one coherent study, from raw genotypes to a biological mechanism, every step justified and shown to recover a known ground truth.

### `ov.genetics.simulate_gwas_study` (new)

A coherent simulated GWAS cohort with explicit ground truth: LD-blocked genotypes with population structure, a heritable quantitative trait **mediated through a causal gene**, cis-eQTL expression, and a matched scRNA atlas where the causal gene is cell-type-selective. Returns a `GWASStudy` with `.genotype` / `.phenotype` / `.expression` / `.scrna` / `.truth`. `@register_function`, deterministic, ~5 s.

### Tutorial — a two-notebook chapter

**`t_genetics_01_gwas_pipeline`** — from genotypes to loci: sample QC → variant QC (MAF/HWE/call-rate) → genotype-PCA population-structure correction → naive vs PC-adjusted association → λGC + Q-Q + Manhattan → LD clumping → SuSiE fine-mapping. (26 code cells, 5 figures, 0 errors.)

**`t_genetics_02_functional_followup`** — from loci to mechanism: cis-eQTL mapping → colocalization → TWAS → Mendelian randomization (with MR-Egger pleiotropy sensitivity) → LDSC heritability → scDRS. (30 code cells, 4 figures, 0 errors.)

Every step opens with the rationale, the standard thresholds and how to interpret — it reads as a GWAS protocol, not a catalogue. Ground truth is recovered throughout: λGC 1.50→1.00 after PC adjustment, fine-mapped credible set = the planted causal SNP (PIP 1.0), colocalization PP.H4 1.0, TWAS/MR pinpoint the causal gene, LDSC h² 0.39 vs simulated 0.40, scDRS recovers the planted cell type.

## Test plan

- [x] both notebooks execute end-to-end, 0 empty cells, 0 errors
- [x] `simulate_gwas_study` registered and importable
- [x] every pipeline step recovers the planted ground truth
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)