### PR TITLE
feat(pp): support custom keys in ov.pp.regress

### DIFF
--- a/omicverse/pp/_preprocess.py
+++ b/omicverse/pp/_preprocess.py
@@ -10,6 +10,7 @@ import pandas as pd
 import skmisc.loess as sl
 import scanpy as sc
 import time 
+import warnings
 
 from scipy.sparse import issparse, csr_matrix
 
@@ -1156,7 +1157,7 @@ def scale(adata, max_value=10, layers_add='scaled', to_sparse=False, **kwargs):
     ],
     related=["scale", "regress_and_scale", "pca"],
 )
-def regress(adata, *, keys: list[str] | None = None, layer=None, n_jobs=8, **kwargs):
+def regress(adata, *, keys: Optional[List[str]] = None, layer=None, n_jobs=8, **kwargs):
     """Regress out technical covariates from each gene.
 
     Parameters
@@ -1190,7 +1191,7 @@ def regress(adata, *, keys: list[str] | None = None, layer=None, n_jobs=8, **kwa
             "keys must be a non-empty list of adata.obs column names.")
     missing = [k for k in keys if k not in adata.obs.columns]
     if missing:
-        raise KeyError(
+        raise ValueError(
             f"Columns {missing} not found in adata.obs. "
             f"Available columns (first 10): "
             f"{list(adata.obs.columns)[:10]}"
@@ -1214,8 +1215,6 @@ def regress(adata, *, keys: list[str] | None = None, layer=None, n_jobs=8, **kwa
         # ``layer``, ``n_jobs``, and other ``**kwargs`` are silently
         # ignored by the rapids_singlecell backend.
         if layer is not None:
-            import warnings
-
             warnings.warn(
                 "The GPU (rapids_singlecell) backend ignores the `layer` "
                 "argument and always reads from adata.X. "

--- a/omicverse/pp/_preprocess.py
+++ b/omicverse/pp/_preprocess.py
@@ -1175,8 +1175,9 @@ def regress(adata, *, keys: Optional[List[str]] = None, layer=None, n_jobs=8, **
     n_jobs
         Parallel jobs for the CPU regressor. Default ``8``.
     **kwargs
-        Extra options forwarded to the backend
-        (``scanpy.pp.regress_out`` or ``rapids_singlecell.pp.regress_out``).
+        Extra options forwarded to ``scanpy.pp.regress_out`` on CPU
+        (e.g. ``copy``). Ignored when the GPU backend
+        (``rapids_singlecell``) is active.
 
     Returns
     -------
@@ -1219,6 +1220,13 @@ def regress(adata, *, keys: Optional[List[str]] = None, layer=None, n_jobs=8, **
                 "The GPU (rapids_singlecell) backend ignores the `layer` "
                 "argument and always reads from adata.X. "
                 "The current call specified layer=%r." % layer,
+                UserWarning,
+                stacklevel=2,
+            )
+        if n_jobs != 8:
+            warnings.warn(
+                "The GPU (rapids_singlecell) backend ignores `n_jobs`. "
+                "The current call specified n_jobs=%r." % n_jobs,
                 UserWarning,
                 stacklevel=2,
             )

--- a/omicverse/pp/_preprocess.py
+++ b/omicverse/pp/_preprocess.py
@@ -1138,7 +1138,7 @@ def scale(adata, max_value=10, layers_add='scaled', to_sparse=False, **kwargs):
 @register_function(
     aliases=["回归校正", "regress", "regress_out", "去除技术效应", "协变量回归"],
     category="preprocessing",
-    description="Regress out technical covariates (mitochondrial ratio and UMI counts)",
+    description="Regress out technical covariates (e.g. mitochondrial ratio, UMI counts, or custom variables)",
     prerequisites={
         "optional_functions": ["qc", "normalize_pearson_residuals"]
     },
@@ -1152,18 +1152,23 @@ def scale(adata, max_value=10, layers_add='scaled', to_sparse=False, **kwargs):
     examples=[
         "ov.pp.regress(adata)",
         "ov.pp.regress(adata, n_jobs=4)",
+        "ov.pp.regress(adata, keys=['mito_perc', 'nUMIs', 'S_score', 'G2M_score'])",
     ],
     related=["scale", "regress_and_scale", "pca"],
 )
-def regress(adata, *, layer=None, n_jobs=8, **kwargs):
-    """Regress out technical covariates (``mito_perc``, ``nUMIs``) from
-    each gene.
+def regress(adata, *, keys=None, layer=None, n_jobs=8, **kwargs):
+    """Regress out technical covariates from each gene.
 
     Parameters
     ----------
     adata : anndata.AnnData
-        AnnData object with ``adata.obs['mito_perc']`` and
-        ``adata.obs['nUMIs']`` already computed (by ``ov.pp.qc``).
+        AnnData object. The columns specified in ``keys`` must exist
+        in ``adata.obs``.
+    keys : list of str, optional
+        Column names in ``adata.obs`` to regress out. Defaults to
+        ``['mito_perc', 'nUMIs']``, which are computed by ``ov.pp.qc``.
+        Common additions include cell-cycle scores (``S_score``,
+        ``G2M_score``) and ribosomal gene percentage.
     layer
         Expression layer to regress. ``None`` uses ``adata.X``.
     n_jobs
@@ -1175,19 +1180,28 @@ def regress(adata, *, layer=None, n_jobs=8, **kwargs):
     Returns
     -------
     None
-        Writes the residualised expression to ``adata.layers['regressed']``.
+        Writes the residualised expression to
+        ``adata.layers['regressed']``.
     """
