### PR TITLE
fix(pl): handle COSG dotplot marker lengths

### DIFF
--- a/omicverse/pl/_dotplot.py
+++ b/omicverse/pl/_dotplot.py
@@ -510,12 +510,23 @@ def rank_genes_groups_df(
             return data[:, gi]
         return None
 
-    d = pd.DataFrame()
+    cols = {}
     for k in ['names', 'scores', 'logfoldchanges', 'pvals', 'pvals_adj']:
         if k in result:
             col = _extract(result[k], group, group_index)
             if col is not None:
-                d[k] = col
+                cols[k] = col
+    if cols:
+        lengths = {k: len(v) for k, v in cols.items()}
+        if "names" in lengths:
+            names_len = lengths["names"]
+            cols = {k: v for k, v in cols.items() if len(v) == names_len}
+        elif len(set(lengths.values())) != 1:
+            raise ValueError(
+                f"Inconsistent rank_genes_groups result lengths for group {group!r}: "
+                f"{lengths}"
+            )
+    d = pd.DataFrame(cols)
 
     if log2fc_min is not None and 'logfoldchanges' in d.columns:
         d = d[d['logfoldchanges'].abs() > log2fc_min]

--- a/omicverse/pl/_dotplot.py
+++ b/omicverse/pl/_dotplot.py
@@ -520,6 +520,15 @@ def rank_genes_groups_df(
         lengths = {k: len(v) for k, v in cols.items()}
         if "names" in lengths:
             names_len = lengths["names"]
+            shorter = {k: v for k, v in lengths.items() if v < names_len}
+            if shorter:
+                raise ValueError(
+                    f"Inconsistent rank_genes_groups result lengths for group {group!r}: "
+                    f"{lengths}"
+                )
+            # Longer columns may come from a different full-gene result table (for
+            # example COSG markers paired with Scanpy p-values). Keep only columns
+            # that are safely aligned to the marker names.
             cols = {k: v for k, v in cols.items() if len(v) == names_len}
         elif len(set(lengths.values())) != 1:
             raise ValueError(

--- a/tests/pl/test_dotplot.py
+++ b/tests/pl/test_dotplot.py
@@ -91,3 +91,49 @@ def test_dotplot_does_not_warn_for_fixed_marsilea_versions(simple_adata, stub_ma
         )
 
     assert not [w for w in record if "marsilea 0.5.6" in str(w.message)]
+
+
+def test_rank_genes_groups_df_drops_unaligned_long_statistics():
+    adata = AnnData(np.zeros((4, 78)))
+    adata.uns["cell_type_roughly_cosg"] = {
+        "names": pd.DataFrame({"CMP": [f"g{i}" for i in range(50)]}),
+        "scores": pd.DataFrame({"CMP": np.arange(50, dtype=float)}),
+        "logfoldchanges": pd.DataFrame({"CMP": np.arange(50, dtype=float)}),
+        "pvals": pd.DataFrame({"CMP": np.arange(78, dtype=float)}),
+        "pvals_adj": pd.DataFrame({"CMP": np.arange(78, dtype=float)}),
+    }
+
+    df = dotplot_mod.rank_genes_groups_df(
+        adata,
+        "CMP",
+        key="cell_type_roughly_cosg",
+    )
+
+    assert df.shape == (50, 3)
+    assert df.columns.tolist() == ["names", "scores", "logfoldchanges"]
+
+
+def test_rank_genes_groups_df_rejects_statistics_shorter_than_names():
+    adata = AnnData(np.zeros((4, 5)))
+    adata.uns["bad_markers"] = {
+        "names": pd.DataFrame({"CMP": [f"g{i}" for i in range(5)]}),
+        "scores": pd.DataFrame({"CMP": np.arange(4, dtype=float)}),
+    }
+
+    with pytest.raises(ValueError, match="Inconsistent rank_genes_groups"):
+        dotplot_mod.rank_genes_groups_df(adata, "CMP", key="bad_markers")
+
+
+def test_rank_genes_groups_df_keeps_aligned_pvals():
+    adata = AnnData(np.zeros((4, 5)))
+    adata.uns["rank_genes_groups"] = {
+        "names": pd.DataFrame({"CMP": [f"g{i}" for i in range(5)]}),
+        "scores": pd.DataFrame({"CMP": np.arange(5, dtype=float)}),
+        "pvals": pd.DataFrame({"CMP": np.linspace(0.01, 0.05, 5)}),
+        "pvals_adj": pd.DataFrame({"CMP": np.linspace(0.02, 0.1, 5)}),
+    }
+
+    df = dotplot_mod.rank_genes_groups_df(adata, "CMP")
+
+    assert df.columns.tolist() == ["names", "scores", "pvals", "pvals_adj"]
+    np.testing.assert_allclose(df["pvals_adj"], np.linspace(0.02, 0.1, 5))


### PR DESCRIPTION
Summary:
- Handle COSG rank_genes_groups-like results where marker columns are top-N but p-value columns may be full-length.
- Align dotplot marker selection to the names column instead of silently pairing incompatible statistic lengths.
- Preserve clear errors for malformed results without a names column.

Validation:
- Verified a COSG-like result with names/scores/logfoldchanges length 50 and pvals/pvals_adj length 78 returns the expected top-marker table.
- Verified malformed results without names still raise a clear ValueError.
- Ran git diff --check.
