### PR TITLE
feat(bulk): time-course DE — pyDEG.timecourse_deg + temporal_clusters

### DIFF
--- a/omicverse/bulk/_Deseq2.py
+++ b/omicverse/bulk/_Deseq2.py
@@ -1015,3 +1015,543 @@ class pyDEG(object):
         print(f"✅ Continuous-trait DE complete: {len(use_samples)} samples, "
               f"{int((result['sig'] != 'normal').sum())} genes at q<{alpha}.")
         return result
+
+    @staticmethod
+    def _moderated_f_subset(fit, cols, df_total):
+        r"""Moderated F-test over a SUBSET of design coefficients.
+
+        pylimma's ``topTable`` only returns a per-coefficient moderated
+        *t*-test; it does not expose a multi-column F-test. limma's
+        ``classifyTestsF`` / ``topTableF`` build the F by *whitening* the
+        moderated t-statistics with the eigen-decomposition of the
+        coefficient *correlation* matrix and summing the squares. This
+        helper replicates that procedure, but restricted to the columns
+        in ``cols`` — i.e. the moderated F for "any of these coefficients
+        is non-zero", which is exactly the time-course question (a block
+        of spline / factor columns, or a block of interaction columns).
+
+        It mirrors :func:`omicverse.external.pylimma.fit._classify_tests_f_stat`
+        but slices ``fit.t`` and ``fit.cov_coefficients`` to ``cols``.
+
+        Arguments:
+            fit: An ``MArrayLM`` after ``eBayes`` (needs ``t`` and
+                ``cov_coefficients``).
+            cols: Integer column indices of the coefficient block to test.
+            df_total: Per-gene total (moderated) residual d.f.
+                (``fit.df_total``).
+
+        Returns:
+            ``(F, pvalue, df1)`` — per-gene moderated F statistic, its
+            F-distribution survival p-value, and the numerator d.f.
+        """
+        from scipy import stats as _stats
+        cols = list(cols)
+        tsub = np.asarray(fit.t, dtype=float)[:, cols]      # genes × |cols|
+        ntests = tsub.shape[1]
+        if ntests == 1:
+            f_stat = np.squeeze(tsub * tsub)
+            df1 = 1
+        else:
+            cov = np.asarray(fit.cov_coefficients, dtype=float)
+            cov = cov[np.ix_(cols, cols)].copy()
+            diag = np.diag(cov)
+            diag = np.where(diag == 0, 1.0, diag)
+            cor = cov / np.sqrt(np.outer(diag, diag))
+            vals, vecs = np.linalg.eigh(cor)
+            order = np.argsort(vals)[::-1]
+            vals = vals[order]
+            vecs = vecs[:, order]
+            r = int(np.sum(vals / vals[0] > 1e-8)) if vals[0] > 0 else 1
+            # q already carries the 1/sqrt(r) factor, so sum(z**2) == F.
+            q = (vecs[:, :r] / np.sqrt(vals[:r])[None, :]) / np.sqrt(r)
+            z = tsub @ q
+            f_stat = np.sum(z * z, axis=1)
+            df1 = r
+        f_stat = np.asarray(f_stat, dtype=float)
+        pvalue = _stats.f.sf(f_stat, df1, np.asarray(df_total, dtype=float))
+        return f_stat, pvalue, df1
+
+    def timecourse_deg(self, time, group=None, block=None, covariates=None,
+                       time_basis: str = 'auto', spline_df: int = 3,
+                       alpha: float = 0.05,
+                       multipletests_method: str = 'fdr_bh') -> pd.DataFrame:
+        r"""Time-course / longitudinal differential-expression analysis.
+
+        Where :meth:`deg_analysis` compares two groups and
+        :meth:`continuous_deg` regresses on a single continuous slope,
+        this method answers the three classic time-course questions with
+        a *moderated F-test over a whole block of design columns* — the
+        statistically correct way to ask "does expression change over
+        time" without committing to a single shape. It is built on the
+        vendored pure-Python limma-voom (``omicverse.external.pylimma``)
+        and is isomorphic to :meth:`continuous_deg`: same design-matrix
+        construction, same ``voom → lmFit → eBayes`` call, same
+        ``deg_analysis``-shaped return so ``foldchange_set`` /
+        ``plot_volcano`` keep working.
+
+        Three first-class paths, selected by the arguments:
+
+        1. **Temporal regulation** (``group=None``). Fit
+           ``~ 1 + covariates + time_basis`` and report a moderated
+           F-test over the *whole block* of time-basis columns — "which
+           genes are temporally regulated", regardless of trajectory
+           shape.
+        2. **Group × time interaction** (``group=`` given). Fit
+           ``~ group * time_basis`` and report the moderated F-test over
+           the *interaction columns only* — "do the trajectories differ
+           between groups" (e.g. treated vs control time courses).
+        3. **Repeated measures** (``block=`` given). When the same
+           subject is sampled at several time points, the within-subject
+           correlation is estimated with ``duplicateCorrelation`` and
+           passed as ``block`` / ``correlation`` to ``lmFit`` (limma's
+           two-round longitudinal workflow). Combines with paths 1 or 2.
+
+        Arguments:
+            time: Per-sample time value — a ``pandas.Series`` indexed by
+                sample, a ``dict`` ``{sample: time}``, or an array
+                aligned to the count columns. Samples with a missing
+                (NaN) time are dropped.
+            group: Optional per-sample categorical group label (Series /
+                dict / aligned array). When given, the analysis tests the
+                group×time interaction (path 2). When ``None``, the
+                single-group temporal test (path 1).
+            block: Optional per-sample subject ID (Series / dict /
+                aligned array) for repeated-measures designs — the same
+                subject sampled at multiple times. Triggers the
+                ``duplicateCorrelation`` workflow (path 3).
+            covariates: Optional ``pandas.DataFrame`` (samples × columns)
+                of nuisance variables to hold fixed. Numeric columns
+                enter the design directly; non-numeric columns are
+                one-hot encoded. Same handling as :meth:`continuous_deg`.
+            time_basis: How to encode time —
+                ``'spline'`` (natural cubic / restricted spline of
+                ``spline_df`` degrees of freedom, ``patsy``'s
+                ``cr(time, df=...)``); ``'factor'`` (one-hot of the
+                discrete time points, drop-first); ``'auto'`` (default —
+                ``factor`` if ≤4 unique time values, else ``spline``).
+            spline_df: Degrees of freedom of the natural cubic spline
+                when ``time_basis`` resolves to ``'spline'`` (default 3).
+            alpha: FDR threshold for the ``sig`` column (default 0.05).
+            multipletests_method: ``statsmodels`` multiple-testing
+                method for the q-value (default ``'fdr_bh'``).
+
+        Returns:
+            A genes × stats DataFrame (also stored on ``self.result``):
+            ``F``, ``pvalue``, ``qvalue`` (the moderated F-test over the
+            time block, or the interaction block); ``AveExpr``,
+            ``BaseMean``, ``log2(BaseMean)``; ``-log(pvalue)`` /
+            ``-log(qvalue)``; ``sig`` ∈ {``temporal``, ``normal``} by
+            ``qvalue < alpha`` (an F-test has no direction, so the
+            ``up`` / ``down`` of :meth:`deg_analysis` is replaced by
+            ``temporal`` / ``normal``); plus the per-time-point (factor)
+            or per-spline-term ``log2FC_<term>`` coefficient columns so
+            the *shape* of the trajectory is recoverable. A plain
+            ``log2FC`` column (the largest-magnitude time-block
+            coefficient) is also added so ``plot_volcano`` works.
+            Rows with a missing p-value are dropped.
+        """
+        from ..external import pylimma as _limma
+        from statsmodels.stats.multitest import multipletests
+        print("⏰ Start time-course limma-voom pipeline (pylimma)...")
+
+        samples = list(self.data.columns)
+
+        def _align(x, name, dtype=None):
+            """Align a per-sample variable to the count-matrix columns."""
+            if x is None:
+                return None
+            if isinstance(x, dict):
+                x = pd.Series(x)
+            if isinstance(x, pd.Series):
+                s = x.reindex(samples)
+            else:
+                arr = np.asarray(x).ravel()
+                if len(arr) != len(samples):
+                    raise ValueError(
+                        f"{name} has {len(arr)} values but the count matrix "
+                        f"has {len(samples)} samples; pass a Series indexed "
+                        f"by sample to align unambiguously.")
+                s = pd.Series(arr, index=samples)
+            if dtype is not None:
+                s = s.astype(dtype)
+            return s
+
+        time_s = _align(time, 'time', dtype=float)
+        group_s = _align(group, 'group')
+        block_s = _align(block, 'block')
+
+        # --- keep samples with a non-missing time (and group/block) ----
+        use_samples = [s for s in samples if pd.notna(time_s.get(s))]
+        if group_s is not None:
+            use_samples = [s for s in use_samples if pd.notna(group_s.get(s))]
+        if block_s is not None:
+            use_samples = [s for s in use_samples if pd.notna(block_s.get(s))]
+        if len(use_samples) < 4:
+            raise ValueError(
+                f"Only {len(use_samples)} samples usable — too few for a "
+                f"time-course model.")
+        time_s = time_s.loc[use_samples]
+        if group_s is not None:
+            group_s = group_s.loc[use_samples].astype('category')
+        if block_s is not None:
+            block_s = block_s.loc[use_samples]
+
+        # --- resolve the time basis -----------------------------------
+        n_time = int(time_s.nunique())
+        basis = time_basis
+        if basis == 'auto':
+            basis = 'factor' if n_time <= 4 else 'spline'
+        if basis not in ('factor', 'spline'):
+            raise ValueError(
+                f"time_basis must be 'auto', 'factor' or 'spline', "
+                f"got {time_basis!r}.")
+        if n_time < 2:
+            raise ValueError("Need at least 2 distinct time points.")
+
+        if basis == 'factor':
+            time_dum = pd.get_dummies(
+                pd.Categorical(time_s, categories=sorted(time_s.unique())),
+                prefix='time', drop_first=True)
+            time_dum.index = use_samples
+            time_block = time_dum.astype(float)
+        else:  # natural cubic / restricted spline
+            import patsy
+            sdf = int(spline_df)
+            if sdf >= n_time:
+                sdf = max(1, n_time - 1)
+                print(f"   spline_df reduced to {sdf} (only {n_time} "
+                      f"distinct time points).")
+            # patsy's cr() restricted-cubic-spline span *includes* the
+            # constant: cr(t, df=k) has k effective df total, one of which
+            # is the intercept. Request df=sdf+1 and drop patsy's
+            # intercept so the remaining columns carry exactly `sdf`
+            # shape degrees of freedom on top of our own Intercept.
+            dm = patsy.dmatrix(f"cr(_t, df={sdf + 1})",
+                               {'_t': time_s.values},
+                               return_type='dataframe')
+            if 'Intercept' in dm.columns:
+                dm = dm.drop(columns='Intercept')
+            dm.columns = [f"time_s{i}" for i in range(dm.shape[1])]
+            dm.index = use_samples
+            time_block = dm.astype(float)
+        time_cols = list(time_block.columns)
+
+        # Drop any time-basis column that is collinear with the constant
+        # plus the columns already kept (a restricted-cubic-spline basis
+        # can carry a hidden constant component). This keeps exactly the
+        # independent time degrees of freedom for the F-test.
+        kept, kmat = [], np.ones((len(use_samples), 1))
+        for c in time_cols:
+            cand = np.hstack([kmat, time_block[[c]].values])
+            if np.linalg.matrix_rank(cand) > kmat.shape[1]:
+                kept.append(c)
+                kmat = cand
+        if len(kept) < len(time_cols):
+            dropped = [c for c in time_cols if c not in kept]
+            print(f"   dropped {len(dropped)} collinear time-basis "
+                  f"column(s): {dropped}")
+        time_block = time_block[kept]
+        time_cols = kept
+        if not time_cols:
+            raise ValueError("time basis has no independent columns.")
+
+        # --- assemble the design matrix -------------------------------
+        design = pd.DataFrame({'Intercept': 1.0}, index=use_samples)
+
+        # covariates: numeric in directly, categorical one-hot.
+        if covariates is not None:
+            cov = covariates.reindex(use_samples)
+            for col in cov.columns:
+                series = cov[col]
+                if pd.api.types.is_numeric_dtype(series):
+                    design[col] = series.astype(float)
+                else:
+                    dummies = pd.get_dummies(series.astype('category'),
+                                             prefix=str(col), drop_first=True)
+                    for d in dummies.columns:
+                        design[d] = dummies[d].astype(float)
+
+        if group_s is None:
+            # path 1 — single-group temporal test.
+            for c in time_cols:
+                design[c] = time_block[c]
+            test_cols = list(time_cols)
+            mode = 'temporal'
+        else:
+            # path 2 — group × time interaction test.
+            grp_dum = pd.get_dummies(group_s, prefix='group', drop_first=True)
+            grp_dum.index = use_samples
+            grp_cols = list(grp_dum.columns)
+            for c in grp_cols:
+                design[c] = grp_dum[c].astype(float)
+            for c in time_cols:
+                design[c] = time_block[c]
+            # interaction columns: each group dummy × each time-basis col.
+            inter_cols = []
+            for gc in grp_cols:
+                for tc in time_cols:
+                    name = f"{gc}:{tc}"
+                    design[name] = (design[gc] * design[tc]).astype(float)
+                    inter_cols.append(name)
+            test_cols = inter_cols
+            mode = 'interaction'
+
+        if bool(design.isnull().any().any()):
+            bad = design.columns[design.isnull().any()].tolist()
+            raise ValueError(
+                f"design matrix has missing values in {bad} — covariate / "
+                f"group / time values must be present for every used sample.")
+        # guard against a rank-deficient design (e.g. confounded covariate).
+        if np.linalg.matrix_rank(design.values) < design.shape[1]:
+            raise ValueError(
+                "design matrix is rank-deficient — a covariate or group is "
+                "confounded with time; drop the offending term.")
+
+        counts = self.data[use_samples]
+        test_idx = [list(design.columns).index(c) for c in test_cols]
+
+        # --- limma-voom (+ duplicateCorrelation for repeated measures) -
+        if block_s is not None:
+            block_arr = block_s.values
+            print("⏰ Repeated-measures design — estimating within-subject "
+                  "correlation (duplicateCorrelation)...")
+            # Round 1: voom without weights-aware correlation, estimate corr.
+            v = _limma.voom(counts, design.values)
+            dc = _limma.duplicateCorrelation(v.E, design.values,
+                                             block=block_arr,
+                                             weights=v.weights)
+            corr = float(dc.consensus_correlation)
+            # Round 2: voom with the block correlation, re-estimate, fit.
+            try:
+                v = _limma.voom(counts, design.values,
+                                block=block_arr, correlation=corr)
+                dc = _limma.duplicateCorrelation(v.E, design.values,
+                                                 block=block_arr,
+                                                 weights=v.weights)
+                corr = float(dc.consensus_correlation)
+            except Exception as exc:  # pragma: no cover - defensive
+                print(f"   voom(block=...) round 2 skipped ({exc}); "
+                      f"using round-1 correlation.")
+            print(f"   consensus within-subject correlation = {corr:.4f}")
+            fit = _limma.lmFit(v.E, design.values, weights=v.weights,
+                               block=block_arr, correlation=corr)
+            self.timecourse_correlation = corr
+        else:
+            v = _limma.voom(counts, design.values)
+            fit = _limma.lmFit(v.E, design.values, weights=v.weights)
+
+        print("⏰ Start to adjust pvalue (eBayes)...")
+        fit = _limma.eBayes(fit)
+
+        # --- moderated F-test over the tested coefficient block --------
+        f_stat, pvalue, df1 = self._moderated_f_subset(
+            fit, test_idx, fit.df_total)
+        f_stat = np.asarray(f_stat, dtype=float)
+        pvalue = np.asarray(pvalue, dtype=float)
+
+        print("⏰ Start to calculate qvalue...")
+        qvalue = multipletests(np.nan_to_num(pvalue, nan=1.0),
+                               alpha=alpha, method=multipletests_method,
+                               is_sorted=False, returnsorted=False)[1]
+
+        base_mean = self.data[use_samples].mean(axis=1)
+        result = pd.DataFrame({'F': f_stat, 'pvalue': pvalue, 'qvalue': qvalue},
+                              index=self.data.index)
+        result['AveExpr'] = np.asarray(fit.Amean)
+        result['BaseMean'] = base_mean
+        result['MaxBaseMean'] = base_mean      # kept for column parity
+        result['log2(BaseMean)'] = np.log2(base_mean + 1)
+
+        # per-term coefficients of the tested block — the trajectory shape.
+        coefs = np.asarray(fit.coefficients)
+        for c, idx in zip(test_cols, test_idx):
+            result[f"log2FC_{c}"] = coefs[:, idx]
+        # a single log2FC (largest-magnitude tested coefficient) so the
+        # existing volcano plotting still has something to draw.
+        block_coefs = coefs[:, test_idx]
+        amax = np.argmax(np.abs(block_coefs), axis=1)
+        result['log2FC'] = block_coefs[np.arange(block_coefs.shape[0]), amax]
+        result['abs(log2FC)'] = result['log2FC'].abs()
+        result['size'] = result['abs(log2FC)'] / 10
+
+        result = result.loc[~result['pvalue'].isnull()]
+        result['-log(pvalue)'] = -np.log10(result['pvalue'])
+        result['-log(qvalue)'] = -np.log10(result['qvalue'])
+        result['sig'] = 'normal'
+        result.loc[result['qvalue'] < alpha, 'sig'] = 'temporal'
+
+        self.result = result
+        n_hit = int((result['sig'] == 'temporal').sum())
+        if mode == 'interaction':
+            print(f"✅ Time-course DE (group×time interaction) complete: "
+                  f"{len(use_samples)} samples, {basis} basis ({len(test_cols)} "
+                  f"interaction df), {n_hit} genes with differing trajectories "
+                  f"at q<{alpha}.")
+        else:
+            print(f"✅ Time-course DE (temporal regulation) complete: "
+                  f"{len(use_samples)} samples, {basis} basis ({len(test_cols)} "
+                  f"time df), {n_hit} temporally-regulated genes at q<{alpha}.")
+        return result
+
+
+def _temporal_knee(xs, ys):
+    """Knee of a curve — the point farthest from the chord joining its
+    first and last points (orientation-agnostic elbow detection)."""
+    xs = np.asarray(xs, dtype=float)
+    ys = np.asarray(ys, dtype=float)
+    if len(xs) <= 2:
+        return int(xs[0])
+    x = (xs - xs.min()) / (np.ptp(xs) or 1.0)
+    y = (ys - ys.min()) / (np.ptp(ys) or 1.0)
+    dist = np.abs((y[-1] - y[0]) * x - (x[-1] - x[0]) * y
+                  + x[-1] * y[0] - y[-1] * x[0])
+    return int(xs[int(np.argmax(dist))])
+
+
+@register_function(
+    aliases=["temporal_clusters", "时序聚类", "temporal_clustering",
+             "soft_temporal_clusters"],
+    category="bulk",
+    description=(
+        "Soft-cluster the temporal expression trajectories of time-course "
+        "genes by fuzzy c-means (Mfuzz). Pairs with pyDEG.timecourse_deg — "
+        "after finding which genes are temporally regulated, this groups "
+        "them by trajectory shape (monotone rise / fall, transient). "
+        "Backed by the pure-Python pymfuzz port of Bioconductor Mfuzz."
+    ),
+    examples=[
+        "ov.bulk.temporal_clusters(data, time, genes=deg.index[deg['sig']=='temporal'])",
+        "ov.bulk.temporal_clusters(data, time, n_clusters=9, plot=True)",
+    ],
+    related=["bulk.pyDEG"],
+)
+def temporal_clusters(data, time, *, genes=None, n_clusters="auto",
+                      m="auto", agg="mean", crange=None, seed=0,
+                      plot=False):
+    r"""Soft-cluster temporal expression trajectories by fuzzy c-means.
+
+    Companion to :meth:`pyDEG.timecourse_deg`. ``timecourse_deg`` answers
+    *which* genes change over time; ``temporal_clusters`` answers *what
+    shape* those changes take — grouping the temporally regulated genes
+    into soft clusters of co-trending trajectories (monotone rise / fall,
+    transient up-then-down, ...) via Mfuzz fuzzy c-means on the
+    z-standardised, replicate-averaged time profiles.
+
+    Arguments:
+        data: Expression matrix — a genes x samples ``pandas.DataFrame``
+            (normalised expression is recommended), or an ``AnnData``
+            (samples x genes, transposed internally).
+        time: Per-sample time value — a ``pandas.Series`` indexed by
+            sample, a ``dict`` ``{sample: time}``, or an array aligned to
+            the sample columns.
+        genes: Optional subset of genes to cluster — typically the
+            temporally regulated genes from ``timecourse_deg``
+            (``deg.index[deg['sig'] == 'temporal']``). Default: all genes.
+        n_clusters: Number of soft clusters — an int, or ``'auto'`` to
+            pick the knee of the Mfuzz ``Dmin`` curve.
+        m: Fuzzifier — a float, or ``'auto'`` for Mfuzz ``mestimate``.
+        agg: How to collapse replicate samples sharing a time point —
+            ``'mean'`` (default) or ``'median'``.
+        crange: Candidate cluster counts scanned when ``n_clusters='auto'``
+            (default ``range(2, 13)``).
+        seed: RNG seed for the fuzzy c-means initialisation.
+        plot: If True, draw the Mfuzz soft-cluster trajectory grid.
+
+    Returns:
+        A genes x stats ``pandas.DataFrame`` indexed by gene: ``cluster``
+        (1-based hard assignment) and ``membership`` (the gene's
+        membership in its assigned cluster). ``.attrs`` carries
+        ``centers`` (clusters x time points — the trajectory templates),
+        ``membership_matrix`` (genes x clusters), ``m`` and ``n_clusters``.
+    """
+    try:
+        import pymfuzz
+    except ImportError as exc:
+        raise ImportError(
+            "temporal_clusters needs the 'pymfuzz' package — "
+            "install it with:  pip install pymfuzz"
+        ) from exc
+
+    # --- coerce expression to a genes x samples DataFrame --------------
+    if isinstance(data, ad.AnnData):
+        expr = data.to_df().T          # AnnData is samples x genes
+    else:
+        expr = pd.DataFrame(data).copy()
+    samples = list(expr.columns)
+
+    # --- align the time vector to the sample columns -------------------
+    if isinstance(time, dict):
+        time = pd.Series(time)
+    if isinstance(time, pd.Series):
+        time_s = time.reindex(samples).astype(float)
+    else:
+        arr = np.asarray(time, dtype=float).ravel()
+        if len(arr) != len(samples):
+            raise ValueError(
+                f"time has {len(arr)} values but data has {len(samples)} "
+                f"samples; pass a Series indexed by sample to align.")
+        time_s = pd.Series(arr, index=samples)
+    keep = list(time_s.dropna().index)
+    expr, time_s, samples = expr[keep], time_s.loc[keep], keep
+
+    # --- restrict to the genes of interest ----------------------------
+    if genes is not None:
+        genes = [g for g in pd.Index(genes) if g in expr.index]
+        if len(genes) < 2:
+            raise ValueError("Need at least 2 of the requested genes "
+                             "present in data.")
+        expr = expr.loc[genes]
+
+    # --- collapse replicates -> one mean profile per time point -------
+    times = sorted(time_s.unique())
+    if len(times) < 3:
+        raise ValueError("Temporal clustering needs >=3 distinct time points.")
+    reducer = np.nanmedian if agg == "median" else np.nanmean
+    traj = pd.DataFrame(
+        {t: reducer(expr[[s for s in samples if time_s[s] == t]]
+                    .to_numpy(dtype=float), axis=1)
+         for t in times},
+        index=expr.index,
+    )
+    traj = traj.loc[traj.notna().all(axis=1) & (traj.std(axis=1) > 0)]
+    if traj.shape[0] < 2:
+        raise ValueError("Too few genes with a usable (non-flat) trajectory.")
+
+    # --- standardise (z-score each gene), estimate the fuzzifier ------
+    z = pymfuzz.standardise(traj)
+    m_val = pymfuzz.mestimate(z) if m == "auto" else float(m)
+
+    # --- choose the cluster count -------------------------------------
+    if isinstance(n_clusters, str) and n_clusters == "auto":
+        cr = list(crange) if crange is not None else list(range(2, 13))
+        cr = [c for c in cr if 2 <= c < traj.shape[0]]
+        dmin = np.asarray(
+            pymfuzz.Dmin(z, m=m_val, crange=cr, repeats=3, visu=False,
+                         random_state=seed), dtype=float)
+        c_val = _temporal_knee(cr, dmin)
+    else:
+        c_val = int(n_clusters)
+    print(f"⏰ Mfuzz fuzzy c-means: {traj.shape[0]} genes, "
+          f"{len(times)} time points, c={c_val}, m={m_val:.3f}")
+
+    # --- fuzzy c-means soft clustering --------------------------------
+    fc = pymfuzz.mfuzz(z, c=c_val, m=m_val, random_state=seed)
+    membership = np.asarray(fc.membership, dtype=float)   # genes x clusters
+    hard = membership.argmax(axis=1) + 1                  # 1-based
+    cl_cols = [f"cluster_{i}" for i in fc.cluster_names]
+
+    out = pd.DataFrame(
+        {"cluster": hard, "membership": membership.max(axis=1)},
+        index=list(fc.gene_names),
+    )
+    out.attrs["centers"] = pd.DataFrame(
+        np.asarray(fc.centers, dtype=float),
+        index=cl_cols, columns=list(fc.time_names))
+    out.attrs["membership_matrix"] = pd.DataFrame(
+        membership, index=list(fc.gene_names), columns=cl_cols)
+    out.attrs["m"] = m_val
+    out.attrs["n_clusters"] = c_val
+
+    if plot:
+        pymfuzz.mfuzz_plot(z, fc)
+    return out