+    if keys is None:
+        keys = ['mito_perc', 'nUMIs']
+    missing = [k for k in keys if k not in adata.obs.columns]
+    if missing:
+        raise KeyError(
+            f"Columns {missing} not found in adata.obs. "
+            f"Available columns: {list(adata.obs.columns)}"
+        )
     if layer is not None:
         kwargs.setdefault("layer", layer)
     kwargs.setdefault("n_jobs", n_jobs)
     if settings.mode == 'cpu' or settings.mode == 'cpu-gpu-mixed':
         kwargs.setdefault("copy", True)
-        adata_mock = sc.pp.regress_out(adata, ['mito_perc', 'nUMIs'], **kwargs)
+        adata_mock = sc.pp.regress_out(adata, keys, **kwargs)
         adata.layers['regressed'] = adata_mock.X.copy()
         del adata_mock
     else:
         import rapids_singlecell as rsc
-        adata.layers['regressed']=rsc.pp.regress_out(adata, ['mito_perc', 'nUMIs'], inplace=False)
+        adata.layers['regressed'] = rsc.pp.regress_out(adata, keys, inplace=False)
     add_reference(adata,'scanpy','regressing out covariates with scanpy')
 
 @monitor

--- a/omicverse/pp/_preprocess.py
+++ b/omicverse/pp/_preprocess.py
@@ -1156,7 +1156,7 @@ def scale(adata, max_value=10, layers_add='scaled', to_sparse=False, **kwargs):
     ],
     related=["scale", "regress_and_scale", "pca"],
 )
-def regress(adata, *, keys=None, layer=None, n_jobs=8, **kwargs):
+def regress(adata, *, keys: list[str] | None = None, layer=None, n_jobs=8, **kwargs):
     """Regress out technical covariates from each gene.
 
     Parameters
@@ -1185,6 +1185,9 @@ def regress(adata, *, keys=None, layer=None, n_jobs=8, **kwargs):
     """
     if keys is None:
         keys = ['mito_perc', 'nUMIs']
