### PR TITLE
docs: fix docstring RST so RTD build stops crashing

### DIFF
--- a/omicverse/pp/_champ.py
+++ b/omicverse/pp/_champ.py
@@ -202,9 +202,9 @@ def champ(
 
     Algorithm
     ---------
-    1. Run Leiden at :paramref:`n_partitions` candidate γ values
+    1. Run Leiden at ``n_partitions`` candidate γ values
        evenly spaced over :math:`[\gamma_\min,\,\gamma_\max]` (or use
-       the explicit grid passed in :paramref:`resolutions`). Deduplicate
+       the explicit grid passed in ``resolutions``). Deduplicate
        partitions that produce identical labels.
     2. For each unique partition :math:`P`, compute
        :math:`(a_P, b_P)` such that
@@ -238,8 +238,8 @@ def champ(
         AnnData with a precomputed neighbor graph
         (``adata.obsp['connectivities']``).
     resolutions
-        Explicit γ grid; overrides :paramref:`n_partitions` /
-        :paramref:`gamma_min` / :paramref:`gamma_max`.
+        Explicit γ grid; overrides ``n_partitions`` /
+        ``gamma_min`` / ``gamma_max``.
     n_partitions
         Number of γ values to scan when ``resolutions`` is ``None``.
     gamma_min, gamma_max
@@ -288,10 +288,10 @@ def champ(
     adaptive
         If ``True``, iteratively refine the γ-grid around the current
         hull's crossovers (active-set style): build the hull → for
-        each crossover sample :paramref:`adaptive_n_refine` extra γ
+        each crossover sample ``adaptive_n_refine`` extra γ
         values nearby → re-run leiden → recompute the hull → repeat
         until no new hull vertex appears or
-        :paramref:`adaptive_max_iter` iterations are reached. Catches
+        ``adaptive_max_iter`` iterations are reached. Catches
         hull partitions that uniform γ-sampling misses around sharp
         transitions.
     adaptive_max_iter

--- a/omicverse/single/_autoresolution.py
+++ b/omicverse/single/_autoresolution.py
@@ -212,13 +212,13 @@ def auto_resolution(
     For each candidate resolution :math:`r`:
 
     1. Run Leiden on the **full** AnnData → reference labels at ``r``.
-    2. Take :paramref:`n_subsamples` independent without-replacement
+    2. Take ``n_subsamples`` independent without-replacement
        subsamples of size ``subsample_frac × n_obs``.
     3. For each subsample run Leiden on the induced subgraph and
        compute Adjusted Rand Index against the reference restricted to
        the subsample.
     4. :math:`s_\mathrm{real}(r) = \mathrm{mean\,ARI}` across the
-       :paramref:`n_subsamples` bootstraps — the **observed**
+       ``n_subsamples`` bootstraps — the **observed**
        reproducibility.
 
     Bootstrap stability alone is biased toward fine resolutions: small
@@ -231,7 +231,7 @@ def auto_resolution(
        distributions but destroys all cell-cell co-expression — there
        is no cluster structure left.
     6. Run the same PCA → kNN-graph → bootstrap-stability pipeline on
-       the null with :paramref:`n_null_subsamples` subsamples.
+       the null with ``n_null_subsamples`` subsamples.
        :math:`s_\mathrm{null}(r)` is the chance-level reproducibility
        of leiden at this resolution given the data's marginal-only
        statistical structure.
@@ -242,10 +242,10 @@ def auto_resolution(
            \Delta(r) = s_\mathrm{real}(r) - s_\mathrm{null}(r)
 
        and the chosen resolution is :math:`\arg\max_r \Delta(r)`
-       subject to producing at least :paramref:`min_clusters` clusters
+       subject to producing at least ``min_clusters`` clusters
        on the full data.
 
-    Setting :paramref:`use_null_correction` ``=False`` falls back to
+    Setting ``use_null_correction`` ``=False`` falls back to
     plain bootstrap-ARI; it's exposed mostly for diagnostics. The
     default is the null-adjusted variant.
 
@@ -266,11 +266,11 @@ def auto_resolution(
         Lange et al. 2004. ``False`` returns plain bootstrap stability.
     n_null_subsamples
         Bootstrap subsamples per resolution on the **null** data — can
-        be smaller than :paramref:`n_subsamples` because the null is
+        be smaller than ``n_subsamples`` because the null is
         low-variance.
     null_seed
         Seed for the per-gene permutation generating the null. Held
-        separate from :paramref:`random_state` so the null is
+        separate from ``random_state`` so the null is
         reproducible independently of the real-data search.
     null_layer
         ``adata.layers`` key to permute. Defaults to ``adata.X``.

--- a/omicverse/single/_gptcelltype.py
+++ b/omicverse/single/_gptcelltype.py
@@ -47,10 +47,10 @@ def gptcelltype(input, tissuename=None, speciename='human',
     Parameters
     ----------
     input : dict or pandas.DataFrame
-        Cluster marker input. Use either:
-        1) ``dict[cluster_id -> list[str]]`` of marker genes, or
-        2) DE result table containing ``cluster``, ``names``, and
-           ``logfoldchanges`` columns.
+        Cluster marker input. Use either a
+        ``dict[cluster_id -> list[str]]`` of marker genes, or a
+        DE result table containing ``cluster``, ``names``, and
+        ``logfoldchanges`` columns.
     tissuename : str or None, default=None
         Tissue context provided to the model prompt (for example, PBMC or brain).
     speciename : str, default='human'

--- a/omicverse/single/_gptcelltype_local.py
+++ b/omicverse/single/_gptcelltype_local.py
@@ -29,9 +29,9 @@ def gptcelltype_local(input, tissuename=None, speciename='human',
     Parameters
     ----------
     input : dict or pandas.DataFrame
-        Marker definition per cluster. Accepted formats:
-        1) ``dict[cluster_id -> list[str]]`` marker genes, or
-        2) DE table with ``cluster``, ``names``, ``logfoldchanges`` columns.
+        Marker definition per cluster. Accepts either a
+        ``dict[cluster_id -> list[str]]`` of marker genes, or a
+        DE table with ``cluster``, ``names``, ``logfoldchanges`` columns.
     tissuename : str or None, default=None
         Tissue context included in the prompt.
     speciename : str, default='human'


### PR DESCRIPTION
## Summary
- `omicverse.single.gptcelltype` / `gptcelltype_local`: replace "1) … 2) …" numbered list inside the `input` param body with prose. That list confused docutils ("Unexpected indentation"), and `sphinx_autodoc_typehints` then injected a `Returns` block into the broken docstring, raising `SEVERE/4: Unexpected section title. Returns -------` and aborting the whole RTD build.
- `omicverse.single._autoresolution.auto_resolution` and `omicverse.pp._champ`: replace ``:paramref:`x``` (role provided by `sphinx-paramlinks`, which is not in the docs extensions list) with ``\`\`x\`\``` literal markup.

No behavior change — docstrings only.

Fixes the failing RTD build: https://app.readthedocs.org/projects/omicverse/builds/32819567/

## Test plan
- [ ] RTD `latest` build turns green after merge
- [ ] No `Extension error (sphinx_autodoc_typehints)` in the next build log
- [ ] `:paramref:` role errors are gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)