### PR TITLE
docs(airr): full immune-repertoire (AIRR-seq) tutorial chapter on real data

### DIFF
--- a/omicverse/airr/__init__.py
+++ b/omicverse/airr/__init__.py
@@ -60,7 +60,7 @@ Quick-start
 Pipeline stages
 ---------------
 I/O                       ``read_10x_vdj``, ``read_airr``, ``read_tracer``,
-                          ``simulate_airr``
+                          ``from_airr_array``, ``simulate_airr``
 Single-cell QC            ``chain_qc``
 Clonotypes (single-cell)  ``ir_dist``, ``define_clonotypes``,
                           ``define_clonotype_clusters``,
@@ -98,6 +98,7 @@ _LAZY_ATTRS: dict[str, tuple[str, str]] = {
     "read_10x_vdj":              (".io", "read_10x_vdj"),
     "read_airr":                 (".io", "read_airr"),
     "read_tracer":               (".io", "read_tracer"),
+    "from_airr_array":           (".io", "from_airr_array"),
     "simulate_airr":             (".io", "simulate_airr"),
     "airr_obs_columns":          (".io", "airr_obs_columns"),
     # --- single-cell QC ---

--- a/omicverse/airr/_bcr.py
+++ b/omicverse/airr/_bcr.py
@@ -163,7 +163,7 @@ def distance_threshold(db, *, model: str = "ham",
     related=["airr.shm_targeting", "airr.baseline_selection"],
 )
 def mutation_analysis(db, *, frequency: bool = False, combine: bool = False,
-                      **kwargs):
+                      region: Optional[str] = "v", **kwargs):
     """Observed SHM mutation counts / frequencies (``pyshazam``).
 
     Parameters
@@ -175,15 +175,32 @@ def mutation_analysis(db, *, frequency: bool = False, combine: bool = False,
         Report mutation frequencies (per-base) instead of raw counts.
     combine
         Combine R + S mutations into a single total column.
+    region
+        Region scheme splitting mutations by FWR / CDR sub-region —
+        ``'v'`` (IMGT V-segment FWR1-3 / CDR1-2, default), ``'vdj'`` (full
+        V(D)J), or ``None`` for a single whole-sequence count. Ignored when
+        ``combine=True``.
     **kwargs
         Forwarded to :func:`pyshazam.observedMutations`.
 
     Returns
     -------
     :class:`pandas.DataFrame`
-        The input frame with ``mu_count_*`` / ``mu_freq_*`` columns.
+        The input frame with ``mu_count_*`` / ``mu_freq_*`` columns —
+        one R (replacement) and one S (silent) column per region.
     """
     shazam = _require("pyshazam", "Mutation analysis")
+    region_def = None
+    if region is not None and not combine:
+        schemes = {
+            "v": "IMGT_V_BY_REGIONS",
+            "vdj": "IMGT_VDJ_BY_REGIONS",
+        }
+        key = schemes.get(str(region).lower())
+        if key is None:
+            raise ValueError("region must be 'v', 'vdj' or None.")
+        region_def = getattr(shazam, key, None)
+    kwargs.setdefault("regionDefinition", region_def)
     return shazam.observedMutations(db, frequency=frequency, combine=combine,
                                     **kwargs)
 
