### PR TITLE
chore: bump version to 2.2.2rc1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "omicverse"
-version = "2.2.1"
+version = "2.2.2rc1"
 description = "OmicVerse: A single pipeline for exploring the entire transcriptome universe"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Post-2.2.1-release version bump (`2.2.1` → `2.2.2rc1`) to open the 2.2.2 dev cycle. 2.2.1 is live on PyPI: https://pypi.org/project/omicverse/2.2.1/

🤖 Generated with [Claude Code](https://claude.com/claude-code)