### PR TITLE
fix(dynamic_heatmap): cluster-strip desync, per-lineage standardisation, reverse_ht warning

### DIFF
--- a/omicverse/pl/_heatmap_marsilea.py
+++ b/omicverse/pl/_heatmap_marsilea.py
@@ -135,6 +135,21 @@ def _resolve_reverse_lineages(reverse_ht, lineage_names):
     else:
         items = list(items)
 
+    # ``reverse_ht`` is intended for the two-lineage "diverging cascade"
+    # layout (one terminal at far-left reading right-to-left, the trunk
+    # in the middle, the other terminal at far-right reading left-to-
+    # right). With more than two lineages each panel reads in a
+    # different direction, which is confusing — warn the caller.
+    if len(lineage_names) > 2 and items:
+        import warnings
+        warnings.warn(
+            f"reverse_ht is only meaningful for the two-lineage diverging "
+            f"layout; got {len(lineage_names)} lineages ({lineage_names!r}). "
+            "Each panel will read in a different direction. Consider "
+            "passing reverse_ht=None.",
+            UserWarning, stacklevel=3,
+        )
+
     resolved = set()
     for item in items:
         if isinstance(item, (int, np.integer)) and not isinstance(item, bool):
@@ -1048,6 +1063,15 @@ def _prepare_dynamic_matrix(
                             )
                             .to_numpy()
                         )
+                    # Mirror the ``grouped.iloc[::-1]`` reversal applied
+                    # to the expression matrix above — otherwise the
+                    # cluster-annotation strip stays in pt-ascending order
+                    # while the heatmap columns are in pt-descending order,
+                    # so e.g. ``reverse_ht=['Beta']`` paints Beta markers
+                    # on the LEFT while the Beta cluster strip still sits
+                    # on the RIGHT.
+                    if lineage_name in reverse_lineages:
+                        annotation_values[key] = annotation_values[key][::-1]
             metadata_rows.extend(
                 {
                     "column": label,
@@ -1061,8 +1085,17 @@ def _prepare_dynamic_matrix(
                 }
                 for idx, label in enumerate(labels)
             )
+        # Per-lineage standardisation: pooling all lineages before
+        # z-scoring lets a single high-expressing lineage (e.g. Delta's
+        # Sst peak) dominate the global ``std``, which compresses the
+        # other panels' cascades to noise. Each lineage tells a
+        # separate developmental story, so we standardise each chunk
+        # independently and only then concatenate.
+        chunks = [_scale_dynamic_frame(chunk, standard_scale)
+                  for chunk in chunks]
         matrix = pd.concat(chunks, axis=1)
         metadata = pd.DataFrame(metadata_rows).set_index("column")
+        return matrix, metadata
 
     matrix = _scale_dynamic_frame(matrix, standard_scale)
     return matrix, metadata


### PR DESCRIPTION
## Summary

Three lineage-handling bug fixes flagged by the t_traj_fate tutorial heatmap.

### 1. Cluster-strip / expression desync when ``reverse_ht`` is set

Each lineage chunk reverses its expression column order via ``grouped.iloc[::-1]`` (so the heatmap reads right-to-left for that lineage), but ``annotation_values[key]`` — used to build the cluster-annotation bar at the top of the panel — was left in the original pt-ascending order. Visible bug: ``reverse_ht=['Beta']`` in the pancreas tutorial painted Beta markers (Ins1/Ins2/Pdx1) on the LEFT of the Beta panel while the Beta-cluster strip at the top of that same panel stayed on the RIGHT. The two halves of the panel disagreed on which side was "late".

Fix: apply the same ``[::-1]`` to ``annotation_values`` when the lineage is in ``reverse_lineages``.

### 2. Per-lineage standardisation

``_scale_dynamic_frame`` ran once on the *concatenated* matrix, so a single high-expressing lineage (Delta's Sst ~9) dominated the global ``std`` and compressed the other panels' cascades into the colour-bar's near-zero region. Small Sst noise in Beta panel (mean ~0.5) was painted faint red, suggesting a spurious Sst spike.

Fix: scale each lineage chunk independently before concatenation. Pair with ``standard_scale=None`` and a sequential cmap (e.g. ``'Reds'``) when absolute-magnitude comparison across lineages is desired — the colour-bar is then shared and reflects raw expression directly.

### 3. ``reverse_ht`` semantics for >2 lineages

``reverse_ht`` enables a diverging-cascade layout — one terminal at far-left reading right-to-left, the other at far-right reading left-to-right. With more than two lineages each panel reads in a different direction, which is confusing. Add a ``UserWarning`` flagging this.

## Test plan

- [x] ``reverse_ht=['Beta']`` on pancreas now paints Beta markers AND Beta cluster strip on the same side
- [x] Per-lineage standardisation: ``standard_scale=None`` + ``'Reds'`` shows Sst dark red ~8 in Delta panel, faint near-zero everywhere else (matches the underlying ``mean(Sst | lineage)`` values: 9.6/0.5/0.18/0.07 for Delta/Beta/Epsilon/Alpha)
- [x] Warning fires for >2 lineages with non-empty ``reverse_ht``

🤖 Generated with [Claude Code](https://claude.com/claude-code)