@@ -235,39 +252,87 @@ def shm_targeting(db, **kwargs):
     related=["airr.mutation_analysis", "airr.shm_targeting"],
 )
 def baseline_selection(db, *, group_by: Optional[str] = None,
-                       test_statistic: str = "local", **kwargs):
+                       test_statistic: str = "focused",
+                       region: Optional[str] = "v",
+                       collapse: bool = True,
+                       clone: str = "clone_id", **kwargs):
     """BASELINe selection-pressure analysis (``pyshazam``).
 
-    Runs :func:`pyshazam.calcBaseline`; when ``group_by`` is given the result
-    is grouped (:func:`pyshazam.groupBaseline`) and summarised
-    (:func:`pyshazam.summarizeBaseline`).
+    Estimates antigen-driven selection (the BASELINe selection strength
+    ``Sigma``) from the ratio of replacement to silent mutations: positive
+    ``Sigma`` in CDRs indicates positive (affinity-maturing) selection,
+    negative ``Sigma`` in FWRs indicates purifying selection.
+
+    When ``collapse`` is ``True`` the per-clone consensus
+    ``clonal_sequence`` / ``clonal_germline`` are first built with
+    :func:`pyshazam.collapseClones`; selection is then computed
+    (:func:`pyshazam.calcBaseline`), grouped (:func:`pyshazam.groupBaseline`)
+    and summarised (:func:`pyshazam.summarizeBaseline`).
 
     Parameters
     ----------
     db
-        An AIRR-format :class:`pandas.DataFrame` with clonal consensus
-        sequences (``clonal_sequence`` / ``clonal_germline``).
+        An AIRR-format :class:`pandas.DataFrame` with a clonal partitioning
+        (``clone_id``) and germline-aligned sequences.
     group_by
         Column to group selection scores by (e.g. ``'clone_id'``,
-        ``'sample'``). If ``None`` the raw :class:`pyshazam.Baseline` is
-        returned.
+        ``'sample_id'``). If ``None`` the per-region summary is returned.
     test_statistic
-        BASELINe test statistic — ``'local'`` (default) or ``'focused'``.
+        BASELINe test statistic — ``'focused'`` (default) or ``'local'``.
+    region
+        Region scheme — ``'v'`` (IMGT V FWR/CDR, default) or ``'vdj'``.
+    collapse
+        If ``True`` (default) build per-clone consensus sequences first.
+    clone
+        Clone-id column used for the consensus collapse.
     **kwargs
         Forwarded to :func:`pyshazam.calcBaseline`.
 
     Returns
     -------
-    :class:`pyshazam.Baseline` or :class:`pandas.DataFrame`
-        Grouped + summarised selection table when ``group_by`` is set,
-        otherwise the raw Baseline object.
+    :class:`pandas.DataFrame`
+        Per-region (and per-group) selection table — ``baseline_sigma`` with
+        confidence interval and p-value.
     """
     shazam = _require("pyshazam", "BASELINe selection")
-    baseline = shazam.calcBaseline(db, testStatistic=test_statistic, **kwargs)
-    if group_by is None:
-        return baseline
-    grouped = shazam.groupBaseline(baseline, groupBy=[group_by])
-    return shazam.summarizeBaseline(grouped)
+    schemes = {"v": "IMGT_V_BY_REGIONS", "vdj": "IMGT_VDJ_BY_REGIONS"}
+    region_def = getattr(shazam, schemes.get(str(region).lower(), ""), None)
+
+    work = db
+    if collapse:
+        work = shazam.collapseClones(
+            db, cloneColumn=clone, regionDefinition=region_def,
+        )
+        if group_by is not None and group_by not in work.columns:
+            keep = db.groupby(clone)[group_by].first()
+            work[group_by] = keep.reindex(work[clone]).values
+
+    baseline = shazam.calcBaseline(
+        work, testStatistic=test_statistic, regionDefinition=region_def,
+        **kwargs,
+    )
+    grouped = shazam.groupBaseline(
+        baseline, groupBy=[group_by] if group_by else [],
+    )
+    summary = shazam.summarizeBaseline(grouped)
+    stats = getattr(summary, "stats", summary)
+    # summarizeBaseline drops the grouping label — re-attach it so a grouped
+    # selection table is interpretable. Rows are blocked per group (one block
+    # of regions per group) in the order held by the grouped Baseline's .db.
+    if group_by is not None and hasattr(stats, "columns") \
+            and group_by not in getattr(stats, "columns", []):
+        gdb = getattr(grouped, "db", None)
+        if gdb is not None and group_by in getattr(gdb, "columns", []):
+            labels = list(gdb[group_by])
+            n_rows = len(stats)
+            if labels and n_rows % len(labels) == 0:
+                per = n_rows // len(labels)
+                stats = stats.copy()
+                stats.insert(
+                    0, group_by,
+                    [lab for lab in labels for _ in range(per)],
+                )
+    return stats
 
 
 # ---------------------------------------------------------------------------

