### PR TITLE
feat: global random seed for reproducibility — ov.set_seed (closes #807)

### DIFF
--- a/omicverse/__init__.py
+++ b/omicverse/__init__.py
@@ -113,6 +113,9 @@ _LAZY_ATTRS = {
     'export_registry': ('._registry', 'export_registry'),
     'import_registry': ('._registry', 'import_registry'),
 
+    # From utils._seed - global reproducibility
+    'set_seed': ('.utils._seed', 'set_seed'),
+
     # From utils.smart_agent
     'Agent': ('.utils.smart_agent', 'Agent'),
     'list_supported_models': ('.utils.smart_agent', 'list_supported_models'),

--- a/omicverse/_settings.py
+++ b/omicverse/_settings.py
@@ -4,10 +4,21 @@ class omicverseConfig:
 
     def __init__(self,mode='cpu'):
         self.mode = mode
+        self.seed = None
         from .utils._analytics_sender import send_analytics_full_silent
         import datetime
         test_id_full = f"FULL-{datetime.datetime.now().strftime('%Y%m%d-%H%M%S')}"
         send_analytics_full_silent(test_id_full)
+
+    def set_seed(self, seed: int = 0, *, deterministic: bool = False,
+                 verbose: bool = True) -> int:
+        """Set the global random seed for reproducible results.
+
+        Seeds Python / NumPy / PyTorch (CPU+CUDA) / MLX and stores the value
+        in ``self.seed``. See :func:`omicverse.set_seed` for details.
+        """
+        from .utils._seed import set_seed as _set_seed
+        return _set_seed(seed, deterministic=deterministic, verbose=verbose)
 
     @register_function(
         aliases=["GPU初始化", "gpu_init", "gpu_mode", "GPU模式", "rapids_init"],

--- a/omicverse/pp/_preprocess.py
+++ b/omicverse/pp/_preprocess.py
@@ -15,6 +15,7 @@ import warnings
 from scipy.sparse import issparse, csr_matrix
 
 from ..utils import load_signatures_from_file,predefined_signatures
+from ..utils._seed import SEED_DEFAULT, resolve_random_state
 from .._registry import register_function
 from .._settings import settings,print_gpu_usage_color,EMOJI,Colors,add_reference
 from .._oom_compat import oom_guard as _oom_guard
@@ -1434,24 +1435,28 @@ class my_PCA:
     related=["umap", "tsne", "mde"]
 )
 @tracked("pca", "ov.pp.pca")
-def pca(adata, n_pcs=50, layer='scaled',inplace=True,**kwargs):
+def pca(adata, n_pcs=50, layer='scaled',inplace=True,random_state=SEED_DEFAULT,**kwargs):
     """
     Performs Principal Component Analysis (PCA) on the data stored in a scanpy AnnData object.
 
     Arguments:
-        adata : Annotated data matrix with rows representing cells 
+        adata : Annotated data matrix with rows representing cells
         and columns representing features.
         n_pcs : Number of principal components to calculate.
-        layer : The name of the layer in `adata` where the data to be analyzed is stored. 
+        layer : The name of the layer in `adata` where the data to be analyzed is stored.
         Defaults to the 'scaled' layer,
-            and falls back to 'lognorm' if that layer does not exist. 
+            and falls back to 'lognorm' if that layer does not exist.
         Raises a KeyError if the specified layer is not present.
+        random_state : Random seed for reproducibility. Defaults to the global
+            seed set by ``ov.set_seed`` (else 0).
 
     Returns:
-        adata : The original AnnData object with the calculated PCA embeddings 
+        adata : The original AnnData object with the calculated PCA embeddings
         and other information stored in its `obsm`, `varm`,
             and `uns` fields.
     """
+    random_state = resolve_random_state(random_state)
+    kwargs['random_state'] = random_state
     #if 'lognorm' not in adata.layers:
     #    adata.layers['lognorm'] = adata.X
     # Implicit-centered scale: ov.pp.scale(use_implicit_centering=True) stores
@@ -1475,7 +1480,7 @@ def pca(adata, n_pcs=50, layer='scaled',inplace=True,**kwargs):
     if settings.mode == 'cpu':
         if sc.__version__ <'1.10':
             adata_mock=sc.AnnData(adata.layers[layer],obs=adata.obs,var=adata.var)
-            sc.pp.pca(adata_mock, n_comps=n_pcs)
+            sc.pp.pca(adata_mock, n_comps=n_pcs, random_state=random_state)
             adata.obsm[key + '|X_pca'] = adata_mock.obsm['X_pca']
             adata.varm[key + '|pca_loadings'] = adata_mock.varm['PCs']
             adata.uns[key + '|pca_var_ratios'] = adata_mock.uns['pca']['variance_ratio']
@@ -1643,7 +1648,7 @@ def neighbors(
     n_pcs: Optional[int] = None,
     use_rep: Optional[str] = None,
     knn: bool = True,
-    random_state: int= 0,
+    random_state= SEED_DEFAULT,
     n_jobs: Optional[int] = None,
     method: Optional[_Method] = 'umap',
     transformer: Optional[str] = None,
@@ -1714,6 +1719,7 @@ def neighbors(
     and in later versions it will become a hard dependency.
     
     """
+    random_state = resolve_random_state(random_state)
     # Ensure PCA exists; compute a default if missing so downstream code can proceed
     if settings.mode =='cpu':
         print(f"{EMOJI['cpu']} Using Scanpy CPU to calculate neighbors...")
@@ -1777,7 +1783,7 @@ def umap(
     gamma: float = 1.0,
     negative_sample_rate: int = 5,
     init_pos=None,
-    random_state=0,
+    random_state=SEED_DEFAULT,
     a: float | None = None,
     b: float | None = None,
     method: str | None = None,
@@ -1847,6 +1853,7 @@ def umap(
     * anything else (``'gpu'``)    — RAPIDS if available, falls back to
                                      pumap on import error.
     """
+    random_state = resolve_random_state(random_state)
     # Build the kwargs dict that downstream dispatchers expect. Keep
     # `method` and `init_pos` optional so each branch can pick its default.
     forward = dict(
@@ -2053,11 +2060,12 @@ def louvain(
 )
 @tracked("leiden", "ov.pp.leiden")
 def leiden(
-    adata, resolution=1.0, random_state=0,
+    adata, resolution=1.0, random_state=SEED_DEFAULT,
     key_added='leiden', local_iterations=100, max_levels=10, device=None, symmetrize=None, **kwargs):
     '''
     leiden clustering
     '''
+    random_state = resolve_random_state(random_state)
     if settings.mode == 'cpu':
         print(f"{EMOJI['cpu']} Using Scanpy CPU Leiden...")
         from ._leiden import leiden as _leiden
@@ -2228,7 +2236,7 @@ def tsne(
     metric: str = "euclidean",
     early_exaggeration: float = 12,
     learning_rate: float = 1000,
-    random_state=0,
+    random_state=SEED_DEFAULT,
     key_added: str | None = None,
     copy: bool = False,
     n_iter: int | None = None,
@@ -2276,6 +2284,7 @@ def tsne(
     ``cpu-gpu-mixed`` mode uses our KL-loss native torch t-SNE
     (see ``omicverse/external/torch_tsne.py``) — no ``torchdr`` dependency.
     """
+    random_state = resolve_random_state(random_state)
     kwargs.setdefault("n_pcs", n_pcs)
     kwargs.setdefault("n_components", n_components)
     if use_rep is not None:

--- a/omicverse/utils/__init__.py
+++ b/omicverse/utils/__init__.py
@@ -120,6 +120,7 @@ from ._sample_metadata_alignment import (
     align_samples,
 )
 from ._metabolights import load_metabolights
+from ._seed import set_seed
 from ._ovagent_lookup import (
     RegistryScanner,
     initialize_skill_registry,
@@ -198,6 +199,8 @@ verifier = _verifier_module
 
 # Explicit public exports for stable, non-wildcard imports
 __all__ = [
+    # @ _seed
+    "set_seed",
     # @ _metabolights
     "load_metabolights",
     # @ _data

--- a/omicverse/utils/_seed.py
+++ b/omicverse/utils/_seed.py
@@ -1,0 +1,107 @@
+"""Global random-seed control for reproducible omicverse runs (issue #807).
+
+One call seeds every RNG backend omicverse touches — Python ``random``,
+NumPy, PyTorch (CPU + CUDA), and MLX (Apple) — and records the seed in
+``ov.settings.seed`` so downstream steps can pick it up. Functions that
+already expose a ``random_state``/``seed`` argument still honour an explicit
+value; ``set_seed`` fixes the *global* generators those functions fall back
+on (and the non-seedable corners of the GPU paths).
+"""
+from __future__ import annotations
+
+import os
+import random as _random
+
+
+def set_seed(seed: int = 0, *, deterministic: bool = False,
+             verbose: bool = True) -> int:
+    """Seed all RNGs used by omicverse for reproducible results.
+
+    Seeds Python ``random``, ``PYTHONHASHSEED``, NumPy, PyTorch (CPU + every
+    CUDA device) and MLX (if installed). Optionally forces deterministic GPU
+    kernels.
+
+    Parameters
+    ----------
+    seed
+        The seed value (default ``0``).
+    deterministic
+        If ``True``, also request deterministic algorithms on GPU
+        (``cudnn.deterministic=True``, ``cudnn.benchmark=False`` and
+        ``torch.use_deterministic_algorithms(True, warn_only=True)``). This
+        trades some speed for bit-level reproducibility and is off by default.
+    verbose
+        Print a short confirmation.
+
+    Returns
+    -------
+    int
+        The seed that was set.
+
+    Examples
+    --------
+    >>> import omicverse as ov
+    >>> ov.set_seed(0)              # at the top of your script / notebook
+    >>> # ... ov.pp.neighbors / ov.pp.umap / ov.pp.leiden now reproducible
+    """
+    seed = int(seed)
+    os.environ["PYTHONHASHSEED"] = str(seed)
+    _random.seed(seed)
+
+    backends = ["python"]
+
+    try:
+        import numpy as np
+
+        np.random.seed(seed)
+        backends.append("numpy")
+    except Exception:  # noqa: BLE001
+        pass
+
+    try:
+        import torch
+
+        torch.manual_seed(seed)
+        backends.append("torch")
+        if torch.cuda.is_available():
+            torch.cuda.manual_seed_all(seed)
+            backends.append("cuda")
+        if deterministic:
+            torch.backends.cudnn.deterministic = True
+            torch.backends.cudnn.benchmark = False
+            try:
+                torch.use_deterministic_algorithms(True, warn_only=True)
+            except Exception:  # noqa: BLE001
+                pass
+            # cuBLAS determinism for matmul on CUDA >= 10.2
+            os.environ.setdefault("CUBLAS_WORKSPACE_CONFIG", ":4096:8")
+            backends.append("deterministic")
+    except Exception:  # noqa: BLE001
+        pass
+
+    try:
+        import mlx.core as mx
+
+        mx.random.seed(seed)
+        backends.append("mlx")
+    except Exception:  # noqa: BLE001
+        pass
+
+    # Record globally so other code can read ov.settings.seed.
+    try:
+        from .._settings import settings
+
+        settings.seed = seed
+    except Exception:  # noqa: BLE001
+        pass
+
+    if verbose:
+        try:
+            from .._settings import Colors, EMOJI
+
+            print(f"{Colors.GREEN}{EMOJI.get('done', '✓')} "
+                  f"Global seed set to {seed} "
+                  f"[{', '.join(backends)}]{Colors.ENDC}")
+        except Exception:  # noqa: BLE001
+            print(f"Global seed set to {seed} [{', '.join(backends)}]")
+    return seed

--- a/omicverse/utils/_seed.py
+++ b/omicverse/utils/_seed.py
@@ -13,6 +13,38 @@ import os
 import random as _random
 
 
+class _SeedDefault:
+    """Sentinel default for ``random_state`` args that should follow the
+    global seed (``ov.settings.seed``) when one has been set, else 0."""
+
+    def __repr__(self):  # pragma: no cover - cosmetic
+        return "<ov.seed-default>"
+
+
+SEED_DEFAULT = _SeedDefault()
+
+
+def resolve_random_state(random_state=SEED_DEFAULT, fallback: int = 0):
+    """Resolve a ``random_state`` argument against the global seed.
+
+    * An explicit value (int / ``RandomState`` / ``None``) is returned as-is.
+    * The :data:`SEED_DEFAULT` sentinel resolves to ``ov.settings.seed`` if
+      :func:`set_seed` has set one, otherwise ``fallback`` (0). This lets
+      ``ov.set_seed(s)`` drive every ``ov.pp`` function's default seed without
+      passing ``random_state`` to each call, while keeping any explicit value.
+    """
+    if isinstance(random_state, _SeedDefault):
+        try:
+            from .._settings import settings
+
+            if getattr(settings, "seed", None) is not None:
+                return settings.seed
+        except Exception:  # noqa: BLE001
+            pass
+        return fallback
+    return random_state
+
+
 def set_seed(seed: int = 0, *, deterministic: bool = False,
              verbose: bool = True) -> int:
     """Seed all RNGs used by omicverse for reproducible results.

--- a/tests/test_set_seed.py
+++ b/tests/test_set_seed.py
@@ -55,3 +55,24 @@ def test_deterministic_flag_runs():
     # should not raise even when requesting deterministic algorithms
     seed = ov.set_seed(0, deterministic=True, verbose=False)
     assert seed == 0
+
+
+def test_seed_propagates_to_pp_random_state():
+    """ov.set_seed should drive the default random_state of pp functions."""
+    import omicverse as ov
+    from omicverse.utils._seed import SEED_DEFAULT, resolve_random_state
+
+    ov.settings.seed = None
+    assert resolve_random_state(SEED_DEFAULT) == 0          # no seed -> 0
+    ov.set_seed(42, verbose=False)
+    assert resolve_random_state(SEED_DEFAULT) == 42         # follows global seed
+    assert resolve_random_state(7) == 7                     # explicit wins
+    ov.settings.seed = None
+
+
+def test_pca_exposes_random_state():
+    import inspect
+
+    import omicverse as ov
+
+    assert "random_state" in inspect.signature(ov.pp.pca).parameters

--- a/tests/test_set_seed.py
+++ b/tests/test_set_seed.py
@@ -1,0 +1,57 @@
+"""Tests for the global random-seed control ov.set_seed (issue #807)."""
+import numpy as np
+
+
+def test_set_seed_exposed_and_records():
+    import omicverse as ov
+
+    ov.set_seed(123, verbose=False)
+    assert ov.settings.seed == 123
+    # settings method form
+    ov.settings.set_seed(7, verbose=False)
+    assert ov.settings.seed == 7
+
+
+def test_numpy_reproducible():
+    import omicverse as ov
+
+    ov.set_seed(42, verbose=False)
+    a = np.random.rand(5)
+    ov.set_seed(42, verbose=False)
+    b = np.random.rand(5)
+    assert np.allclose(a, b)
+
+
+def test_python_random_reproducible():
+    import random
+
+    import omicverse as ov
+
+    ov.set_seed(1, verbose=False)
+    a = [random.random() for _ in range(5)]
+    ov.set_seed(1, verbose=False)
+    b = [random.random() for _ in range(5)]
+    assert a == b
+
+
+def test_torch_reproducible_if_available():
+    import omicverse as ov
+
+    try:
+        import torch
+    except Exception:
+        import pytest
+        pytest.skip("torch not installed")
+    ov.set_seed(5, verbose=False)
+    a = torch.randn(4)
+    ov.set_seed(5, verbose=False)
+    b = torch.randn(4)
+    assert torch.allclose(a, b)
+
+
+def test_deterministic_flag_runs():
+    import omicverse as ov
+
+    # should not raise even when requesting deterministic algorithms
+    seed = ov.set_seed(0, deterministic=True, verbose=False)
+    assert seed == 0


### PR DESCRIPTION
Closes #807.

## Problem

Randomised steps (UMAP, leiden, neighbors, doublet detection, the GPU/torch backends) could give different results across runs. There was no single place to fix reproducibility.

## What this adds

`ov.set_seed(seed=0, deterministic=False)` — seeds **every RNG backend omicverse touches in one call**:
- Python `random` + `PYTHONHASHSEED`
- NumPy
- PyTorch (CPU + all CUDA devices)
- MLX (Apple, if installed)

and records it in `ov.settings.seed`. Also available as `ov.settings.set_seed(...)`.

```python
import omicverse as ov
ov.set_seed(0)   # at the top of your script/notebook
# ov.pp.neighbors / ov.pp.umap / ov.pp.leiden ... now reproducible
```

`deterministic=True` additionally requests deterministic GPU kernels (`cudnn.deterministic=True`, `cudnn.benchmark=False`, `torch.use_deterministic_algorithms(True, warn_only=True)`, `CUBLAS_WORKSPACE_CONFIG`) for bit-level reproducibility, trading some speed.

Functions that already expose `random_state`/`seed` keep honouring an explicit value; `set_seed` fixes the **global** generators they fall back on plus the non-seedable corners of the GPU paths.

## Tests

`tests/test_set_seed.py` — top-level + settings exposure, `settings.seed` recording, and reproducibility of NumPy / Python `random` / torch, plus the `deterministic=True` path. All pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)