### PR TITLE
feat(scale): use_implicit_centering=True for million-cell in-memory pipelines

### DIFF
--- a/omicverse/pp/_pca.py
+++ b/omicverse/pp/_pca.py
@@ -870,7 +870,26 @@ def pca(  # noqa: PLR0912, PLR0913, PLR0915
         adata.varm["PCs"] = pcs
         return adata if copy else None
 
-    X = _get_obs_rep(adata_comp, layer=layer)
+    # Implicit-centered scale wrapper (anndataoom.CenteredSparseArray) ────
+    # ov.pp.scale(use_implicit_centering=True) stores the scaled matrix as
+    # a lazy wrapper in adata.uns['_scaled_implicit'] (anndata's layer
+    # registry rejects custom array types). Densify only the HVG slice
+    # the SVD will actually consume: at 1M cells × 2000 HVG that is ~8 GB
+    # instead of the 240 GB the full-panel dense scale would need.
+    X = None
+    _implicit = adata.uns.get('_scaled_implicit') if not is_oom else None
+    if _implicit is not None and layer in (None, 'scaled'):
+        try:
+            from anndataoom import CenteredSparseArray
+            if isinstance(_implicit, CenteredSparseArray):
+                if mask_var is not None:
+                    X = np.asarray(_implicit[:, mask_var])
+                else:
+                    X = np.asarray(_implicit.toarray())
+        except ImportError:
+            pass
+    if X is None:
+        X = _get_obs_rep(adata_comp, layer=layer)
 
     # Previously this block materialised X for a standalone rust/snapatac2
     # adata. Only AnnDataOOM is supported now, and the is_oom branch above

--- a/omicverse/pp/_preprocess.py
+++ b/omicverse/pp/_preprocess.py
@@ -1060,7 +1060,8 @@ def highly_variable_genes(
     related=["normalize", "regress"]
 )
 @tracked("scale", "ov.pp.scale")
-def scale(adata, max_value=10, layers_add='scaled', to_sparse=False, **kwargs):
+def scale(adata, max_value=10, layers_add='scaled', to_sparse=False,
+          use_implicit_centering=False, **kwargs):
     """
     Scale the input AnnData object.
 
@@ -1073,6 +1074,18 @@ def scale(adata, max_value=10, layers_add='scaled', to_sparse=False, **kwargs):
             passing anything else raises ValueError.
         to_sparse: If True, convert the result to csr_matrix format. Default: False.
             Scaled data is 100% dense, so sparse storage only adds overhead.
+        use_implicit_centering: If True and the in-memory adata.X is sparse,
+            store the scaled matrix as a lazy ``CenteredSparseArray`` (anndataoom)
+            in ``adata.uns['_scaled_implicit']`` instead of materialising a dense
+            ``adata.layers['scaled']``. Trades a small dispatch hop in downstream
+            consumers (only ``ov.pp.pca`` knows how to read this layout) for
+            ``n_obs * n_vars * 4 bytes`` of avoided allocation -- at 1M cells x
+            60606 genes that is ~240 GB, the difference between OOM-killed and
+            completing under a typical 256 GB per-process RSS cap. ``ov.pp.pca``
+            densifies only the HVG-subset slice the SVD actually needs.
+            Default: False (preserves existing behavior). Ignored on the OOM
+            backend (which already uses a lazy ``ScaledBackedArray``) and on
+            GPU mode.
         **kwargs: Additional arguments passed to scaling functions.
 
     Returns:
@@ -1086,6 +1099,8 @@ def scale(adata, max_value=10, layers_add='scaled', to_sparse=False, **kwargs):
         >>> ov.pp.scale(adata, max_value=10)
         >>> # Scale data keeping dense format
         >>> ov.pp.scale(adata, max_value=10, to_sparse=False)
+        >>> # Lazy implicit centering for million-cell in-memory pipelines
+        >>> ov.pp.scale(adata, max_value=10, use_implicit_centering=True)
     """
     from ._qc import _is_oom
     if _is_oom(adata):
@@ -1105,6 +1120,45 @@ def scale(adata, max_value=10, layers_add='scaled', to_sparse=False, **kwargs):
         adata.uns["status"]["scaled"] = True
         note(backend=f"omicverse({settings.mode}) · oom")
         return
+    # Opt-in implicit-centered path: produce a CenteredSparseArray and
+    # store it in adata.uns['_scaled_implicit'] rather than densifying.
+    # Only runs when (a) caller asked for it, (b) we are on CPU mode, and
+    # (c) adata.X is sparse (the densification this avoids is exactly the
+    # sparse zero-centering step). zero_center defaults True in kwargs.
+    _zero_center = kwargs.get('zero_center', True)
+    if (use_implicit_centering
+            and (settings.mode == 'cpu' or settings.mode == 'cpu-gpu-mixed')
+            and _zero_center
+            and issparse(adata.X)):
+        try:
+            from anndataoom import CenteredSparseArray
+        except ImportError as exc:
+            raise ImportError(
+                "use_implicit_centering=True requires the anndataoom package "
+                "(>=0.1.7); install with `pip install anndataoom`."
+            ) from exc
+        X = adata.X.tocsr().astype(np.float32)
+        # Sparse-native E[X^2] − E[X]^2; matches scanpy / sklearn convention.
+        mean = np.asarray(X.mean(axis=0)).ravel().astype(np.float32)
+        ex2 = np.asarray(X.multiply(X).mean(axis=0)).ravel().astype(np.float32)
+        var = np.maximum(ex2 - mean * mean, 0.0)
+        std = np.sqrt(var).astype(np.float32)
+        wrapper = CenteredSparseArray(X, mean, std, max_value=max_value)
+        adata.uns['_scaled_implicit'] = wrapper
+        # Expose mean/std on adata.var (matches scale_anndata's behavior).
+        adata.var['mean'] = mean
+        adata.var['std'] = std
+        if 'status' not in adata.uns.keys():
+            adata.uns['status'] = {}
+        if 'status_args' not in adata.uns.keys():
+            adata.uns['status_args'] = {}
+        adata.uns['status']['scaled'] = True
+        adata.uns['status_args']['scaled'] = {'implicit': True,
+                                              'max_value': max_value}
+        add_reference(adata, 'scanpy', 'scaling with scanpy')
+        note(backend=f"omicverse({settings.mode}) · implicit")
+        return
+
     if settings.mode == 'cpu' or settings.mode == 'cpu-gpu-mixed':
         from ._scale import scale_anndata as scale
         adata_mock = scale(adata, copy=True, max_value=max_value, **kwargs)
@@ -1307,8 +1361,21 @@ def pca(adata, n_pcs=50, layer='scaled',inplace=True,**kwargs):
     """
     #if 'lognorm' not in adata.layers:
     #    adata.layers['lognorm'] = adata.X
+    # Implicit-centered scale: ov.pp.scale(use_implicit_centering=True) stores
+    # the lazy CenteredSparseArray in adata.uns['_scaled_implicit'] rather
+    # than a dense adata.layers['scaled'] (anndata's layer registry rejects
+    # custom array types). When the caller asks for layer='scaled' and the
+    # implicit wrapper is present, that counts as 'computed' — the deeper
+    # _pca.pca() picks it up via the same uns key and densifies only the
+    # HVG subset the SVD actually needs.
+    _has_implicit_scaled = (
+        layer == 'scaled' and '_scaled_implicit' in adata.uns
+    )
     if layer in adata.layers:
         X = adata.layers[layer]
+        key = f'{layer}|original'
+    elif _has_implicit_scaled:
+        X = adata.uns['_scaled_implicit']  # CenteredSparseArray
         key = f'{layer}|original'
     else:
         raise KeyError(f'Selected layer {layer} is not present. Compute it first!')


### PR DESCRIPTION
## Summary
- Adds `use_implicit_centering=True` opt-in to `ov.pp.scale`. When set on a sparse CPU adata, the scaled matrix is stored as an `anndataoom.CenteredSparseArray` in `adata.uns['_scaled_implicit']` instead of being materialised into `adata.layers['scaled']`.
- `ov.pp.pca` (both the in-`_preprocess` dispatcher and the deeper `_pca.pca`) learns to recognise the implicit wrapper and densify only the HVG slice the SVD actually consumes.

## Why
`ov.pp.scale` on a sparse adata densifies via the sparse-zero-centering step `(X − μ)/σ`. Cost: `n_obs · n_vars · 4 bytes`. The cellxgene Tabula Sapiens benchmark measured:

| dataset | n_obs | scale stage Δ RSS | result |
|---|---|---|---|
| TS-Stromal | 232 684 | +64 GB | completes (peak 99 GB) |
| TS-Epi    | 228 032 | +66 GB | completes (peak 107 GB) |
| TS-Immune | 592 317 | — | **OOM-killed at 256 GB cap** |
| TS-1M     | 1 053 033 | — | **OOM-killed at 256 GB cap** |

At 1M cells × 60 606 genes the dense scaled matrix alone is ~240 GB — the in-memory pipeline cannot run on a typical commodity node regardless of how fast PCA is.

The OOM backend (`anndataoom`) already side-steps this with a lazy `ScaledBackedArray`. This PR ports the same design to in-memory by wrapping the scale output in a sparse-backed `CenteredSparseArray` that holds `(X/σ : sparse CSR, μ/σ : ndarray)`. Per-gene access materialises only the requested rectangle and stays bit-equal to the textbook reference; `@ W` matmuls go through the identity `(X − μ)/σ · W = (X/σ) · W − (μ/σ) · W` used by `chunked_pca` path 2.

## End-to-end validation
TS-Vasc (42 650 × 36 554, the standard cellxgene Tabula Sapiens slice in our bench):

| path | scale | pca | total | peak RSS | cos(50 PCs) |
|---|---|---|---|---|---|
| dense (default) | 22.7 s | 4.9 s | 27.5 s | 26.7 GB | baseline |
| `use_implicit_centering=True` | 6.7 s | 52.7 s | 59.4 s | **16.3 GB** | **1.0000 / 50** |

TS-10k full panel: dense peak 7.0 GB → implicit 3.2 GB. Cosine 1.0000 on all 50 PCs.

Per-component cosine equals 1.0000 because the per-element materialisation at the consumer boundary preserves the textbook `clip((X − μ)/σ, -∞, max_value)` operator exactly. The implicit path is slower at small sizes because sklearn picks a different SVD solver between float32 (implicit) and float64 (dense layer view) inputs — `covariance_eigh` on float64 outpaces randomized SVD on float32 when `n_features ≪ n_samples`. The flag is opt-in: default dense path stays the small-data winner.

## Requirements
- Companion PR `omicverse/anndata-oom#6` lands `CenteredSparseArray` and exports it from `anndataoom`. This PR's flag raises `ImportError` with a clear pointer when the prereq is missing.

## Test plan
- [x] TS-10k full panel: cosine 1.0000 / 50, RSS 7.0 GB → 3.2 GB.
- [x] TS-Vasculature 42 k: cosine 1.0000 / 50, RSS 26.7 GB → 16.3 GB.
- [ ] TS-Immune (592 k) full pipeline — was OOM-killed in the dense path; running this PR with `use_implicit_centering=True` to confirm completion. Result will be appended in a follow-up comment.
- [ ] CI on existing test matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)