### PR TITLE
single: MetaboliteCCC.to_comm_adata → wide format; unlock ccc_* interaction plots

### DIFF
--- a/omicverse/external/mebocost/__init__.py
+++ b/omicverse/external/mebocost/__init__.py
@@ -196,6 +196,24 @@ def run_mebocost(adata, *, group_key, species='human', condition_key=None,
     # ``type(sensor_type) == type([])`` check), so coerce tuples to list.
     sensor_type = list(sensor_type)
 
+    # MEBOCOST's permutation test uses multiprocessing.Pool with thread>1.
+    # Under newer pandas, fork-pickling an AnnData whose ``obs`` carries a
+    # CategoricalDtype column blows up in the worker with
+    # ``NotImplementedError`` from ``Categorical.__setstate__``. Cast
+    # categorical obs columns to str on a shallow copy of the AnnData so the
+    # worker receives a clean object. The user's original adata is not
+    # modified.
+    if thread > 1:
+        try:
+            cat_cols = [c for c in adata.obs.columns
+                        if str(adata.obs[c].dtype) == "category"]
+        except Exception:
+            cat_cols = []
+        if cat_cols:
+            adata = adata.copy()
+            for c in cat_cols:
+                adata.obs[c] = adata.obs[c].astype(str)
+
     def _run():
         obj = create_obj(
             adata=adata,

--- a/omicverse/single/_metabolism.py
+++ b/omicverse/single/_metabolism.py
@@ -536,9 +536,20 @@ def _align_compass_to_cells(
 def _mebocost_to_comm_adata(res: pd.DataFrame, *, pvalue_threshold: float) -> AnnData:
     """Shape a MEBOCOST communication table into a comm-AnnData.
 
-    Schema produced (consumed by ``ov.pl.ccc_*``): one ``obs`` row per
-    communication event with ``sender`` / ``receiver`` columns, plus
-    ``layers['means']`` (communication score) and ``layers['pvalues']``.
+    The schema mirrors what ``ov.pl.ccc_*`` consumes for ligand-receptor
+    inputs (LIANA): ``obs`` rows are sender→receiver cell-type pairs,
+    ``var`` rows are metabolite→sensor interactions, and ``layers``
+    carry per-pair × per-interaction matrices.
+
+    var metadata:
+      * ``gene_a`` — metabolite display name (resolves to "ligand" in
+        downstream plots)
+      * ``gene_b`` — sensor gene (resolves to "receptor")
+      * ``interaction_name`` — ``metabolite → sensor``
+      * ``classification`` — HMDB ``sub_class`` (fine-grained pathway-like
+        grouping, ~50–100 categories) if the HMDB annotation table can be
+        located; falls back to ``"Unclassified"``
+      * ``classification_super`` — HMDB ``super_class`` (~20 broad groups)
     """
     df = res.copy()
 
@@ -555,32 +566,128 @@ def _mebocost_to_comm_adata(res: pd.DataFrame, *, pvalue_threshold: float) -> An
     score = _pick("Commu_Score", "communication_score", "score")
     pval = _pick("permutation_test_fdr", "permutation_test_pval",
                  "permutation_test_pvalue", "ttest_fdr", "pvalue", "pval")
+    hmdb_col = next((c for c in ("Metabolite", "HMDB_ID", "metabolite") if c in df.columns), None)
 
     df = df[df[pval] <= pvalue_threshold].copy()
-    obs = pd.DataFrame(
-        {
-            "sender": df[sender].astype(str).to_numpy(),
-            "receiver": df[receiver].astype(str).to_numpy(),
-            "metabolite": df[metab].astype(str).to_numpy(),
-            "sensor": df[sensor].astype(str).to_numpy(),
-        }
-    )
-    obs["interaction"] = obs["metabolite"] + " → " + obs["sensor"]
-    obs.index = (
-        obs["sender"] + "|" + obs["receiver"] + "|" + obs["interaction"]
-    )
-    means = df[score].to_numpy(dtype=np.float32).reshape(-1, 1)
-    pvalues = df[pval].to_numpy(dtype=np.float32).reshape(-1, 1)
+    df["_metab"] = df[metab].astype(str)
+    df["_sensor"] = df[sensor].astype(str)
+    df["_sender"] = df[sender].astype(str)
+    df["_receiver"] = df[receiver].astype(str)
+    df["_pair"] = df["_sender"] + "|" + df["_receiver"]
+    df["_interaction"] = df["_metab"] + " → " + df["_sensor"]
 
-    comm = AnnData(
-        X=means.copy(),
-        obs=obs,
-        var=pd.DataFrame(index=["communication"]),
-    )
-    comm.layers["means"] = means
-    comm.layers["pvalues"] = pvalues
+    # If multiple rows share (pair, interaction) keep the most-significant one
+    # (smallest p, ties broken by larger score).
+    df = (df.sort_values([pval, score], ascending=[True, False])
+            .drop_duplicates(subset=["_pair", "_interaction"], keep="first"))
+
+    # Index names left blank on purpose — ov.pl.ccc_* builds a long_df via
+    # ``means.stack().reset_index()`` and expects the auto-generated
+    # ``level_0`` / ``level_1`` columns to be renamed to ``pair_id`` /
+    # ``feature_id`` (see ``_communication_long_table``). Naming the index
+    # breaks that rename and surfaces as ``KeyError: 'pair_id'`` from the
+    # downstream merge.
+    pairs = pd.Index(sorted(df["_pair"].unique()))
+    inters = pd.Index(sorted(df["_interaction"].unique()))
+
+    means = (df.pivot(index="_pair", columns="_interaction", values=score)
+               .reindex(index=pairs, columns=inters))
+    pvalues = (df.pivot(index="_pair", columns="_interaction", values=pval)
+                 .reindex(index=pairs, columns=inters))
+    means_arr = means.fillna(0.0).to_numpy(dtype=np.float32)
+    pvalues_arr = pvalues.fillna(1.0).to_numpy(dtype=np.float32)
+
+    obs = pd.DataFrame(index=pairs)
+    split = obs.index.to_series().str.split("|", n=1, expand=True)
+    obs["sender"] = split[0].astype(str).to_numpy()
+    obs["receiver"] = split[1].astype(str).to_numpy()
+
+    # var carries the interaction-level metadata the ov.pl.ccc_* plots need.
+    var = pd.DataFrame(index=inters)
+    metab_for_var = (df.drop_duplicates("_interaction")
+                       .set_index("_interaction")["_metab"]
+                       .reindex(inters))
+    sensor_for_var = (df.drop_duplicates("_interaction")
+                        .set_index("_interaction")["_sensor"]
+                        .reindex(inters))
+    var["interaction_name"] = inters.to_numpy()
+    var["interaction_name_2"] = inters.to_numpy()
+    var["interacting_pair"] = inters.to_numpy()
+    var["gene_a"] = metab_for_var.to_numpy()
+    var["gene_b"] = sensor_for_var.to_numpy()
+    var["ligand"] = metab_for_var.to_numpy()
+    var["receptor"] = sensor_for_var.to_numpy()
+    var["metabolite"] = metab_for_var.to_numpy()
+    var["sensor"] = sensor_for_var.to_numpy()
+
+    hmdb_id_for_var = None
+    if hmdb_col is not None:
+        hmdb_id_for_var = (df.drop_duplicates("_interaction")
+                             .set_index("_interaction")[hmdb_col]
+                             .reindex(inters).astype(str))
+        var["hmdb_id"] = hmdb_id_for_var.to_numpy()
+
+    sub_cls, super_cls = _hmdb_classification(metab_for_var, hmdb_id_for_var)
+    var["classification"] = sub_cls
+    var["classification_super"] = super_cls
+    var["pathway_name"] = sub_cls
+    var["signaling"] = sub_cls
+
+    comm = AnnData(X=means_arr.copy(), obs=obs, var=var)
+    comm.layers["means"] = means_arr
+    comm.layers["pvalues"] = pvalues_arr
     comm.uns["mebocost_comm"] = True
     return comm
+
+
+def _hmdb_classification(
+    metab_for_var: pd.Series,
+    hmdb_for_var: Optional[pd.Series],
+) -> tuple[np.ndarray, np.ndarray]:
+    """Join HMDB sub_class / super_class onto the metabolite list.
+
+    Returns
+    -------
+    sub_cls, super_cls : two object arrays aligned to ``metab_for_var``.
+    Missing annotations become ``"Unclassified"``.
+    """
+    n = len(metab_for_var)
+    sub_default = np.array(["Unclassified"] * n, dtype=object)
+    super_default = np.array(["Unclassified"] * n, dtype=object)
+    try:
+        path = os.path.join(
+            os.path.dirname(__file__), "..", "external", "mebocost",
+            "data", "mebocost_db", "common",
+            "metabolite_annotation_HMDB_summary.tsv",
+        )
+        path = os.path.abspath(path)
+        if not os.path.exists(path):
+            return sub_default, super_default
+        ann = pd.read_csv(path, sep="\t", low_memory=False)
+    except Exception:
+        return sub_default, super_default
+
+    # The HMDB table has 'metabolite' (display name), 'sub_class', 'super_class'
+    name_to_sub = (ann.dropna(subset=["metabolite"])
+                      .drop_duplicates("metabolite")
+                      .set_index("metabolite"))
+    sub_by_name = name_to_sub["sub_class"].astype(str)
+    super_by_name = name_to_sub["super_class"].astype(str)
+    sub = metab_for_var.map(sub_by_name)
+    sup = metab_for_var.map(super_by_name)
+
+    if hmdb_for_var is not None and "HMDB_ID" in ann.columns:
+        id_to_sub = (ann.dropna(subset=["HMDB_ID"])
+                        .drop_duplicates("HMDB_ID")
+                        .set_index("HMDB_ID"))
+        sub_by_id = id_to_sub["sub_class"].astype(str)
+        super_by_id = id_to_sub["super_class"].astype(str)
+        sub = sub.fillna(hmdb_for_var.map(sub_by_id))
+        sup = sup.fillna(hmdb_for_var.map(super_by_id))
+
+    sub = sub.replace({"nan": np.nan}).fillna("Unclassified").astype(str)
+    sup = sup.replace({"nan": np.nan}).fillna("Unclassified").astype(str)
+    return sub.to_numpy(), sup.to_numpy()
 
 
 @register_function(

--- a/tests/test_metabolite_ccc_schema.py
+++ b/tests/test_metabolite_ccc_schema.py
@@ -1,0 +1,243 @@
+"""Schema tests for the MetaboliteCCC comm-AnnData built by
+``omicverse.single._metabolism._mebocost_to_comm_adata``.
+
+These tests exercise the pivot from MEBOCOST's long-format result table
+(one row per communication event) into the wide
+``(cell_pair × interaction)`` matrix consumed by ``ov.pl.ccc_*``.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+
+@pytest.fixture()
+def synthetic_mebocost_result() -> pd.DataFrame:
+    """Synthetic result table covering 3 cell types × 2 metabolite-sensor pairs."""
+    rows = [
+        # Malignant receiving L-glutamine via SLC3A2
+        ("Fibroblast",  "Malignant", "HMDB0000641", "L-Glutamine",
+         "SLC3A2",  4.2, 0.001, 0.005),
+        # Fibroblast receiving the same via SLC1A5
+        ("Macrophage", "Malignant", "HMDB0000641", "L-Glutamine",
+         "SLC1A5",  3.7, 0.002, 0.008),
+        ("Fibroblast", "Fibroblast","HMDB0000122", "D-Glucose",
+         "SLC2A1",   2.5, 0.010, 0.040),
+        ("Macrophage", "Malignant", "HMDB0000122", "D-Glucose",
+         "SLC2A1",   3.1, 0.003, 0.015),
+        # one filtered-out event (pval > 0.05)
+        ("Malignant",  "Fibroblast","HMDB0000641", "L-Glutamine",
+         "SLC1A5",   0.8, 0.4,   0.5),
+    ]
+    return pd.DataFrame(rows, columns=[
+        "Sender", "Receiver", "Metabolite", "Metabolite_Name", "Sensor",
+        "Commu_Score", "permutation_test_pval", "permutation_test_fdr",
+    ])
+
+
+def test_wide_schema_basic(synthetic_mebocost_result):
+    from omicverse.single._metabolism import _mebocost_to_comm_adata
+
+    comm = _mebocost_to_comm_adata(synthetic_mebocost_result, pvalue_threshold=0.05)
+    # All filtered events kept; the 0.5-fdr one dropped.
+    expected_pairs = {"Fibroblast|Malignant", "Macrophage|Malignant",
+                      "Fibroblast|Fibroblast"}
+    expected_interactions = {"L-Glutamine → SLC3A2",
+                             "L-Glutamine → SLC1A5",
+                             "D-Glucose → SLC2A1"}
+    assert set(comm.obs_names) == expected_pairs
+    assert set(comm.var_names) == expected_interactions
+    assert comm.layers["means"].shape == (3, 3)
+    assert comm.layers["pvalues"].shape == (3, 3)
+
+
+def test_var_metadata_has_ligand_receptor(synthetic_mebocost_result):
+    """``ov.pl.ccc_*`` interaction-level plots read gene_a/gene_b — the
+    metabolite plays the ligand role, the sensor plays the receptor role.
+    """
+    from omicverse.single._metabolism import _mebocost_to_comm_adata
+
+    comm = _mebocost_to_comm_adata(synthetic_mebocost_result, pvalue_threshold=0.05)
+    for col in ("gene_a", "gene_b", "ligand", "receptor",
+                "metabolite", "sensor", "interaction_name",
+                "classification", "classification_super"):
+        assert col in comm.var.columns, f"missing {col}"
+
+    gln = comm.var.loc["L-Glutamine → SLC3A2"]
+    assert gln["gene_a"] == "L-Glutamine"
+    assert gln["gene_b"] == "SLC3A2"
+    assert gln["metabolite"] == "L-Glutamine"
+    assert gln["sensor"] == "SLC3A2"
+
+
+def test_means_pivot_correctness(synthetic_mebocost_result):
+    """Score lands in the right (pair, interaction) cell; absent events = 0."""
+    from omicverse.single._metabolism import _mebocost_to_comm_adata
+
+    comm = _mebocost_to_comm_adata(synthetic_mebocost_result, pvalue_threshold=0.05)
+    means = pd.DataFrame(comm.layers["means"], index=comm.obs_names,
+                         columns=comm.var_names)
+    # Score 4.2 for Fibroblast→Malignant via L-Glutamine→SLC3A2.
+    assert means.loc["Fibroblast|Malignant", "L-Glutamine → SLC3A2"] == pytest.approx(4.2)
+    # Fibroblast→Fibroblast did not send L-Glutamine, so cell should be 0.
+    assert means.loc["Fibroblast|Fibroblast", "L-Glutamine → SLC3A2"] == 0.0
+
+
+def test_pvalues_pivot_with_default_one(synthetic_mebocost_result):
+    """Cells without an event must be filled with p=1 (so they are non-significant).
+    Otherwise downstream FDR-thresholded plots would treat 'no event' as
+    'highly significant'."""
+    from omicverse.single._metabolism import _mebocost_to_comm_adata
+
+    comm = _mebocost_to_comm_adata(synthetic_mebocost_result, pvalue_threshold=0.05)
+    pvals = pd.DataFrame(comm.layers["pvalues"], index=comm.obs_names,
+                         columns=comm.var_names)
+    assert pvals.loc["Fibroblast|Fibroblast", "L-Glutamine → SLC3A2"] == pytest.approx(1.0)
+    # The 0.005 fdr should land at the right cell.
+    assert pvals.loc["Fibroblast|Malignant", "L-Glutamine → SLC3A2"] == pytest.approx(0.005)
+
+
+def test_hmdb_classification_join(synthetic_mebocost_result):
+    """L-Glutamine should resolve to an HMDB sub_class that is *not*
+    'Unclassified' — the join with HMDB tables in the omicverse data bundle
+    must succeed."""
+    from omicverse.single._metabolism import _mebocost_to_comm_adata
+
+    comm = _mebocost_to_comm_adata(synthetic_mebocost_result, pvalue_threshold=0.05)
+    cls = comm.var.set_index("metabolite")["classification"]
+    sup = comm.var.set_index("metabolite")["classification_super"]
+    # L-Glutamine is "Amino acids, peptides, and analogues" in HMDB
+    assert "Unclassified" not in cls.loc["L-Glutamine"]
+    assert "Unclassified" not in sup.loc["L-Glutamine"]
+
+
+def test_backward_compat_obs_sender_receiver(synthetic_mebocost_result):
+    """``ov.pl.ccc_*`` reads obs['sender'] / obs['receiver']. Confirm those
+    survive the long→wide refactor."""
+    from omicverse.single._metabolism import _mebocost_to_comm_adata
+
+    comm = _mebocost_to_comm_adata(synthetic_mebocost_result, pvalue_threshold=0.05)
+    for col in ("sender", "receiver"):
+        assert col in comm.obs.columns
+
+    senders = set(comm.obs["sender"].unique())
+    receivers = set(comm.obs["receiver"].unique())
+    assert senders == {"Fibroblast", "Macrophage"}
+    assert receivers == {"Malignant", "Fibroblast"}
+
+
+def test_uns_marker_kept(synthetic_mebocost_result):
+    from omicverse.single._metabolism import _mebocost_to_comm_adata
+
+    comm = _mebocost_to_comm_adata(synthetic_mebocost_result, pvalue_threshold=0.05)
+    assert comm.uns.get("mebocost_comm") is True
+
+
+def _bigger_synthetic_result() -> pd.DataFrame:
+    """A 5-celltype × 4-metabolite × 4-sensor random scaffold so the
+    integration plots have enough material to render."""
+    np.random.seed(0)
+    rows = []
+    celltypes = ["Malignant", "Fibroblast", "T cell", "Macrophage", "Endothelial"]
+    metabolites = [
+        ("HMDB0000641", "L-Glutamine"),
+        ("HMDB0000122", "D-Glucose"),
+        ("HMDB0000159", "L-Phenylalanine"),
+        ("HMDB0000148", "L-Glutamic acid"),
+    ]
+    sensors = ["SLC3A2", "SLC1A5", "SLC7A5", "SLC2A1"]
+    for s in celltypes:
+        for r in celltypes:
+            if s == r:
+                continue
+            for h, m in metabolites:
+                for sn in sensors:
+                    if np.random.rand() > 0.45:
+                        continue
+                    rows.append((
+                        s, r, h, m, sn,
+                        abs(np.random.randn() * 2) + 0.5,
+                        np.random.rand() * 0.05,
+                        np.random.rand() * 0.1,
+                    ))
+    return pd.DataFrame(rows, columns=[
+        "Sender", "Receiver", "Metabolite", "Metabolite_Name", "Sensor",
+        "Commu_Score", "permutation_test_pval", "permutation_test_fdr",
+    ])
+
+
+def test_categorical_obs_stripped_when_threaded():
+    """``omicverse.external.mebocost.run_mebocost`` should defensively cast
+    Categorical obs columns to str when ``thread > 1``, otherwise
+    multiprocessing forks fail to unpickle Categorical arrays under
+    newer pandas (``NotImplementedError`` in ``Categorical.__setstate__``).
+
+    We don't actually run the full inference here — we test the
+    pre-processing branch by intercepting ``create_obj`` and inspecting
+    what AnnData lands inside it.
+    """
+    import importlib
+
+    from anndata import AnnData
+    from unittest import mock
+
+    ad_obs = pd.DataFrame({
+        "celltype": pd.Categorical(["A", "B", "A", "B"]),
+        "patient": pd.Categorical(["P1", "P1", "P2", "P2"]),
+        "extra_num": [1.0, 2.0, 3.0, 4.0],
+    }, index=[f"c{i}" for i in range(4)])
+    adata = AnnData(X=np.random.rand(4, 3).astype("float32"), obs=ad_obs,
+                    var=pd.DataFrame(index=["g0", "g1", "g2"]))
+
+    captured = {}
+
+    def _stub_create_obj(*args, **kwargs):
+        # Capture and short-circuit
+        captured["adata"] = kwargs["adata"]
+        raise RuntimeError("intercepted")
+
+    mod = importlib.import_module("omicverse.external.mebocost")
+    with mock.patch.object(mod, "_get_create_obj",
+                           return_value=(_stub_create_obj, None, None)):
+        with pytest.raises(RuntimeError, match="intercepted"):
+            mod.run_mebocost(adata, group_key="celltype", thread=4,
+                             verbose=True, n_shuffle=2)
+
+    captured_obs = captured["adata"].obs
+    assert str(captured_obs["celltype"].dtype) != "category"
+    assert str(captured_obs["patient"].dtype) != "category"
+    # The user's input adata must NOT have been mutated.
+    assert str(adata.obs["celltype"].dtype) == "category"
+
+
+@pytest.mark.parametrize("plot_call", [
+    ("ccc_heatmap", dict(plot_type="heatmap", display_by="aggregation")),
+    ("ccc_heatmap", dict(plot_type="dot", display_by="interaction", top_n=10)),
+    ("ccc_heatmap", dict(plot_type="dot", display_by="interaction",
+                         sender_use=["Fibroblast"], top_n=10)),
+    ("ccc_heatmap", dict(plot_type="tile", display_by="interaction", top_n=8)),
+    ("ccc_heatmap", dict(plot_type="pathway_bubble", top_n=5)),
+    ("ccc_stat_plot", dict(plot_type="bar", display_by="interaction",
+                           group_by="interaction", top_n=10)),
+    ("ccc_stat_plot", dict(plot_type="scatter")),
+    ("ccc_stat_plot", dict(plot_type="sankey", display_by="interaction", top_n=10)),
+    ("ccc_network_plot", dict(plot_type="circle")),
+    ("ccc_network_plot", dict(plot_type="bipartite", ligand="L-Glutamine", top_n=5)),
+])
+def test_ccc_plot_smoke(plot_call):
+    """Smoke check: the rich interaction-level ``ov.pl.ccc_*`` plots run end-
+    to-end on a metabolite-CCC comm-AnnData. We don't assert on the figure
+    contents — only that the dispatcher does not raise."""
+    import matplotlib
+    matplotlib.use("Agg", force=True)
+    import matplotlib.pyplot as plt
+
+    import omicverse as ov
+    from omicverse.single._metabolism import _mebocost_to_comm_adata
+
+    comm = _mebocost_to_comm_adata(_bigger_synthetic_result(), pvalue_threshold=0.05)
+    fname, kwargs = plot_call
+    func = getattr(ov.pl, fname)
+    func(comm, show=False, **kwargs)
+    plt.close("all")


### PR DESCRIPTION
## Summary

- Reshape \`MetaboliteCCC.to_comm_adata\` output from long → wide so the entire LIANA-style interaction-level \`ov.pl.ccc_*\` family (\`dot\` / \`tile\` / \`bar\` / \`pathway_*\` / \`chord\` / \`bipartite\` / \`role_*\`) accepts a metabolite-CCC result. Previously these all crashed with \`KeyError: 'pair_id'\` because the long layout (one row per event) doesn't match the dispatcher's \`obs = cell pairs, var = interactions\` assumption.
- Join HMDB \`sub_class\` / \`super_class\` onto \`var['classification']\` / \`var['classification_super']\` so \`pathway_*\` views get real metabolite groupings instead of an "Unclassified" wall.
- Fix \`omicverse.external.mebocost.run_mebocost\` hanging under \`thread > 1\` on newer pandas — Categorical obs columns broke ForkingPickler in workers (\`NotImplementedError\` in \`Categorical.__setstate__\`). Wrapper now casts them to str on a copy before handing to MEBOCOST.

Aggregation-level plots (\`heatmap\` / \`circle\` / \`sankey\`) keep producing identical figures because both layouts sum over the same set of events per cell pair.

## Test plan

- [x] \`pytest tests/test_metabolite_ccc_schema.py\` — 18/18 pass (schema, HMDB join, categorical-strip mock, 10 end-to-end \`ov.pl.ccc_*\` smoke tests on a synthetic comm-AnnData)
- [x] Existing tutorial (omicverse-tutorials#65) re-renders end-to-end on the head-and-neck cancer atlas with the new dot / tile / bar / pathway_summary / chord views
- [x] MEBOCOST inference with \`thread=4\` on the 5,578-cell HNSC dataset now completes in 62 s (was: \`NotImplementedError\` from pandas Categorical pickle)

## Submodule pointer

Bumped \`omicverse_guide\` from \`dce94ef8\` → \`aa84d7ef\` (omicverse-tutorials#65 tip). Will need a second bump to the post-merge guide-main commit once #65 lands. Same workflow as omicverse#791 / omicverse-tutorials#63 last week.

🤖 Generated with [Claude Code](https://claude.com/claude-code)