### PR TITLE
fix(via): guard small lineage plotting edges

### DIFF
--- a/omicverse/external/VIA/plotting_via.py
+++ b/omicverse/external/VIA/plotting_via.py
@@ -964,7 +964,7 @@ def plot_differentiation_flow(via_object, idx: list = None, dpi=150, marker_line
     p_ds = hnswlib.Index(space='l2', dim=X_ds.shape[1])
     p_ds.init_index(max_elements=X_ds.shape[0], ef_construction=200, M=16)
     p_ds.add_items(X_ds)
-    p_ds.set_ef(50)
+    p_ds.set_ef(max(1, min(50, X_ds.shape[0])))
     num_cluster = len(set(via_object.labels))
     G_orange = ig.Graph(n=num_cluster, edges=via_object.edgelist_maxout,
                         edge_attrs={'weight': via_object.edgeweights_maxout})
@@ -1223,7 +1223,7 @@ def plot_sc_lineage_probability(via_object, embedding: ndarray = None, idx: list
     p_ds = hnswlib.Index(space='l2', dim=X_ds.shape[1])
     p_ds.init_index(max_elements=X_ds.shape[0], ef_construction=200, M=16)
     p_ds.add_items(X_ds)
-    p_ds.set_ef(50)
+    p_ds.set_ef(max(1, min(50, X_ds.shape[0])))
     num_cluster = len(set(via_object.labels))
     G_orange = ig.Graph(n=num_cluster, edges=via_object.edgelist_maxout,
                         edge_attrs={'weight': via_object.edgeweights_maxout})
@@ -2955,6 +2955,7 @@ def get_gene_expression(via_object, gene_exp: pd.DataFrame, cmap: str = 'jet', d
                         else:
                             print(
                                 f'{datetime.now()}\tLineage {i_terminal} cannot be reached. Exclude this lineage in trend plotting')
+                            continue
                         if cmap_dict is None:
                             color_ = cmap_[enum_i_lineage]
                         else:

--- a/omicverse/external/VIA/plotting_via_ov.py
+++ b/omicverse/external/VIA/plotting_via_ov.py
@@ -963,7 +963,7 @@ def plot_differentiation_flow(via_object, idx: list = None, dpi=150, marker_line
     p_ds = hnswlib.Index(space='l2', dim=X_ds.shape[1])
     p_ds.init_index(max_elements=X_ds.shape[0], ef_construction=200, M=16)
     p_ds.add_items(X_ds)
-    p_ds.set_ef(50)
+    p_ds.set_ef(max(1, min(50, X_ds.shape[0])))
     num_cluster = len(set(via_object.labels))
     G_orange = ig.Graph(n=num_cluster, edges=via_object.edgelist_maxout,
                         edge_attrs={'weight': via_object.edgeweights_maxout})
@@ -1222,7 +1222,7 @@ def plot_sc_lineage_probability(via_object, embedding: ndarray = None, idx: list
     p_ds = hnswlib.Index(space='l2', dim=X_ds.shape[1])
     p_ds.init_index(max_elements=X_ds.shape[0], ef_construction=200, M=16)
     p_ds.add_items(X_ds)
-    p_ds.set_ef(50)
+    p_ds.set_ef(max(1, min(50, X_ds.shape[0])))
     num_cluster = len(set(via_object.labels))
     G_orange = ig.Graph(n=num_cluster, edges=via_object.edgelist_maxout,
                         edge_attrs={'weight': via_object.edgeweights_maxout})
@@ -2959,6 +2959,7 @@ def get_gene_expression_ov(adata,clusters,via_object,
                         else:
                             print(
                                 f'{datetime.now()}\tLineage {i_terminal} cannot be reached. Exclude this lineage in trend plotting')
+                            continue
                         if cmap_dict is None:
                             color_ = cmap_[enum_i_lineage]
                         else:

--- a/omicverse/external/VIA/utils_via.py
+++ b/omicverse/external/VIA/utils_via.py
@@ -1016,7 +1016,7 @@ def sc_loc_ofsuperCluster_PCAspace(p0, idx):
         p_ds = hnswlib.Index(space='l2', dim=p0.data.shape[1])
         p_ds.init_index(max_elements=X_ds.shape[0], ef_construction=200, M=16)
         p_ds.add_items(X_ds)
-        p_ds.set_ef(50)
+        p_ds.set_ef(max(1, min(50, X_ds.shape[0])))
 
         new_superclust_index_ds = {}
         for en_item, item in enumerate(ci_list):

--- a/tests/single/test_stavia.py
+++ b/tests/single/test_stavia.py
@@ -296,6 +296,47 @@ def test_via_core_get_gene_expression_uses_shared_legend(monkeypatch):
     plt.close(fig)
 
 
+def test_via_get_gene_expression_skips_single_cell_lineage(monkeypatch):
+    _install_fake_pygam(monkeypatch)
+    from omicverse.external.VIA import core as via_core
+    from omicverse.external.VIA import plotting_via_ov
+
+    class FakeVIA:
+        terminal_clusters = [1]
+        labels = np.array([1, 0, 0])
+        true_label = np.array(["A", "B", "B"])
+        single_cell_pt_markov = np.array([0.0, 0.5, 1.0])
+        single_cell_bp = np.array([[1.0], [0.0], [0.0]], dtype=float)
+
+        @staticmethod
+        def func_mode(values):
+            return pd.Series(values).mode().iloc[0]
+
+    gene_exp = pd.DataFrame({"G0": [1.0, 2.0, 3.0]})
+
+    fig, axs = via_core.get_gene_expression(
+        FakeVIA(),
+        gene_exp=gene_exp,
+        marker_genes=["G0"],
+        marker_lineages=[1],
+        dpi=80,
+    )
+    assert sum(len(ax.lines) for ax in np.ravel(axs)) == 0
+    plt.close(fig)
+
+    fig, axs = plotting_via_ov.get_gene_expression_ov(
+        None,
+        None,
+        FakeVIA(),
+        gene_exp=gene_exp,
+        marker_genes=["G0"],
+        marker_lineages=[1],
+        dpi=80,
+    )
+    assert sum(len(ax.lines) for ax in np.ravel(axs)) == 0
+    plt.close(fig)
+
+
 def test_stavia_rejects_missing_spatial_key():
     adata = _make_adata()
     model = StaVIA(adata, spatial_key="missing")


### PR DESCRIPTION
Follow up on the Claude review posted in omicverse/omicverse#766 and the closed draft PR omicverse/omicverse#773. The change keeps the #773 code patch but creates a fresh head SHA for a new PR after CI failed before running Python tests.

Fixes the remaining VIA review items: skip gene-expression plotting for lineages with too few cells to fit a GAM, and clamp hnswlib set_ef calls to the downsampled index size.