### PR TITLE
fix(single): make pyVIA importable and runnable again

### DIFF
--- a/omicverse/single/_via.py
+++ b/omicverse/single/_via.py
@@ -4,6 +4,9 @@ import scanpy as sc
 import pandas as pd
 
 import igraph as ig
+import matplotlib
+import matplotlib.figure
+import matplotlib.axes
 
 from datetime import datetime
 from typing import Union,Tuple

--- a/omicverse/single/_via.py
+++ b/omicverse/single/_via.py
@@ -281,7 +281,7 @@ class pyVIA(object):
         
 
         self.model=VIA(data=data,true_label=true_label,
-                 dist_std_local=dist_std_local,jac_std_global=jac_std_global,labels=labels,
+                 edgepruning_clustering_resolution_local=dist_std_local,edgepruning_clustering_resolution=jac_std_global,labels=labels,
                  keep_all_local_dist=keep_all_local_dist,too_big_factor=too_big_factor,resolution_parameter=resolution_parameter,partition_type=partition_type,small_pop=small_pop,
                  jac_weighted_edges=jac_weighted_edges,knn=knn,n_iter_leiden=n_iter_leiden,random_seed=random_seed,
                  num_threads=num_threads,distance=distance,time_smallpop=time_smallpop,
@@ -290,7 +290,7 @@ class pyVIA(object):
                  is_coarse=is_coarse,csr_full_graph=csr_full_graph,csr_array_locally_pruned=csr_array_locally_pruned,ig_full_graph=ig_full_graph,
                  full_neighbor_array=full_neighbor_array,full_distance_array=full_distance_array,embedding=embedding,df_annot=df_annot,
                  preserve_disconnected_after_pruning=preserve_disconnected_after_pruning,
-                 secondary_annotations=secondary_annotations,pseudotime_threshold_TS=pseudotime_threshold_TS,cluster_graph_pruning_std=cluster_graph_pruning_std,
+                 secondary_annotations=secondary_annotations,pseudotime_threshold_TS=pseudotime_threshold_TS,cluster_graph_pruning=cluster_graph_pruning_std,
                  visual_cluster_graph_pruning=visual_cluster_graph_pruning,neighboring_terminal_states_threshold=neighboring_terminal_states_threshold,num_mcmc_simulations=num_mcmc_simulations,
                  piegraph_arrow_head_width=piegraph_arrow_head_width,
                  piegraph_edgeweight_scalingfactor=piegraph_edgeweight_scalingfactor,max_visual_outgoing_edges=max_visual_outgoing_edges,via_coarse=via_coarse,velocity_matrix=velocity_matrix,


### PR DESCRIPTION
## Summary

`ov.single.pyVIA` was broken on two counts. This PR fixes both; the
VIA trajectory pipeline now runs end to end.

### 1. `import pyVIA` → `NameError: name 'matplotlib' is not defined`

`_via.py`'s plotting methods (`plot_piechart_graph`,
`plot_trajectory_gams`, `plot_stream`, `plot_gene_trend`,
`plot_lineage_probability`, `plot_clustergraph`, …) annotate their
return type as `Tuple[matplotlib.figure.Figure,
matplotlib.axes._axes.Axes, ...]`, but the module never imported
`matplotlib`. Those annotations are evaluated at class-definition
time, so even `from omicverse.single._via import pyVIA` raised
`NameError`.

Fix: add the module-level imports `matplotlib` / `matplotlib.figure` /
`matplotlib.axes`.

### 2. `pyVIA(...)` → `TypeError: VIA.__init__() got an unexpected keyword argument 'dist_std_local'`

The bundled VIA core (`omicverse/external/VIA`) was updated to a newer
pyVIA release that **renamed three constructor parameters**, but the
`pyVIA` wrapper still passed the old names:

| wrapper kwarg (old) | VIA core param (new) |
|---|---|
| `dist_std_local` | `edgepruning_clustering_resolution_local` |
| `jac_std_global` | `edgepruning_clustering_resolution` |
| `cluster_graph_pruning_std` | `cluster_graph_pruning` |

Fix: map the wrapper's kwargs onto the new names in the internal
`VIA(...)` call. The wrapper's **public signature is unchanged** —
`pyVIA(dist_std_local=…)` still works, so this is backward compatible.
A full diff of all 67 kwargs the wrapper passes vs the VIA signature
confirmed these are the only three mismatches; the new VIA params the
wrapper omits all have defaults.

## Test plan

- [x] `from omicverse.single._via import pyVIA` imports cleanly
- [x] `pyVIA(...)` constructs (`v0.model` is a `VIA` instance)
- [x] End-to-end on synthetic trajectory data: construct → `run()` →
  `get_pseudotime()` recovers the ground-truth ordering (Spearman 0.99)

🤖 Generated with [Claude Code](https://claude.com/claude-code)