### PR TITLE
ci: avoid uv run dependency resolution

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   claude-review:
+    if: github.event.pull_request.head.repo.full_name == github.repository
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -52,10 +52,10 @@ jobs:
       run: |
         source .venv/bin/activate
         # stop the build if there are Python syntax errors
-        uv run flake8 . --exclude=.venv --count --select=E9,F63,F7 --show-source --statistics
+        uv run --no-sync flake8 . --exclude=.venv --count --select=E9,F63,F7 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        uv run flake8 . --exclude=.venv --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        uv run --no-sync flake8 . --exclude=.venv --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
         source .venv/bin/activate
-        uv run python -m pytest
+        uv run --no-sync python -m pytest


### PR DESCRIPTION
ci: avoid uv dependency sync during lint and tests

Use `uv run --no-sync` for flake8 and pytest so CI continues to run
commands through uv without triggering an extra project dependency sync.
This avoids resolving optional extras such as `omicverse[full]`, which can
fail when unavailable packages like `dynamo-release` are not installable from
the current package index.

Also skip the automatic Claude review job for fork-based pull requests, where
repository secrets and OIDC permissions may be unavailable.