### PR TITLE
feat(epi): add ov.epi epigenomics module + tutorial-epigenetics chapter

### DIFF
--- a/omicverse/__init__.py
+++ b/omicverse/__init__.py
@@ -91,6 +91,7 @@ _LAZY_MODULES = {
     'genetics',
     'airr',
     'report',
+    'epi',
 }
 
 # Lazy attribute mappings: {attribute_name: (module_path, attr_name)}

--- a/omicverse/epi/__init__.py
+++ b/omicverse/epi/__init__.py
@@ -1,0 +1,75 @@
+r"""``ov.epi`` — epigenomics analysis for omicverse.
+
+A thin, omicverse-flavoured bridge over the `epione
+<https://github.com/aristoteleo/epione>`_ package, giving single-cell and
+bulk **epigenomics** (scATAC-seq, bulk ATAC/ChIP/CUT&RUN, footprinting,
+chromVAR motif activity, peak-to-gene linkage, and Hi-C) a home next to
+the rest of omicverse. Every wrapper imports epione internally and
+delegates, so ``import omicverse`` stays light — epione's heavier
+optional dependencies (snapatac2, anndataoom, cooler, MOODS, pysam) load
+only when an ``ov.epi.*`` function is first called.
+
+Submodules
+----------
+- :mod:`ov.epi.pp`        preprocessing — fragments, QC, tile/peak/gene matrices
+- :mod:`ov.epi.tl`        tools — iterative LSI, clustering, gene scores, chromVAR, footprints, peak2gene, integration
+- :mod:`ov.epi.pl`        plotting — QC, embeddings, differential, peak2gene, footprints, Hi-C
+- :mod:`ov.epi.io`        readers — 10x ATAC, GTF/GFF, gene annotation, peak utilities
+- :mod:`ov.epi.datasets`  fetch-on-demand example datasets (PBMC 5k/500 scATAC, PBMC 10k multiome)
+- :mod:`ov.epi.data`      prebuilt reference genomes (hg38/hg19/mm39/mm10)
+- :mod:`ov.epi.single`    single-cell ATAC/Hi-C specifics (macs3, pseudobulk, scHiCluster)
+- :mod:`ov.epi.bulk`      bulk ATAC/ChIP/Hi-C specifics (bigwig engine, motif enrichment)
+- :mod:`ov.epi.upstream`  FASTQ→BAM→bigwig/pairs→cool pipelines (CLI-driven)
+- :mod:`ov.epi.utils`     genome accessors and region operations
+
+Quick start (single-cell ATAC, fully reproducible on CPU)::
+
+    import omicverse as ov
+
+    frag  = ov.epi.datasets.atac_pbmc5k_fragments()
+    adata = ov.epi.pp.import_fragments(frag, chrom_sizes=ov.epi.data.hg38)
+    genes = ov.epi.io.get_gene_annotation(ov.epi.data.hg38)
+
+    ov.epi.pp.tsse(adata, genes)
+    ov.epi.pp.frag_size_distr(adata)
+    ov.epi.pp.nucleosome_signal(adata)
+    adata = ov.epi.pp.qc(adata)
+
+    ov.epi.pp.add_tile_matrix(adata)
+    ov.epi.pp.select_features(adata, n_features=250000)
+    ov.epi.tl.iterative_lsi(adata, n_components=30)
+    ov.epi.pp.neighbors(adata, use_rep='X_iterative_lsi')
+    ov.epi.tl.clusters(adata, method='leiden', use_rep='X_iterative_lsi')
+    ov.epi.tl.umap(adata)
+    ov.epi.pl.umap(adata, color='leiden')
+"""
+
+from __future__ import annotations
+
+from . import pp, tl, pl, io, datasets, data, single, bulk, upstream, utils
+from ._utils import import_epione
+
+
+def check_epione(verbose: bool = True):
+    """Check that the backing ``epione`` package is importable.
+
+    Returns the epione version string on success; raises an informative
+    :class:`ImportError` (with an install hint) otherwise.
+    """
+    epi = import_epione()
+    ver = getattr(epi, "__version__", None)
+    if ver is None:
+        try:
+            from importlib.metadata import version as _v
+            ver = _v("epione")
+        except Exception:
+            ver = "unknown"
+    if verbose:
+        print(f"epione is available (version {ver}); ov.epi is ready.")
+    return ver
+
+
+__all__ = [
+    "pp", "tl", "pl", "io", "datasets", "data",
+    "single", "bulk", "upstream", "utils", "check_epione",
+]

