### PR TITLE
feat(airr): airr_singlecell_bcr loader + extract_heavy_chains helper

### DIFF
--- a/omicverse/airr/__init__.py
+++ b/omicverse/airr/__init__.py
@@ -111,6 +111,7 @@ _LAZY_ATTRS: dict[str, tuple[str, str]] = {
     "read_airr":                 (".io", "read_airr"),
     "read_tracer":               (".io", "read_tracer"),
     "from_airr_array":           (".io", "from_airr_array"),
+    "extract_heavy_chains":      (".io", "extract_heavy_chains"),
     "simulate_airr":             (".io", "simulate_airr"),
     "airr_obs_columns":          (".io", "airr_obs_columns"),
     # --- single-cell QC ---

--- a/omicverse/airr/io.py
+++ b/omicverse/airr/io.py
@@ -520,3 +520,150 @@ def simulate_airr(
         ["s1", "s2", "s3", "s4"], size=adata.n_obs
     )
     return adata
+
+
+# ---------------------------------------------------------------------------
+# Per-cell heavy-chain extraction — bridges sc-BCR AnnData → AIRR DataFrame
+# ---------------------------------------------------------------------------
+@register_function(
+    aliases=[
+        "extract_heavy_chains", "heavy_chain_table", "bcr_heavy_chain_table",
+        "igh_table", "重链表", "BCR重链提取",
+    ],
+    category="airr",
+    description=(
+        "Extract the dominant productive IgH (or, for TCR, VDJ-arm) contig "
+        "per cell from a single-cell AIRR AnnData (``obsm['airr']`` awkward "
+        "array) into a flat AIRR-format ``pandas.DataFrame``. This is the "
+        "bridge between the AnnData-native single-cell side and the "
+        "DataFrame-native B-cell / Immcantation side of ``ov.airr`` — feed "
+        "the result into ``mutation_analysis``, ``clonal_clustering``, "
+        "``lineage_trees`` etc."
+    ),
+    examples=[
+        "db = ov.airr.extract_heavy_chains(adata)",
+        "db = ov.airr.extract_heavy_chains(adata, locus='IGH', fields=['sequence_alignment','germline_alignment_d_mask','mu_freq'])",
+    ],
+    related=["airr.from_airr_array", "airr.mutation_analysis",
+             "airr.clonal_clustering"],
+)
+def extract_heavy_chains(
+    adata,
+    *,
+    airr_key: str = "airr",
+    locus: str = "IGH",
+    fields: Optional[list] = None,
+    obs_cols: Optional[list] = None,
+):
+    """Extract the dominant productive heavy-chain contig per cell.
+
+    Single-cell AIRR data stores per-cell contigs as a ragged awkward array
+    in ``adata.obsm[airr_key]`` — convenient for storage, awkward for the
+    Immcantation backends (which expect a flat AIRR-format
+    ``pandas.DataFrame``). This helper:
+
+    * Iterates over each cell;
+    * Keeps only **productive** contigs at the requested ``locus`` (``IGH``
+      by default for BCR; pass e.g. ``'TRB'`` for TCR beta);
+    * Picks the **dominant** contig per cell, ranked by
+      ``duplicate_count`` (UMI support);
+    * Emits one row per cell into an AIRR-format ``DataFrame`` carrying
+      the standard sequence / germline / mutation columns plus any extra
+      ``obs`` columns requested.
+
+    Parameters
+    ----------
+    adata
+        Single-cell AIRR AnnData with ``obsm[airr_key]`` (e.g. as returned
+        by :func:`ov.datasets.airr_singlecell_bcr` or any scirpy-style
+        loader).
+    airr_key
+        ``obsm`` key holding the awkward contig array (default ``'airr'``).
+    locus
+        Locus to extract: ``'IGH'`` (default — heavy chain) for BCR,
+        ``'TRB'`` for TCR beta, etc.
+    fields
+        AIRR fields to pull from each contig. If ``None``, a useful default
+        is used: ``v_call`` / ``d_call`` / ``j_call`` / ``c_call`` /
+        ``junction`` / ``junction_aa`` / ``sequence_alignment`` /
+        ``germline_alignment_d_mask`` / ``mu_freq`` / ``duplicate_count`` /
+        ``sample_id``. Missing fields are silently skipped.
+    obs_cols
+        ``adata.obs`` columns to attach to each row (default: none).
+
+    Returns
+    -------
+    :class:`pandas.DataFrame`
+        One row per cell with the requested fields and a ``cell_id`` column
+        matching ``adata.obs_names``. Cells without a productive heavy
+        chain are dropped.
+    """
+    if airr_key not in adata.obsm:
+        raise KeyError(
+            f"obsm[{airr_key!r}] not found — expected per-cell receptor "
+            "contigs (e.g. from ov.datasets.airr_singlecell_bcr)."
+        )
+    arr = adata.obsm[airr_key]
+    default_fields = [
+        "v_call", "d_call", "j_call", "c_call",
+        "junction", "junction_aa",
+        "sequence_alignment", "germline_alignment_d_mask",
+        "mu_freq", "duplicate_count", "sample_id", "productive",
+    ]
+    wanted = list(fields) if fields is not None else default_fields
+    avail_fields = set(getattr(arr, "fields", []) or [])
+    if len(arr) > 0:
+        avail_fields |= set(getattr(arr[0], "fields", []) or [])
+    wanted = [f for f in wanted if f in avail_fields]
+
+    def _str_or_none(v):
+        if v is None:
+            return None
+        s = str(v)
+        return None if s in ("None", "nan", "") else s
+
+    def _to_float(v):
+        if v is None:
+            return float("nan")
+        try:
+            return float(v)
+        except (TypeError, ValueError):
+            return float("nan")
+
+    rows = []
+    for i in range(len(arr)):
+        cell_id = str(adata.obs_names[i])
+        best = None
+        for chain in arr[i]:
+            loc = _str_or_none(chain["locus"]) if "locus" in avail_fields else None
+            if loc != locus:
+                continue
+            prod = (
+                _str_or_none(chain["productive"])
+                if "productive" in avail_fields else "True"
+            )
+            if prod not in ("T", "True", "true", "TRUE"):
+                continue
+            dc_v = (
+                _to_float(chain["duplicate_count"])
+                if "duplicate_count" in avail_fields else 0.0
+            )
+            if not (best and dc_v <= best[0]):
+                rec = {}
+                for f in wanted:
+                    val = chain[f]
+                    if f in ("duplicate_count", "mu_freq", "junction_length"):
+                        rec[f] = _to_float(val)
+                    else:
+                        rec[f] = _str_or_none(val)
+                rec["cell_id"] = cell_id
+                best = (dc_v, rec)
+        if best is not None:
+            rows.append(best[1])
+
+    db = pd.DataFrame(rows)
+    if obs_cols:
+        meta = adata.obs[list(obs_cols)].copy()
+        meta.index = meta.index.astype(str)
+        db = db.merge(meta, left_on="cell_id", right_index=True, how="left")
+    return db

--- a/omicverse/datasets/__init__.py
+++ b/omicverse/datasets/__init__.py
@@ -125,6 +125,7 @@ from ._timecourse import (
 from ._airr import (
     # Real immune-repertoire (AIRR) datasets for the ov.airr tutorials
     airr_singlecell,
+    airr_singlecell_bcr,
     airr_bcr,
     airr_tcr_antigen,
     vdjdb_reference,

--- a/omicverse/datasets/_airr.py
+++ b/omicverse/datasets/_airr.py
@@ -10,6 +10,7 @@ The AIRR tutorial chapter spans several modalities, one real dataset each:
 | Loader | Returns | Modality | Source |
 |---|---|---|---|
 | :func:`airr_singlecell` | AnnData (cells x genes) | single-cell TCR + GEX | Wu et al., Nature 2020 |
+| :func:`airr_singlecell_bcr` | AnnData (cells x genes) | single-cell BCR + GEX | Stephenson et al., Nat Med 2021 |
 | :func:`airr_bcr` | DataFrame (AIRR rearrangement) | B-cell BCR (SHM / lineage) | Laserson et al., PNAS 2014 |
 | :func:`airr_tcr_antigen` | AnnData (cells x genes) | antigen-labelled scTCR + GEX | 10x Genomics dCODE dextramer |
 | :func:`vdjdb_reference` | DataFrame (TCR-epitope) | antigen-specificity reference | VDJdb (antigenomics) |
@@ -79,6 +80,68 @@ def airr_singlecell(dir: str = "./data") -> "AnnData":
     """Load the real Wu 2020 single-cell TCR + GEX dataset (5k cells)."""
     import anndata as ad
     return ad.read_h5ad(_fetch("wu2020_sctcr.h5ad", dir))
+
+
+@register_function(
+    aliases=[
+        "airr_singlecell_bcr", "airr_scbcr", "stephenson2021", "stephenson2021_bcr",
+        "single_cell_bcr", "covid_bcr", "单细胞BCR", "新冠BCR",
+    ],
+    category="datasets",
+    description=(
+        "Real single-cell BCR + gene-expression dataset for the single-cell "
+        "BCR arm of the AIRR tutorial — Stephenson et al. (Nature Medicine "
+        "2021, 27:904-916; PMID 33879890) 10x 5' scBCR-seq + GEX of "
+        "PBMC B cells from COVID-19 patients spanning the full severity "
+        "spectrum (Ward / Ward-O2 / Ward-NIV / ITU-O2 / ITU-NIV / "
+        "ITU-intubated). Obtained via scirpy.datasets.stephenson2021_5k() "
+        "and curated to a balanced 5,000-cell x 24,929-gene tutorial "
+        "subset (29 patients, 9 published B-cell states from naive through "
+        "memory to plasmablast and IgG/IgA/IgM plasma cells). The BCR "
+        "library was IgBLAST/Change-O processed upstream so per-contig "
+        "``sequence_alignment`` / ``germline_alignment_d_mask`` / ``mu_freq`` "
+        "are already populated. Returned as an AnnData: ``.X`` holds "
+        "log-normalised expression (raw UMIs kept in ``.layers['raw']``), "
+        "``.obsm['airr']`` holds the per-cell IgH/IgK/IgL contigs in "
+        "scirpy's awkward-array format, ``.obsm['X_umap']`` the published "
+        "GEX UMAP, and ``.obs`` carries ``sample_id`` / ``patient_id`` / "
+        "``full_clustering`` (B_naive / B_immature / B_switched_memory / "
+        "Plasmablast / Plasma_cell_Ig*) / ``Status_on_day_collection`` "
+        "(severity at sampling). Feed straight into the ``ov.airr`` "
+        "single-cell BCR clonotype + SHM workflow "
+        "(``from_airr_array`` → ``chain_qc`` → ``define_clonotypes`` → "
+        "``clonal_expansion`` → ``isotype_class`` → ``mutation_analysis``)."
+    ),
+    examples=[
+        "adata = ov.datasets.airr_singlecell_bcr()",
+        "adata = ov.airr.from_airr_array(adata)",
+    ],
+)
+def airr_singlecell_bcr(dir: str = "./data") -> "AnnData":
+    """Load the real Stephenson 2021 single-cell BCR + GEX dataset (5k cells).
+
+    Wraps ``scirpy.datasets.stephenson2021_5k()`` — which fetches the
+    pre-processed MuData from the scirpy figshare DOI (10.6084/m9.figshare.
+    22249894) — and merges its ``gex`` + ``airr`` modalities back into a
+    single AnnData with the per-cell BCR contigs in ``obsm['airr']`` (the
+    on-disk layout ``ov.airr.from_airr_array`` expects).
+
+    Parameters
+    ----------
+    dir
+        Ignored; kept for API symmetry with the other AIRR loaders.
+        Caching uses the scirpy / pooch default location.
+
+    Returns
+    -------
+    :class:`~anndata.AnnData`
+        5,000 B-cells x 24,929 genes with BCR contigs in ``obsm['airr']``.
+    """
+    import scirpy as ir
+    mdata = ir.datasets.stephenson2021_5k()
+    gex = mdata.mod["gex"].copy()
+    gex.obsm["airr"] = mdata.mod["airr"].obsm["airr"]
+    return gex
 
 
 @register_function(


### PR DESCRIPTION
## Summary

Add the two missing `ov.airr` / `ov.datasets` building blocks needed for an end-to-end single-cell BCR tutorial against `ov.airr`. The tutorial itself ships in the matching companion PR omicverse/omicverse-tutorials#67 (which this PR bumps the `omicverse_guide` submodule to).

## What's added

### `ov.datasets.airr_singlecell_bcr()`
Real single-cell BCR + GEX dataset for the AIRR tutorial chapter — Stephenson et al. *Nature Medicine* 2021 ([PMID 33879890](https://pubmed.ncbi.nlm.nih.gov/33879890/)), 5,000 BCR-bearing B cells across 29 COVID-19 patients spanning the full Ward → ITU severity spectrum. Wraps `scirpy.datasets.stephenson2021_5k()` (fetched from the scirpy figshare DOI [10.6084/m9.figshare.22249894](https://doi.org/10.6084/m9.figshare.22249894)) and merges its `gex` + `airr` MuData modalities back into one AnnData with the BCR contigs in `obsm['airr']` — the scirpy on-disk layout `ov.airr.from_airr_array` already expects.

### `ov.airr.extract_heavy_chains(adata, ...)`
Bridge between the AnnData-native single-cell side of `ov.airr` and the DataFrame-native Immcantation backends. Pulls the dominant productive `IGH` contig per cell (ranked by `duplicate_count`) from the ragged `obsm['airr']` awkward array into a flat AIRR-format DataFrame with `sequence_alignment` / `germline_alignment_d_mask` / `mu_freq` / `c_call` / … — the format `mutation_analysis`, `clonal_clustering`, `lineage_trees` etc. need. Optional \`obs_cols=\` attaches cell metadata for group-by analysis. Lives in \`airr/io.py\` next to \`from_airr_array\`.

## Companion PR

omicverse/omicverse-tutorials#67 — adds **`t_airr_06_bcr_singlecell.ipynb`** (single-cell BCR + GEX end-to-end on the loader above) plus audits the four existing AIRR tutorials and fixes a narrative-vs-data error in `t_airr_01`, adds Morisita-Horn overlap to `t_airr_02`, adds a TIgGER production-ordering callout to `t_airr_03`, and annotates the canonical `ov.pl.dotplot` replacement in `t_airr_05`. This PR bumps the `omicverse_guide` submodule to that branch's head (`376821a`).

## Test plan

- [x] `python -c \"import omicverse as ov; print(ov.datasets.airr_singlecell_bcr, ov.airr.extract_heavy_chains)\"` resolves both symbols
- [x] `ov.datasets.airr_singlecell_bcr()` returns a 5,000 × 24,929 AnnData with `obsm['airr']` populated
- [x] `ov.airr.from_airr_array(adata) → ov.airr.chain_qc(adata) → ov.airr.extract_heavy_chains(adata)` round-trips correctly
- [x] Resulting DataFrame works with `ov.airr.mutation_analysis`, `ov.airr.distance_threshold`, `ov.airr.clonal_clustering` end-to-end (companion tutorial executes 60 cells / 10 figs / 0 errors)
- [ ] Reviewer: sanity-check the figshare URL lifecycle (scirpy's loader caches per their pooch defaults)

🤖 Generated with [Claude Code](https://claude.com/claude-code)