### PR TITLE
feat(bulk): enrichment entry points accept geneset names/paths

### DIFF
--- a/omicverse/bulk/_Enrichment.py
+++ b/omicverse/bulk/_Enrichment.py
@@ -12,30 +12,47 @@ from ..utils import plot_text_set
 from .._registry import register_function
 import matplotlib
 
+
+def _resolve_genesets(pathways, organism: str = 'Human') -> dict:
+    """Normalise a gene-set argument to a ``{pathway: [genes]}`` dict.
+
+    Accepts a ready dict, a path to a ``.gmt`` / ``.txt`` file, or an
+    Enrichr library name (e.g. ``'MSigDB_Hallmark_2020'`` /
+    ``'KEGG_2021_Human'``). Paths and library names are resolved with
+    :func:`omicverse.utils.geneset_prepare`, which auto-downloads and
+    caches the library on first use; a dict is returned unchanged.
+    """
+    if isinstance(pathways, dict):
+        return pathways
+    if isinstance(pathways, str):
+        from ..utils import geneset_prepare
+        return geneset_prepare(pathways, organism=organism)
+    raise TypeError(
+        "pathways_dict must be a dict, or a str (a .gmt/.txt path or an "
+        f"Enrichr library name); got {type(pathways).__name__}"
+    )
+
+
 @register_function(
     aliases=["基因集富集", "geneset_enrichment", "enrichr_analysis", "pathway_enrichment", "富集分析"],
     category="bulk",
-    description="Perform gene set enrichment analysis. IMPORTANT: pathways_dict must be a dictionary loaded via ov.utils.geneset_prepare(), NOT a file path string!",
+    description="Over-representation (ORA) gene-set enrichment for a discrete gene list. pathways_dict accepts a prepared dict, a .gmt/.txt path, or an Enrichr library name (resolved + auto-downloaded internally).",
     prerequisites={
-        'optional_functions': ['download_pathway_database', 'geneset_prepare']
+        'optional_functions': ['geneset_prepare', 'download_pathway_database']
     },
     examples=[
-        "# STEP 1: Download pathway database (run once)",
-        "ov.utils.download_pathway_database()",
-        "",
-        "# STEP 2: Load geneset into dictionary - REQUIRED!",
-        "pathways_dict = ov.utils.geneset_prepare('genesets/GO_Biological_Process_2021.txt', organism='Human')",
-        "",
-        "# STEP 3: Run enrichment with the DICTIONARY (NOT file path!)",
+        "# pathways_dict accepts an Enrichr library name directly —",
+        "# it is auto-downloaded and cached on first use.",
         "enr = ov.bulk.geneset_enrichment(",
         "    gene_list=deg_genes,",
-        "    pathways_dict=pathways_dict,  # Must be dict, NOT string path!",
+        "    pathways_dict='MSigDB_Hallmark_2020',",
         "    pvalue_type='auto',",
-        "    organism='Human'",
+        "    organism='Human',",
         ")",
         "",
-        "# WRONG - DO NOT DO THIS:",
-        "# enr = ov.bulk.geneset_enrichment(gene_list=genes, pathways_dict='file.gmt')  # ERROR!"
+        "# A prepared dict or a local .gmt/.txt path also work:",
+        "# pathways_dict=ov.utils.geneset_prepare('genesets/h.all.symbols.gmt')",
+        "# pathways_dict='genesets/GO_Biological_Process_2021.txt'"
     ],
     related=["utils.geneset_prepare", "utils.download_pathway_database", "bulk.geneset_plot", "bulk.pyGSEA"]
 )