--- a/omicverse/epi/_utils.py
+++ b/omicverse/epi/_utils.py
@@ -1,0 +1,92 @@
+r"""Internal helpers shared by the ``ov.epi`` wrappers.
+
+``ov.epi`` is a thin bridge over the `epione
+<https://github.com/aristoteleo/epione>`_ epigenomics package: every
+public function imports :mod:`epione` *inside* the call and delegates to
+the matching ``epione`` symbol. Keeping the import inside the function
+(rather than at module top level) means ``import omicverse`` never pulls
+in epione's heavy optional dependencies (snapatac2, anndataoom, cooler,
+MOODS, pysam, ...) unless an ``ov.epi.*`` function is actually called.
+"""
+
+from __future__ import annotations
+
+import functools
+import importlib
+from types import ModuleType
+from typing import Any, Callable
+
+_INSTALL_HINT = (
+    "ov.epi requires the 'epione' package, which is not installed.\n"
+    "Install it with:\n"
+    "    pip install epione            # core\n"
+    "    pip install 'epione[full]'    # + motif / footprint extras\n"
+    "or from source: pip install git+https://github.com/aristoteleo/epione"
+)
+
+
+def import_epione() -> ModuleType:
+    """Import and return the top-level :mod:`epione` module.
+
+    Raises a friendly :class:`ImportError` (with an install hint) when
+    epione is missing, instead of a bare ``ModuleNotFoundError`` from
+    deep inside a wrapper.
+    """
+    try:
+        return importlib.import_module("epione")
+    except ImportError as exc:  # pragma: no cover - depends on env
+        raise ImportError(_INSTALL_HINT) from exc
+
+
+def epione_module(name: str) -> ModuleType:
+    """Return an epione submodule by dotted suffix, e.g. ``"pp"`` or ``"bulk.atac"``."""
+    import_epione()  # ensure top-level import + friendly error first
+    return importlib.import_module(f"epione.{name}")
+
+
+def delegate(submodule: str, attr: str) -> Callable[..., Any]:
+    """Build a wrapper that forwards ``*args, **kwargs`` to ``epione.<submodule>.<attr>``.
+
+    The returned function imports epione lazily on first call and copies
+    the target's ``__doc__`` / ``__name__`` so ``help()`` and Sphinx see
+    the real epione documentation.
+    """
+
+    def _wrapper(*args: Any, **kwargs: Any) -> Any:
+        mod = epione_module(submodule)
+        target = getattr(mod, attr)
+        return target(*args, **kwargs)
+
+    _wrapper.__name__ = attr
+    _wrapper.__qualname__ = attr
+    _wrapper.__doc__ = (
+        f"omicverse wrapper around :func:`epione.{submodule}.{attr}`.\n\n"
+        f"This calls ``epione.{submodule}.{attr}(*args, **kwargs)`` directly; "
+        f"see the epione documentation for the full signature."
+    )
+    _wrapper.__wrapped_target__ = f"epione.{submodule}.{attr}"  # type: ignore[attr-defined]
+    return _wrapper
+
+
+def make_passthrough_getattr(submodule: str) -> Callable[[str], Any]:
+    """Build a module-level ``__getattr__`` that forwards any unknown name to an epione submodule.
+
+    Curated wrappers defined explicitly in the ov.epi submodule take
+    precedence (normal attribute lookup happens first); anything not
+    explicitly wrapped is resolved lazily from ``epione.<submodule>`` so
+    the full epione surface remains reachable through ``ov.epi``.
+    """
+
+    @functools.lru_cache(maxsize=None)
+    def _getattr(name: str) -> Any:
+        if name.startswith("__") and name.endswith("__"):
+            raise AttributeError(name)
+        mod = epione_module(submodule)
+        try:
+            return getattr(mod, name)
+        except AttributeError as exc:
+            raise AttributeError(
+                f"'epione.{submodule}' has no attribute '{name}'"
+            ) from exc
+
+    return _getattr

--- a/omicverse/epi/bulk.py
+++ b/omicverse/epi/bulk.py
@@ -1,0 +1,17 @@
+r"""``ov.epi.bulk`` — bulk epigenomics tooling.
+
+Passthrough to :mod:`epione.bulk` (``epione.bulk.atac`` /
+``epione.bulk.hic``): the ``bigwig`` track/matrix engine, HOMER motif
+enrichment (``find_motifs_genome`` / ``run_homer_motifs``), ArchR-style
+footprinting (``footprint_archr``), and bulk Hi-C compartment/insulation/
+loop analysis. Names resolve lazily from epione on first access.
+
+>>> bw = ov.epi.bulk.bigwig()          # track viewer + matrix engine (a class)
+>>> ov.epi.bulk.find_motifs_genome(...)
+"""
+
+from __future__ import annotations
+
+from ._utils import make_passthrough_getattr
+
+__getattr__ = make_passthrough_getattr("bulk")

--- a/omicverse/epi/data.py
+++ b/omicverse/epi/data.py
@@ -1,0 +1,37 @@
+r"""``ov.epi.data`` — prebuilt reference genomes.
+
+Re-exports epione's :class:`~epione.core.genome.Genome` instances. Access
+a genome to lazily download (and cache) its FASTA + Gencode annotation via
+pooch on first use::
+
+    g = ov.epi.data.hg38
+    g.fasta()        # downloads GRCh38 FASTA on first call
+    g.annotation     # Gencode GFF3
+
+Available: ``hg38``/``GRCh38``, ``hg19``/``GRCh37``, ``mm39``/``GRCm39``,
+``mm10``/``GRCm38``, plus the ``Genome`` class.
+"""
+
+from __future__ import annotations
+
+from ._utils import epione_module, import_epione
+
+_NAMES = ("GRCh37", "GRCh38", "GRCm38", "GRCm39", "hg19", "hg38", "mm10", "mm39")
+
+
+def __getattr__(name):
+    import_epione()
+    if name == "Genome":
+        return epione_module("core").Genome
+    data = epione_module("data")
+    try:
+        return getattr(data, name)
+    except AttributeError as exc:
+        raise AttributeError(f"ov.epi.data has no genome '{name}'") from exc
+
+
+def __dir__():
+    return list(_NAMES) + ["Genome"]
+
+
+__all__ = list(_NAMES) + ["Genome"]