--- a/omicverse/bulk/_Deseq2.py
+++ b/omicverse/bulk/_Deseq2.py
@@ -1073,7 +1073,7 @@ class pyDEG(object):
 
     def timecourse_deg(self, time, group=None, block=None, covariates=None,
                        time_basis: str = 'auto', spline_df: int = 3,
-                       alpha: float = 0.05,
+                       data_type: str = 'auto', alpha: float = 0.05,
                        multipletests_method: str = 'fdr_bh') -> pd.DataFrame:
         r"""Time-course / longitudinal differential-expression analysis.
 
@@ -1083,11 +1083,22 @@ class pyDEG(object):
         a *moderated F-test over a whole block of design columns* — the
         statistically correct way to ask "does expression change over
         time" without committing to a single shape. It is built on the
-        vendored pure-Python limma-voom (``omicverse.external.pylimma``)
+        vendored pure-Python limma (``omicverse.external.pylimma``)
         and is isomorphic to :meth:`continuous_deg`: same design-matrix
-        construction, same ``voom → lmFit → eBayes`` call, same
+        construction, same ``lmFit → eBayes`` core, same
         ``deg_analysis``-shaped return so ``foldchange_set`` /
         ``plot_volcano`` keep working.
+
+        The method (a port of splineTimeR's design) accepts **two kinds
+        of input**, switched by ``data_type``:
+
+        * RNA-seq **counts** — the mean-variance trend is removed with
+          ``voom``, which feeds precision weights into ``lmFit``.
+        * **continuous** expression — microarray log-ratios, log-CPM, or
+          any already-normalized / log-scaled matrix. splineTimeR was
+          originally a *microarray* time-course method, so this path
+          runs ``lmFit`` directly on the expression matrix with no
+          ``voom`` and no weights.
 
         Three first-class paths, selected by the arguments:
 
@@ -1131,6 +1142,16 @@ class pyDEG(object):
                 ``factor`` if ≤4 unique time values, else ``spline``).
             spline_df: Degrees of freedom of the natural cubic spline
                 when ``time_basis`` resolves to ``'spline'`` (default 3).
+            data_type: Nature of the expression matrix —
+                ``'counts'`` (RNA-seq raw counts: ``voom`` removes the
+                mean-variance trend, then ``lmFit`` with precision
+                weights); ``'continuous'`` (microarray log-ratios,
+                log-CPM, or any already-normalized / log-scaled matrix:
+                ``lmFit`` is run directly, no ``voom``, no weights);
+                ``'auto'`` (default — inspect the matrix: an all
+                non-negative, near-integer matrix is treated as
+                ``'counts'``, anything with negative or non-integer
+                values as ``'continuous'``).
             alpha: FDR threshold for the ``sig`` column (default 0.05).
             multipletests_method: ``statsmodels`` multiple-testing
                 method for the q-value (default ``'fdr_bh'``).
@@ -1152,7 +1173,27 @@ class pyDEG(object):
         """
         from ..external import pylimma as _limma
         from statsmodels.stats.multitest import multipletests
