### PR TITLE
pl: add ov.pl.funky_heatmap (pyfunkyheatmap wrapper) + tutorial

### DIFF
--- a/omicverse/pl/__init__.py
+++ b/omicverse/pl/__init__.py
@@ -218,6 +218,11 @@ from ._plot_backend import (
     plot_pca_variance_ratio1,
     gen_mpl_labels,
 )
+from ._funkyheatmap import (
+    funky_heatmap,
+    position_arguments as funky_position_arguments,
+    scale_minmax as funky_scale_minmax,
+)
 
 
 def curved_graph(*args, **kwargs):

--- a/omicverse/pl/_funkyheatmap.py
+++ b/omicverse/pl/_funkyheatmap.py
@@ -1,0 +1,71 @@
+"""Thin wrapper around :mod:`pyfunkyheatmap` for ``omicverse.pl``.
+
+Re-exports the upstream :func:`pyfunkyheatmap.funky_heatmap` entry point and
+helpers so users can call them via ``ov.pl.funky_heatmap(...)`` without
+importing the third-party package explicitly. The dependency is loaded
+lazily so that importing :mod:`omicverse.pl` doesn't fail if
+``pyfunkyheatmap`` isn't installed.
+
+Example::
+
+    import omicverse as ov
+    ov.style(font_path='Arial')
+
+    import pandas as pd
+    df = pd.DataFrame({
+        'id':  ['A', 'B', 'C', 'D'],
+        'x':   [0.1, 0.55, 0.8, 0.95],
+        'y':   [0.5, 0.25, 0.75, 0.6],
+        'tag': ['alpha', 'beta', 'gamma', 'delta'],
+    })
+    fh = ov.pl.funky_heatmap(df)
+    fh.save('out.png', dpi=150)
+
+Upstream: https://github.com/omicverse/py-funkyheatmap
+"""
+
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
+
+_MISSING_MSG = (
+    "ov.pl.funky_heatmap requires the `pyfunkyheatmap` package.\n"
+    "Install with: pip install pyfunkyheatmap"
+)
+
+
+def _load():
+    try:
+        return import_module("pyfunkyheatmap")
+    except ImportError as exc:  # pragma: no cover - exercised at call time
+        raise ImportError(_MISSING_MSG) from exc
+
+
+def funky_heatmap(*args: Any, **kwargs: Any):
+    """Generate a funky heatmap from a :class:`pandas.DataFrame`.
+
+    Thin wrapper around :func:`pyfunkyheatmap.funky_heatmap` — see the
+    upstream docs for the full parameter list.
+    """
+    return _load().funky_heatmap(*args, **kwargs)
+
+
+def position_arguments(**kwargs: Any):
+    """Build a layout-args container.
+
+    Thin wrapper around :func:`pyfunkyheatmap.position_arguments`.
+    """
+    return _load().position_arguments(**kwargs)
+
+
+def scale_minmax(x):
+    """Min-max scale a vector to ``[0, 1]``.
+
+    Thin wrapper around :func:`pyfunkyheatmap.scale_minmax`.
+    """
+    return _load().scale_minmax(x)
+
+
+__all__ = ["funky_heatmap", "position_arguments", "scale_minmax"]


### PR DESCRIPTION
## Summary

- Adds `ov.pl.funky_heatmap` — a thin lazy-import wrapper around the new [`pyfunkyheatmap`](https://pypi.org/project/pyfunkyheatmap/) PyPI package (pure-Python port of the R [`funkyheatmap`](https://funkyheatmap.github.io/funkyheatmap/) package, built under the omicverse-rebuildr reference-driven porting protocol — repo: https://github.com/omicverse/py-funkyheatmap).
- Adds tutorial `omicverse_guide/docs/Tutorials-plotting/t_funkyheatmap.ipynb` (six worked examples on `mtcars` + dynbenchmark-style row-grouped figure) and links it from `Tutorial.md` and `Tutorials-plotting/index.md`.
- Bumps the `omicverse_guide` submodule pointer to pick up the tutorial (companion PR: https://github.com/omicverse/omicverse-tutorials/pull/new/add-funkyheatmap-tutorial).

## Public surface

```python
import omicverse as ov
ov.style(font_path='Arial')

fh = ov.pl.funky_heatmap(
    data,
    column_info=column_info,
    column_groups=column_groups,
    row_info=row_info,
    row_groups=row_groups,
    palettes=palettes,
    legends=legends,
)
fh.save('out.png', dpi=150)
```

Also exported:
- `ov.pl.funky_position_arguments(...)` (layout knobs)
- `ov.pl.funky_scale_minmax(x)` (rank/score min-max scaling helper)

## Why lazy import?

`omicverse.pl` imports cleanly even if `pyfunkyheatmap` isn't installed; the helpful `ImportError` only fires when the user actually calls `ov.pl.funky_heatmap`. This avoids hard-coupling `pyfunkyheatmap` into the omicverse install.

> Install with `pip install pyfunkyheatmap`. The CI/test environment doesn't need it unless it exercises `funky_heatmap` directly.

## Test plan

- [x] `python -c "import omicverse.pl as pl; print(pl.funky_heatmap)"` — works with `pyfunkyheatmap` installed.
- [x] Tutorial notebook (`t_funkyheatmap.ipynb`) executes end-to-end without errors, produces six figures.
- [x] `ov.style(font_path='Arial')` runs before each plotting example in the tutorial (per project convention).
- [ ] CI green on the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)