--- a/omicverse/epi/datasets.py
+++ b/omicverse/epi/datasets.py
@@ -1,0 +1,106 @@
+r"""``ov.epi.datasets`` — fetch-on-demand example epigenomics datasets.
+
+Convenience wrappers over epione's pooch registry
+(:func:`epione.utils.register_datasets`). Each fetcher downloads (once,
+then caches under epione's pooch cache) a small public dataset suitable
+for running an ``ov.epi`` tutorial end-to-end, mirroring the
+``scanpy.datasets`` style.
+
+>>> import omicverse as ov
+>>> frag = ov.epi.datasets.atac_pbmc5k_fragments()   # 10x PBMC 5k fragments
+>>> adata = ov.epi.datasets.atac_pbmc5k()            # prebuilt tile-matrix h5ad
+"""
+
+from __future__ import annotations
+
+from ._utils import epione_module, import_epione
+
+
+def register_datasets():
+    r"""Return epione's :class:`pooch.Pooch` example-data registry.
+
+    Use ``.fetch(key)`` to download any registered file; see
+    :data:`available_keys` for the catalogue. Wraps
+    :func:`epione.utils.register_datasets`.
+    """
+    return epione_module("utils").register_datasets()
+
+
+def available_keys():
+    """List the keys available in epione's example-data registry."""
+    return list(register_datasets().registry.keys())
+
+
+def _fetch(key: str) -> str:
+    return register_datasets().fetch(key)
+
+
+def _read_h5ad(path: str):
+    import anndata as ad
+    return ad.read_h5ad(path)
+
+
+# ---- 10x PBMC 5k scATAC ----------------------------------------------------
+def atac_pbmc5k_fragments() -> str:
+    """Path to the 10x PBMC-5k scATAC ``fragments.tsv.gz`` (GRCh38).
+
+    Feed straight into :func:`ov.epi.pp.import_fragments`.
+    """
+    return _fetch("atac_pbmc_5k.tsv.gz")
+
+
+def atac_pbmc5k(annotated: bool = False):
+    """Prebuilt 10x PBMC-5k scATAC tile-matrix AnnData (GRCh38).
+
+    Parameters
+    ----------
+    annotated
+        If True, return the version carrying published cell-type labels
+        (``atac_pbmc_5k_annotated.h5ad``); otherwise the unlabeled
+        tile-matrix (``atac_pbmc_5k.h5ad``).
+    """
+    key = "atac_pbmc_5k_annotated.h5ad" if annotated else "atac_pbmc_5k.h5ad"
+    return _read_h5ad(_fetch(key))
+
+
+# ---- 10x PBMC 500 scATAC (smallest) ---------------------------------------
+def atac_pbmc500_fragments(downsample: bool = False) -> str:
+    """Path to the 10x PBMC-500 scATAC ``fragments.tsv.gz`` (GRCh38).
+
+    The smallest fragments file in the registry — handy for fast,
+    low-memory demos. Set ``downsample=True`` for the even smaller
+    downsampled variant.
+    """
+    return _fetch("atac_pbmc_500_downsample.tsv.gz" if downsample else "atac_pbmc_500.tsv.gz")
+
+
+# ---- 10x PBMC 10k multiome -------------------------------------------------
+def pbmc10k_multiome():
+    """The paired 10x PBMC-10k multiome ATAC + RNA AnnData pair (GRCh38).
+
+    Returns
+    -------
+    (atac, rna)
+        Two :class:`~anndata.AnnData` objects sharing cell barcodes —
+        the input for :func:`ov.epi.tl.peak_to_gene`.
+    """
+    atac = _read_h5ad(_fetch("10x-Multiome-Pbmc10k-ATAC.h5ad"))
+    rna = _read_h5ad(_fetch("10x-Multiome-Pbmc10k-RNA.h5ad"))
+    return atac, rna
+
+
+def pbmc10k_atac_fragments() -> str:
+    """Path to the 10x PBMC-10k multiome ATAC ``fragments.tsv.gz`` (GRCh38)."""
+    return _fetch("pbmc_10k_atac.tsv.gz")
+
+
+def __getattr__(name):  # forward e.g. raw registry helpers
+    import_epione()
+    return getattr(epione_module("datasets"), name)
+
+
+__all__ = [
+    "register_datasets", "available_keys", "atac_pbmc5k_fragments",
+    "atac_pbmc5k", "atac_pbmc500_fragments", "pbmc10k_multiome",
+    "pbmc10k_atac_fragments",
+]

