### PR TITLE
fix(tests): give TestRunningTask.test_dataclass_fields its own event loop

### DIFF
--- a/tests/jarvis/test_channel_core.py
+++ b/tests/jarvis/test_channel_core.py
@@ -454,11 +454,19 @@ class TestDefaultSummary:
 
 class TestRunningTask:
     def test_dataclass_fields(self) -> None:
-        task = asyncio.Future()
-        rt = RunningTask(task=task, request="test", started_at=1.0)
-        assert rt.task is task
-        assert rt.request == "test"
-        assert rt.started_at == 1.0
+        # asyncio.Future() called bare in MainThread relies on the
+        # deprecated implicit-loop fallback, which raises RuntimeError on
+        # Python 3.12+. Allocate the future against an explicit loop so
+        # the test works on every supported interpreter.
+        loop = asyncio.new_event_loop()
+        try:
+            task = loop.create_future()
+            rt = RunningTask(task=task, request="test", started_at=1.0)
+            assert rt.task is task
+            assert rt.request == "test"
+            assert rt.started_at == 1.0
+        finally:
+            loop.close()
 
 
 # ── Channel imports use shared code ──────────────────────────────────────────


### PR DESCRIPTION
## Summary

The single test `tests/jarvis/test_channel_core.py::TestRunningTask::test_dataclass_fields` has been reddening the `py310|py311|py312` workflow on every commit since the channel-core test landed. Latest run [#26567345219](https://github.com/omicverse/omicverse/actions/runs/26567345219):

```
=== 1 failed, 4958 passed, 1059 skipped, 2039 warnings in 687.54s ===
FAILED tests/jarvis/test_channel_core.py::TestRunningTask::test_dataclass_fields
       — RuntimeError: There is no current event loop in thread 'MainThread'.
```

## Root cause

The test constructed an `asyncio.Future` bare in `MainThread`:

```python
def test_dataclass_fields(self) -> None:
    task = asyncio.Future()                       # <-- needs a current loop
    rt = RunningTask(task=task, request="test", started_at=1.0)
    ...
```

`asyncio.Future()` with no `loop=` argument falls back to `asyncio.events.get_event_loop()`. That fallback was deprecated in Python 3.10 and **removed in 3.12** — calling it from `MainThread` with no running loop now raises `RuntimeError`. The test ran fine locally only when an earlier async test happened to leave a loop installed; in the CI ordering it ran first and blew up.

## Fix

Allocate an explicit loop, derive the future via `loop.create_future()`, close the loop in `finally`:

```python
def test_dataclass_fields(self) -> None:
    loop = asyncio.new_event_loop()
    try:
        task = loop.create_future()
        rt = RunningTask(task=task, request="test", started_at=1.0)
        assert rt.task is task
        assert rt.request == "test"
        assert rt.started_at == 1.0
    finally:
        loop.close()
```

This still validates the same dataclass-field contract (`task is task`, `request == "test"`, `started_at == 1.0`) but no longer depends on the deprecated implicit-loop machinery. Works back to Python 3.4, so it covers all three CI matrix versions (3.10 / 3.11 / 3.12).

## Test plan

- [x] `pytest tests/jarvis/test_channel_core.py::TestRunningTask::test_dataclass_fields` — PASS locally (py3.10).
- [x] `pytest tests/jarvis/test_channel_core.py -q` — 55/55 pass.
- [ ] CI `py310|py311|py312` should now go green on all three matrix versions (waiting on this PR's run).

## Out of scope

Verified the same anti-pattern doesn't exist elsewhere in `tests/`:

```
$ grep -rn "asyncio\.Future()\|asyncio\.get_event_loop()" tests/
tests/jarvis/test_channel_core.py:457  ← the one fixed here, no other hits
```

The lint warnings about unused imports in the same file (F401 on `Any`/`Dict`/`List`/`Optional`/`pytest`) are flagged by flake8's `--exit-zero` pass and do not fail CI, so I left them for a separate cleanup PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)