### PR TITLE
ci: fix py3.11/3.12 build — run on numpy>=2, pin jax<0.7

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -41,8 +41,13 @@ jobs:
     - name: Install dependencies
       run: |
         uv venv .venv --python ${{ matrix.python-version }}
-        uv pip install --python .venv/bin/python flake8 torch tensorboard mellon torch_geometric POT wget lifelines boltons ctxcore ktplotspy leidenalg datashader graphtools phate python-dotplot metatime pydeseq2 bioservices tomli wandb munch datasets
-        uv pip install --python .venv/bin/python -e ".[tests,mcp]"
+        # Run CI on numpy>=2 (omicverse core supports it) and keep jax on the
+        # 0.6.x line. On py3.11/3.12 the resolver otherwise pulls jax 0.10.x
+        # (transitively via mellon), which is broken against numpy 2.4.x
+        # (`np.dtypes.StringDType`) and crashes test collection. jax 0.6.2 is
+        # the version py3.10 already resolved + passed with, on numpy 2.2.6.
+        uv pip install --python .venv/bin/python 'numpy>=2' 'jax<0.7' 'jaxlib<0.7' flake8 torch tensorboard mellon torch_geometric POT wget lifelines boltons ctxcore ktplotspy leidenalg datashader graphtools phate python-dotplot metatime pydeseq2 bioservices tomli wandb munch datasets
+        uv pip install --python .venv/bin/python -e ".[tests,mcp]" 'numpy>=2' 'jax<0.7' 'jaxlib<0.7'
     - name: Lint with flake8
       run: |
         source .venv/bin/activate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,7 +139,7 @@ easy=[
   'graphtools>=1.5',
   'pandas<3.0.0',
   'anndata<0.12.0',
-  'numpy>=1.23, <2.0.0',
+  'numpy>=1.23',
 ]
 
 web = [


### PR DESCRIPTION
Follow-up to #806. The `py310|py311|py312` build has been failing on 3.11/3.12 (pre-existing on master): the resolver pulls `jax 0.10.x` transitively (via `mellon`), which is broken against numpy 2.4.x — it calls `np.dtypes.StringDType` at import and crashes test collection of `tests/micro/test_*.py`. py3.10 passed because it resolved `jax 0.6.2` with numpy 2.2.6.

omicverse core already supports numpy≥2 (the only `<2.0.0` cap was a stale leftover in the `easy` extra). Fix:
- anchor `numpy>=2` in the CI install (CI now runs on numpy≥2, matching core)
- pin `jax/jaxlib<0.7` → 0.6.2, the version py3.10 proved works on numpy≥2
- drop the stale `numpy<2.0.0` cap in the `easy` extra (now `numpy>=1.23`, == core)

Verified resolution: `numpy>=2` + `jax<0.7` → jax 0.6.2 + numpy 2.4.6, clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)