--- a/omicverse/epi/io.py
+++ b/omicverse/epi/io.py
@@ -1,0 +1,67 @@
+r"""``ov.epi.io`` — epigenomics readers & region utilities.
+
+Pure-format readers (10x ATAC matrices, GTF/GFF) plus coordinate ↔ gene
+annotation and peak-set helpers, delegating to :mod:`epione.io` and
+:mod:`epione.utils`. Each function imports epione internally.
+"""
+
+from __future__ import annotations
+
+from ._utils import epione_module, make_passthrough_getattr
+
+
+def read_ATAC_10x(*args, **kwargs):
+    r"""Read a CellRanger / 10x scATAC matrix into AnnData. Wraps :func:`epione.io.read_ATAC_10x`."""
+    return epione_module("io").read_ATAC_10x(*args, **kwargs)
+
+
+def read_gtf(*args, **kwargs):
+    r"""Read a GTF/GFF3 into a DataFrame. Wraps :func:`epione.io.read_gtf`."""
+    return epione_module("io").read_gtf(*args, **kwargs)
+
+
+def read_features(*args, **kwargs):
+    r"""Read a feature/peak file. Wraps :func:`epione.io.read_features`."""
+    return epione_module("io").read_features(*args, **kwargs)
+
+
+def convert_gff_to_gtf(*args, **kwargs):
+    r"""Convert GFF3 → GTF. Wraps :func:`epione.io.convert_gff_to_gtf`."""
+    return epione_module("io").convert_gff_to_gtf(*args, **kwargs)
+
+
+def get_gene_annotation(genome, **kwargs):
+    r"""Parse a :class:`~epione.core.genome.Genome` into a per-gene TSS DataFrame.
+
+    Wraps :func:`epione.io.get_gene_annotation`. The returned frame
+    (chrom/start/end/strand, one row per gene) is the input expected by
+    :func:`ov.epi.pp.tsse` and :func:`ov.epi.tl.add_gene_score_matrix`.
+    """
+    return epione_module("io").get_gene_annotation(genome, **kwargs)
+
+
+def merge_peaks(*args, **kwargs):
+    r"""Merge per-group peak calls into a unified non-overlapping set.
+
+    Wraps :func:`epione.utils.merge_peaks`.
+    """
+    return epione_module("utils").merge_peaks(*args, **kwargs)
+
+
+def save(*args, **kwargs):
+    r"""Pickle/h5ad cache helper. Wraps :func:`epione.io.save`."""
+    return epione_module("io").save(*args, **kwargs)
+
+
+def load(*args, **kwargs):
+    r"""Pickle/h5ad cache loader. Wraps :func:`epione.io.load`."""
+    return epione_module("io").load(*args, **kwargs)
+
+
+# Forward any other reader to epione.io (e.g. ``cached``).
+__getattr__ = make_passthrough_getattr("io")
+
+__all__ = [
+    "read_ATAC_10x", "read_gtf", "read_features", "convert_gff_to_gtf",
+    "get_gene_annotation", "merge_peaks", "save", "load",
+]

--- a/omicverse/epi/pl.py
+++ b/omicverse/epi/pl.py
@@ -1,0 +1,92 @@
+r"""``ov.epi.pl`` — epigenomics plotting (wraps :mod:`epione.pl`).
+
+QC diagnostics, embeddings, differential-accessibility and peak-to-gene
+plots, footprints and Hi-C contact visualisations, delegating to
+`epione <https://github.com/aristoteleo/epione>`_. Each function imports
+epione internally and returns the matplotlib figure/axes that epione
+produces.
+"""
+
+from __future__ import annotations
+
+from ._utils import epione_module, make_passthrough_getattr
+
+
+def plot_set(*args, **kwargs):
+    r"""Apply omicverse/epione publication plotting defaults. Wraps :func:`epione.pl.plot_set`."""
+    return epione_module("pl").plot_set(*args, **kwargs)
+
+
+def frag_size_distr(adata, **kwargs):
+    r"""Plot the fragment-size distribution (nucleosome periodicity). Wraps :func:`epione.pl.frag_size_distr`."""
+    return epione_module("pl").frag_size_distr(adata, **kwargs)
+
+
+def tss_enrichment(adata, **kwargs):
+    r"""Plot the TSS-enrichment profile. Wraps :func:`epione.pl.tss_enrichment`."""
+    return epione_module("pl").tss_enrichment(adata, **kwargs)
+
+
+def plot_joint(adata, **kwargs):
+    r"""KDE-overlaid joint QC scatter (e.g. log-fragments vs TSSe). Wraps :func:`epione.pl.plot_joint`."""
+    return epione_module("pl").plot_joint(adata, **kwargs)
+
+
+def fragment_histogram(adata, **kwargs):
+    r"""Histogram of fragment sizes. Wraps :func:`epione.pl.fragment_histogram`."""
+    return epione_module("pl").fragment_histogram(adata, **kwargs)
+
+
+def umap(adata, **kwargs):
+    r"""UMAP scatter colored by an obs/var key. Wraps :func:`epione.pl.umap`."""
+    return epione_module("pl").umap(adata, **kwargs)
+
+
+def embedding(adata, *args, **kwargs):
+    r"""Generic embedding scatter. Wraps :func:`epione.pl.embedding`."""
+    return epione_module("pl").embedding(adata, *args, **kwargs)
+
+
+def pca(adata, **kwargs):
+    r"""PCA scatter. Wraps :func:`epione.pl.pca`."""
+    return epione_module("pl").pca(adata, **kwargs)
+
+
+def tsne(adata, **kwargs):
+    r"""t-SNE scatter. Wraps :func:`epione.pl.tsne`."""
+    return epione_module("pl").tsne(adata, **kwargs)
+
+
+def volcano(*args, **kwargs):
+    r"""Volcano plot for differential accessibility. Wraps :func:`epione.pl.volcano`."""
+    return epione_module("pl").volcano(*args, **kwargs)
+
+
+def ma_plot(*args, **kwargs):
+    r"""MA plot for differential accessibility. Wraps :func:`epione.pl.ma_plot`."""
+    return epione_module("pl").ma_plot(*args, **kwargs)
+
+
+def plot_peak2gene(*args, **kwargs):
+    r"""Arc/track plot of peak→gene links. Wraps :func:`epione.pl.plot_peak2gene`."""
+    return epione_module("pl").plot_peak2gene(*args, **kwargs)
+
+
+def plot_footprints(*args, **kwargs):
+    r"""TF footprint profile plot. Wraps :func:`epione.pl.plot_footprints`."""
+    return epione_module("pl").plot_footprints(*args, **kwargs)
+
+
+def homer_motif_table(*args, **kwargs):
+    r"""Render a HOMER motif-enrichment table. Wraps :func:`epione.pl.homer_motif_table`."""
+    return epione_module("pl").homer_motif_table(*args, **kwargs)
+
+
+# Hi-C contact-map family + anything else forwarded to epione.pl.
+__getattr__ = make_passthrough_getattr("pl")
+
+__all__ = [
+    "plot_set", "frag_size_distr", "tss_enrichment", "plot_joint",
+    "fragment_histogram", "umap", "embedding", "pca", "tsne", "volcano",
+    "ma_plot", "plot_peak2gene", "plot_footprints", "homer_motif_table",
+]

