### PR TITLE
pl: register ov.pl.funky_heatmap with @register_function + extend module docstring

### DIFF
--- a/omicverse/pl/__init__.py
+++ b/omicverse/pl/__init__.py
@@ -15,7 +15,7 @@ Visualization categories:
     
 Key modules:
     _single: Single-cell specific plotting functions
-    _bulk: Bulk RNA-seq plotting functions  
+    _bulk: Bulk RNA-seq plotting functions
     _space: Spatial transcriptomics visualizations
     _multi: Multi-omics integration plots
     _heatmap: Heatmap and clustering visualizations
@@ -25,6 +25,9 @@ Key modules:
     _flowsig: Flow cytometry-style visualizations
     _embedding: Dimensionality reduction visualizations
     _density: Density and distribution plots
+    _funkyheatmap: dynbenchmark-style benchmark / multi-metric heatmaps
+        (funky rectangles + circles + bars + pies + text + image glyphs,
+        wraps the pyfunkyheatmap PyPI package)
 
 Features:
     - Publication-ready figures with customizable aesthetics
@@ -47,6 +50,18 @@ Examples:
     >>> # Spatial visualization
     >>> ov.pl.spatial(adata, color='total_counts')
     >>> ov.pl.spatial_domains(adata, color='domain')
+    >>>
+    >>> # Benchmark / multi-metric tables — dynbenchmark / scIB style
+    >>> # (requires the pyfunkyheatmap PyPI package: pip install pyfunkyheatmap)
+    >>> import pandas as pd
+    >>> bench = pd.DataFrame({
+    ...     'id':       ['UMAP', 't-SNE', 'PHATE', 'PCA'],
+    ...     'accuracy': [0.83, 0.71, 0.94, 0.62],
+    ...     'speed':    [0.42, 0.30, 0.20, 0.91],
+    ...     'memory':   [0.60, 0.55, 0.85, 0.30],
+    ... })
+    >>> fh = ov.pl.funky_heatmap(bench)
+    >>> fh.save('benchmark.png', dpi=150)
 """
 from warnings import warn
 

--- a/omicverse/pl/_funkyheatmap.py
+++ b/omicverse/pl/_funkyheatmap.py
@@ -29,6 +29,8 @@ from __future__ import annotations
 from importlib import import_module
 from typing import Any
 
+from .._registry import register_function
+
 
 _MISSING_MSG = (
     "ov.pl.funky_heatmap requires the `pyfunkyheatmap` package.\n"
@@ -43,11 +45,71 @@ def _load():
         raise ImportError(_MISSING_MSG) from exc
 
 
+@register_function(
+    aliases=[
+        "funkyheatmap", "funky_heatmap", "funky 热图", "花式热图",
+        "基准热图", "benchmark heatmap", "dynbenchmark heatmap",
+        "scIB heatmap", "多指标表可视化",
+    ],
+    category="pl",
+    description=(
+        "Publication-ready dynbenchmark-style heatmap for benchmark / "
+        "multi-metric tables, with funky rectangles, circles, bars, pies, "
+        "text and image glyphs. Thin wrapper over pyfunkyheatmap — pure "
+        "Python port of the R funkyheatmap package."
+    ),
+    examples=[
+        "# Default heatmap from a DataFrame",
+        "import omicverse as ov",
+        "import pandas as pd",
+        "ov.style(font_path='Arial')",
+        "df = pd.DataFrame({",
+        "    'id':   ['UMAP','t-SNE','PHATE','PCA','Diffusion','Slingshot'],",
+        "    'accuracy': [0.83, 0.71, 0.94, 0.62, 0.88, 0.79],",
+        "    'speed':    [0.42, 0.30, 0.20, 0.91, 0.55, 0.68],",
+        "    'memory':   [0.60, 0.55, 0.85, 0.30, 0.70, 0.50],",
+        "})",
+        "fh = ov.pl.funky_heatmap(df)",
+        "fh.save('benchmark.png', dpi=150)",
+        "",
+        "# Custom geoms per column",
+        "column_info = pd.DataFrame({",
+        "    'id':   ['id','accuracy','speed','memory'],",
+        "    'name': ['Method','Accuracy','Speed','Memory'],",
+        "    'geom': ['text','funkyrect','circle','bar'],",
+        "})",
+        "ov.pl.funky_heatmap(df, column_info=column_info)",
+        "",
+        "# Grouped columns + custom palettes + legends + row groups",
+        "column_groups = pd.DataFrame({",
+        "    'group': ['perf','resources'],",
+        "    'level1':['Perf','Resources'],",
+        "})",
+        "palettes = {'perf_pal':'Blues','res_pal':'Reds'}",
+        "legends = [dict(palette='perf_pal', geom='rect',",
+        "                title='Overall', labels=['0','','0.5','','1'])]",
+        "ov.pl.funky_heatmap(df, column_info=column_info,",
+        "                    column_groups=column_groups,",
+        "                    palettes=palettes, legends=legends)",
+    ],
+    related=["heatmap", "marsilea_heatmap", "dotplot"],
+)
 def funky_heatmap(*args: Any, **kwargs: Any):
     """Generate a funky heatmap from a :class:`pandas.DataFrame`.
 
-    Thin wrapper around :func:`pyfunkyheatmap.funky_heatmap` — see the
-    upstream docs for the full parameter list.
+    Thin wrapper around :func:`pyfunkyheatmap.funky_heatmap`. Supports the
+    full upstream parameter list: ``column_info``, ``row_info``,
+    ``column_groups``, ``row_groups``, ``palettes``, ``legends``,
+    ``position_args``, ``scale_column``, ``add_abc``, and rendering
+    knobs ``fig``, ``ax``, ``fig_scale``, ``dpi``.
+
+    Returns a :class:`pyfunkyheatmap.FunkyHeatmap` object wrapping the
+    matplotlib figure (``fh.figure``) and the underlying geometry tables
+    (``fh.geom_positions``). Call ``fh.save(path)`` to write the figure.
+
+    See :mod:`pyfunkyheatmap` for the full reference, and the
+    `t_funkyheatmap.ipynb tutorial
+    <https://omicverse.readthedocs.io/en/latest/Tutorials-plotting/t_funkyheatmap.html>`__.
     """
     return _load().funky_heatmap(*args, **kwargs)
 


### PR DESCRIPTION
Follow-up to #776 (which added the \`ov.pl.funky_heatmap\` wrapper):

1. Adds the \`@register_function\` decorator on \`funky_heatmap\` so it's
   discoverable via \`ov.recommend_function\` / \`ov.find_function\` and
   shows up alongside the rest of the \`pl\` catalog.
   * Chinese + English aliases (\`funkyheatmap\`, \`funky 热图\`, \`花式热图\`, \`基准热图\`, \`benchmark heatmap\`, \`dynbenchmark heatmap\`, \`scIB heatmap\`, \`多指标表可视化\`)
   * \`category=\"pl\"\`, \`related=[\"heatmap\", \"marsilea_heatmap\", \"dotplot\"]\`
   * Three short, copy-pastable usage examples
2. Extends the \`omicverse.pl\` module docstring:
   * one-line entry in the \"Key modules\" list
   * a 5-line example block at the bottom of \"Examples\"

The wrapper itself stays a lazy import (no hard dependency on
\`pyfunkyheatmap\` at \`omicverse.pl\` import time).

Verified locally with \`ov.find_function('funky_heatmap')\` returning
the registered function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)