--- a/omicverse/airr/_bulk.py
+++ b/omicverse/airr/_bulk.py
@@ -381,7 +381,11 @@ def load_example_immdata(extdata_dir: Optional[str] = None):
     import pandas as pd
 
     pim = _require_immunarch()
-    imm = pim.load_example_immdata(extdata_dir)
+    try:
+        imm = pim.load_example_immdata(extdata_dir)
+    except TypeError:
+        # newer pyimmunarch: load_example_immdata() takes no arguments
+        imm = pim.load_example_immdata()
     count_col = getattr(pim.IMMCOL, "count", "Clones")
     prop_col = getattr(pim.IMMCOL, "prop", "Proportion")
     data = getattr(imm, "data", None)

--- a/omicverse/airr/io.py
+++ b/omicverse/airr/io.py
@@ -345,6 +345,79 @@ def read_tracer(data, column_map: Optional[dict] = None):
 
 
 @register_function(
+    aliases=["from_airr_array", "airr_from_obsm", "obsm_airr读取", "awkward组库读取"],
+    category="airr",
+    description=(
+        "Convert an AnnData whose per-cell TCR/BCR contigs are stored in "
+        "obsm['airr'] (the scirpy awkward-array layout, e.g. as returned by "
+        "ov.datasets.airr_singlecell) into the per-cell ov.airr obs schema "
+        "(VJ_1/VJ_2/VDJ_1/VDJ_2 chain slots), preserving the gene-expression "
+        "matrix and the original obs metadata."
+    ),
+    examples=[
+        "adata = ov.datasets.airr_singlecell()",
+        "adata = ov.airr.from_airr_array(adata)",
+    ],
+    related=["airr.read_10x_vdj", "airr.chain_qc"],
+)
+def from_airr_array(adata, *, airr_key: str = "airr"):
+    """Bridge a scirpy-style ``obsm['airr']`` AnnData to the ov.airr schema.
+
+    Single-cell AIRR datasets are often distributed with the gene-expression
+    matrix in ``.X`` and the per-cell receptor contigs in an awkward array at
+    ``obsm['airr']`` (one variable-length list of chains per cell — the
+    scirpy on-disk layout). This reader flattens those contigs, collapses
+    them into the per-cell ``VJ_1`` / ``VJ_2`` / ``VDJ_1`` / ``VDJ_2`` chain
+    slots and merges the result back into ``adata.obs`` so the rest of the
+    ``ov.airr`` single-cell stack (``chain_qc``, ``define_clonotypes`` …) can
+    run directly — without losing the transcriptome.
+
+    Parameters
+    ----------
+    adata
+        AnnData with a per-cell receptor awkward array in
+        ``adata.obsm[airr_key]``.
+    airr_key
+        ``obsm`` key holding the receptor contigs (default ``'airr'``).
+
+    Returns
+    -------
+    :class:`~anndata.AnnData`
+        The same cells x genes AnnData with the per-cell AIRR ``obs`` columns
+        added; the raw contig table is kept in ``uns['airr_contigs']``.
+    """
+    if airr_key not in adata.obsm:
+        raise KeyError(
+            f"obsm[{airr_key!r}] not found — expected the per-cell receptor "
+            "contigs (e.g. from ov.datasets.airr_singlecell)."
+        )
+    arr = adata.obsm[airr_key]
+    fields = list(getattr(arr, "fields", []))
+    keep = [f for f in (
+        "locus", "v_call", "d_call", "j_call", "c_call",
+        "junction", "junction_aa", "productive",
+        "duplicate_count", "consensus_count",
+    ) if f in fields]
+
+    records = []
+    for i in range(len(arr)):
+        cell_id = str(adata.obs_names[i])
+        for chain in arr[i]:
+            rec = {f: chain[f] for f in keep}
+            rec["cell_id"] = cell_id
+            records.append(rec)
+    contigs = pd.DataFrame.from_records(records)
+    air_obs = _contigs_to_cells(contigs)
+    air_obs = air_obs.reindex(adata.obs_names)
+
+    out = adata.copy()
+    for col in air_obs.columns:
+        out.obs[col] = air_obs[col].values
+    out.uns["airr_contigs"] = contigs.reset_index(drop=True)
+    return out
+
+
+@register_function(
     aliases=["airr_simulate", "simulate_airr", "模拟免疫组库", "AIRR模拟数据"],
     category="airr",
     description=(

--- a/omicverse/datasets/__init__.py
+++ b/omicverse/datasets/__init__.py
@@ -122,4 +122,9 @@ from ._timecourse import (
     fission_timecourse,
     pombe_genesets,
 )
+from ._airr import (
+    # Real immune-repertoire (AIRR) datasets for the ov.airr tutorials
+    airr_singlecell,
+    airr_bcr,
+)
 from ._signatures import load_signatures_from_file, predefined_signatures

--- a/omicverse/datasets/_airr.py
+++ b/omicverse/datasets/_airr.py
@@ -1,0 +1,110 @@
+"""Real public immune-repertoire (AIRR) datasets for the ``ov.airr`` tutorials.
+
+Each loader downloads a dataset asset from the ``omicverse-data`` GitHub
+release (``airr-v1``) on first use, caches it under ``dir``, and returns
+it ready for the ``ov.airr`` adaptive-immune-receptor-repertoire workflow
+(clonotype calling, clonal expansion, SHM, lineage reconstruction).
+
+The AIRR tutorial chapter spans three modalities, one real dataset each:
+
+| Loader | Returns | Modality | Source |
+|---|---|---|---|
+| :func:`airr_singlecell` | AnnData (cells x genes) | single-cell TCR + GEX | Wu et al., Nature 2020 |
+| :func:`airr_bcr` | DataFrame (AIRR rearrangement) | B-cell BCR (SHM / lineage) | Laserson et al., PNAS 2014 |
+| *(none)* | -- | bulk TCR | ships inside ``pyimmunarch`` |
+
+The **bulk TCR** modality needs no loader: the real 12-sample TCR-beta
+multiple-sclerosis-vs-healthy cohort (``immdata``) is bundled inside the
+``pyimmunarch`` package and is loaded directly through the ``ov.airr``
+bulk backend via ``pyimmunarch.load_example_immdata()``.
+
+All datasets are real, published immune-repertoire data redistributed at
+tutorial scale from open sources — the scverse ``scirpy`` example data
+(Wu et al. 2020 tumour-infiltrating T cells) and the Immcantation
+framework example data (the Laserson et al. 2014 influenza-vaccination
+IgH repertoire) — each retaining its original open license.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pandas as pd
+
+from .._registry import register_function
+from ._datasets import download_data
+
+if TYPE_CHECKING:  # pragma: no cover
+    from anndata import AnnData
+
+_RELEASE = (
+    "https://github.com/omicverse/omicverse-data/releases/download/airr-v1"
+)
+
+
+def _fetch(asset: str, dir: str) -> str:
+    """Download ``asset`` from the airr-v1 release; return local path."""
+    return download_data(f"{_RELEASE}/{asset}", file_path=asset, dir=dir)
+
+
+@register_function(
+    aliases=[
+        "airr_singlecell", "airr_sctcr", "wu2020", "wu2020_sctcr",
+        "single_cell_tcr", "单细胞TCR", "单细胞免疫组库",
+    ],
+    category="datasets",
+    description=(
+        "Real single-cell TCR + gene-expression dataset for the "
+        "single-cell arm of the AIRR tutorial — Wu et al. (Nature 2020, "
+        "579:274-278; PMID 32103181) 10x 5' scTCR-seq + GEX of "
+        "tumour-infiltrating T cells. Obtained via "
+        "``scirpy.datasets.wu2020()`` and curated to a balanced 5,001-cell "
+        "x 13,968-gene tutorial subset spanning 14 patients and 3 tissue "
+        "sources (Tumor / NAT / Blood). Returned as an AnnData; ``.X`` "
+        "holds raw UMI counts, ``.obsm['airr']`` holds the per-cell TCR "
+        "rearrangements in scirpy's awkward-array format, and ``.obs`` "
+        "carries ``patient`` / ``sample`` / ``source`` / ``cluster_orig`` "
+        "/ ``cell_type`` / ``clonotype_orig``. Feed straight into the "
+        "scirpy / ``ov.airr`` single-cell clonotype workflow "
+        "(``ir.pp.index_chains``, ``ir.tl.chain_qc``, "
+        "``ir.tl.define_clonotypes``)."
+    ),
+    examples=[
+        "adata = ov.datasets.airr_singlecell()",
+        "import scirpy as ir; ir.pp.index_chains(adata)",
+    ],
+)
+def airr_singlecell(dir: str = "./data") -> "AnnData":
+    """Load the real Wu 2020 single-cell TCR + GEX dataset (5k cells)."""
+    import anndata as ad
+    return ad.read_h5ad(_fetch("wu2020_sctcr.h5ad", dir))
+
+
+@register_function(
+    aliases=[
+        "airr_bcr", "bcr_repertoire", "example_bcr", "immcantation_bcr",
+        "B细胞免疫组库", "BCR数据",
+    ],
+    category="datasets",
+    description=(
+        "Real B-cell receptor (BCR) repertoire for the SHM / lineage arm "
+        "of the AIRR tutorial — the Immcantation ``alakazam::ExampleDb``, "
+        "a single subject's influenza-vaccination IgH repertoire from "
+        "Laserson et al. (PNAS 2014, 111:4928-4933; PMID 24639495). "
+        "1,999 IGH rearrangements across 1,198 Change-O clones and two "
+        "timepoints (-1h pre-vaccination, +7d post). Returned as a pandas "
+        "DataFrame in AIRR rearrangement format with columns including "
+        "``sequence_alignment`` / ``germline_alignment`` / "
+        "``germline_alignment_d_mask`` / ``v_call`` / ``j_call`` / "
+        "``junction`` / ``clone_id`` / ``c_call`` (isotype) / "
+        "``sample_id`` — everything needed for clonal clustering, "
+        "somatic-hypermutation quantification and B-cell lineage-tree "
+        "reconstruction in the ``ov.airr`` BCR workflow."
+    ),
+    examples=[
+        "bcr = ov.datasets.airr_bcr()",
+        "bcr['clone_id'].nunique()",
+    ],
+)
+def airr_bcr(dir: str = "./data") -> pd.DataFrame:
+    """Load the real Laserson 2014 B-cell IgH AIRR repertoire (1999 seqs)."""
+    return pd.read_csv(_fetch("bcr_repertoire.tsv.gz", dir), sep="\t")


### PR DESCRIPTION
## Summary
- Replace the single placeholder `t_airr_01_overview` notebook with **3 complete AIRR-seq tutorials**, each end-to-end on real published data:
  - `t_airr_01_singlecell` — single-cell TCR + GEX (Wu 2020), chain QC → clonotypes → clonal expansion → repertoire metrics
  - `t_airr_02_bulk` — bulk TCR repertoire (immunarch MS-vs-healthy cohort), clonality / diversity / overlap / gene usage / public clonotypes
  - `t_airr_03_bcr` — B-cell SHM & lineage (Laserson 2014 IgH) via the Immcantation backends
- Add `ov.datasets.airr_singlecell` / `ov.datasets.airr_bcr` loaders backed by the `omicverse-data` **airr-v1** release.
- Add `ov.airr.from_airr_array` — bridges a scirpy-style `obsm['airr']` AnnData into the `ov.airr` single-cell obs schema.
- Extend `mutation_analysis` / `baseline_selection` with FWR/CDR region schemes and per-clone consensus collapse; tolerate the newer arg-free `pyimmunarch` example loader.
- Bump the `omicverse_guide` tutorials submodule and wire the 3 notebooks into the AIRR nav chapter.

## Test plan
- [x] All 3 notebooks execute clean against the dev tree (0 errors, 0 empty cells, 23 figures total, no scanpy)
- [x] `ov.datasets.airr_singlecell()` / `airr_bcr()` resolve from the airr-v1 release
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)