### PR TITLE
docs: fix root-cause RTD break — hematopoiesis docstring

### DIFF
--- a/omicverse/single/_via.py
+++ b/omicverse/single/_via.py
@@ -123,15 +123,17 @@ def _patched_lineage_probability_layout(plot_func, ncol):
 )
 def hematopoiesis()->anndata.AnnData:
     r"""Load scRNA-seq hematopoiesis dataset for trajectory inference.
-        Returns
-        -------
-        AnnData: Preprocessed hematopoiesis dataset with embeddings and annotations.
-    
-    Examples:
-        >>> import omicverse as ov
-        >>> # Load the dataset
-        >>> adata = ov.single.scRNA_hematopoiesis()
-        >>> print(adata.shape)
+
+    Returns
+    -------
+    AnnData
+        Preprocessed hematopoiesis dataset with embeddings and annotations.
+
+    Examples
+    --------
+    >>> import omicverse as ov
+    >>> adata = ov.single.scRNA_hematopoiesis()
+    >>> print(adata.shape)
     """
     _load_via_modules()
     return scRNA_hematopoiesis()


### PR DESCRIPTION
## Root cause

The reason the RTD build started failing in #766 is **one single docstring**:
\`omicverse.single.hematopoiesis\`. Until #766, this symbol was commented out of \`omicverse/single/__init__.py\` so autosummary couldn't import it (it appears in build 32818656's log as a \"[autosummary] failed to import\" warning and was silently skipped). #766 restored the import — and exposed this malformed docstring:

\`\`\`python
def hematopoiesis() -> anndata.AnnData:
    r\"\"\"Load scRNA-seq hematopoiesis dataset for trajectory inference.
        Returns
        -------
        AnnData: Preprocessed hematopoiesis dataset with embeddings and annotations.
    ...
\`\`\`

The \`Returns\` section is indented *under* the summary paragraph instead of being top-level. Napoleon doesn't recognise it as a Returns block, so it survives into the rendered docstring as literal text. docutils then sees a section title at line 3 with no parent and raises \`SystemMessage(SEVERE/4): Unexpected section title. Returns -------\` — aborting the entire build.

This is the same \`Returns / -------\` SEVERE that #768, #769, #770 each chased from different angles (gptcelltype, paramref, extract_summary safety nets). Fixing this one docstring is the *real* fix.

## Change
Rewrite \`hematopoiesis\` docstring in proper NumPy style (Returns and Examples sections at correct indent).

## Test plan
- [ ] RTD build of \`latest\` succeeds with the same \"build succeeded, N warnings\" footer that build 32818656 produced
- [ ] No more \`SystemMessage(SEVERE/4)\` in the log