### PR TITLE
feat(pl): add UpSet plot support

### DIFF
--- a/omicverse/pl/__init__.py
+++ b/omicverse/pl/__init__.py
@@ -147,6 +147,7 @@ from ._heatmap_marsilea import (
 )
 from ._multi import embedding_multi
 from ._bulk import boxplot, plot_grouped_fractions, venn, volcano
+from ._upset import upset
 from ._space import (
     add_pie2spatial,
     add_pie_charts_to_spatial,
@@ -360,6 +361,7 @@ __all__ = [
     # @ _bulk
     "boxplot",
     "plot_grouped_fractions",
+    "upset",
     "venn",
     "volcano",
     # @ _space

--- a/omicverse/pl/_upset.py
+++ b/omicverse/pl/_upset.py
@@ -1,0 +1,493 @@
+import numpy as np
+import pandas as pd
+import matplotlib.pyplot as plt
+from matplotlib import rcParams
+
+from .._registry import register_function
+
+
+def _build_upset_intersections(sets, min_size=1):
+    names = list(sets.keys())
+    normalized = {name: set(values) for name, values in sets.items()}
+    records = []
+
+    for mask in range(1, 2 ** len(names)):
+        included = [names[i] for i in range(len(names)) if mask & (1 << i)]
+        excluded = [name for name in names if name not in included]
+        elements = set.intersection(*(normalized[name] for name in included))
+        if excluded:
+            elements = elements.difference(*(normalized[name] for name in excluded))
+        if len(elements) >= min_size:
+            records.append(
+                {
+                    "sets": tuple(included),
+                    "degree": len(included),
+                    "size": len(elements),
+                    "elements": elements,
+                }
+            )
+
+    return pd.DataFrame.from_records(records, columns=["sets", "degree", "size", "elements"])
+
+
+def _is_adata_like(data):
+    return all(hasattr(data, attr) for attr in ("obs", "var", "obs_names", "var_names"))
+
+
+def _coerce_upset_sets(data, keys=None, axis="obs"):
+    if isinstance(data, dict):
+        if keys is None:
+            return data
+        return {key: data[key] for key in keys}
+
+    if not _is_adata_like(data):
+        raise ValueError("`sets` must be a dictionary or an AnnData object.")
+
+    if axis not in {"obs", "var"}:
+        raise ValueError("`axis` must be either 'obs' or 'var'.")
+
+    frame = data.obs if axis == "obs" else data.var
+    names = data.obs_names if axis == "obs" else data.var_names
+
+    if keys is None:
+        keys = [
+            column
+            for column in frame.columns
+            if pd.api.types.is_bool_dtype(frame[column].dropna())
+        ]
+        if not keys:
+            raise ValueError(
+                "AnnData input requires `keys` unless `adata.obs` or `adata.var` "
+                "contains boolean columns."
+            )
+
+    missing = [key for key in keys if key not in frame.columns]
+    if missing:
+        raise KeyError(f"Keys not found in adata.{axis}: {', '.join(map(str, missing))}")
+
+    result = {}
+    for key in keys:
+        series = frame[key]
+        if not pd.api.types.is_bool_dtype(series.dropna()):
+            raise TypeError(
+                f"`adata.{axis}[{key!r}]` must be boolean to define an UpSet set."
+            )
+        mask = series.fillna(False).astype(bool).to_numpy()
+        result[str(key)] = set(pd.Index(names)[mask])
+    return result
+
+
+def _apply_ov_style(style):
+    if style in (None, False):
+        return
+    if style is True:
+        from ._plot_backend import style as ov_style
+
+        ov_style(show_monitor=False)
+        return
+    if isinstance(style, dict):
+        from ._plot_backend import style as ov_style
+
+        kwargs = dict(style)
+        kwargs.setdefault("show_monitor", False)
+        ov_style(**kwargs)
+        return
+    if callable(style):
+        try:
+            style(show_monitor=False)
+        except TypeError:
+            style()
+        return
+    raise TypeError("`style` must be None, bool, dict, or a callable such as `ov.style`.")
+
+
+def _upset_colors(empty_color, line_color):
+    cycle = rcParams["axes.prop_cycle"].by_key().get("color", [])
+    if not cycle:
+        cycle = ["#30343b", "#7aa6c2", "#b7c7d8"]
+    return {
+        "intersection_color": cycle[0],
+        "set_size_color": cycle[min(1, len(cycle) - 1)],
+        "matrix_color": cycle[0],
+        "empty_color": empty_color or "#d9dde1",
+        "line_color": line_color or "#9aa1a8",
+    }
+
+
+def _format_intersection_key(names):
+    return "&".join(map(str, names))
+
+
+def _canonical_intersection_key(key):
+    if isinstance(key, str):
+        parts = key.split("&")
+    else:
+        parts = list(key)
+    return tuple(sorted(map(str, parts)))
+
+
+def _resolve_column_colors(color, intersections, default):
+    if color is None:
+        return default
+    if isinstance(color, str):
+        return color
+    if isinstance(color, dict):
+        color_map = {
+            _canonical_intersection_key(key): value
+            for key, value in color.items()
+        }
+        return [
+            color_map.get(_canonical_intersection_key(names), default)
+            for names in intersections["sets"]
+        ]
+
+    values = list(color)
+    if not values:
+        return default
+    repeats = int(np.ceil(len(intersections) / len(values)))
+    return (values * repeats)[: len(intersections)]
+
+
+def _resolve_set_colors(color, set_names, default):
+    if color is None:
+        return [default] * len(set_names)
+    if isinstance(color, str):
+        return [color] * len(set_names)
+    if isinstance(color, dict):
+        return [color.get(name, default) for name in set_names]
+
+    values = list(color)
+    if not values:
+        return [default] * len(set_names)
+    repeats = int(np.ceil(len(set_names) / len(values)))
+    return (values * repeats)[: len(set_names)]
+
+
+def _normalize_intersection_key(key):
+    return _canonical_intersection_key(key)
+
+
+def _apply_intersection_order(intersections, intersection_order):
+    if intersection_order is None:
+        return intersections
+
+    order = {
+        _normalize_intersection_key(key): idx
+        for idx, key in enumerate(intersection_order)
+    }
+    intersections = intersections.copy()
+    intersections["_manual_order"] = intersections["sets"].map(
+        lambda values: order.get(_canonical_intersection_key(values), len(order))
+    )
+    return (
+        intersections.sort_values(
+            ["_manual_order", "size", "degree", "_sort_key"],
+            ascending=[True, False, False, True],
+        )
+        .drop(columns="_manual_order")
+    )
+
+
+@register_function(
+    aliases=["upset", "upset_plot", "UpSet", "集合交集图", "多集合交集图"],
+    category="pl",
+    description="Create an UpSet plot to visualize intersections across many sets",
+    examples=[
+        "# Basic UpSet plot from a dictionary",
+        "sets = {'A': {'g1','g2'}, 'B': {'g2','g3'}, 'C': {'g2','g4'}}",
+        "fig, axes = ov.pl.upset(sets)",
+        "# Cell-level UpSet plot from AnnData boolean obs columns",
+        "fig, axes = ov.pl.upset(adata, keys=['high_CD3D', 'cycling'], axis='obs')",
+        "# Apply OmicVerse style just for this plot",
+        "fig, axes = ov.pl.upset(adata, keys=keys, style=ov.style)",
+    ],
+    related=["pl.venn"]
+)
+def upset(
+    sets,
+    keys=None,
+    axis="obs",
+    top_n=30,
+    min_size=1,
+    sort_by="size",
+    figsize=None,
+    style=None,
+    intersection_color=None,
+    set_size_color=None,
+    matrix_color=None,
+    empty_color=None,
+    line_color=None,
+    title="",
+    show_counts=True,
+    grid=True,
+    bar_width=0.72,
+    set_bar_height=0.58,
+    dot_size=42,
+    empty_dot_size=34,
+    line_width=1.3,
+    grid_color="#e7eaee",
+    grid_linewidth=0.8,
+    count_fontsize=None,
+    count_offset=None,
+    matrix_alpha=1.0,
+    empty_alpha=1.0,
+    set_order=None,
+    intersection_order=None,
+    height_ratios=None,
+    max_sets=12,
+):
+    r"""
+    Create an UpSet plot to visualize overlaps across multiple sets.
+
+    Parameters
+    ----------
+    sets : dict or AnnData
+        Dictionary mapping set names to iterables of elements, or an AnnData
+        object with boolean columns in ``adata.obs`` or ``adata.var``.
+    keys : list or None
+        For AnnData input, boolean columns to use as sets. For dictionary input,
+        optional subset/reordering of dictionary keys.
+    axis : {"obs", "var"}
+        AnnData axis used when ``sets`` is an AnnData object. ``"obs"`` plots
+        cell-set intersections; ``"var"`` plots feature/gene-set intersections.
+    top_n : int or None
+        Maximum number of non-empty intersections to show. ``None`` shows all.
+    min_size : int
+        Minimum exclusive intersection size to retain.
+    sort_by : {"size", "degree"}
+        Sort intersections by size or by number of participating sets.
+    figsize : tuple or None
+        Figure size. If ``None``, size is chosen from the number of displayed
+        intersections and input sets.
+    style : None, bool, dict, or callable
+        Optional OmicVerse style application. Use ``style=ov.style`` to apply
+        the package plotting style before drawing, ``style=True`` to call
+        ``ov.pl.style(show_monitor=False)``, or a dict of keyword arguments to
+        pass to ``ov.pl.style``.
+    intersection_color : str, sequence, or dict
+        Color for the top intersection-size bars. A sequence colors bars by
+        displayed column order; a dict can map ``("A", "B")`` or ``"A&B"`` to
+        colors.
+    set_size_color : str, sequence, or dict
+        Color for the left set-size bars. A dict maps set names to colors and
+        leaves unspecified rows with the default color.
+    matrix_color : str, sequence, or dict
+        Color for active dots in the intersection matrix. A dict maps set names
+        to row colors and leaves unspecified rows with the default color.
+    empty_color : str
+        Color for inactive dots in the intersection matrix.
+    line_color : str
+        Color for vertical lines connecting active dots.
+    title : str
+        Optional figure title. Defaults to an empty title.
+    show_counts : bool
+        Whether to annotate bar counts.
+    grid : bool
+        Whether to show a light y-axis grid behind intersection bars.
+    bar_width : float
+        Width of the top intersection-size bars.
+    set_bar_height : float
+        Height of the left set-size bars.
+    dot_size : float
+        Size of active dots in the intersection matrix.
+    empty_dot_size : float
+        Size of inactive dots in the intersection matrix.
+    line_width : float
+        Width of vertical lines connecting active dots.
+    grid_color : str
+        Color for the intersection and set-size grids.
+    grid_linewidth : float
+        Line width for the intersection and set-size grids.
+    count_fontsize : float or None
+        Font size for bar count labels. Defaults to a value derived from
+        ``matplotlib.rcParams``.
+    count_offset : float or None
+        Vertical offset for bar count labels. Defaults to a small fraction of
+        the maximum intersection size.
+    matrix_alpha : float
+        Alpha value for active dots.
+    empty_alpha : float
+        Alpha value for inactive dots.
+    set_order : sequence or None
+        Optional set row order. Unlisted sets are appended in their original
+        order.
+    intersection_order : sequence or None
+        Optional intersection column order. Entries can be ``"A&B"`` strings or
+        tuples such as ``("A", "B")``. Unlisted intersections keep the default
+        sorted order after the listed intersections.
+    height_ratios : tuple or None
+        Relative heights for the top intersection bars and lower matrix/set-size
+        panels. If ``None``, the lower panel height is chosen from the number of
+        sets.
+    max_sets : int or None
+        Maximum number of sets to enumerate. UpSet intersection enumeration is
+        exponential in the number of sets. Use ``None`` to disable the guard.
+
+    Returns
+    -------
+    tuple
+        ``(fig, axes)`` where ``axes`` is a dictionary containing
+        ``"intersections"``, ``"matrix"``, and ``"set_sizes"`` axes.
+    """
+    _apply_ov_style(style)
+
+    if min_size < 1:
+        raise ValueError("`min_size` must be at least 1.")
+    if top_n is not None and int(top_n) < 1:
+        raise ValueError("`top_n` must be at least 1 or None.")
+    if max_sets is not None and int(max_sets) < 1:
+        raise ValueError("`max_sets` must be at least 1 or None.")
+
+    normalized = _coerce_upset_sets(sets, keys=keys, axis=axis)
+    if not isinstance(normalized, dict) or len(normalized) == 0:
+        raise ValueError("`sets` must resolve to a non-empty dictionary of set names to iterables.")
+    if max_sets is not None and len(normalized) > int(max_sets):
+        raise ValueError(
+            f"UpSet plots enumerate 2^n intersections; received {len(normalized)} sets. "
+            f"Pass fewer `keys`, increase `max_sets`, or set `max_sets=None`."
+        )
+
+    set_names = list(normalized.keys())
+    if set_order is not None:
+        requested = [name for name in set_order if name in normalized]
+        set_names = requested + [name for name in set_names if name not in requested]
+    normalized = {name: set(values) for name, values in normalized.items()}
+    if any(len(name_set) == 0 for name_set in normalized.values()):
+        empty = [str(name) for name, values in normalized.items() if len(values) == 0]
+        raise ValueError(f"All input sets must be non-empty; empty sets: {', '.join(empty)}")
+
+    intersections = _build_upset_intersections(normalized, min_size=min_size)
+    if intersections.empty:
+        raise ValueError("No intersections meet `min_size`; lower `min_size` or check the input sets.")
+
+    intersections["_sort_key"] = intersections["sets"].map(lambda values: "||".join(map(str, values)))
+    if sort_by == "size":
+        intersections = intersections.sort_values(["size", "degree", "_sort_key"], ascending=[False, False, True])
+    elif sort_by == "degree":
+        intersections = intersections.sort_values(["degree", "size", "_sort_key"], ascending=[False, False, True])
+    else:
+        raise ValueError("`sort_by` must be either 'size' or 'degree'.")
+    intersections = _apply_intersection_order(intersections, intersection_order)
+
+    if top_n is not None:
+        intersections = intersections.head(int(top_n))
+    intersections = intersections.drop(columns="_sort_key").reset_index(drop=True)
+
+    if figsize is None:
+        figsize = (max(6, 0.42 * len(intersections) + 2.5), max(4, 0.35 * len(set_names) + 2.8))
+    if height_ratios is None:
+        height_ratios = (2.5, max(1.4, 0.35 * len(set_names)))
+    colors = _upset_colors(
+        empty_color=empty_color,
+        line_color=line_color,
+    )
+    intersection_colors = _resolve_column_colors(
+        intersection_color,
+        intersections,
+        colors["intersection_color"],
+    )
+    set_size_colors = _resolve_set_colors(
+        set_size_color,
+        set_names,
+        colors["set_size_color"],
+    )
+    matrix_colors = _resolve_set_colors(
+        matrix_color,
+        set_names,
+        colors["matrix_color"],
+    )
+    label_fontsize = count_fontsize or max(8, rcParams["font.size"] * 0.68)
+
+    fig = plt.figure(figsize=figsize, facecolor=rcParams["figure.facecolor"])
+    layout = fig.add_gridspec(
+        2,
+        2,
+        width_ratios=(1.5, max(3.5, 0.42 * len(intersections))),
+        height_ratios=height_ratios,
+        hspace=0.10,
+        wspace=0.05,
+    )
+    ax_empty = fig.add_subplot(layout[0, 0])
+    ax_intersections = fig.add_subplot(layout[0, 1])
+    ax_set_sizes = fig.add_subplot(layout[1, 0])
+    ax_matrix = fig.add_subplot(layout[1, 1], sharex=ax_intersections)
+    ax_empty.axis("off")
+
+    x = np.arange(len(intersections))
+    sizes = intersections["size"].to_numpy()
+    ax_intersections.bar(x, sizes, color=intersection_colors, width=bar_width)
+    ax_intersections.set_ylabel("Intersection size")
+    ax_intersections.set_xticks([])
+    ax_intersections.tick_params(axis="x", bottom=False, labelbottom=False)
+    ax_intersections.spines[["top", "right"]].set_visible(False)
+    if title:
+        ax_intersections.set_title(title)
+    if show_counts:
+        offset = count_offset
+        if offset is None:
+            offset = max(sizes) * 0.02 if max(sizes) > 0 else 0.2
+        for xpos, value in zip(x, sizes):
+            ax_intersections.text(
+                xpos,
+                value + offset,
+                str(int(value)),
+                ha="center",
+                va="bottom",
+                fontsize=label_fontsize,
+                color=rcParams["text.color"],
+            )
+        ax_intersections.set_ylim(0, max(sizes) * 1.18)
+    if grid:
+        ax_intersections.yaxis.grid(True, color=grid_color, linewidth=grid_linewidth)
+        ax_intersections.set_axisbelow(True)
+    else:
+        ax_intersections.xaxis.grid(False)
+        ax_intersections.yaxis.grid(False)
+        for line in [*ax_intersections.get_xgridlines(), *ax_intersections.get_ygridlines()]:
+            line.set_visible(False)
+
+    y = np.arange(len(set_names))
+    set_sizes = [len(normalized[name]) for name in set_names]
+    ax_set_sizes.barh(y, set_sizes, color=set_size_colors, height=set_bar_height)
+    ax_set_sizes.set_yticks(y, labels=set_names)
+    ax_set_sizes.invert_xaxis()
+    ax_set_sizes.invert_yaxis()
+    ax_set_sizes.set_xlabel("Set size")
+    ax_set_sizes.spines[["top", "right"]].set_visible(False)
+    if grid:
+        ax_set_sizes.xaxis.grid(True, color=grid_color, linewidth=grid_linewidth)
+        ax_set_sizes.set_axisbelow(True)
+    else:
+        ax_set_sizes.xaxis.grid(False)
+        ax_set_sizes.yaxis.grid(False)
+        for line in [*ax_set_sizes.get_xgridlines(), *ax_set_sizes.get_ygridlines()]:
+            line.set_visible(False)
+
+    membership = np.zeros((len(set_names), len(intersections)), dtype=bool)
+    name_to_row = {name: idx for idx, name in enumerate(set_names)}
+    for col, group_names in enumerate(intersections["sets"]):
+        rows = [name_to_row[name] for name in group_names]
+        membership[rows, col] = True
+        if len(rows) > 1:
+            ax_matrix.plot([col, col], [min(rows), max(rows)], color=colors["line_color"], lw=line_width, zorder=1)
+
+    for row in range(len(set_names)):
+        ax_matrix.scatter(x, np.full_like(x, row), s=empty_dot_size, color=colors["empty_color"], alpha=empty_alpha, zorder=2)
+        active = membership[row]
+        if active.any():
+            ax_matrix.scatter(x[active], np.full(active.sum(), row), s=dot_size, color=matrix_colors[row], alpha=matrix_alpha, zorder=3)
+
+    ax_matrix.set_yticks([])
+    ax_matrix.tick_params(axis="y", left=False, labelleft=False)
+    ax_matrix.set_xticks(x, labels=[])
+    ax_matrix.set_ylim(len(set_names) - 0.5, -0.5)
+    ax_matrix.set_xlim(-0.6, len(intersections) - 0.4)
+    ax_matrix.set_xlabel("Intersections")
+    ax_matrix.spines[["top", "right", "left"]].set_visible(False)
+
+    axes = {
+        "intersections": ax_intersections,
+        "matrix": ax_matrix,
+        "set_sizes": ax_set_sizes,
+    }
+    return fig, axes

--- a/omicverse/pl/_upset.py
+++ b/omicverse/pl/_upset.py
@@ -38,6 +38,9 @@ def _coerce_upset_sets(data, keys=None, axis="obs"):
     if isinstance(data, dict):
         if keys is None:
             return data
+        missing = [key for key in keys if key not in data]
+        if missing:
+            raise KeyError(f"Keys not found in dictionary input: {', '.join(map(str, missing))}")
         return {key: data[key] for key in keys}
 
     if not _is_adata_like(data):
@@ -112,10 +115,6 @@ def _upset_colors(empty_color, line_color):
         "empty_color": empty_color or "#d9dde1",
         "line_color": line_color or "#9aa1a8",
     }
-
-
-def _format_intersection_key(names):
-    return "&".join(map(str, names))
 
 
 def _canonical_intersection_key(key):
@@ -419,7 +418,8 @@ def upset(
     ax_intersections.set_ylabel("Intersection size")
     ax_intersections.set_xticks([])
     ax_intersections.tick_params(axis="x", bottom=False, labelbottom=False)
-    ax_intersections.spines[["top", "right"]].set_visible(False)
+    for spine in ("top", "right"):
+        ax_intersections.spines[spine].set_visible(False)
     if title:
         ax_intersections.set_title(title)
     if show_counts:
@@ -453,7 +453,8 @@ def upset(
     ax_set_sizes.invert_xaxis()
     ax_set_sizes.invert_yaxis()
     ax_set_sizes.set_xlabel("Set size")
-    ax_set_sizes.spines[["top", "right"]].set_visible(False)
+    for spine in ("top", "right"):
+        ax_set_sizes.spines[spine].set_visible(False)
     if grid:
         ax_set_sizes.xaxis.grid(True, color=grid_color, linewidth=grid_linewidth)
         ax_set_sizes.set_axisbelow(True)
@@ -483,7 +484,8 @@ def upset(
     ax_matrix.set_ylim(len(set_names) - 0.5, -0.5)
     ax_matrix.set_xlim(-0.6, len(intersections) - 0.4)
     ax_matrix.set_xlabel("Intersections")
-    ax_matrix.spines[["top", "right", "left"]].set_visible(False)
+    for spine in ("top", "right", "left"):
+        ax_matrix.spines[spine].set_visible(False)
 
     axes = {
         "intersections": ax_intersections,

--- a/tests/pl/test_upset.py
+++ b/tests/pl/test_upset.py
@@ -44,6 +44,11 @@ def test_upset_validates_empty_sets():
         ov.pl.upset({"A": {"g1"}, "B": set()})
 
 
+def test_upset_validates_missing_dict_keys():
+    with pytest.raises(KeyError, match="Keys not found in dictionary input: missing"):
+        ov.pl.upset({"A": {"g1"}, "B": {"g2"}}, keys=["A", "missing"])
+
+
 def test_upset_accepts_adata_obs_boolean_sets(tmp_path):
     obs = pd.DataFrame(
         {

--- a/tests/pl/test_upset.py
+++ b/tests/pl/test_upset.py
@@ -1,0 +1,276 @@
+import matplotlib
+
+matplotlib.use("Agg")
+
+from cycler import cycler
+import matplotlib as mpl
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import pytest
+from anndata import AnnData
+
+import omicverse as ov
+
+
+def _gene_sets():
+    return {
+        "A": {"g1", "g2", "g3", "g4"},
+        "B": {"g2", "g3", "g5", "g6"},
+        "C": {"g3", "g4", "g6", "g7"},
+        "D": {"g1", "g3", "g8"},
+        "E": {"g3", "g9", "g10"},
+    }
+
+
+def test_upset_is_exported_and_draws_many_sets(tmp_path):
+    fig, axes = ov.pl.upset(_gene_sets(), top_n=10)
+
+    assert fig is not None
+    assert set(axes) == {"intersections", "matrix", "set_sizes"}
+    assert axes["intersections"].get_ylabel() == "Intersection size"
+    assert axes["matrix"].get_xlabel() == "Intersections"
+    assert axes["intersections"].get_title() == ""
+
+    out = tmp_path / "upset.png"
+    fig.savefig(out)
+    plt.close(fig)
+    assert out.exists()
+    assert out.stat().st_size > 0
+
+
+def test_upset_validates_empty_sets():
+    with pytest.raises(ValueError, match="empty sets"):
+        ov.pl.upset({"A": {"g1"}, "B": set()})
+
+
+def test_upset_accepts_adata_obs_boolean_sets(tmp_path):
+    obs = pd.DataFrame(
+        {
+            "high_CD3D": [True, True, False, False, True],
+            "cycling": [False, True, True, False, True],
+            "treated": [True, False, True, False, False],
+        },
+        index=[f"cell_{i}" for i in range(5)],
+    )
+    adata = AnnData(np.ones((5, 2)), obs=obs, var=pd.DataFrame(index=["g1", "g2"]))
+
+    fig, axes = ov.pl.upset(adata, keys=["high_CD3D", "cycling", "treated"], axis="obs")
+
+    assert fig is not None
+    assert axes["set_sizes"].get_xlabel() == "Set size"
+    out = tmp_path / "adata_upset.png"
+    fig.savefig(out)
+    plt.close(fig)
+    assert out.stat().st_size > 0
+
+
+def test_upset_accepts_adata_var_boolean_sets(tmp_path):
+    var = pd.DataFrame(
+        {
+            "pathway_A": [True, True, False, False],
+            "pathway_B": [False, True, True, False],
+        },
+        index=[f"gene_{i}" for i in range(4)],
+    )
+    adata = AnnData(np.ones((2, 4)), obs=pd.DataFrame(index=["cell_1", "cell_2"]), var=var)
+
+    fig, axes = ov.pl.upset(adata, keys=["pathway_A", "pathway_B"], axis="var")
+
+    assert fig is not None
+    out = tmp_path / "var_upset.png"
+    fig.savefig(out)
+    plt.close(fig)
+    assert out.stat().st_size > 0
+
+
+def test_upset_requires_boolean_adata_keys():
+    obs = pd.DataFrame({"cell_type": ["T", "B"]}, index=["cell_1", "cell_2"])
+    adata = AnnData(np.ones((2, 1)), obs=obs, var=pd.DataFrame(index=["g1"]))
+
+    with pytest.raises(TypeError, match="must be boolean"):
+        ov.pl.upset(adata, keys=["cell_type"])
+
+
+def test_upset_accepts_style_callable_and_uses_rc_cycle():
+    calls = []
+
+    def custom_style(show_monitor=True):
+        calls.append(show_monitor)
+        mpl.rcParams["axes.prop_cycle"] = cycler(color=["#123456", "#abcdef"])
+
+    with mpl.rc_context():
+        fig, axes = ov.pl.upset(_gene_sets(), top_n=3, style=custom_style)
+
+    first_bar = axes["intersections"].patches[0]
+    assert calls == [False]
+    assert mpl.colors.to_hex(first_bar.get_facecolor()) == "#123456"
+    plt.close(fig)
+
+
+def test_upset_grid_false_overrides_global_grid():
+    with mpl.rc_context({"axes.grid": True}):
+        fig, axes = ov.pl.upset(_gene_sets(), top_n=3, grid=False)
+
+    assert not any(line.get_visible() for line in axes["intersections"].get_ygridlines())
+    assert not any(line.get_visible() for line in axes["set_sizes"].get_xgridlines())
+    plt.close(fig)
+
+
+def test_upset_grid_true_applies_to_set_size_axis():
+    with mpl.rc_context({"axes.grid": False}):
+        fig, axes = ov.pl.upset(_gene_sets(), top_n=3, grid=True)
+
+    assert any(line.get_visible() for line in axes["intersections"].get_ygridlines())
+    assert any(line.get_visible() for line in axes["set_sizes"].get_xgridlines())
+    plt.close(fig)
+
+
+def test_upset_accepts_per_intersection_bar_colors():
+    colors = ["#111111", "#222222", "#333333"]
+
+    fig, axes = ov.pl.upset(_gene_sets(), top_n=3, intersection_color=colors)
+
+    bar_colors = [
+        mpl.colors.to_hex(patch.get_facecolor())
+        for patch in axes["intersections"].patches[:3]
+    ]
+    assert bar_colors == colors
+    plt.close(fig)
+
+
+def test_upset_dict_colors_only_override_matching_columns_and_rows():
+    sets = {
+        "A": {"shared_1", "shared_2", "shared_3", "a"},
+        "B": {"shared_1", "shared_2", "shared_3", "b"},
+        "C": {"shared_1", "shared_2", "shared_3", "c"},
+    }
+
+    with mpl.rc_context({"axes.prop_cycle": cycler(color=["#101010", "#202020"])}):
+        fig, axes = ov.pl.upset(
+            sets,
+            top_n=10,
+            intersection_color={"A&B&C": "#abcdef"},
+            set_size_color={"A": "#fedcba"},
+            matrix_color={"A": "#123456"},
+        )
+
+    intersection_colors = [
+        mpl.colors.to_hex(patch.get_facecolor())
+        for patch in axes["intersections"].patches
+    ]
+    set_size_colors = [
+        mpl.colors.to_hex(patch.get_facecolor())
+        for patch in axes["set_sizes"].patches
+    ]
+    active_dot_colors = [
+        mpl.colors.to_hex(collection.get_facecolors()[0])
+        for collection in axes["matrix"].collections[1::2]
+    ]
+
+    assert intersection_colors[0] == "#abcdef"
+    assert all(color == "#101010" for color in intersection_colors[1:])
+    assert set_size_colors[0] == "#fedcba"
+    assert all(color == "#202020" for color in set_size_colors[1:])
+    assert active_dot_colors[0] == "#123456"
+    assert all(color == "#101010" for color in active_dot_colors[1:])
+    plt.close(fig)
+
+
+def test_upset_intersection_color_keys_are_order_insensitive():
+    sets = {
+        "A": {"shared_1", "shared_2", "a"},
+        "B": {"shared_1", "shared_2", "b"},
+        "C": {"c"},
+    }
+
+    fig, axes = ov.pl.upset(
+        sets,
+        top_n=3,
+        intersection_color={"B&A": "#abcdef"},
+    )
+
+    first_bar_color = mpl.colors.to_hex(axes["intersections"].patches[0].get_facecolor())
+    assert first_bar_color == "#abcdef"
+    plt.close(fig)
+
+
+def test_upset_accepts_size_and_grid_style_parameters():
+    fig, axes = ov.pl.upset(
+        _gene_sets(),
+        top_n=3,
+        bar_width=0.5,
+        set_bar_height=0.35,
+        dot_size=60,
+        empty_dot_size=20,
+        line_width=2.5,
+        grid_color="#eeeeee",
+        grid_linewidth=1.7,
+        count_fontsize=9,
+        count_offset=0.4,
+        matrix_alpha=0.8,
+        empty_alpha=0.3,
+    )
+
+    assert axes["intersections"].patches[0].get_width() == pytest.approx(0.5)
+    assert axes["set_sizes"].patches[0].get_height() == pytest.approx(0.35)
+    assert axes["matrix"].collections[0].get_sizes()[0] == pytest.approx(20)
+    assert axes["matrix"].collections[1].get_sizes()[0] == pytest.approx(60)
+    assert axes["matrix"].collections[0].get_alpha() == pytest.approx(0.3)
+    assert axes["matrix"].collections[1].get_alpha() == pytest.approx(0.8)
+    assert axes["matrix"].lines[0].get_linewidth() == pytest.approx(2.5)
+    assert axes["intersections"].texts[0].get_fontsize() == pytest.approx(9)
+
+    gridline = next(line for line in axes["intersections"].get_ygridlines() if line.get_visible())
+    assert mpl.colors.to_hex(gridline.get_color()) == "#eeeeee"
+    assert gridline.get_linewidth() == pytest.approx(1.7)
+    plt.close(fig)
+
+
+def test_upset_accepts_manual_set_and_intersection_order():
+    fig, axes = ov.pl.upset(
+        _gene_sets(),
+        top_n=4,
+        set_order=["C", "A"],
+        intersection_order=["A&B&C&D&E", ("A", "D")],
+        intersection_color={"A&B&C&D&E": "#abcdef"},
+    )
+
+    ytick_labels = [label.get_text() for label in axes["set_sizes"].get_yticklabels()]
+    first_bar_color = mpl.colors.to_hex(axes["intersections"].patches[0].get_facecolor())
+    assert ytick_labels[:2] == ["C", "A"]
+    assert first_bar_color == "#abcdef"
+    plt.close(fig)
+
+
+def test_upset_intersection_order_is_order_insensitive():
+    fig, axes = ov.pl.upset(
+        _gene_sets(),
+        top_n=4,
+        intersection_order=[("E", "D", "C", "B", "A")],
+        intersection_color={"A&B&C&D&E": "#abcdef"},
+    )
+
+    first_bar_color = mpl.colors.to_hex(axes["intersections"].patches[0].get_facecolor())
+    assert first_bar_color == "#abcdef"
+    plt.close(fig)
+
+
+def test_upset_accepts_height_ratios():
+    fig, axes = ov.pl.upset(_gene_sets(), top_n=3, height_ratios=(1, 3))
+
+    top_height = axes["intersections"].get_position().height
+    lower_height = axes["matrix"].get_position().height
+    assert lower_height / top_height == pytest.approx(3, rel=0.05)
+    plt.close(fig)
+
+
+def test_upset_rejects_too_many_sets_by_default():
+    obs = pd.DataFrame(
+        {f"flag_{i}": [True, False, True] for i in range(13)},
+        index=["cell_1", "cell_2", "cell_3"],
+    )
+    adata = AnnData(np.ones((3, 1)), obs=obs, var=pd.DataFrame(index=["gene_1"]))
+
+    with pytest.raises(ValueError, match="max_sets"):
+        ov.pl.upset(adata)


### PR DESCRIPTION
## Problem

Venn plots are useful for small numbers of sets, but they become hard to read once users compare more than four gene sets or cell-state sets.

## What this adds

Adds `ov.pl.upset` for visualizing exclusive intersections across many sets.

### `ov.pl.upset`

Supports:
- dictionary input: `{set_name: iterable_of_items}`
- AnnData input using boolean columns in `adata.obs` or `adata.var`
- selective row/column coloring through `intersection_color`, `set_size_color`, and `matrix_color`
- OmicVerse style integration through `style=ov.style`
- layout controls including `height_ratios`, bar widths, dot sizes, line widths, grid styling, count labels, and manual row/column ordering
- `max_sets` guard to avoid accidental exponential blowups when too many boolean columns are inferred

Intersection color/order keys are order-insensitive, so `"A&B"` and `"B&A"` refer to the same intersection.

## Notes

- No new dependency is introduced.
- Existing `ov.pl.venn` behavior is unchanged.
