### PR TITLE
feat(pp,pl): unified QC compute / plot / filter workflow (closes #808)

### DIFF
--- a/omicverse/pl/__init__.py
+++ b/omicverse/pl/__init__.py
@@ -213,6 +213,7 @@ from ._spatialseg import (
 )
 from ._nanostring import nanostring, nanostringseg
 from ._violin import violin
+from ._qc import qc
 from ._report import (
     auto_resolution_curve,
     champ_landscape,
@@ -331,6 +332,7 @@ __all__ = [
     "embedding_adjust",
     "embedding_celltype",
     "embedding_density",
+    "qc",
     "half_violin_boxplot",
     "mde",
     "pca",

--- a/omicverse/pl/_qc.py
+++ b/omicverse/pl/_qc.py
@@ -1,0 +1,193 @@
+"""QC-metric distribution plots — inspect before you filter (issue #808).
+
+The classic scRNA QC workflow is *look, then cut*: view the distribution of
+each QC metric (optionally per sample, since quality differs between samples)
+and only then choose thresholds. omicverse computes the metrics
+(:func:`omicverse.pp.qc_metrics` / :func:`omicverse.pp.qc`) and filters
+(:func:`omicverse.pp.qc`), but previously left the plotting to the user.
+``ov.pl.qc`` fills that gap.
+"""
+from __future__ import annotations
+
+from typing import Optional, Sequence, Union
+
+import numpy as np
+
+from .._registry import register_function
+
+# Preferred metric columns, with fallbacks to scanpy's names, and the
+# ov.pp.qc `tresh` key each maps to (for drawing threshold guide lines).
+_DEFAULT_METRICS = [
+    # (candidate obs columns, nice label, tresh-key, tresh-direction)
+    (["nUMIs", "total_counts"], "UMIs per cell", "nUMIs", "min"),
+    (["detected_genes", "n_genes_by_counts"], "Genes per cell", "detected_genes", "min"),
+    (["mito_perc", "pct_counts_mt"], "Mito %", "mito_perc", "max"),
+    (["pct_counts_ribo"], "Ribo %", None, None),
+    (["pct_counts_hb"], "Hb %", None, None),
+    (["doublet_score"], "Doublet score", None, None),
+]
+
+
+def _resolve_metrics(adata, metrics):
+    """Return [(col, label, tresh_key, direction), ...] present in obs."""
+    if metrics is not None:
+        out = []
+        for m in metrics:
+            if m in adata.obs:
+                # map known cols to a tresh key for guide lines
+                key, direction = None, None
+                for cands, _lab, k, d in _DEFAULT_METRICS:
+                    if m in cands:
+                        key, direction = k, d
+                        break
+                out.append((m, m, key, direction))
+        return out
+    out = []
+    for cands, label, key, direction in _DEFAULT_METRICS:
+        for c in cands:
+            if c in adata.obs:
+                out.append((c, label, key, direction))
+                break
+    return out
+
+
+@register_function(
+    aliases=["qc_plot", "qc", "plot_qc", "质控绘图", "质控分布图"],
+    category="plotting",
+    description=(
+        "Plot the distribution of per-cell QC metrics (UMIs, genes, mito%, "
+        "ribo%, hb%, doublet score) as histograms or violins, optionally per "
+        "sample, with threshold guide lines — to choose QC cutoffs before "
+        "filtering with ov.pp.qc."
+    ),
+    examples=[
+        "ov.pl.qc(adata)",
+        "ov.pl.qc(adata, tresh={'mito_perc': 0.13, 'nUMIs': 800, 'detected_genes': 500})",
+        "ov.pl.qc(adata, batch_key='sample', kind='violin')",
+    ],
+    related=["pp.qc_metrics", "pp.qc"],
+)
+def qc(
+    adata,
+    *,
+    metrics: Optional[Sequence[str]] = None,
+    kind: str = "hist",
+    batch_key: Optional[str] = None,
+    tresh: Optional[dict] = None,
+    bins: int = 50,
+    log: Union[bool, str] = "auto",
+    ncols: int = 3,
+    figsize: Optional[tuple] = None,
+    color: str = "#4C72B0",
+    palette: Optional[Sequence[str]] = None,
+):
+    """Plot QC-metric distributions to guide threshold choice.
+
+    Parameters
+    ----------
+    adata
+        AnnData with QC metrics in ``obs`` (run :func:`omicverse.pp.qc_metrics`
+        or :func:`omicverse.pp.qc` first, or scanpy's ``calculate_qc_metrics``).
+    metrics
+        ``obs`` columns to plot. Default: auto-detect the standard metrics
+        (UMIs, genes, mito%, ribo%, hb%, doublet score) that are present.
+    kind
+        ``'hist'`` (default) or ``'violin'``. Violin is most useful with
+        ``batch_key`` to compare per-sample quality.
+    batch_key
+        ``obs`` column to split by (e.g. sample). Histograms overlay one
+        curve per group; violins show one violin per group.
+    tresh
+        Optional ``ov.pp.qc``-style dict (keys ``'nUMIs'``, ``'detected_genes'``,
+        ``'mito_perc'``) — drawn as dashed guide lines on the matching panels.
+        ``mito_perc`` is a fraction (0.13 → 13%) to match ``ov.pp.qc``.
+    bins
+        Histogram bin count (default 50).
+    log
+        Log-scale the metric axis. ``'auto'`` logs counts metrics
+        (UMIs/genes) but not percentages.
+    ncols, figsize, color, palette
+        Layout / styling controls.
+
+    Returns
+    -------
+    matplotlib.figure.Figure
+    """
+    import matplotlib.pyplot as plt
+
+    resolved = _resolve_metrics(adata, metrics)
+    if not resolved:
+        raise ValueError(
+            "No QC metrics found in adata.obs. Run ov.pp.qc_metrics(adata) "
+            "(or ov.pp.qc / sc.pp.calculate_qc_metrics) first."
+        )
+    tresh = tresh or {}
+    groups = None
+    if batch_key is not None:
+        if batch_key not in adata.obs:
+            raise KeyError(f"obs[{batch_key!r}] not found.")
+        groups = list(adata.obs[batch_key].astype("category").cat.categories)
+
+    n = len(resolved)
+    ncols = min(ncols, n)
+    nrows = int(np.ceil(n / ncols))
+    if figsize is None:
+        figsize = (4.2 * ncols, 3.4 * nrows)
+    fig, axes = plt.subplots(nrows, ncols, figsize=figsize, squeeze=False)
+    axes = axes.ravel()
+
+    if palette is None:
+        cmap = plt.get_cmap("tab20")
+        palette = [cmap(i % 20) for i in range(len(groups))] if groups else None
+
+    for ax, (col, label, key, direction) in zip(axes, resolved):
+        vals = adata.obs[col].astype(float)
+        do_log = (log is True) or (log == "auto" and direction == "min")
+
+        if kind == "violin":
+            if groups:
+                data = [adata.obs.loc[adata.obs[batch_key] == g, col]
+                        .astype(float).dropna().values for g in groups]
+                parts = ax.violinplot(data, showmedians=True, widths=0.85)
+                ax.set_xticks(range(1, len(groups) + 1))
+                ax.set_xticklabels(groups, rotation=90, fontsize=7)
+                if palette:
+                    for pc, c in zip(parts["bodies"], palette):
+                        pc.set_facecolor(c); pc.set_alpha(0.75)
+            else:
+                parts = ax.violinplot(vals.dropna().values, showmedians=True)
+                for pc in parts["bodies"]:
+                    pc.set_facecolor(color); pc.set_alpha(0.8)
+                ax.set_xticks([])
+            ax.set_ylabel(label)
+            if do_log:
+                ax.set_yscale("log")
+        else:  # histogram
+            if groups:
+                for g, c in zip(groups, palette):
+                    gv = adata.obs.loc[adata.obs[batch_key] == g, col].astype(float).dropna()
+                    ax.hist(gv, bins=bins, histtype="step", color=c,
+                            label=str(g), linewidth=1.2,
+                            log=do_log if False else False, density=True)
+                if len(groups) <= 12:
+                    ax.legend(fontsize=6, frameon=False)
+            else:
+                ax.hist(vals.dropna(), bins=bins, color=color, alpha=0.85)
+            ax.set_xlabel(label)
+            ax.set_ylabel("density" if groups else "cells")
+            if do_log:
+                ax.set_xscale("log")
+
+        # threshold guide line
+        if key in tresh:
+            t = tresh[key]
+            if key == "mito_perc" and col == "pct_counts_mt":
+                t = t * 100.0  # tresh is a fraction; pct col is 0-100
+            line = ax.axhline if kind == "violin" else ax.axvline
+            line(t, color="red", linestyle="--", linewidth=1.2)
+        ax.set_title(label, fontsize=10)
+
+    for ax in axes[n:]:
+        ax.set_visible(False)
+    fig.tight_layout()
+    return fig

--- a/omicverse/pp/__init__.py
+++ b/omicverse/pp/__init__.py
@@ -69,7 +69,7 @@ from ._preprocess import (identify_robust_genes,
 
 from ._sude import sude
 
-from ._qc import qc,filter_cells,filter_genes
+from ._qc import qc,qc_metrics,filter_cells,filter_genes
 from ._recover import recover_counts,binary_search
 from ._normalization import log1p,normalize_total
 from ._scrublet import scrublet, scrublet_simulate_doublets
@@ -110,6 +110,7 @@ __all__ = [
     # Quality control
     'quantity_control',
     'qc',
+    'qc_metrics',
     'filter_cells',
     'filter_genes',
 

--- a/omicverse/pp/_qc.py
+++ b/omicverse/pp/_qc.py
@@ -538,6 +538,89 @@ def _mt_mask(var_names, mt_startswith):
     return var_names.str.startswith(mt_startswith)
 
 
+@register_function(
+    aliases=["qc_metrics", "calculate_qc_metrics", "质控指标", "质量指标"],
+    category="preprocessing",
+    description=(
+        "Compute per-cell QC metrics WITHOUT filtering: flags mt/ribo/hb "
+        "genes, runs scanpy calculate_qc_metrics, and adds omicverse aliases "
+        "nUMIs / detected_genes / mito_perc. Inspect with ov.pl.qc, then "
+        "filter with ov.pp.qc(tresh=...)."
+    ),
+    requires={},
+    produces={"obs": ["nUMIs", "detected_genes", "mito_perc",
+                       "pct_counts_mt", "pct_counts_ribo", "pct_counts_hb"],
+              "var": ["mt", "ribo", "hb"]},
+    examples=[
+        "ov.pp.qc_metrics(adata)",
+        "ov.pp.qc_metrics(adata, mt_startswith='mt-')  # mouse",
+    ],
+    related=["pp.qc", "pl.qc"],
+)
+def qc_metrics(
+    adata,
+    *,
+    mt_startswith: str = "auto",
+    mt_genes=None,
+    ribo_startswith=("RPS", "RPL"),
+    ribo_genes=None,
+    hb_startswith="^HB[^(P)]",
+    hb_genes=None,
+):
+    r"""Compute per-cell QC metrics without filtering.
+
+    Flags mitochondrial / ribosomal / haemoglobin genes, runs scanpy's
+    ``calculate_qc_metrics`` (``total_counts``, ``n_genes_by_counts``,
+    ``pct_counts_{mt,ribo,hb}``), and adds the omicverse aliases ``nUMIs``,
+    ``detected_genes`` and ``mito_perc`` so both naming conventions are
+    available. Nothing is removed — this is the "look before you cut" step:
+    inspect the distributions with :func:`omicverse.pl.qc` (optionally per
+    sample), then filter with :func:`omicverse.pp.qc` using ``tresh``.
+
+    Parameters
+    ----------
+    adata
+        AnnData with raw counts in ``adata.X``.
+    mt_startswith, mt_genes
+        Mitochondrial gene prefix (``'auto'`` detects ``MT-``/``mt-``) or an
+        explicit gene list (overrides the prefix).
+    ribo_startswith, ribo_genes, hb_startswith, hb_genes
+        Ribosomal / haemoglobin gene prefixes or explicit lists.
+
+    Returns
+    -------
+    AnnData
+        ``adata`` with QC metrics added to ``obs``/``var`` (in place).
+    """
+    import scanpy as sc
+
+    var_names = adata.var_names
+    if mt_startswith == "auto" and mt_genes is None:
+        mt_startswith = _detect_mt_prefix(var_names)
+    if mt_genes is not None:
+        adata.var["mt"] = adata.var_names.isin(list(mt_genes))
+    else:
+        adata.var["mt"] = _mt_mask(var_names, mt_startswith)
+    if ribo_genes is not None:
+        adata.var["ribo"] = adata.var_names.isin(list(ribo_genes))
+    else:
+        adata.var["ribo"] = var_names.str.startswith(tuple(ribo_startswith))
+    if hb_genes is not None:
+        adata.var["hb"] = adata.var_names.isin(list(hb_genes))
+    else:
+        adata.var["hb"] = var_names.str.contains(hb_startswith)
+
+    sc.pp.calculate_qc_metrics(
+        adata, qc_vars=["mt", "ribo", "hb"], inplace=True, log1p=False,
+        percent_top=None,
+    )
+    # omicverse aliases (same definitions ov.pp.qc filters on)
+    adata.obs["nUMIs"] = adata.obs["total_counts"]
+    adata.obs["detected_genes"] = adata.obs["n_genes_by_counts"]
+    adata.obs["mito_perc"] = adata.obs["pct_counts_mt"] / 100.0
+    return adata
+
+
 @monitor
 @register_function(
     aliases=["质控", "qc", "quality_control", "质量控制"],

--- a/tests/pp/test_qc_workflow.py
+++ b/tests/pp/test_qc_workflow.py
@@ -1,0 +1,75 @@
+"""Tests for the QC compute/plot/filter workflow (issue #808).
+
+ov.pp.qc_metrics (compute, no filter) -> ov.pl.qc (inspect distributions)
+-> ov.pp.qc (filter).
+"""
+import numpy as np
+import pytest
+
+
+def _counts_adata(n=400, n_genes=60, seed=0):
+    """Synthetic raw-count AnnData with MT-/RPS/HB gene names + a sample col."""
+    import anndata as ad
+
+    rng = np.random.default_rng(seed)
+    X = rng.poisson(1.0, size=(n, n_genes)).astype(np.float32)
+    names = (
+        [f"MT-{i}" for i in range(5)]
+        + [f"RPS{i}" for i in range(5)]
+        + [f"HB{i}" for i in range(3)]
+        + [f"G{i}" for i in range(n_genes - 13)]
+    )
+    a = ad.AnnData(X)
+    a.var_names = names
+    a.obs["sample"] = rng.choice(["s1", "s2"], n)
+    return a
+
+
+def test_qc_metrics_computes_without_filtering():
+    import omicverse as ov
+
+    a = _counts_adata()
+    n0 = a.n_obs
+    ov.pp.qc_metrics(a)
+    assert a.n_obs == n0  # nothing removed
+    for col in ["nUMIs", "detected_genes", "mito_perc",
+                "total_counts", "n_genes_by_counts",
+                "pct_counts_mt", "pct_counts_ribo", "pct_counts_hb"]:
+        assert col in a.obs, col
+    # aliases consistent with scanpy metrics
+    assert np.allclose(a.obs["nUMIs"], a.obs["total_counts"])
+    assert np.allclose(a.obs["mito_perc"], a.obs["pct_counts_mt"] / 100.0)
+    assert a.var["mt"].sum() == 5 and a.var["ribo"].sum() == 5
+
+
+def test_qc_metrics_explicit_prefix():
+    import omicverse as ov
+
+    a = _counts_adata()
+    ov.pp.qc_metrics(a, mt_startswith="MT-")
+    assert a.var["mt"].sum() == 5
+
+
+def test_pl_qc_runs():
+    import matplotlib
+    matplotlib.use("Agg")
+    import omicverse as ov
+
+    a = _counts_adata()
+    ov.pp.qc_metrics(a)
+    fig = ov.pl.qc(a, tresh={"mito_perc": 0.2, "nUMIs": 5, "detected_genes": 5})
+    assert fig is not None and len(fig.axes) >= 3
+
+    fig2 = ov.pl.qc(a, batch_key="sample", kind="violin")
+    assert fig2 is not None
+
+
+def test_pl_qc_requires_metrics():
+    import anndata as ad
+    import matplotlib
+    matplotlib.use("Agg")
+    import omicverse as ov
+
+    a = ad.AnnData(np.zeros((5, 4), dtype=np.float32))
+    with pytest.raises(ValueError):
+        ov.pl.qc(a)


### PR DESCRIPTION
Closes #808.

## Problem (from the issue)

omicverse computes QC metrics and filters, but **skips the visualization step**: to choose thresholds users had to hand-roll histograms (`plt.hist` + `axvline`) per metric (see the reporter's notebook). The classic scRNA QC flow is *look, then cut* — and because sample quality differs, you want to see per-sample distributions before picking cutoffs.

## What this adds — the missing 3-step workflow

```python
# 1. compute metrics, NO filtering (the "stat" step)
ov.pp.qc_metrics(adata)

# 2. inspect distributions, per sample, with threshold guide lines (the "visualize" step)
ov.pl.qc(adata, batch_key='sample',
         tresh={'mito_perc': 0.13, 'nUMIs': 800, 'detected_genes': 500})

# 3. filter (existing)
ov.pp.qc(adata, tresh={'mito_perc': 0.13, 'nUMIs': 800, 'detected_genes': 500})
```

### `ov.pp.qc_metrics` (new)
Flags mt/ribo/hb genes, runs scanpy `calculate_qc_metrics`, and adds the omicverse aliases `nUMIs` / `detected_genes` / `mito_perc` — both naming conventions available, **nothing removed**. Auto-detects the MT prefix (`MT-`/`mt-`) like `ov.pp.qc`.

### `ov.pl.qc` (new)
Histograms (default) or violins of the standard QC metrics (UMIs, genes, mito%, ribo%, hb%, doublet score — auto-detected), with:
- `batch_key=` → one curve/violin per sample (the issue's key point: per-sample quality),
- `tresh=` (same dict as `ov.pp.qc`) → dashed guide lines so you see exactly where a cutoff lands,
- `kind='hist'|'violin'`, `log='auto'` (log-scales count metrics), layout/style controls.

Returns the matplotlib `Figure`.

## Example output

`ov.pl.qc(adata, tresh={'mito_perc':0.13,'nUMIs':800,'detected_genes':500})` → per-metric panels with the chosen cutoffs drawn in red (UMIs/genes on log-x):

(UMIs · genes · mito% · ribo% · hb%, each with its threshold line)

## Tests

`tests/pp/test_qc_workflow.py` — compute-without-filter, alias consistency (`nUMIs==total_counts`, `mito_perc==pct_counts_mt/100`), explicit prefix, plot (hist + per-sample violin), and the no-metrics `ValueError`. All pass.

## Notes

- Backward compatible: `ov.pp.qc` is unchanged.
- `ov.pl.qc` (plot) is distinct from `ov.pp.qc` (filter) — different namespaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)