### PR TITLE
docs: build-resilience shim for sphinx + fix four malformed docstrings

### DIFF
--- a/omicverse/io/spatial/_nanostring.py
+++ b/omicverse/io/spatial/_nanostring.py
@@ -356,13 +356,15 @@ def read_nanostring(
     """Read Nanostring formatted dataset.
 
     This follows the Squidpy nanostring reader layout:
+
     - ``obsm['spatial']``: local cell center coordinates.
     - ``obsm['spatial_fov']``: global cell center coordinates.
     - ``uns['spatial'][fov]['images']``: hires and segmentation images from
       ``CellComposite`` and ``CellLabels``.
     - ``uns['spatial'][fov]['metadata']``: optional FOV-level metadata.
-    - If geometry-like columns exist in metadata, writes ``obs['geometry']`` as
-      WKT strings to match ``read_visium_hd_seg`` format for ``ov.pl.spatialseg``.
+    - If geometry-like columns exist in metadata, writes ``obs['geometry']``
+      as WKT strings to match ``read_visium_hd_seg`` format for
+      ``ov.pl.spatialseg``.
     """
     root = Path(path).resolve()
     _progress(f"Reading Nanostring data from: {root}")

--- a/omicverse/metabol/_qc.py
+++ b/omicverse/metabol/_qc.py
@@ -232,7 +232,7 @@ def blank_filter(
     blank_mask: str | np.ndarray,
     ratio: float = 3.0,
 ) -> AnnData:
-    """Drop features whose sample-mean intensity isn't at least ``ratio``×
+    """Drop features whose sample-mean intensity isn't at least ``ratio``\ ×
     the blank-mean intensity.
 
     Parameters

--- a/omicverse/metabol/plotting.py
+++ b/omicverse/metabol/plotting.py
@@ -562,7 +562,7 @@ def corr_network_plot(
 
     Renders the output of :func:`omicverse.metabol.corr_network` as a
     correlation graph: nodes are metabolites, edges are pairs whose
-    Spearman / Pearson |r| exceeded the network's threshold. Edge
+    Spearman / Pearson ``|r|`` exceeded the network's threshold. Edge
     colour encodes the sign of the correlation (red = positive,
     blue = negative); edge width is proportional to ``|r|``.
 

--- a/omicverse/micro/_pair.py
+++ b/omicverse/micro/_pair.py
@@ -105,13 +105,13 @@ def fetch_franzosa_ibd_2019(
     microbe_count_scale
         The Borenstein TSV delivers per-sample *relative abundances*.
         To make the tables look like familiar 16S count matrices
-        (integer counts, range 10⁰–10⁵) we multiply by this scale and
-        round — a pseudo-count-per-million by default. Pass 1.0 to
-        keep proportions (most useful if you plan to CLR-transform
-        immediately and don't need integer counts). All downstream
-        ov.micro APIs (``filter_by_prevalence``, ``paired_spearman``,
-        ``paired_cca``, ``MMvec``) work on either, but ``min_count``
-        filters expect counts ≥ 1.
+        (integer counts, range 1 to ~100,000) we multiply by this
+        scale and round — a pseudo-count-per-million by default.
+        Pass ``1.0`` to keep proportions (most useful if you plan to
+        CLR-transform immediately and don't need integer counts). All
+        downstream ``ov.micro`` APIs (``filter_by_prevalence``,
+        ``paired_spearman``, ``paired_cca``, ``MMvec``) work on either,
+        but ``min_count`` filters expect counts >= 1.
 
     Returns
     -------


### PR DESCRIPTION
## Summary
Per-PR docstring whack-a-mole is too slow — every RTD build surfaces a new \`SystemMessage(SEVERE/4)\` from a different function (#768 fixed gptcelltype + paramref; #769 disabled rtype injection; the next build crashed in extract_summary on \`run_cellphonedb_v5\`). One bad docstring shouldn't take down the whole site.

This PR installs a one-shot safety net in \`omicverse_guide/docs/conf.py\` plus fixes four immediate offenders.

### Safety net
A new \`setup()\` hook wraps the two call sites that raise \`SystemMessage\`:

- \`sphinx.ext.autosummary.extract_summary\` — used by every \`.. autosummary::\` directive.
- \`sphinx_autodoc_typehints._inject_types_to_docstring\` — covers both param and rtype injection (rtype was already off; this catches the param path too).

Each failure is downgraded to a logged warning + empty/no-op for that object only. Underlying docstring quality issues should still be cleaned up, but the build no longer waits for that.

### Docstring fixes
- \`omicverse.metabol.plotting.corr_network_plot\` — escape \`|r|\` pipes (docutils read them as undefined substitution refs).
- \`omicverse.io.spatial._nanostring.read_nanostring\` — blank line before bullet list.
- \`omicverse.metabol._qc.blank_filter\` — backslash-escape \`×\` after closing literal.
- \`omicverse.micro._pair.fetch_franzosa_ibd_2019\` — replace Unicode superscripts and \`≥\` with ASCII.

## Test plan
- [ ] RTD \`latest\` build of \`master\` after merge completes successfully
- [ ] Build log shows the safety-net warnings (proves the shim caught something) but no aborting traceback
- [ ] \`Extension error\` / \`SystemMessage\` no longer in log

🤖 Generated with [Claude Code](https://claude.com/claude-code)