-        print("⏰ Start time-course limma-voom pipeline (pylimma)...")
+
+        # --- resolve counts vs continuous input ------------------------
+        if data_type not in ('auto', 'counts', 'continuous'):
+            raise ValueError(
+                f"data_type must be 'auto', 'counts' or 'continuous', "
+                f"got {data_type!r}.")
+        dt = data_type
+        if dt == 'auto':
+            vals = np.asarray(self.data.values, dtype=float)
+            finite = vals[np.isfinite(vals)]
+            near_int = (finite.size > 0
+                        and np.allclose(finite, np.round(finite)))
+            all_nonneg = finite.size > 0 and (finite >= 0).all()
+            dt = 'counts' if (near_int and all_nonneg) else 'continuous'
+            print(f"   data_type='auto' resolved to {dt!r} "
+                  f"({'non-negative integers' if dt == 'counts' else 'has negative / non-integer values'}).")
+        if dt == 'counts':
+            print("⏰ Start time-course limma-voom pipeline (pylimma)...")
+        else:
+            print("⏰ Start time-course limma pipeline "
+                  "(continuous input, no voom)...")
 
         samples = list(self.data.columns)
 
@@ -1310,35 +1351,56 @@ class pyDEG(object):
         counts = self.data[use_samples]
         test_idx = [list(design.columns).index(c) for c in test_cols]
 