+    if not keys:
+        raise ValueError(
+            "keys must be a non-empty list of adata.obs column names.")
     missing = [k for k in keys if k not in adata.obs.columns]
     if missing:
         raise KeyError(
@@ -1210,6 +1213,16 @@ def regress(adata, *, keys=None, layer=None, n_jobs=8, **kwargs):
         # NOTE: GPU path only forwards ``keys`` and ``inplace=False``;
         # ``layer``, ``n_jobs``, and other ``**kwargs`` are silently
         # ignored by the rapids_singlecell backend.
+        if layer is not None:
+            import warnings
+
+            warnings.warn(
+                "The GPU (rapids_singlecell) backend ignores the `layer` "
+                "argument and always reads from adata.X. "
+                "The current call specified layer=%r." % layer,
+                UserWarning,
+                stacklevel=2,
+            )
         adata.layers['regressed'] = rsc.pp.regress_out(adata, keys, inplace=False)
     add_reference(adata,'scanpy','regressing out covariates with scanpy')
 

--- a/omicverse/pp/_preprocess.py
+++ b/omicverse/pp/_preprocess.py
@@ -1189,7 +1189,13 @@ def regress(adata, *, keys=None, layer=None, n_jobs=8, **kwargs):
     if missing:
         raise KeyError(
             f"Columns {missing} not found in adata.obs. "
-            f"Available columns: {list(adata.obs.columns)}"
+            f"Available columns (first 10): "
+            f"{list(adata.obs.columns)[:10]}"
+            + (
+                " ..."
+                if len(adata.obs.columns) > 10
+                else ""
+            )
         )
     if layer is not None:
         kwargs.setdefault("layer", layer)
@@ -1201,6 +1207,9 @@ def regress(adata, *, keys=None, layer=None, n_jobs=8, **kwargs):
         del adata_mock
     else:
         import rapids_singlecell as rsc
+        # NOTE: GPU path only forwards ``keys`` and ``inplace=False``;
+        # ``layer``, ``n_jobs``, and other ``**kwargs`` are silently
+        # ignored by the rapids_singlecell backend.
         adata.layers['regressed'] = rsc.pp.regress_out(adata, keys, inplace=False)
     add_reference(adata,'scanpy','regressing out covariates with scanpy')
 

--- a/tests/pp/test_regress.py
+++ b/tests/pp/test_regress.py
@@ -4,7 +4,7 @@ Verifies:
 - Default call (``keys=None``) regresses ``mito_perc`` and ``nUMIs``
   and writes ``adata.layers['regressed']``.
 - Custom ``keys`` with cell-cycle scores regress additional covariates.
-- Missing columns raise ``KeyError`` with the available column list.
+- Missing columns raise ``ValueError`` with the available column list.
 - Compatibility with ``regress_and_scale`` downstream.
 """
 from __future__ import annotations

--- a/tests/pp/test_regress.py
+++ b/tests/pp/test_regress.py
@@ -79,13 +79,13 @@ def test_regress_single_custom_key():
 # ── error handling ────────────────────────────────────────────────────────
 
 
-def test_regress_missing_key_raises_keyerror_with_available_columns():
+def test_regress_missing_key_raises_valueerror_with_available_columns():
     """When a requested column does not exist in ``adata.obs``,
-    ``regress()`` must raise ``KeyError`` and include the list of
+    ``regress()`` must raise ``ValueError`` and include the list of
     available column names in the message.
     """
     adata = _small_adata()
-    with pytest.raises(KeyError, match="not found in adata.obs"):
+    with pytest.raises(ValueError, match="not found in adata.obs"):
         ov.pp.regress(adata, keys=["mito_perc", "nonexistent_column"])
 
 
@@ -94,7 +94,7 @@ def test_regress_nonexistent_key_message_lists_columns():
     see what columns actually exist.
     """
     adata = _small_adata()
-    with pytest.raises(KeyError, match="Available columns"):
+    with pytest.raises(ValueError, match="Available columns"):
         ov.pp.regress(adata, keys=["nUMIs", "bad_key"])
 
 

--- a/tests/pp/test_regress.py
+++ b/tests/pp/test_regress.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import numpy as np
 import pytest
 from anndata import AnnData
+import omicverse as ov
 
 
 def _small_adata(n_cells: int = 50, n_genes: int = 100, seed: int = 42) -> AnnData:
@@ -39,8 +40,6 @@ def test_regress_default_keys_writes_regressed_layer():
     ``mito_perc`` and ``nUMIs`` and store the result in
     ``adata.layers['regressed']``, preserving the original shape.
     """
-    import omicverse as ov
-
     adata = _small_adata()
     original_shape = adata.shape
 
@@ -62,8 +61,6 @@ def test_regress_custom_keys_with_cell_cycle():
     must accept and regress additional ``adata.obs`` columns beyond the
     default ``mito_perc`` / ``nUMIs`` pair.
     """
-    import omicverse as ov
-
     adata = _small_adata()
     ov.pp.regress(
         adata,
@@ -74,8 +71,6 @@ def test_regress_custom_keys_with_cell_cycle():
 
 def test_regress_single_custom_key():
     """Regression with only a single custom column must succeed."""
-    import omicverse as ov
-
     adata = _small_adata()
     ov.pp.regress(adata, keys=["S_score"])
     assert "regressed" in adata.layers
@@ -89,8 +84,6 @@ def test_regress_missing_key_raises_keyerror_with_available_columns():
     ``regress()`` must raise ``KeyError`` and include the list of
     available column names in the message.
     """
-    import omicverse as ov
-
     adata = _small_adata()
     with pytest.raises(KeyError, match="not found in adata.obs"):
         ov.pp.regress(adata, keys=["mito_perc", "nonexistent_column"])
@@ -100,8 +93,6 @@ def test_regress_nonexistent_key_message_lists_columns():
     """The error message must include 'Available columns' so users can
     see what columns actually exist.
     """
-    import omicverse as ov
-
     adata = _small_adata()
     with pytest.raises(KeyError, match="Available columns"):
         ov.pp.regress(adata, keys=["nUMIs", "bad_key"])
@@ -115,8 +106,6 @@ def test_regress_and_scale_works_after_custom_keys_regress():
     custom-keys ``regress()`` call, producing a
     ``regressed_and_scaled`` layer.
     """
-    import omicverse as ov
-
     adata = _small_adata()
     ov.pp.regress(adata, keys=["mito_perc", "nUMIs", "S_score"])
     ov.pp.regress_and_scale(adata)
@@ -128,8 +117,6 @@ def test_regress_and_scale_works_after_custom_keys_regress():
 
 def test_regress_preserves_obs_columns():
     """``regress()`` must not mutate or drop existing ``.obs`` columns."""
-    import omicverse as ov
-
     adata = _small_adata()
     original_obs_cols = set(adata.obs.columns)
     ov.pp.regress(adata)
@@ -138,9 +125,17 @@ def test_regress_preserves_obs_columns():
 
 def test_regress_idempotent_with_same_keys():
     """Calling ``regress()`` twice with the same keys must not raise."""
-    import omicverse as ov
-
     adata = _small_adata()
     ov.pp.regress(adata)
-    ov.pp.regress(adata)  # second call overwrites 'regressed' layer
+    ov.pp.regress(adata)  # second call re-computes from adata.X, overwriting 'regressed'
     assert "regressed" in adata.layers
+
+
+# ── empty keys guard ──────────────────────────────────────────────────────
+
+
+def test_regress_empty_keys_raises_valueerror():
+    """``ov.pp.regress(adata, keys=[])`` must raise ``ValueError``."""
+    adata = _small_adata()
+    with pytest.raises(ValueError, match="non-empty list"):
+        ov.pp.regress(adata, keys=[])

--- a/tests/pp/test_regress.py
+++ b/tests/pp/test_regress.py
@@ -1,0 +1,146 @@
+"""Tests for ``ov.pp.regress`` — custom ``keys`` parameter (issue #798).
+
+Verifies:
+- Default call (``keys=None``) regresses ``mito_perc`` and ``nUMIs``
+  and writes ``adata.layers['regressed']``.
+- Custom ``keys`` with cell-cycle scores regress additional covariates.
+- Missing columns raise ``KeyError`` with the available column list.
+- Compatibility with ``regress_and_scale`` downstream.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from anndata import AnnData
+
+
+def _small_adata(n_cells: int = 50, n_genes: int = 100, seed: int = 42) -> AnnData:
+    """Minimal Poisson-counts AnnData with ``mito_perc``, ``nUMIs``,
+    ``S_score``, and ``G2M_score`` in ``.obs`` — mimicking the output
+    of ``ov.pp.qc`` followed by ``ov.pp.score_genes_cell_cycle``.
+    """
+    rng = np.random.default_rng(seed)
+    counts = rng.poisson(lam=3.0, size=(n_cells, n_genes)).astype(np.float32)
+    adata = AnnData(X=counts)
+    adata.var_names = [f"Gene{i:04d}" for i in range(n_genes)]
+    adata.obs_names = [f"cell{i:04d}" for i in range(n_cells)]
+    adata.obs["nUMIs"] = np.array(counts.sum(axis=1)).ravel()
+    adata.obs["mito_perc"] = rng.uniform(0.01, 0.15, size=n_cells).astype(np.float32)
+    adata.obs["S_score"] = rng.normal(0, 1, size=n_cells).astype(np.float32)
+    adata.obs["G2M_score"] = rng.normal(0, 1, size=n_cells).astype(np.float32)
+    return adata
+
+
+# ── default behaviour (backward compatibility) ────────────────────────────
+
+
+def test_regress_default_keys_writes_regressed_layer():
+    """``ov.pp.regress(adata)`` with no ``keys`` argument must regress
+    ``mito_perc`` and ``nUMIs`` and store the result in
+    ``adata.layers['regressed']``, preserving the original shape.
+    """
+    import omicverse as ov
+
+    adata = _small_adata()
+    original_shape = adata.shape
+
+    ov.pp.regress(adata)
+
+    assert "regressed" in adata.layers, (
+        "regress() did not create adata.layers['regressed']"
+    )
+    assert adata.layers["regressed"].shape == original_shape, (
+        "regressed layer shape mismatch"
+    )
+
+
+# ── custom keys ───────────────────────────────────────────────────────────
+
+
+def test_regress_custom_keys_with_cell_cycle():
+    """``ov.pp.regress(adata, keys=[..., 'S_score', 'G2M_score'])``
+    must accept and regress additional ``adata.obs`` columns beyond the
+    default ``mito_perc`` / ``nUMIs`` pair.
+    """
+    import omicverse as ov
+
+    adata = _small_adata()
+    ov.pp.regress(
+        adata,
+        keys=["mito_perc", "nUMIs", "S_score", "G2M_score"],
+    )
+    assert "regressed" in adata.layers
+
+
+def test_regress_single_custom_key():
+    """Regression with only a single custom column must succeed."""
+    import omicverse as ov
+
+    adata = _small_adata()
+    ov.pp.regress(adata, keys=["S_score"])
+    assert "regressed" in adata.layers
+
+
+# ── error handling ────────────────────────────────────────────────────────
+
+
+def test_regress_missing_key_raises_keyerror_with_available_columns():
+    """When a requested column does not exist in ``adata.obs``,
+    ``regress()`` must raise ``KeyError`` and include the list of
+    available column names in the message.
+    """
+    import omicverse as ov
+
+    adata = _small_adata()
+    with pytest.raises(KeyError, match="not found in adata.obs"):
+        ov.pp.regress(adata, keys=["mito_perc", "nonexistent_column"])
+
+
+def test_regress_nonexistent_key_message_lists_columns():
+    """The error message must include 'Available columns' so users can
+    see what columns actually exist.
+    """
+    import omicverse as ov
+
+    adata = _small_adata()
+    with pytest.raises(KeyError, match="Available columns"):
+        ov.pp.regress(adata, keys=["nUMIs", "bad_key"])
+
+
+# ── downstream compatibility ──────────────────────────────────────────────
+
+
+def test_regress_and_scale_works_after_custom_keys_regress():
+    """``ov.pp.regress_and_scale(adata)`` must succeed after a
+    custom-keys ``regress()`` call, producing a
+    ``regressed_and_scaled`` layer.
+    """
+    import omicverse as ov
+
+    adata = _small_adata()
+    ov.pp.regress(adata, keys=["mito_perc", "nUMIs", "S_score"])
+    ov.pp.regress_and_scale(adata)
+    assert "regressed_and_scaled" in adata.layers
+
+
+# ── edge cases ────────────────────────────────────────────────────────────
+
+
+def test_regress_preserves_obs_columns():
+    """``regress()`` must not mutate or drop existing ``.obs`` columns."""
+    import omicverse as ov
+
+    adata = _small_adata()
+    original_obs_cols = set(adata.obs.columns)
+    ov.pp.regress(adata)
+    assert set(adata.obs.columns) == original_obs_cols
+
+
+def test_regress_idempotent_with_same_keys():
+    """Calling ``regress()`` twice with the same keys must not raise."""
+    import omicverse as ov
+
+    adata = _small_adata()
+    ov.pp.regress(adata)
+    ov.pp.regress(adata)  # second call overwrites 'regressed' layer
+    assert "regressed" in adata.layers


### PR DESCRIPTION
Add optional ``keys`` parameter to ``ov.pp.regress``, defaulting to ``['mito_perc', 'nUMIs']`` for full backward compatibility. Users can now regress out arbitrary ``adata.obs`` columns, such as cell-cycle scores (``S_score``, ``G2M_score`` from ``ov.pp.score_genes_cell_cycle``) or
ribosomal gene percentage.
A validation guard raises ``KeyError`` with the list of available columns when a requested key is missing from ``adata.obs``. Updated ``register_function`` metadata and docstring accordingly.
Related to #798 .