--- a/omicverse/epi/pp.py
+++ b/omicverse/epi/pp.py
@@ -1,0 +1,140 @@
+r"""``ov.epi.pp`` — epigenomics preprocessing (wraps :mod:`epione.pp`).
+
+Quality control, fragment ingestion and feature-matrix construction for
+single-cell ATAC-seq, delegating to `epione <https://github.com/aristoteleo/epione>`_.
+Each function imports epione internally, so importing omicverse stays cheap.
+
+Typical scATAC ingest → QC → feature-matrix flow::
+
+    import omicverse as ov
+    frag = ov.epi.datasets.atac_pbmc5k_fragments()
+    adata = ov.epi.pp.import_fragments(frag, chrom_sizes=ov.epi.data.hg38)
+    genes = ov.epi.io.get_gene_annotation(ov.epi.data.hg38)
+    ov.epi.pp.tsse(adata, genes)
+    ov.epi.pp.frag_size_distr(adata)
+    ov.epi.pp.nucleosome_signal(adata)
+    adata = ov.epi.pp.qc(adata)
+    ov.epi.pp.add_tile_matrix(adata)
+    ov.epi.pp.select_features(adata, n_features=250000)
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from ._utils import epione_module, make_passthrough_getattr
+
+
+def import_fragments(fragment_file, chrom_sizes, *, file: Optional[str] = None,
+                     min_num_fragments: int = 200, n_jobs: int = 1, **kwargs):
+    r"""Scan a bgzipped ``fragments.tsv.gz`` into a per-cell QC AnnData.
+
+    Wraps :func:`epione.pp.import_fragments`.
+
+    Parameters
+    ----------
+    fragment_file
+        Path (or list of paths) to a tabix-indexed ``fragments.tsv.gz``.
+    chrom_sizes
+        An :class:`epione.core.genome.Genome` (e.g. ``ov.epi.data.hg38``)
+        or a ``{chrom: length}`` dict.
+    file
+        Optional output ``.h5ad`` path; when given, ``X`` is stored
+        out-of-memory via anndataoom.
+    min_num_fragments
+        Minimum unique fragments per cell to retain.
+    """
+    return epione_module("pp").import_fragments(
+        fragment_file, chrom_sizes, file=file,
+        min_num_fragments=min_num_fragments, n_jobs=n_jobs, **kwargs)
+
+
+def concat_samples(*args, **kwargs):
+    r"""Concatenate multiple per-sample ATAC AnnData objects. Wraps :func:`epione.pp.concat_samples`."""
+    return epione_module("pp").concat_samples(*args, **kwargs)
+
+
+def frag_size_distr(adata, **kwargs):
+    r"""Compute the fragment-size distribution (nucleosome periodicity QC).
+
+    Wraps :func:`epione.pp.frag_size_distr`. Plot it with
+    :func:`ov.epi.pl.frag_size_distr`.
+    """
+    return epione_module("pp").frag_size_distr(adata, **kwargs)
+
+
+def nucleosome_signal(adata, n: Optional[int] = None, **kwargs):
+    r"""Per-cell mono/nucleosome-free fragment ratio. Wraps :func:`epione.pp.nucleosome_signal`."""
+    if n is None:
+        return epione_module("pp").nucleosome_signal(adata, **kwargs)
+    return epione_module("pp").nucleosome_signal(adata, n=n, **kwargs)
+
+
+def tsse(adata, gene_anno, **kwargs):
+    r"""TSS-enrichment score per cell (ArchR-style).
+
+    Wraps :func:`epione.pp.tsse`. ``gene_anno`` is the per-gene frame from
+    :func:`ov.epi.io.get_gene_annotation`.
+    """
+    return epione_module("pp").tsse(adata, gene_anno, **kwargs)
+
+
+def tss_enrichment(adata, *args, **kwargs):
+    r"""Alias kept for parity with epione's ``tss_enrichment``. Wraps :func:`epione.pp.tss_enrichment`."""
+    return epione_module("pp").tss_enrichment(adata, *args, **kwargs)
+
+
+def qc(adata, tresh: Optional[dict] = None, **kwargs):
+    r"""One-step QC filter on fragment count / TSSe / nucleosome signal.
+
+    Wraps :func:`epione.pp.qc`. ``tresh`` keys: ``fragment_counts_min``,
+    ``fragment_counts_max``, ``TSS_score_min``, ``TSS_score_max``,
+    ``Nucleosome_singal_max``.
+    """
+    return epione_module("pp").qc(adata, tresh=tresh, **kwargs)
+
+
+def add_tile_matrix(adata, *, bin_size: int = 500, **kwargs):
+    r"""Bin the genome into ``bin_size`` windows and count per-cell insertions.
+
+    Wraps :func:`epione.pp.add_tile_matrix`. The tile matrix lands in ``adata.X``.
+    """
+    return epione_module("pp").add_tile_matrix(adata, bin_size=bin_size, **kwargs)
+
+
+def select_features(adata, n_features: int = 500_000, **kwargs):
+    r"""Select the most-accessible features for dimensionality reduction.
+
+    Wraps :func:`epione.pp.select_features` (writes ``adata.var['selected']``).
+    """
+    return epione_module("pp").select_features(adata, n_features=n_features, **kwargs)
+
+
+def make_peak_matrix(adata, *args, **kwargs):
+    r"""Build a cell × peak count matrix from a peak set. Wraps :func:`epione.pp.make_peak_matrix`."""
+    return epione_module("pp").make_peak_matrix(adata, *args, **kwargs)
+
+
+def make_gene_matrix(adata, gene_anno, **kwargs):
+    r"""Build a cell × gene activity matrix. Wraps :func:`epione.pp.make_gene_matrix`."""
+    return epione_module("pp").make_gene_matrix(adata, gene_anno, **kwargs)
+
+
+def scrublet(adata, *args, **kwargs):
+    r"""Doublet scoring for scATAC. Wraps :func:`epione.pp.scrublet`."""
+    return epione_module("pp").scrublet(adata, *args, **kwargs)
+
+
+def neighbors(adata, *args, **kwargs):
+    r"""Build the kNN graph on a low-dimensional representation. Wraps :func:`epione.pp.neighbors`."""
+    return epione_module("pp").neighbors(adata, *args, **kwargs)
+
+
+# Anything not explicitly wrapped above is forwarded to ``epione.pp``.
+__getattr__ = make_passthrough_getattr("pp")
+
+__all__ = [
+    "import_fragments", "concat_samples", "frag_size_distr", "nucleosome_signal",
+    "tsse", "tss_enrichment", "qc", "add_tile_matrix", "select_features",
+    "make_peak_matrix", "make_gene_matrix", "scrublet", "neighbors",
+]