@@ -50,8 +67,10 @@ def geneset_enrichment(gene_list:list,pathways_dict:dict,
     ----------
     gene_list:list
         Input gene symbols (typically DEGs) for enrichment testing.
-    pathways_dict:dict
-        Gene-set dictionary loaded by ``ov.utils.geneset_prepare``.
+    pathways_dict:dict|str
+        Gene sets — a prepared dict (``ov.utils.geneset_prepare``), a
+        ``.gmt``/``.txt`` path, or an Enrichr library name (resolved and
+        auto-downloaded internally).
     pvalue_threshold:float, optional
         Significance threshold used to filter enrichment terms.
     pvalue_type:str, optional
@@ -72,6 +91,7 @@ def geneset_enrichment(gene_list:list,pathways_dict:dict,
     pandas.DataFrame
         Enrichment result table with statistics and derived plotting columns.
     """
+    pathways_dict = _resolve_genesets(pathways_dict, organism)
     from ..external.gseapy import enrichr
     # ``background=None`` is now passed straight through to the bundled
     # gseapy fork. Its ``Enrichr.enrich`` resolves a None background to the
@@ -139,7 +159,8 @@ def enrichment_multi_concat(enr_dict: Dict[str, pd.DataFrame]) -> pd.DataFrame:
 def geneset_enrichment_GSEA(gene_rnk:pd.DataFrame,pathways_dict:dict,
                             processes:int=8,
                      permutation_num:int=100, # reduce number to speed up testing
-                     outdir:str='./enrichr_gsea', format:str='png', seed:int=112)->dict:
+                     outdir:str='./enrichr_gsea', format:str='png', seed:int=112,
+                     organism:str='Human')->dict:
     r"""Enrichment analysis using GSEA.
 
     Parameters
@@ -157,6 +178,7 @@ def geneset_enrichment_GSEA(gene_rnk:pd.DataFrame,pathways_dict:dict,
         pre_res: A prerank object containing the enrichment results.
     
     """
+    pathways_dict = _resolve_genesets(pathways_dict, organism)
     from ..external.gseapy import prerank
     pre_res = prerank(rnk=gene_rnk, gene_sets=pathways_dict,
                      processes=processes,
@@ -396,7 +418,7 @@ class pyGSE(object):
         """
 
         self.gene_list=gene_list
-        self.pathways_dict=pathways_dict
+        self.pathways_dict=_resolve_genesets(pathways_dict, organism)
         self.pvalue_threshold=pvalue_threshold
         self.pvalue_type=pvalue_type
         self.organism=organism
@@ -454,10 +476,10 @@ class pyGSE(object):
 @register_function(
     aliases=["GSEA分析", "pyGSEA", "gene_set_enrichment", "基因集富集分析"],
     category="bulk",
-    description="Gene Set Enrichment Analysis (GSEA) for ranked gene lists",
+    description="Pre-ranked Gene Set Enrichment Analysis (GSEA) for a ranked gene list. pathways_dict accepts a prepared dict, a .gmt/.txt path, or an Enrichr library name (resolved + auto-downloaded internally).",
     examples=[
-        "# Initialize GSEA object",
-        "gsea_obj = ov.bulk.pyGSEA(ranked_genes, pathway_dict)",
+        "# Initialize GSEA — pathways_dict can be an Enrichr library name",
+        "gsea_obj = ov.bulk.pyGSEA(ranked_genes, 'MSigDB_Hallmark_2020')",
         "# Run enrichment analysis",
         "enrich_res = gsea_obj.enrichment()",
         "# Visualize enrichment results",
@@ -475,8 +497,9 @@ class pyGSEA(object):
     ----------
     gene_rnk:pd.DataFrame
         Ranked gene table used for enrichment scoring.
-    pathways_dict:dict
-        Mapping from pathway name to gene-set members.
+    pathways_dict:dict|str
+        Gene sets — a prepared dict, a ``.gmt``/``.txt`` path, or an
+        Enrichr library name (resolved and auto-downloaded internally).
     processes:int, optional, default=8
         Number of worker processes.
     permutation_num:int, optional, default=100
@@ -498,7 +521,8 @@ class pyGSEA(object):
 
     def __init__(self,gene_rnk:pd.DataFrame,pathways_dict:dict,
                  processes:int=8,permutation_num:int=100,
-                 outdir:str='./enrichr_gsea',cutoff:float=0.5) -> None:
+                 outdir:str='./enrichr_gsea',cutoff:float=0.5,
+                 organism:str='Human') -> None:
         """Initialize pyGSEA with ranked genes and pathway libraries.
 
         Parameters
@@ -518,7 +542,7 @@ class pyGSEA(object):
         """
 
         self.gene_rnk=gene_rnk
-        self.pathways_dict=pathways_dict
+        self.pathways_dict=_resolve_genesets(pathways_dict, organism)
         self.processes=processes
         self.permutation_num=permutation_num
         self.outdir=outdir

--- a/tests/bulk/test_geneset_resolution.py
+++ b/tests/bulk/test_geneset_resolution.py
@@ -1,0 +1,68 @@
+"""Tests for `_resolve_genesets` — the gene-set argument normaliser that
+lets the enrichment entry points (`geneset_enrichment`, `pyGSEA`,
+`pyGSE`, `geneset_enrichment_GSEA`) accept a prepared dict, a local
+`.gmt`/`.txt` path, or an Enrichr library name.
+
+Network-free: only the dict-passthrough, error, and local-path branches
+are exercised. Resolving an Enrichr library name downloads from Enrichr
+and is covered by `geneset_prepare`'s own tests.
+"""
+
+import inspect
+
+import pandas as pd
+import pytest
+
+from omicverse.bulk._Enrichment import (
+    _resolve_genesets,
+    geneset_enrichment_GSEA,
+    pyGSE,
+    pyGSEA,
+)
+
+
+@pytest.fixture
+def geneset_txt(tmp_path):
+    """A tiny Enrichr-format gene-set file: `name<tab>gene<tab>gene...`."""
+    p = tmp_path / "sets.txt"
+    p.write_text("PATHWAY_A\tTP53\tBRCA1\tATM\n"
+                 "PATHWAY_B\tEGFR\tMYC\tPTEN\n")
+    return str(p)
+
+
+def test_resolve_dict_passthrough():
+    d = {"PATHWAY_A": ["TP53", "BRCA1"]}
+    assert _resolve_genesets(d) is d
+
+
+def test_resolve_bad_type_raises():
+    with pytest.raises(TypeError, match="dict.*or a str"):
+        _resolve_genesets(123)
+
+
+def test_resolve_local_path(geneset_txt):
+    res = _resolve_genesets(geneset_txt, organism="Human")
+    assert res == {"PATHWAY_A": ["TP53", "BRCA1", "ATM"],
+                   "PATHWAY_B": ["EGFR", "MYC", "PTEN"]}
+
+
+def test_pyGSEA_accepts_path_and_dict(geneset_txt):
+    rnk = pd.DataFrame({"gene_name": ["TP53", "EGFR", "MYC"],
+                        "rnk": [3.0, 1.0, -2.0]})
+    # path -> resolved dict
+    g = pyGSEA(rnk, geneset_txt)
+    assert g.pathways_dict["PATHWAY_A"] == ["TP53", "BRCA1", "ATM"]
+    # dict -> unchanged
+    d = {"P": ["TP53"]}
+    assert pyGSEA(rnk, d).pathways_dict is d
+
+
+def test_pyGSE_accepts_path(geneset_txt):
+    e = pyGSE(["TP53", "EGFR"], geneset_txt)
+    assert e.pathways_dict["PATHWAY_B"] == ["EGFR", "MYC", "PTEN"]
+
+
+def test_organism_param_present():
+    # organism was added to the two entry points that lacked it.
+    assert "organism" in inspect.signature(pyGSEA.__init__).parameters
+    assert "organism" in inspect.signature(geneset_enrichment_GSEA).parameters


### PR DESCRIPTION
## Summary

Running enrichment required a two-step ritual — call `geneset_prepare()`
to build a dict, then pass that dict to the enrichment function. The
functions rejected anything but a dict (the `geneset_enrichment`
registry metadata even declared a file-path argument an error).

This adds a small normaliser, `_resolve_genesets(pathways, organism)`:

- a `dict` passes through unchanged;
- a `str` — a `.gmt`/`.txt` path **or** an Enrichr library name
  (`MSigDB_Hallmark_2020`, `KEGG_2021_Human`, …) — is resolved via
  `geneset_prepare`, which already auto-downloads and caches on first
  use;
- anything else raises a clear `TypeError`.

`geneset_enrichment`, `geneset_enrichment_GSEA`, `pyGSE` and `pyGSEA`
now accept `pathways_dict` as `dict | str`, so
`ov.bulk.pyGSEA(rnk, 'MSigDB_Hallmark_2020')` works directly.
`organism` is added to the two entry points (`geneset_enrichment_GSEA`,
`pyGSEA`) that lacked it — it drives symbol-case normalisation during
resolution.

Fully backwards compatible: a prepared dict still works everywhere.
`geneset_enrichment`'s registry `description`/`examples` are updated to
match the new behaviour.

## Test plan

- [x] `tests/bulk/test_geneset_resolution.py` — 6 tests: dict
  passthrough, `TypeError` on bad type, local `.gmt`/`.txt` path
  resolution, `pyGSEA` / `pyGSE` accept path & dict, `organism`
  param present. Network-free (Enrichr-name download is covered by
  `geneset_prepare`'s own path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)