-        # --- limma-voom (+ duplicateCorrelation for repeated measures) -
-        if block_s is not None:
-            block_arr = block_s.values
-            print("⏰ Repeated-measures design — estimating within-subject "
-                  "correlation (duplicateCorrelation)...")
-            # Round 1: voom without weights-aware correlation, estimate corr.
-            v = _limma.voom(counts, design.values)
-            dc = _limma.duplicateCorrelation(v.E, design.values,
-                                             block=block_arr,
-                                             weights=v.weights)
-            corr = float(dc.consensus_correlation)
-            # Round 2: voom with the block correlation, re-estimate, fit.
-            try:
-                v = _limma.voom(counts, design.values,
-                                block=block_arr, correlation=corr)
+        # --- fit the linear model -------------------------------------
+        # 'counts'     : voom removes the mean-variance trend, then lmFit
+        #                runs with the voom precision weights.
+        # 'continuous' : the matrix is already log-scaled / normalized —
+        #                lmFit runs directly on it, no voom, no weights.
+        if dt == 'counts':
+            if block_s is not None:
+                block_arr = block_s.values
+                print("⏰ Repeated-measures design — estimating "
+                      "within-subject correlation (duplicateCorrelation)...")
+                # Round 1: voom without weights-aware corr, estimate corr.
+                v = _limma.voom(counts, design.values)
                 dc = _limma.duplicateCorrelation(v.E, design.values,
                                                  block=block_arr,
                                                  weights=v.weights)
                 corr = float(dc.consensus_correlation)
-            except Exception as exc:  # pragma: no cover - defensive
-                print(f"   voom(block=...) round 2 skipped ({exc}); "
-                      f"using round-1 correlation.")
-            print(f"   consensus within-subject correlation = {corr:.4f}")
-            fit = _limma.lmFit(v.E, design.values, weights=v.weights,
-                               block=block_arr, correlation=corr)
-            self.timecourse_correlation = corr
+                # Round 2: voom with the block correlation, re-estimate.
+                try:
+                    v = _limma.voom(counts, design.values,
+                                    block=block_arr, correlation=corr)
+                    dc = _limma.duplicateCorrelation(v.E, design.values,
+                                                     block=block_arr,
+                                                     weights=v.weights)
+                    corr = float(dc.consensus_correlation)
+                except Exception as exc:  # pragma: no cover - defensive
+                    print(f"   voom(block=...) round 2 skipped ({exc}); "
+                          f"using round-1 correlation.")
+                print(f"   consensus within-subject correlation = {corr:.4f}")
+                fit = _limma.lmFit(v.E, design.values, weights=v.weights,
+                                   block=block_arr, correlation=corr)
+                self.timecourse_correlation = corr
+            else:
+                v = _limma.voom(counts, design.values)
+                fit = _limma.lmFit(v.E, design.values, weights=v.weights)
         else:
