### PR TITLE
release: v2.2.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "omicverse"
-version = "2.2.1rc1"
+version = "2.2.1"
 description = "OmicVerse: A single pipeline for exploring the entire transcriptome universe"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Bumps `version` `2.2.1rc1` → `2.2.1` for the final 2.2.1 release.

Includes everything merged since v2.2.0 (~190 commits), most recently the
on-device MLX UMAP negative-sampling perf fix (#814).

Full changelog: v2.2.1 section of the release notes (8 new modules —
genetics / protein / mol / epi / airr / single-metabolism / EV / histo —
out-of-core preprocessing, rebuilt trajectory & pseudotime, edgeR/limma +
time-course DEG, unified MetaCell, GPU non-parametric UMAP, simpleaf
alignment, funkyheatmap, and bug fixes).

After this merges: tag `v2.2.1` and publish to PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)