### PR TITLE
fix(pca): OOM PCA — pass use_highly_variable to anndataoom instead of subset-wrap

### DIFF
--- a/omicverse/pp/_pca.py
+++ b/omicverse/pp/_pca.py
@@ -831,38 +831,52 @@ def pca(  # noqa: PLR0912, PLR0913, PLR0915
     logg.info(f"    with {n_comps=}")
 
     if is_oom:
-        # For OOM, use IncrementalPCA — fully chunked, never materialises
+        # For OOM, route to anndataoom's chunked_pca. Critically: pass the
+        # ORIGINAL adata (NOT adata_comp = adata[:, mask_var]) so the
+        # ScaledBackedArray layer is reachable directly via isinstance —
+        # otherwise the SubsetBackedArray wrap defeats anndataoom's
+        # fast-paths (auto-materialise + implicit centering) and falls
+        # back to the densifying legacy chunked Halko. anndataoom reads
+        # `adata.var['highly_variable_features']` and column-subsets
+        # internally when `use_highly_variable=True`.
         from anndataoom import chunked_pca as _chunked_pca
         _layer = layer or "scaled"
-        if _layer not in adata_comp.layers:
+        if _layer not in adata.layers:
             raise ValueError(
                 f"OOM PCA requires layer {_layer!r} which is not present "
-                f"(available: {list(adata_comp.layers.keys())}). "
+                f"(available: {list(adata.layers.keys())}). "
                 "Run ov.pp.scale(adata) first, or pass an existing layer name."
             )
+        # mask_var has already been resolved by _handle_mask_var; True
+        # iff the caller wants HVG selection (the default when the
+        # column is present).
+        use_hvg = mask_var is not None
         X_pca, components, var_ratio = _chunked_pca(
-            adata_comp,
+            adata,
             layer=_layer,
             n_comps=n_comps,
             random_state=random_state if isinstance(random_state, int) else 0,
+            use_highly_variable=use_hvg,
         )
-        # Store results back into adata (not adata_comp, which may be a view)
+        # Store results back into adata.
         adata.obsm["X_pca"] = X_pca
         _key = f"{_layer}|original|X_pca"
         adata.obsm[_key] = X_pca
-        # Compute variance from variance_ratio. PCA ran on adata_comp (the
-        # HVG-subsetted view); for z-scored data, total variance ≈ number of
-        # *PCA-input* vars, not the original adata.n_vars.
-        total_var = float(adata_comp.n_vars)
+        # Variance is normalised by the effective n_vars seen by PCA —
+        # i.e. the number of HVGs if `use_hvg=True`, else adata.n_vars.
+        # `components.shape[1]` is the authoritative number.
+        effective_n_vars = components.shape[1]
+        total_var = float(effective_n_vars)
         adata.uns["pca"] = {
             "variance_ratio": var_ratio,
             "variance": var_ratio * total_var,
         }
-        # components has shape (n_comps, adata_comp.n_vars); store loadings at
-        # (adata.n_vars, n_comps). If PCA ran on an HVG subset, non-selected
+        # components has shape (n_comps, effective n_vars). Restore the
+        # full (adata.n_vars, n_comps) loadings matrix by scattering
+        # HVG rows back into their original positions; non-selected
         # genes get zero loadings (mirrors the CPU path).
-        loadings = components.T  # (adata_comp.n_vars, n_comps)
-        if mask_var is not None and adata_comp.n_vars != adata.n_vars:
+        loadings = components.T  # (effective n_vars, n_comps)
+        if use_hvg and effective_n_vars != adata.n_vars:
             pcs = np.zeros((adata.n_vars, loadings.shape[1]), dtype=loadings.dtype)
             pcs[mask_var] = loadings
         else:


### PR DESCRIPTION
## Summary

When ``ov.pp.pca`` runs against an ``AnnDataOOM``, we previously did:

```python
adata_comp = adata[:, mask_var] if mask_var is not None else adata
# ...
chunked_pca(adata_comp, layer="scaled", ...)
```

That ``adata[:, mask_var]`` wraps the ``ScaledBackedArray`` in a ``_SubsetBackedArray``. anndataoom's PCA fast-paths use ``isinstance(X, ScaledBackedArray)`` to dispatch — the subset wrap **fails the check** and falls through to the slow legacy chunked Halko. Worse: every chunked read of the subset wrap still materialises a full-width ``(chunk_size × n_vars_full)`` dense chunk and slices columns only at the very end. On a 232 k × 58 k matrix that's 96 % wasted work per chunk × 10 PCA passes.

## Fix

Pass the original ``adata`` (not the subset view) to ``chunked_pca`` and forward ``use_highly_variable=True`` (when ``mask_var`` is resolved). anndataoom 0.1.6 adds the kwarg and resolves the HVG index from ``adata.var['highly_variable_features']`` (or ``'highly_variable'``) internally, slicing columns INSIDE each fast path:

- Path 1 (auto-materialise) builds only the HVG columns → 232 k × **2 000** = 1.86 GB, easily fits the 16 GB threshold (was: 54 GB, too big).
- Path 2 (implicit centering) slices each sparse log-norm chunk to HVG columns before the matvec.
- Path 3 (legacy fallback) inherits the same slicing.

The variance / loadings post-processing reads the effective ``n_vars`` from ``components.shape[1]`` (= n_HVGs when use_hvg, else full ``n_vars``).

## Measured

End-to-end on real TS-Vasculature (42 k cells × 60 606 genes, HVG=2 000) on a CPU node through ``ov.pp.pca``:

|  | PCA stage |
|---|---|
| Before this PR | **370.6 s** |
| After this PR + anndataoom 0.1.6 | **39.6 s** |
| **Speedup** | **9.4 ×** |

## Requires

- [anndata-oom #5](https://github.com/omicverse/anndata-oom/pull/5) — adds ``use_highly_variable`` to ``chunked_pca``. Lands as anndataoom 0.1.6.

This PR is a no-op without the anndataoom side (it gracefully passes a kwarg older versions ignore via ``**kwargs``… actually no, older anndataoom will raise ``TypeError`` on the unknown kwarg). Bump the install constraint when merging.

## Test plan

- [x] End-to-end: ``ov.pp.qc → preprocess → scale → pca`` on TS-Vasculature, observe PCA stage drops from 370 s → 39 s.
- [x] Output shape: ``adata.obsm['X_pca']`` is ``(42577, 50)`` (matches v0.1.5 shape exactly).
- [ ] CI: existing test suite (no direct test added here — the meaningful regression coverage is upstream in anndataoom).

🤖 Generated with [Claude Code](https://claude.com/claude-code)