-            v = _limma.voom(counts, design.values)
-            fit = _limma.lmFit(v.E, design.values, weights=v.weights)
+            # continuous expression — lmFit directly on the matrix.
+            expr = counts.astype(float)
+            if block_s is not None:
+                block_arr = block_s.values
+                print("⏰ Repeated-measures design — estimating "
+                      "within-subject correlation (duplicateCorrelation)...")
+                dc = _limma.duplicateCorrelation(expr.values, design.values,
+                                                 block=block_arr)
+                corr = float(dc.consensus_correlation)
+                print(f"   consensus within-subject correlation = {corr:.4f}")
+                fit = _limma.lmFit(expr.values, design.values,
+                                   block=block_arr, correlation=corr)
+                self.timecourse_correlation = corr
+            else:
+                fit = _limma.lmFit(expr.values, design.values)
 
         print("⏰ Start to adjust pvalue (eBayes)...")
         fit = _limma.eBayes(fit)

--- a/omicverse/bulk/__init__.py
+++ b/omicverse/bulk/__init__.py
@@ -42,7 +42,7 @@ from .._optional import bind_optional_symbols
 from ._Enrichment import pyGSEA,pyGSE,geneset_enrichment,geneset_plot,geneset_enrichment_GSEA,geneset_plot_multi,enrichment_multi_concat
 from ._network import pyPPI,string_interaction,string_map,generate_G
 from ._chm13 import get_chm13_gene,find_chm13_gene
-from ._Deseq2 import pyDEG,deseq2_normalize,estimateSizeFactors,estimateDispersions,Matrix_ID_mapping,data_drop_duplicates_index
+from ._Deseq2 import pyDEG,deseq2_normalize,estimateSizeFactors,estimateDispersions,Matrix_ID_mapping,data_drop_duplicates_index,temporal_clusters
 from ._tcga import pyTCGA
 from ._combat import batch_correction
 
@@ -98,6 +98,7 @@ __all__ = [
     'estimateDispersions',
     'Matrix_ID_mapping',
     'data_drop_duplicates_index',
+    'temporal_clusters',
     
     # TCGA analysis
     'pyTCGA',

--- a/omicverse/datasets/__init__.py
+++ b/omicverse/datasets/__init__.py
@@ -117,4 +117,9 @@ from ._genetics import (
     recombination_map,
     gene_annotation,
 )
+from ._timecourse import (
+    # Real bulk RNA-seq time-course datasets for the ov.bulk tutorials
+    fission_timecourse,
+    pombe_genesets,
+)
 from ._signatures import load_signatures_from_file, predefined_signatures

--- a/omicverse/datasets/_timecourse.py
+++ b/omicverse/datasets/_timecourse.py
@@ -1,0 +1,91 @@
+"""Real bulk RNA-seq time-course datasets for the ``ov.bulk`` tutorials.
+
+Each loader downloads a dataset asset from the ``omicverse-data`` GitHub
+release (``timecourse-v1``) on first use, caches it under ``dir``, and
+returns it ready for the ``ov.bulk`` time-course workflow
+(``pyDEG.timecourse_deg``, ``temporal_clusters``).
+
+| Loader | Returns | Source |
+|---|---|---|
+| :func:`fission_timecourse` | AnnData (samples × genes) | Bioconductor ``fission`` package |
+| :func:`pombe_genesets` | dict of gene-set dicts | PomBase GO + Chen et al. 2003 CESR |
+
+All datasets are real, published data redistributed from open sources:
+the Bioconductor ``fission`` experiment-data package (Leong et al.,
+*Nat Commun* 2014), the PomBase Gene Ontology annotation, and the
+*S. pombe* Core Environmental Stress Response gene cores of Chen et al.
+2003 (*Mol Biol Cell* 14:214-229).
+"""
+from __future__ import annotations
+
+import gzip
+import json
+from typing import TYPE_CHECKING
+
+from .._registry import register_function
+from ._datasets import download_data
+
+if TYPE_CHECKING:  # pragma: no cover
+    from anndata import AnnData
+
+_RELEASE = (
+    "https://github.com/omicverse/omicverse-data/releases/download/timecourse-v1"
+)
+
+
+def _fetch(asset: str, dir: str) -> str:
+    """Download ``asset`` from the timecourse-v1 release; return local path."""
+    return download_data(f"{_RELEASE}/{asset}", file_path=asset, dir=dir)
+
+
+@register_function(
+    aliases=["fission_timecourse", "fission", "时间序列数据", "时序数据"],
+    category="datasets",
+    description=(
+        "Real bulk RNA-seq time-course dataset — the Schizosaccharomyces "
+        "pombe oxidative-stress series of the Bioconductor 'fission' "
+        "package (Leong et al., Nat Commun 2014). Wild-type vs an "
+        "atf21-delta deletion mutant, 6 time points (0/15/30/60/120/180 "
+        "min), 3 replicates -> 36 samples × 7039 genes, raw counts. The "
+        "canonical DESeq2-vignette two-group time-course dataset. "
+        "Returned as an AnnData (samples × genes); ``.obs`` carries "
+        "``strain`` (wt/mut), ``minute``, ``replicate`` and ``id``; "
+        "``.var`` carries the gene ``symbol`` and ``biotype``. Feed "
+        "straight into ``ov.bulk.pyDEG(...).timecourse_deg``."
+    ),
+    examples=["adata = ov.datasets.fission_timecourse()"],
+)
+def fission_timecourse(dir: str = "./data") -> "AnnData":
+    """Load the real fission-yeast oxidative-stress RNA-seq time course."""
+    import anndata as ad
+    return ad.read_h5ad(_fetch("fission_timecourse.h5ad", dir))
+
+
+@register_function(
+    aliases=["pombe_genesets", "pombe_go", "fission_genesets", "酵母基因集"],
+    category="datasets",
+    description=(
+        "Schizosaccharomyces pombe gene-set bundle for the time-course "
+        "functional-enrichment step. Returns a dict with three keys: "
+        "``'GO_BP'`` — ~1950 Gene Ontology biological-process gene sets "
+        "built from the PomBase GAF and propagated over the GO DAG "
+        "(``{term: [systematic ids]}``); ``'CESR'`` — the Core "
+        "Environmental Stress Response induced / repressed gene cores of "
+        "Chen et al. 2003 (Mol Biol Cell 14:214-229), the textbook "
+        "S. pombe stress program; ``'gene_symbols'`` — a "
+        "systematic-id -> symbol map. All identifiers are S. pombe "
+        "systematic IDs (SPAC.../SPBC...), matching the "
+        ":func:`fission_timecourse` count matrix. Pass ``GO_BP`` (or "
+        "``CESR``) straight to ``ov.bulk.geneset_enrichment`` as the "
+        "``pathways_dict``."
+    ),
+    examples=[
+        "gs = ov.datasets.pombe_genesets()",
+        "enr = ov.bulk.geneset_enrichment(genes, gs['GO_BP'], organism='Yeast')",
+    ],
+)
+def pombe_genesets(dir: str = "./data") -> dict:
+    """Load the S. pombe GO + CESR gene-set bundle (systematic IDs)."""
+    path = _fetch("pombe_genesets.json.gz", dir)
+    with gzip.open(path, "rt") as fh:
+        return json.load(fh)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -238,6 +238,15 @@ lipidomics = [
   "pygoslin>=2.2",         # Goslin — LIPID MAPS shorthand parser
 ]
 
+# Time-course / longitudinal bulk RNA-seq. Install via:
+#   pip install omicverse[timecourse]
+# pyDEG.timecourse_deg (limma-voom + moderated F over a spline/factor
+# time basis) needs no extra package; temporal_clusters soft-clusters the
+# trajectories via pymfuzz, a pure-Python port of Bioconductor Mfuzz.
+timecourse = [
+  "pymfuzz>=0.1.0",        # Bioconductor Mfuzz — fuzzy c-means time-series clustering
+]
+
 
 [project.urls]
 Github = 'https://github.com/Starlitnightly/omicverse'

--- a/tests/architecture/test_optional_torch_dependencies.py
+++ b/tests/architecture/test_optional_torch_dependencies.py
@@ -138,6 +138,7 @@ def _install_bulk_dependency_stubs():
             "estimateDispersions": object(),
             "Matrix_ID_mapping": object(),
             "data_drop_duplicates_index": object(),
+            "temporal_clusters": object(),
         },
         "omicverse.bulk._tcga": {"pyTCGA": object()},
         "omicverse.bulk._combat": {"batch_correction": object()},