--- a/omicverse/epi/single.py
+++ b/omicverse/epi/single.py
@@ -1,0 +1,16 @@
+r"""``ov.epi.single`` — single-cell-specific epigenomics tooling.
+
+Passthrough to :mod:`epione.single` (``epione.single.atac`` /
+``epione.single.hic``): scATAC peak calling (``macs3``), pseudobulk
+generation, and single-cell Hi-C imputation/embedding. Names resolve
+lazily from epione on first access.
+
+>>> ov.epi.single.macs3(adata, groupby='leiden', ...)
+>>> ov.epi.single.pseudobulk(adata, groupby='cell_type')
+"""
+
+from __future__ import annotations
+
+from ._utils import make_passthrough_getattr
+
+__getattr__ = make_passthrough_getattr("single")

--- a/omicverse/epi/tl.py
+++ b/omicverse/epi/tl.py
@@ -1,0 +1,169 @@
+r"""``ov.epi.tl`` — epigenomics analysis tools (wraps :mod:`epione.tl`).
+
+Dimensionality reduction (iterative LSI), clustering, gene-activity
+scores, peak-to-gene linkage, chromVAR motif deviations, footprinting and
+cross-modality integration — all delegating to
+`epione <https://github.com/aristoteleo/epione>`_. Each function imports
+epione internally.
+
+scATAC embedding → clustering → gene scores::
+
+    ov.epi.tl.iterative_lsi(adata, n_components=30)
+    ov.epi.pp.neighbors(adata, use_rep='X_iterative_lsi')
+    ov.epi.tl.clusters(adata, method='leiden', use_rep='X_iterative_lsi')
+    ov.epi.tl.umap(adata)
+    ov.epi.tl.add_gene_score_matrix(adata, gene_anno)
+
+chromVAR motif/TF activity::
+
+    ov.epi.tl.build_motif_database(genome_fasta, out_dir)
+    ov.epi.tl.add_motif_matrix(adata, motif_database=out_dir)
+    ov.epi.tl.add_background_peaks(adata, genome_fasta=genome_fasta)
+    ov.epi.tl.compute_deviations(adata)
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ._utils import epione_module, make_passthrough_getattr
+
+
+# ---- dimensionality reduction / clustering ---------------------------------
+def lsi(adata, *args, **kwargs):
+    r"""Latent semantic indexing (single-pass). Wraps :func:`epione.tl.lsi`."""
+    return epione_module("tl").lsi(adata, *args, **kwargs)
+
+
+def iterative_lsi(adata, *, n_components: int = 30, iterations: int = 2,
+                  var_features: int = 25000, **kwargs):
+    r"""ArchR-style iterative LSI on a cell × tile/peak matrix.
+
+    Wraps :func:`epione.tl.iterative_lsi`; stores the embedding in
+    ``adata.obsm['X_iterative_lsi']`` by default.
+    """
+    return epione_module("tl").iterative_lsi(
+        adata, n_components=n_components, iterations=iterations,
+        var_features=var_features, **kwargs)
+
+
+def clusters(adata, *args, **kwargs):
+    r"""Leiden / Louvain / kmeans clustering on a representation. Wraps :func:`epione.tl.clusters`."""
+    return epione_module("tl").clusters(adata, *args, **kwargs)
+
+
+def umap(adata, *args, **kwargs):
+    r"""UMAP embedding. Wraps :func:`epione.tl.umap`."""
+    return epione_module("tl").umap(adata, *args, **kwargs)
+
+
+def find_marker_features(adata, *args, **kwargs):
+    r"""Rank marker peaks/features per group. Wraps :func:`epione.tl.find_marker_features`."""
+    return epione_module("tl").find_marker_features(adata, *args, **kwargs)
+
+
+def differential_peaks(*args, **kwargs):
+    r"""Differential accessibility testing (pyDESeq2 backend). Wraps :func:`epione.tl.differential_peaks`."""
+    return epione_module("tl").differential_peaks(*args, **kwargs)
+
+
+# ---- gene activity / linkage -----------------------------------------------
+def add_gene_score_matrix(adata, gene_anno, **kwargs):
+    r"""ArchR-style gene-activity scores from tile accessibility.
+
+    Wraps :func:`epione.tl.add_gene_score_matrix`.
+    """
+    return epione_module("tl").add_gene_score_matrix(adata, gene_anno, **kwargs)
+
+
+def peak_to_gene(adata, *args, **kwargs):
+    r"""Correlate peak accessibility with gene expression to link peaks→genes.
+
+    Wraps :func:`epione.tl.peak_to_gene`. Visualise with
+    :func:`ov.epi.pl.plot_peak2gene`.
+    """
+    return epione_module("tl").peak_to_gene(adata, *args, **kwargs)
+
+
+def coaccessibility(adata, *args, **kwargs):
+    r"""Peak co-accessibility (Cicero-style) links. Wraps :func:`epione.tl.coaccessibility`."""
+    return epione_module("tl").coaccessibility(adata, *args, **kwargs)
+
+
+# ---- motif / chromVAR ------------------------------------------------------
+def build_motif_database(*args, **kwargs):
+    r"""Scan a genome for motif hits, building a reusable motif database.
+
+    Wraps :func:`epione.tl.build_motif_database`.
+    """
+    return epione_module("tl").build_motif_database(*args, **kwargs)
+
+
+def query_motif_database(*args, **kwargs):
+    r"""Query a prebuilt motif database for a set of peaks. Wraps :func:`epione.tl.query_motif_database`."""
+    return epione_module("tl").query_motif_database(*args, **kwargs)
+
+
+def add_motif_matrix(adata, *args, **kwargs):
+    r"""Add a peak × motif membership matrix to ``adata``. Wraps :func:`epione.tl.add_motif_matrix`."""
+    return epione_module("tl").add_motif_matrix(adata, *args, **kwargs)
+
+
+def add_background_peaks(adata, *args, **kwargs):
+    r"""Sample GC/accessibility-matched background peaks for chromVAR.
+
+    Wraps :func:`epione.tl.add_background_peaks`.
+    """
+    return epione_module("tl").add_background_peaks(adata, *args, **kwargs)
+
+
+def compute_deviations(adata, *args, **kwargs):
+    r"""chromVAR motif/TF deviation z-scores per cell. Wraps :func:`epione.tl.compute_deviations`."""
+    return epione_module("tl").compute_deviations(adata, *args, **kwargs)
+
+
+# ---- footprinting ----------------------------------------------------------
+def compute_tn5_bias_table(*args, **kwargs):
+    r"""Estimate the Tn5 sequence-insertion bias table. Wraps :func:`epione.tl.compute_tn5_bias_table`."""
+    return epione_module("tl").compute_tn5_bias_table(*args, **kwargs)
+
+
+def get_footprints(adata, *args, **kwargs):
+    r"""Aggregate TF footprints over motif sites. Wraps :func:`epione.tl.get_footprints`."""
+    return epione_module("tl").get_footprints(adata, *args, **kwargs)
+
+
+def multi_scale_footprint_region(adata, *args, **kwargs):
+    r"""Multi-scale footprint profile over a region. Wraps :func:`epione.tl.multi_scale_footprint_region`."""
+    return epione_module("tl").multi_scale_footprint_region(adata, *args, **kwargs)
+
+
+# ---- cross-modality integration --------------------------------------------
+def integrate(adata1, adata2, *args, **kwargs):
+    r"""CCA-style integration of two modalities/datasets. Wraps :func:`epione.tl.integrate`."""
+    return epione_module("tl").integrate(adata1, adata2, *args, **kwargs)
+
+
+def transfer_labels(query, reference, *args, **kwargs):
+    r"""Transfer reference labels onto a query via kNN in a shared space.
+
+    Wraps :func:`epione.tl.transfer_labels`.
+    """
+    return epione_module("tl").transfer_labels(query, reference, *args, **kwargs)
+
+
+def joint_embedding(adata1, adata2, *args, **kwargs):
+    r"""Joint embedding of two integrated modalities. Wraps :func:`epione.tl.joint_embedding`."""
+    return epione_module("tl").joint_embedding(adata1, adata2, *args, **kwargs)
+
+
+__getattr__ = make_passthrough_getattr("tl")
+
+__all__ = [
+    "lsi", "iterative_lsi", "clusters", "umap", "find_marker_features",
+    "differential_peaks", "add_gene_score_matrix", "peak_to_gene",
+    "coaccessibility", "build_motif_database", "query_motif_database",
+    "add_motif_matrix", "add_background_peaks", "compute_deviations",
+    "compute_tn5_bias_table", "get_footprints", "multi_scale_footprint_region",
+    "integrate", "transfer_labels", "joint_embedding",
+]

--- a/omicverse/epi/upstream.py
+++ b/omicverse/epi/upstream.py
@@ -1,0 +1,14 @@
+r"""``ov.epi.upstream`` — FASTQ → BAM → bigwig / pairs → cool pipelines.
+
+Passthrough to :mod:`epione.upstream`: aligner wrappers (bowtie2,
+bwa-mem2), samtools/BAM utilities, MACS2 peak calling, Tn5 shifting,
+reference preparation, and the Hi-C ``pairs``/``cool`` chain. These call
+external command-line tools, so they are not exercised by the shipped
+tutorials. Names resolve lazily from epione on first access.
+"""
+
+from __future__ import annotations
+
+from ._utils import make_passthrough_getattr
+
+__getattr__ = make_passthrough_getattr("upstream")

--- a/omicverse/epi/utils.py
+++ b/omicverse/epi/utils.py
@@ -1,0 +1,17 @@
+r"""``ov.epi.utils`` — epigenomics utilities & region operations.
+
+Passthrough to :mod:`epione.utils`: genome accessors
+(``utils.genome.hg38`` / ``hg19`` / ...), peak-set operations
+(``merge_peaks``, ``annotate_peaks``, ``classify_peaks_by_overlap``),
+gene-annotation parsing and AnnData on-disk helpers (``obs_to_pandas``).
+Names resolve lazily from epione on first access.
+
+>>> genes = ov.epi.utils.get_gene_annotation(ov.epi.data.hg38)
+>>> obs = ov.epi.utils.obs_to_pandas(adata)   # pull a backed obs into memory
+"""
+
+from __future__ import annotations
+
+from ._utils import make_passthrough_getattr
+
+__getattr__ = make_passthrough_getattr("utils")


### PR DESCRIPTION
## Summary
Adds **`omicverse.epi` (`ov.epi`)** — a thin omicverse-flavoured bridge over the [epione](https://github.com/aristoteleo/epione) package, bringing **epigenomics** (single-cell ATAC-seq, footprinting, chromVAR motif activity, peak-to-gene linkage, and Hi-C) into omicverse. Every wrapper imports `epione` internally and delegates, so `import omicverse` stays light and epione is an optional dependency (lazy-loaded via the existing `_LAZY_MODULES` mechanism).

### `ov.epi` layout
- `pp` / `tl` / `pl` / `io` / `datasets` / `data` — curated wrappers (real signatures + docstrings, `import epione` inside each)
- `single` / `bulk` / `upstream` / `utils` — lazy passthroughs to the matching epione submodules
- Each submodule has a module-level `__getattr__` forwarding any uncurated name to epione, so the full surface stays reachable
- `'epi'` registered in `omicverse/__init__.py` `_LAZY_MODULES`

### Tutorials (submodule bump → omicverse-tutorials#feat/epigenetics-tutorials)
New `tutorial-epigenetics` chapter with **8 executed notebooks** (real baked outputs, run in conda `omicdev`):
1. scATAC preprocessing & QC
2. clustering, annotation & gene activity
3. chromVAR TF motif activity
4. peak-to-gene linkage (multiome)
5. marker peaks / differential accessibility
6. scRNA–scATAC integration & label transfer (~83% acc vs paired ground truth)
7. bulk Hi-C (contact maps, compartments, TADs)
8. single-cell Hi-C (imputation + cell-cycle embedding)

Tutorials 1–6 auto-download public 10x PBMC data via `ov.epi.datasets`; 7–8 read local `.cool`/`.scool` (provenance noted in-notebook).

## Local checks
- `flake8 --select=E9,F63,F7 omicverse/epi/` → 0
- all `ov.epi` submodules import cleanly
- isolated `sphinx-build -W` of the new chapter → build succeeded, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)