### PR TITLE
fix(pyscenic): avoid removed NumPy msort

### DIFF
--- a/omicverse/external/pyscenic/binarization.py
+++ b/omicverse/external/pyscenic/binarization.py
@@ -40,7 +40,7 @@ def derive_threshold(
     def isbimodal(data, method):
         if method == "hdt":
             # Use Hartigan's dip statistic to decide if distribution deviates from unimodality.
-            _, pval, _ = diptst(np.msort(data))
+            _, pval, _ = diptst(data)
             return (pval is not None) and (pval <= 0.05)
         else:
             # Compare Bayesian Information Content of two Gaussian Mixture Models.

--- a/omicverse/external/pyscenic/diptest.py
+++ b/omicverse/external/pyscenic/diptest.py
@@ -54,8 +54,9 @@ def diptst(dat, is_hist=False, numt=1000):
 
     Parameters
     ----------
-    dat : ndarray
-        Input data.
+    dat : array-like
+        One-dimensional sample values, or histogram bin counts when
+        ``is_hist=True``.
     is_hist : bool
         Whether ``dat`` is a histogram (equidistant bins).
     numt : int

--- a/omicverse/external/pyscenic/diptest.py
+++ b/omicverse/external/pyscenic/diptest.py
@@ -44,27 +44,46 @@ def _lcm_(cdf, idxs):
 
 
 def _touch_diffs_(part1, part2, touchpoints):
-    diff = np.abs((part2[touchpoints] - part1[touchpoints]))
+    diff = np.abs(part2[touchpoints] - part1[touchpoints])
     return diff.max(), diff
 
 
 def diptst(dat, is_hist=False, numt=1000):
-    """diptest with pval"""
-    # sample dip
+    """
+    diptest with pval.
+
+    Parameters
+    ----------
+    dat : ndarray
+        Input data.
+    is_hist : bool
+        Whether ``dat`` is a histogram (equidistant bins).
+    numt : int
+        Number of uniform bootstrap samples. Default 1000 gives ~0.001
+        p-value resolution; 200 is sufficient for bimodality screening.
+
+    Returns
+    -------
+    d : float
+        Dip statistic.
+    pval : float or None
+        Approximate p-value from bootstrap.
+    indices : tuple
+        Modal interval indices.
+    """
     d, (_, idxs, left, _, right, _) = dip_fn(dat, is_hist)
 
     # simulate from null uniform
     unifs = np.random.uniform(size=numt * idxs.shape[0]).reshape([numt, idxs.shape[0]])
     unif_dips = np.apply_along_axis(dip_fn, 1, unifs, is_hist, True)
 
-    # count dips greater or equal to d, add 1/1 to prevent a pvalue of 0
     pval = (
         None
         if unif_dips.sum() == 0
         else (np.less(d, unif_dips).sum() + 1) / (float(numt) + 1.0)
     )
 
-    return (d, pval, (len(left) - 1, len(idxs) - len(right)))  # dip, pvalue  # indices
+    return (d, pval, (len(left) - 1, len(idxs) - len(right)))
 
 
 def dip_fn(dat, is_hist=False, just_dip=False):
@@ -77,10 +96,9 @@ def dip_fn(dat, is_hist=False, just_dip=False):
         idxs = np.arange(len(histogram))
     else:
         counts = collections.Counter(dat)
-        idxs = np.msort(list(counts.keys()))
+        idxs = np.sort(list(counts.keys()))
         histogram = np.array([counts[i] for i in idxs])
 
-    # check for case 1<N<4 or all identical values
     if len(idxs) <= 4 or idxs[0] == idxs[-1]:
         left = []
         right = [1]

--- a/tests/external/test_pyscenic_binarization.py
+++ b/tests/external/test_pyscenic_binarization.py
@@ -1,0 +1,13 @@
+import numpy as np
+import pandas as pd
+
+from omicverse.external.pyscenic.binarization import derive_threshold
+
+
+def test_derive_threshold_hdt_does_not_require_numpy_msort(monkeypatch):
+    monkeypatch.delattr(np, "msort", raising=False)
+    auc_mtx = pd.DataFrame({"regulon": [0.1, 0.2, 0.2, 0.8, 0.9, 1.0]})
+
+    threshold = derive_threshold(auc_mtx, "regulon", seed=1, method="hdt")
+
+    assert np.isfinite(threshold)


### PR DESCRIPTION
Summary:
- Remove np.msort usage from the pySCENIC binarization path for NumPy 2 compatibility.
- Keep diptest behavior aligned with the previous implementation while replacing the removed NumPy API.
- Fix the AttributeError reported in #826.

Validation:
- Confirmed no np.msort references remain.
- Simulated NumPy 2 behavior by removing np.msort at runtime and verified dip_fn, diptst, and derive_threshold still return successfully.
- Compared diptest outputs against the previous implementation under fixed seeds.

Fixes #826.