--- a/tests/bulk/test_timecourse_deg.py
+++ b/tests/bulk/test_timecourse_deg.py
@@ -1,0 +1,331 @@
+"""Tests for ov.bulk.pyDEG.timecourse_deg — time-course / longitudinal DE.
+
+``timecourse_deg`` is isomorphic to ``continuous_deg``: it is built on the
+vendored pure-Python limma-voom (``omicverse.external.pylimma``) and answers
+the three classic time-course questions with a *moderated F-test over a
+block of design columns*:
+
+1. which genes are temporally regulated (``group=None``),
+2. whether trajectories differ between groups (``group=`` given — the
+   group×time interaction F-test),
+3. repeated-measures designs (``block=`` given — duplicateCorrelation).
+
+These tests build small synthetic count matrices with a *known* temporal
+pattern and assert that the method recovers the planted genes with high
+power and controlled FDR on the null genes, that the group path flags the
+interaction genes, and that the ``block=`` path runs.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import omicverse as ov
+
+
+# ---------------------------------------------------------------------------
+# synthetic data
+# ---------------------------------------------------------------------------
+# Enough total genes that the planted (inflated) genes do not dominate the
+# library size — otherwise voom's per-sample normalization would induce a
+# spurious compositional time trend in the null genes.
+N_GENES = 600
+N_TRUE = 40          # genes 0..39 carry the planted temporal / interaction signal
+
+
+def _temporal_counts(seed=0):
+    """Counts (genes × samples) with genes 0..39 rising over time."""
+    rng = np.random.default_rng(seed)
+    times = np.array([0, 1, 2, 4, 8])
+    reps = 4
+    samp_t = np.repeat(times, reps).astype(float)
+    n = len(samp_t)
+    samples = [f"s{i}" for i in range(n)]
+    genes = [f"g{i:04d}" for i in range(N_GENES)]
+    base = rng.negative_binomial(50, 0.4, size=(N_GENES, n)).astype(float)
+    for i in range(N_TRUE):                       # planted: rise with time
+        base[i] *= (1.0 + 0.3 * samp_t)
+    counts = pd.DataFrame(base, index=genes, columns=samples)
+    return counts, pd.Series(samp_t, index=samples)
+
+
+def _interaction_counts(seed=2):
+    """Counts where genes 0..39 rise over time ONLY in group B."""
+    rng = np.random.default_rng(seed)
+    times = np.array([0, 1, 2, 4])
+    reps = 5
+    samp_t = np.tile(np.repeat(times, reps), 2).astype(float)
+    grp = np.array(["A"] * (len(times) * reps) + ["B"] * (len(times) * reps))
+    n = len(samp_t)
+    samples = [f"s{i}" for i in range(n)]
+    genes = [f"g{i:04d}" for i in range(N_GENES)]
+    base = rng.negative_binomial(60, 0.4, size=(N_GENES, n)).astype(float)
+    for i in range(N_TRUE):                       # planted: time effect in B only
+        base[i] *= np.where(grp == "B", 1.0 + 0.6 * samp_t, 1.0)
+    counts = pd.DataFrame(base, index=genes, columns=samples)
+    # subject IDs: 5 subjects, each sampled at all 4 time points, per group.
+    subj = np.concatenate([
+        np.tile(np.arange(reps), len(times)),                  # group A subjects 0..4
+        np.tile(np.arange(reps, 2 * reps), len(times)),        # group B subjects 5..9
+    ])
+    return (counts, pd.Series(samp_t, index=samples),
+            pd.Series(grp, index=samples), pd.Series(subj, index=samples))
+
+
+_SCHEMA = {
+    "F", "pvalue", "qvalue", "AveExpr", "BaseMean", "log2(BaseMean)",
+    "log2FC", "abs(log2FC)", "-log(pvalue)", "-log(qvalue)", "sig",
+}
+
+
+# ---------------------------------------------------------------------------
+# path 1 — temporal regulation (group=None)
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("time_basis", ["factor", "spline", "auto"])
+def test_temporal_recovery(time_basis):
+    counts, time = _temporal_counts()
+    dds = ov.bulk.pyDEG(counts.copy())
+    dds.drop_duplicates_index()
+    res = dds.timecourse_deg(time=time, time_basis=time_basis)
+
+    # standard pyDEG-style schema.
+    assert _SCHEMA.issubset(res.columns), f"missing: {_SCHEMA - set(res.columns)}"
+    assert res is dds.result
+    assert res.shape[0] == N_GENES
+
+    # F-test => sig is temporal / normal, never up / down.
+    assert set(res["sig"]).issubset({"temporal", "normal"})
+
+    # trajectory-shape columns are present and recoverable.
+    shape_cols = [c for c in res.columns if c.startswith("log2FC_")]
+    assert len(shape_cols) >= 1
+
+    # p / q values are valid probabilities; F is non-negative.
+    for col in ("pvalue", "qvalue"):
+        v = res[col].dropna()
+        assert ((v >= 0) & (v <= 1)).all()
+    assert (res["F"].dropna() >= 0).all()
+
+    # high power on the planted temporally-regulated genes.
+    planted = [f"g{i:04d}" for i in range(N_TRUE)]
+    hit = set(res.index[res["sig"] == "temporal"])
+    recovered = sum(g in hit for g in planted)
+    assert recovered >= int(0.9 * N_TRUE), \
+        f"{time_basis}: only {recovered}/{N_TRUE} temporal genes recovered"
+
+    # controlled false-discovery on the null genes.
+    null_genes = res.index[N_TRUE:]
+    fdr = (res.loc[null_genes, "sig"] == "temporal").mean()
+    assert fdr < 0.10, f"{time_basis}: null FDR too high ({fdr:.3f})"
+
+
+def test_temporal_auto_picks_factor_then_spline():
+    """auto => factor for <=4 time points, spline for more."""
+    counts, time = _temporal_counts()
+    dds = ov.bulk.pyDEG(counts.copy())
+    dds.drop_duplicates_index()
+    # 5 distinct time points -> auto resolves to spline (3 df by default).
+    res = dds.timecourse_deg(time=time, time_basis="auto", spline_df=3)
+    shape_cols = [c for c in res.columns if c.startswith("log2FC_time_s")]
+    assert len(shape_cols) >= 2          # spline basis columns
+
+    # collapse to 3 distinct time points -> auto resolves to factor.
+    t3 = time.replace({4.0: 2.0, 8.0: 2.0})
+    res3 = dds.timecourse_deg(time=t3, time_basis="auto")
+    fac_cols = [c for c in res3.columns if c.startswith("log2FC_time_")]
+    assert len(fac_cols) == 2            # one-hot of 3 levels, drop-first
+
+
+def test_factor_columns_match_time_points():
+    counts, time = _temporal_counts()
+    dds = ov.bulk.pyDEG(counts.copy())
+    dds.drop_duplicates_index()
+    res = dds.timecourse_deg(time=time, time_basis="factor")
+    # 5 distinct time points => 4 factor coefficients (drop-first).
+    fac_cols = sorted(c for c in res.columns if c.startswith("log2FC_time_"))
+    assert len(fac_cols) == 4
+
+
+def test_null_pvalues_are_calibrated():
+    """A pure-null matrix (no time signal) must give a uniform-ish p."""
+    rng = np.random.default_rng(7)
+    times = np.array([0, 1, 2, 4, 8])
+    samp_t = np.repeat(times, 4).astype(float)
+    samples = [f"s{i}" for i in range(len(samp_t))]
+    counts = pd.DataFrame(
+        rng.negative_binomial(50, 0.4, size=(800, len(samp_t))).astype(float),
+        index=[f"g{i:04d}" for i in range(800)], columns=samples,
+    )
+    dds = ov.bulk.pyDEG(counts)
+    dds.drop_duplicates_index()
+    res = dds.timecourse_deg(time=pd.Series(samp_t, index=samples),
+                             time_basis="factor")
+    # under the null, ~5% of genes should fall below p<0.05 and FDR ~ 0.
+    assert (res["pvalue"] < 0.05).mean() < 0.12
+    assert (res["qvalue"] < 0.05).mean() < 0.02
+
+
+# ---------------------------------------------------------------------------
+# path 2 — group × time interaction
+# ---------------------------------------------------------------------------
+def test_group_interaction_recovery():
+    counts, time, group, _ = _interaction_counts()
+    dds = ov.bulk.pyDEG(counts.copy())
+    dds.drop_duplicates_index()
+    res = dds.timecourse_deg(time=time, group=group, time_basis="factor")
+
+    assert _SCHEMA.issubset(res.columns)
+    assert set(res["sig"]).issubset({"temporal", "normal"})
+
+    # the interaction F-test is over the group:time columns only.
+    inter_cols = [c for c in res.columns if c.startswith("log2FC_group_")
+                  and ":" in c]
+    assert len(inter_cols) >= 1
+
+    # genes with a group-specific trajectory are flagged.
+    planted = [f"g{i:04d}" for i in range(N_TRUE)]
+    hit = set(res.index[res["sig"] == "temporal"])
+    recovered = sum(g in hit for g in planted)
+    assert recovered >= int(0.85 * N_TRUE), \
+        f"only {recovered}/{N_TRUE} interaction genes recovered"
+
+    null_genes = res.index[N_TRUE:]
+    fdr = (res.loc[null_genes, "sig"] == "temporal").mean()
+    assert fdr < 0.10, f"interaction null FDR too high ({fdr:.3f})"
+
+
+def test_group_interaction_ignores_shared_time_trend():
+    """A time trend shared by BOTH groups must NOT be called by the
+    interaction test (only group-specific trajectories should)."""
+    rng = np.random.default_rng(11)
+    times = np.array([0, 1, 2, 4])
+    reps = 5
+    samp_t = np.tile(np.repeat(times, reps), 2).astype(float)
+    grp = np.array(["A"] * (len(times) * reps) + ["B"] * (len(times) * reps))
+    samples = [f"s{i}" for i in range(len(samp_t))]
+    base = rng.negative_binomial(60, 0.4, size=(N_GENES, len(samp_t))).astype(float)
+    # genes 0..39 rise with time IDENTICALLY in both groups (no interaction).
+    for i in range(N_TRUE):
+        base[i] *= (1.0 + 0.5 * samp_t)
+    counts = pd.DataFrame(base, index=[f"g{i:04d}" for i in range(N_GENES)],
+                          columns=samples)
+    dds = ov.bulk.pyDEG(counts)
+    dds.drop_duplicates_index()
+    res = dds.timecourse_deg(time=pd.Series(samp_t, index=samples),
+                             group=pd.Series(grp, index=samples),
+                             time_basis="factor")
+    # the shared-trend genes should NOT be flagged by the interaction test.
+    planted = [f"g{i:04d}" for i in range(N_TRUE)]
+    flagged = (res.loc[planted, "sig"] == "temporal").mean()
+    assert flagged < 0.25, \
+        f"interaction test wrongly flagged shared-trend genes ({flagged:.2f})"
+
+
+# ---------------------------------------------------------------------------
+# path 3 — repeated measures (block=)
+# ---------------------------------------------------------------------------
+def test_block_repeated_measures_runs():
+    counts, time, group, block = _interaction_counts()
+    dds = ov.bulk.pyDEG(counts.copy())
+    dds.drop_duplicates_index()
+    res = dds.timecourse_deg(time=time, group=group, block=block,
+                             time_basis="factor")
+    # the repeated-measures path estimates a within-subject correlation.
+    assert hasattr(dds, "timecourse_correlation")
+    assert -1.0 < dds.timecourse_correlation < 1.0
+    assert _SCHEMA.issubset(res.columns)
+    assert res.shape[0] == N_GENES
+    # still recovers the planted interaction genes.
+    planted = [f"g{i:04d}" for i in range(N_TRUE)]
+    hit = set(res.index[res["sig"] == "temporal"])
+    assert sum(g in hit for g in planted) >= int(0.7 * N_TRUE)
+
+
+def test_block_temporal_only_runs():
+    """block= combines with the single-group temporal path too."""
+    counts, time = _temporal_counts()
+    # build per-subject block IDs: 4 subjects sampled at all 5 time points.
+    samp_t = time.values
+    times = sorted(set(samp_t))
+    block = np.empty(len(samp_t), dtype=int)
+    for t in times:
+        idx = np.where(samp_t == t)[0]
+        block[idx] = np.arange(len(idx))
+    dds = ov.bulk.pyDEG(counts.copy())
+    dds.drop_duplicates_index()
+    res = dds.timecourse_deg(time=time,
+                             block=pd.Series(block, index=time.index),
+                             time_basis="factor")
+    assert hasattr(dds, "timecourse_correlation")
+    assert _SCHEMA.issubset(res.columns)
+
+
+# ---------------------------------------------------------------------------
+# covariates and edge cases
+# ---------------------------------------------------------------------------
+def test_covariates_numeric_and_categorical():
+    counts, time = _temporal_counts()
+    rng = np.random.default_rng(3)
+    samples = list(time.index)
+    cov = pd.DataFrame({
+        "rin": rng.normal(8.0, 0.5, size=len(samples)),       # numeric
+        "batch": rng.choice(["b1", "b2"], size=len(samples)),  # categorical
+    }, index=samples)
+    dds = ov.bulk.pyDEG(counts.copy())
+    dds.drop_duplicates_index()
+    res = dds.timecourse_deg(time=time, covariates=cov, time_basis="factor")
+    planted = [f"g{i:04d}" for i in range(N_TRUE)]
+    hit = set(res.index[res["sig"] == "temporal"])
+    assert sum(g in hit for g in planted) >= int(0.8 * N_TRUE)
+
+
+def test_missing_time_samples_dropped():
+    counts, time = _temporal_counts()
+    time = time.copy()
+    time.iloc[:2] = np.nan          # two samples with missing time
+    dds = ov.bulk.pyDEG(counts.copy())
+    dds.drop_duplicates_index()
+    res = dds.timecourse_deg(time=time, time_basis="factor")
+    # method still runs and returns the full gene table.
+    assert res.shape[0] == N_GENES
+
+
+def test_bad_time_basis_raises():
+    counts, time = _temporal_counts()
+    dds = ov.bulk.pyDEG(counts.copy())
+    dds.drop_duplicates_index()
+    with pytest.raises(ValueError):
+        dds.timecourse_deg(time=time, time_basis="not_a_basis")
+
+
+def test_continuous_and_deg_analysis_untouched():
+    """timecourse_deg must not perturb the sibling methods."""
+    assert hasattr(ov.bulk.pyDEG, "continuous_deg")
+    assert hasattr(ov.bulk.pyDEG, "deg_analysis")
+    assert hasattr(ov.bulk.pyDEG, "timecourse_deg")
+
+
+# ---------------------------------------------------------------------------
+# temporal_clusters — soft-cluster the trajectories of time-course genes
+# ---------------------------------------------------------------------------
+def test_temporal_clusters():
+    """temporal_clusters groups time-course genes by trajectory shape via
+    the pymfuzz (Mfuzz) fuzzy c-means backend."""
+    pytest.importorskip("pymfuzz")
+    counts, time = _temporal_counts(seed=0)
+    deg = ov.bulk.pyDEG(counts)
+    res = deg.timecourse_deg(time=time)
+    genes = list(res.index[res["sig"] == "temporal"])
+    assert len(genes) >= 5
+
+    tc = ov.bulk.temporal_clusters(counts, time, genes=genes,
+                                   n_clusters=4, seed=0)
+    assert list(tc.columns) == ["cluster", "membership"]
+    assert len(tc) >= 5
+    assert tc["cluster"].nunique() <= 4
+    assert ((tc["membership"] >= 0) & (tc["membership"] <= 1)).all()
+    assert tc.attrs["centers"].shape == (4, len(time.unique()))
+    assert tc.attrs["membership_matrix"].shape[1] == 4
+    # auto cluster-count selection also runs
+    tc_auto = ov.bulk.temporal_clusters(counts, time, genes=genes, seed=0)
+    assert tc_auto.attrs["n_clusters"] >= 2

--- a/tests/bulk/test_timecourse_deg.py
+++ b/tests/bulk/test_timecourse_deg.py
@@ -49,6 +49,30 @@ def _temporal_counts(seed=0):
     return counts, pd.Series(samp_t, index=samples)
 
 
+def _temporal_continuous(seed=0):
+    """Continuous log-expression (genes × samples) — microarray-style.
+
+    Genes 0..39 follow a smooth cell-cycle-like wave over time; the rest
+    are flat plus noise. The matrix is already log-scaled (it carries
+    negative values), so it must NOT be voom-transformed.
+    """
+    rng = np.random.default_rng(seed)
+    times = np.array([0, 1, 2, 4, 8, 12])
+    reps = 4
+    samp_t = np.repeat(times, reps).astype(float)
+    n = len(samp_t)
+    samples = [f"s{i}" for i in range(n)]
+    genes = [f"g{i:04d}" for i in range(N_GENES)]
+    # log-expression centred at 8 with small biological noise.
+    expr = rng.normal(8.0, 0.4, size=(N_GENES, n))
+    for i in range(N_TRUE):                       # planted: smooth wave
+        expr[i] += 2.0 * np.sin(samp_t / 12.0 * np.pi)
+    # a couple of genes carry log-ratios straddling zero (negative values)
+    expr[0] -= 8.0
+    df = pd.DataFrame(expr, index=genes, columns=samples)
+    return df, pd.Series(samp_t, index=samples)
+
+
 def _interaction_counts(seed=2):
     """Counts where genes 0..39 rise over time ONLY in group B."""
     rng = np.random.default_rng(seed)
@@ -163,6 +187,84 @@ def test_null_pvalues_are_calibrated():
     # under the null, ~5% of genes should fall below p<0.05 and FDR ~ 0.
     assert (res["pvalue"] < 0.05).mean() < 0.12
     assert (res["qvalue"] < 0.05).mean() < 0.02
+
+
+# ---------------------------------------------------------------------------
+# continuous (microarray / pre-normalized) input — data_type
+# ---------------------------------------------------------------------------
+def test_continuous_data_type_recovers_temporal_genes():
+    """data_type='continuous' skips voom and runs lmFit directly on an
+    already-log-scaled expression matrix (microarray-style)."""
+    expr, time = _temporal_continuous()
+    dds = ov.bulk.pyDEG(expr.copy())
+    dds.drop_duplicates_index()
+    res = dds.timecourse_deg(time=time, data_type="continuous",
+                             time_basis="spline")
+
+    assert _SCHEMA.issubset(res.columns)
+    assert res.shape[0] == N_GENES
+    assert set(res["sig"]).issubset({"temporal", "normal"})
+
+    # high power on the planted smooth-wave genes.
+    planted = [f"g{i:04d}" for i in range(N_TRUE)]
+    hit = set(res.index[res["sig"] == "temporal"])
+    recovered = sum(g in hit for g in planted)
+    assert recovered >= int(0.9 * N_TRUE), \
+        f"only {recovered}/{N_TRUE} continuous temporal genes recovered"
+
+    # controlled false-discovery on the flat null genes.
+    null_genes = res.index[N_TRUE:]
+    fdr = (res.loc[null_genes, "sig"] == "temporal").mean()
+    assert fdr < 0.10, f"continuous null FDR too high ({fdr:.3f})"
+
+
+def test_data_type_auto_detection():
+    """auto => 'continuous' for a matrix with negative / non-integer
+    values, 'counts' for a non-negative near-integer matrix."""
+    # continuous matrix (has negatives + non-integers) -> resolves to
+    # the no-voom path; recovers the planted wave genes.
+    expr, time = _temporal_continuous()
+    dds = ov.bulk.pyDEG(expr.copy())
+    dds.drop_duplicates_index()
+    res_auto = dds.timecourse_deg(time=time, data_type="auto",
+                                  time_basis="spline")
+    res_cont = dds.timecourse_deg(time=time, data_type="continuous",
+                                  time_basis="spline")
+    # 'auto' on this matrix must behave exactly like 'continuous'.
+    np.testing.assert_allclose(res_auto["F"].values, res_cont["F"].values)
+    planted = [f"g{i:04d}" for i in range(N_TRUE)]
+    hit = set(res_auto.index[res_auto["sig"] == "temporal"])
+    assert sum(g in hit for g in planted) >= int(0.9 * N_TRUE)
+
+    # a non-negative *integer* count matrix -> resolves to 'counts'
+    # and matches an explicit data_type='counts' run.
+    rng = np.random.default_rng(5)
+    times = np.array([0, 1, 2, 4, 8])
+    samp_t = np.repeat(times, 4).astype(float)
+    csamples = [f"s{i}" for i in range(len(samp_t))]
+    int_counts = pd.DataFrame(
+        rng.negative_binomial(50, 0.4, size=(N_GENES, len(samp_t))),
+        index=[f"g{i:04d}" for i in range(N_GENES)], columns=csamples,
+    ).astype(float)
+    for i in range(N_TRUE):                       # planted, kept integer
+        int_counts.iloc[i] = np.round(
+            int_counts.iloc[i].values * (1.0 + 0.3 * samp_t))
+    ctime = pd.Series(samp_t, index=csamples)
+    dc = ov.bulk.pyDEG(int_counts.copy())
+    dc.drop_duplicates_index()
+    r_auto = dc.timecourse_deg(time=ctime, data_type="auto",
+                               time_basis="factor")
+    r_counts = dc.timecourse_deg(time=ctime, data_type="counts",
+                                 time_basis="factor")
+    np.testing.assert_allclose(r_auto["F"].values, r_counts["F"].values)
+
+
+def test_bad_data_type_raises():
+    expr, time = _temporal_continuous()
+    dds = ov.bulk.pyDEG(expr.copy())
+    dds.drop_duplicates_index()
+    with pytest.raises(ValueError):
+        dds.timecourse_deg(time=time, data_type="not_a_type")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds first-class **bulk time-course / longitudinal** analysis to omicverse, isomorphic to the existing `pyDEG.deg_analysis` / `continuous_deg`.

### `pyDEG.timecourse_deg`
limma-voom + a **moderated F-test over a block of time-basis columns** (natural cubic spline `cr()` or one-hot factor, auto-chosen by the number of distinct time points). One entry point answers all three classic time-course questions:

1. **Which genes are temporally regulated** — F-test over the time-basis block.
2. **Do trajectories differ between groups** — pass `group=` → `~ group * time` design, F-test over the group×time interaction columns only.
3. **Repeated measures** — pass `block=` (subject IDs) → limma's two-round `duplicateCorrelation` longitudinal workflow.

Built entirely on the existing vendored `pylimma` — **no new R-package port**: splineTimeR / splineTC are just limma usage patterns, and the moderated F over a coefficient subset replicates limma's `topTableF` whitening. Returns a `deg_analysis`-shaped table (`F`, `pvalue`, `qvalue`, per-term `log2FC`, `sig`).

### `ov.bulk.temporal_clusters`
Soft-clusters the trajectory **shapes** of time-course genes (monotone rise/fall, transient) by fuzzy c-means — dispatching to **`pymfuzz`**, a pure-Python R-parity port of Bioconductor **Mfuzz** (`standardise`/`mestimate` bit-exact vs R, membership r=1.0). Lazy-imported; new `[timecourse]` optional extra. Pairs with `timecourse_deg`: find the genes, then group them by shape.

## Test plan

- [x] `tests/bulk/test_timecourse_deg.py` — 15 tests pass (temporal recovery for spline/factor/auto bases, FDR calibration on nulls, group×time interaction, repeated measures, `temporal_clusters`)
- [x] `continuous_deg` / `deg_analysis` untouched; `import omicverse` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)