### PR TITLE
fix(pp): normalize CUDA devices for PyG neighbors

### DIFF
--- a/omicverse/_optional.py
+++ b/omicverse/_optional.py
@@ -4,6 +4,26 @@ import importlib
 from typing import Iterable
 
 
+def normalize_torch_device(device=None, *, prefer_cuda=True, fallback_to_cpu=False):
+    """Return a torch.device with bare CUDA normalized to the current index."""
+    import torch
+
+    if device is None:
+        device = "cuda" if prefer_cuda and torch.cuda.is_available() else "cpu"
+    if isinstance(device, int):
+        if not torch.cuda.is_available() and fallback_to_cpu:
+            return torch.device("cpu")
+        return torch.device("cuda", device)
+
+    device = torch.device(device)
+    if device.type == "cuda":
+        if not torch.cuda.is_available():
+            return torch.device("cpu") if fallback_to_cpu else device
+        if device.index is None:
+            return torch.device("cuda", torch.cuda.current_device())
+    return device
+
+
 def _normalize_dependencies(dependencies: Iterable[str]) -> tuple[str, ...]:
     normalized = []
     for dep in dependencies:

--- a/omicverse/_settings.py
+++ b/omicverse/_settings.py
@@ -1,4 +1,5 @@
 from ._registry import register_function
+from ._optional import normalize_torch_device
 
 class omicverseConfig:
 
@@ -294,7 +295,7 @@ def get_optimal_device(prefer_gpu=True, verbose=False):
     
     # Check devices in priority order
     if torch.cuda.is_available():
-        device = torch.device("cuda")
+        device = normalize_torch_device("cuda")
         if verbose:
             print(f"Using CUDA device: {torch.cuda.get_device_name()}")
             print(f"{Colors.GREEN}✅ Using built-in torch_pca for GPU-accelerated PCA{Colors.ENDC}")
@@ -315,9 +316,9 @@ def get_optimal_device(prefer_gpu=True, verbose=False):
                 print(f"{Colors.WARNING}⚠️ MLX not installed - install with: pip install mlx{Colors.ENDC}")
         return device
     
-    if hasattr(torch.version, 'hip') and torch.version.hip is not None:
+    if hasattr(torch.version, 'hip') and torch.version.hip is not None and torch.cuda.is_available():
         # ROCm available
-        device = torch.device("cuda")  # ROCm uses cuda interface
+        device = normalize_torch_device("cuda")  # ROCm uses cuda interface
         if verbose:
             print("Using AMD ROCm device")
         return device

--- a/omicverse/es/_engine.py
+++ b/omicverse/es/_engine.py
@@ -21,6 +21,8 @@ from typing import Literal, Optional
 
 import numpy as np
 
+from .._optional import normalize_torch_device
+
 def _torch_available() -> bool:
     try:
         import torch  # noqa: F401
@@ -41,7 +43,7 @@ def torch_device(prefer: str = 'cuda'):
     """Return a torch.device handle, falling back to CPU when needed."""
     import torch
     if prefer == 'cuda' and torch.cuda.is_available():
-        return torch.device('cuda')
+        return normalize_torch_device("cuda")
     return torch.device('cpu')
 
 # ────────────────────────────────────────────────────────────────────

--- a/omicverse/external/forcedirect2/forceatlas2.py
+++ b/omicverse/external/forcedirect2/forceatlas2.py
@@ -28,6 +28,7 @@ from tqdm import tqdm
 import concurrent.futures  # Added for multithreading support
 import warnings
 
+from ..._optional import normalize_torch_device
 from . import fa2util
 
 
@@ -121,7 +122,7 @@ class ForceAtlas2:
                 if cuda_available:
                     if self.verbose:
                         print(f"✅ Using CUDA GPU acceleration: {torch.cuda.get_device_name(0)}")
-                    self.device = torch.device("cuda")
+                    self.device = normalize_torch_device("cuda")
                     self.torch_available = True
                 elif mps_available:
                     if self.verbose:

--- a/omicverse/external/harmony/harmony.py
+++ b/omicverse/external/harmony/harmony.py
@@ -28,12 +28,28 @@ logger.addHandler(logging.NullHandler())
 
 try:
     from ..._settings import EMOJI, Colors
+    from ..._optional import normalize_torch_device
 except ImportError:
     EMOJI = {'start': '🚀', 'done': '✅', 'warning': '⚠️', 'cpu': '🖥️', 'gpu': '🚀'}
     Colors = type('Colors', (), {
         'CYAN': '\033[96m', 'BOLD': '\033[1m', 'ENDC': '\033[0m',
         'GREEN': '\033[92m', 'WARNING': '\033[93m',
     })()
+
+    def normalize_torch_device(device=None, *, prefer_cuda=True, fallback_to_cpu=False):
+        if device is None:
+            device = "cuda" if prefer_cuda and torch.cuda.is_available() else "cpu"
+        if isinstance(device, int):
+            if not torch.cuda.is_available() and fallback_to_cpu:
+                return torch.device("cpu")
+            return torch.device("cuda", device)
+        device = torch.device(device)
+        if device.type == "cuda":
+            if not torch.cuda.is_available():
+                return torch.device("cpu") if fallback_to_cpu else device
+            if device.index is None:
+                return torch.device("cuda", torch.cuda.current_device())
+        return device
 
 
 def _mlx_available() -> bool:
@@ -53,10 +69,12 @@ def get_device(device=None):
     the standard CUDA > CPU fallback.
     """
     if device is not None:
-        return device if device == "mlx" else torch.device(device)
+        if device == "mlx":
+            return device
+        return normalize_torch_device(device)
 
     if torch.cuda.is_available():
-        return torch.device('cuda')
+        return normalize_torch_device("cuda")
     elif hasattr(torch.backends, 'mps') and torch.backends.mps.is_available():
         if _mlx_available():
             return "mlx"

--- a/omicverse/external/harmony/harmony.py
+++ b/omicverse/external/harmony/harmony.py
@@ -22,34 +22,19 @@ from sklearn.cluster import KMeans
 import logging
 from datetime import datetime
 from tqdm import tqdm
+from ..._optional import normalize_torch_device
 
 logger = logging.getLogger('harmonypy')
 logger.addHandler(logging.NullHandler())
 
 try:
     from ..._settings import EMOJI, Colors
-    from ..._optional import normalize_torch_device
 except ImportError:
     EMOJI = {'start': '🚀', 'done': '✅', 'warning': '⚠️', 'cpu': '🖥️', 'gpu': '🚀'}
     Colors = type('Colors', (), {
         'CYAN': '\033[96m', 'BOLD': '\033[1m', 'ENDC': '\033[0m',
         'GREEN': '\033[92m', 'WARNING': '\033[93m',
     })()
-
-    def normalize_torch_device(device=None, *, prefer_cuda=True, fallback_to_cpu=False):
-        if device is None:
-            device = "cuda" if prefer_cuda and torch.cuda.is_available() else "cpu"
-        if isinstance(device, int):
-            if not torch.cuda.is_available() and fallback_to_cpu:
-                return torch.device("cpu")
-            return torch.device("cuda", device)
-        device = torch.device(device)
-        if device.type == "cuda":
-            if not torch.cuda.is_available():
-                return torch.device("cpu") if fallback_to_cpu else device
-            if device.index is None:
-                return torch.device("cuda", torch.cuda.current_device())
-        return device
 
 
 def _mlx_available() -> bool:

--- a/omicverse/external/topact/classifier.py
+++ b/omicverse/external/topact/classifier.py
@@ -17,6 +17,7 @@ import sklearn
 from .countdata import CountData
 from .sparsetools import rescale_rows
 from . import Colors, EMOJI
+from ..._optional import normalize_torch_device
 
 # Try to import torch for GPU acceleration
 try:
@@ -311,7 +312,7 @@ class TorchLinearClassifier(Classifier):
         if device == 'auto':
             if TORCH_AVAILABLE:
                 if torch.cuda.is_available():
-                    self.device = torch.device('cuda')
+                    self.device = normalize_torch_device("cuda")
                     device_name = f"CUDA ({torch.cuda.get_device_name(0)})"
                 elif hasattr(torch.backends, 'mps') and torch.backends.mps.is_available():
                     self.device = torch.device('mps')
@@ -326,7 +327,7 @@ class TorchLinearClassifier(Classifier):
             else:
                 raise RuntimeError("PyTorch not available. Install with: pip install torch")
         else:
-            self.device = torch.device(device)
+            self.device = normalize_torch_device(device)
             device_name = device
 
         sparse_status = "sparse tensors" if self.use_sparse else "dense tensors"
@@ -591,7 +592,7 @@ class TorchLinearSVMClassifier(Classifier):
 
         if device == 'auto':
             if torch.cuda.is_available():
-                self.device = torch.device('cuda')
+                self.device = normalize_torch_device("cuda")
                 device_name = f"CUDA ({torch.cuda.get_device_name(0)})"
             elif hasattr(torch.backends, 'mps') and torch.backends.mps.is_available():
                 self.device = torch.device('mps')
@@ -600,7 +601,7 @@ class TorchLinearSVMClassifier(Classifier):
                 self.device = torch.device('cpu')
                 device_name = "CPU"
         else:
-            self.device = torch.device(device)
+            self.device = normalize_torch_device(device)
             device_name = device
 
         if self.device.type == 'cuda' and not torch.cuda.is_available():

--- a/omicverse/external/torch_tsne.py
+++ b/omicverse/external/torch_tsne.py
@@ -36,6 +36,8 @@ from typing import Optional
 import numpy as np
 import torch
 
+from .._optional import normalize_torch_device
+
 
 # ---------------------------------------------------------------------------
 # Perplexity-tuned Gaussian affinities
@@ -181,10 +183,7 @@ def tsne_gpu(
     proper Student-t long tails) at GPU speed. Z normaliser is estimated
     each iteration from ``z_sample_size`` random pairs.
     """
-    if device is None:
-        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    else:
-        device = torch.device(device)
+    device = normalize_torch_device(device)
 
     if isinstance(X, np.ndarray):
         X_t = torch.from_numpy(np.ascontiguousarray(X, dtype=np.float32)).to(device)

--- a/omicverse/external/umap_pytorch/modules.py
+++ b/omicverse/external/umap_pytorch/modules.py
@@ -4,6 +4,8 @@ from sklearn.utils import check_random_state
 from umap.umap_ import fuzzy_simplicial_set
 import torch
 
+from ..._optional import normalize_torch_device
+
 # Try to import PyG KNN
 try:
     from ...pp.pyg_knn_implementation import pyg_knn_search
@@ -122,7 +124,7 @@ def get_umap_graph(X, n_neighbors=10, metric="cosine", random_state=None, use_py
             X_torch = torch.from_numpy(X_flat).float()
 
             # Determine device
-            device = 'cuda' if torch.cuda.is_available() else 'cpu'
+            device = normalize_torch_device()
 
             # Get KNN using PyG
             knn_indices, knn_dists = pyg_knn_search(
@@ -193,14 +195,13 @@ def get_umap_graph_gpu(X, n_neighbors=15, metric="euclidean", random_state=None,
         graph = get_umap_graph(X, n_neighbors=n_neighbors, metric=metric,
                                random_state=random_state, use_pyg=False)
         coo = graph.tocoo()
-        device_t = torch.device(device or ("cuda" if torch.cuda.is_available() else "cpu"))
+        device_t = normalize_torch_device(device)
         rows = torch.from_numpy(coo.row.astype('int64')).to(device_t)
         cols = torch.from_numpy(coo.col.astype('int64')).to(device_t)
         vals = torch.from_numpy(coo.data.astype('float32')).to(device_t)
         return rows, cols, vals, coo.shape[0]
 
-    if device is None:
-        device = "cuda" if torch.cuda.is_available() else "cpu"
+    device = normalize_torch_device(device)
 
     if isinstance(X, torch.Tensor):
         X_torch = X.float().contiguous()

--- a/omicverse/pp/_connectivity.py
+++ b/omicverse/pp/_connectivity.py
@@ -6,6 +6,7 @@ from typing import TypeVar
 import numpy as np
 from numpy.typing import NDArray
 from scipy import sparse
+from .._optional import normalize_torch_device
 
 SpBase = sparse.spmatrix | sparse.sparray  # noqa: TID251
 """Only use when you directly convert it to a known subclass."""
@@ -303,7 +304,6 @@ def umap_gpu_optimized(
     torch port shipped in ``omicverse.external.umap_pytorch.fuzzy_gpu``.
     """
     import torch
-    from .._optional import normalize_torch_device
     from ..external.umap_pytorch.fuzzy_gpu import fuzzy_simplicial_set_gpu
 
     device = normalize_torch_device(device)

--- a/omicverse/pp/_connectivity.py
+++ b/omicverse/pp/_connectivity.py
@@ -303,12 +303,10 @@ def umap_gpu_optimized(
     torch port shipped in ``omicverse.external.umap_pytorch.fuzzy_gpu``.
     """
     import torch
+    from .._optional import normalize_torch_device
     from ..external.umap_pytorch.fuzzy_gpu import fuzzy_simplicial_set_gpu
 
-    if device is None:
-        device = "cuda" if torch.cuda.is_available() else "cpu"
-    if not isinstance(device, torch.device):
-        device = torch.device(device)
+    device = normalize_torch_device(device)
     knn_i = torch.as_tensor(knn_indices, dtype=torch.long, device=device)
     knn_d = torch.as_tensor(knn_dists, dtype=torch.float32, device=device)
 

--- a/omicverse/pp/_neighbors.py
+++ b/omicverse/pp/_neighbors.py
@@ -33,6 +33,7 @@ import logging
 
 from ._compat import old_positionals
 from .._settings import EMOJI, Colors, settings as ov_settings
+from .._optional import normalize_torch_device
 from . import _connectivity
 from ._connectivity import (
     _get_indices_distances_from_sparse_matrix,
@@ -899,7 +900,7 @@ class Neighbors:
             from ..external.umap_pytorch.fuzzy_gpu import fuzzy_simplicial_set_gpu
             from scipy.sparse import coo_matrix
 
-            device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+            device = normalize_torch_device()
             print(f"   {Colors.CYAN}Using device: {Colors.BOLD}{device}{Colors.ENDC}")
 
             # Build the fuzzy simplicial set on device once. Convert to scipy
@@ -1034,7 +1035,7 @@ class Neighbors:
                 )
                 raise ImportError(msg) from e
 
-            device = 'cuda' if torch.cuda.is_available() else 'cpu'
+            device = normalize_torch_device()
             print(f"   {Colors.CYAN}💡 Using PyTorch Geometric KNN on {Colors.BOLD}{device}{Colors.ENDC}")
 
             transformer = TorchKNNTransformer(

--- a/omicverse/pp/pyg_knn_implementation.py
+++ b/omicverse/pp/pyg_knn_implementation.py
@@ -232,10 +232,8 @@ class TorchKNNTransformer:
             )
         self.n_neighbors = n_neighbors
         self.metric = metric
-        if device == "auto":
-            self.device = "cuda" if torch.cuda.is_available() else "cpu"
-        else:
-            self.device = device
+        normalized_device = None if device == "auto" else device
+        self.device = normalize_torch_device(normalized_device, fallback_to_cpu=True)
 
     def fit(self, X, y=None):
         return self

--- a/omicverse/pp/pyg_knn_implementation.py
+++ b/omicverse/pp/pyg_knn_implementation.py
@@ -26,6 +26,8 @@ import numpy as np
 import torch
 from scipy import sparse
 
+from .._optional import normalize_torch_device
+
 
 _CHUNK_CAP = 4096  # caps the (Q, N) distance buffer; 4096*1M*4B = 16 GB
 
@@ -72,6 +74,7 @@ def _chunked_knn_l2(X, k, device, chunk_size=None, include_self=True, return_ten
     indices : np.ndarray (N, k) int64
     distances : np.ndarray (N, k) float32
     """
+    device = normalize_torch_device(device, fallback_to_cpu=True)
     n_samples, n_features = X.shape
     Y = X if X.device == device else X.to(device, non_blocking=True)
     y_normsq = (Y * Y).sum(dim=1)  # (N,)
@@ -183,10 +186,7 @@ def pyg_knn_search(X, k=15, device="cuda", chunk_size=None, include_self=True, b
         chunk_size = int(chunk_size)
     if batch_size is not None:
         batch_size = int(batch_size)
-    if isinstance(device, str):
-        device = torch.device(device)
-    if device.type == "cuda" and not torch.cuda.is_available():
-        device = torch.device("cpu")
+    device = normalize_torch_device(device, fallback_to_cpu=True)
 
     if isinstance(X, np.ndarray):
         X_torch = torch.from_numpy(np.ascontiguousarray(X, dtype=np.float32))

--- a/tests/pp/test_pyg_knn_implementation.py
+++ b/tests/pp/test_pyg_knn_implementation.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import torch
 
 from omicverse._optional import normalize_torch_device
@@ -5,17 +7,24 @@ from omicverse.pp import pyg_knn_implementation as pyg_knn
 
 
 def test_optional_device_helper_import_has_no_torch_or_settings_side_effects():
-    import subprocess
+    import importlib.util
     import sys
 
-    code = """
-import sys
-from omicverse._optional import normalize_torch_device
-assert callable(normalize_torch_device)
-assert "torch" not in sys.modules
-assert "omicverse._settings" not in sys.modules
-"""
-    subprocess.run([sys.executable, "-c", code], check=True)
+    root = Path(__file__).resolve().parents[2]
+    pre_modules = set(sys.modules.keys())
+    spec = importlib.util.spec_from_file_location(
+        "_optional_module_test",
+        root / "omicverse" / "_optional.py",
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    added_modules = set(sys.modules.keys()) - pre_modules
+    # Keep the test stable in test runners where optional imports are already warm.
+    assert "torch" not in added_modules
+    assert "omicverse._settings" not in added_modules
+
+    assert callable(module.normalize_torch_device)
 
 
 def test_normalize_torch_device_adds_current_cuda_index(monkeypatch):
@@ -51,6 +60,24 @@ def test_normalize_torch_device_integer_selects_cuda_index(monkeypatch):
     device = normalize_torch_device(1)
 
     assert device == torch.device("cuda:1")
+
+
+def test_normalize_torch_device_integer_keeps_index(monkeypatch):
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+
+    device = normalize_torch_device(1)
+
+    assert device == torch.device("cuda:1")
+
+
+def test_normalize_torch_device_integer_falls_back_to_cpu_when_cuda_unavailable_and_fallback_enabled(
+    monkeypatch,
+):
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+
+    device = normalize_torch_device(1, fallback_to_cpu=True)
+
+    assert device == torch.device("cpu")
 
 
 def test_autotune_chunk_receives_indexed_cuda_device(monkeypatch):

--- a/tests/pp/test_pyg_knn_implementation.py
+++ b/tests/pp/test_pyg_knn_implementation.py
@@ -1,0 +1,108 @@
+import torch
+
+from omicverse._optional import normalize_torch_device
+from omicverse.pp import pyg_knn_implementation as pyg_knn
+
+
+def test_optional_device_helper_import_has_no_torch_or_settings_side_effects():
+    import subprocess
+    import sys
+
+    code = """
+import sys
+from omicverse._optional import normalize_torch_device
+assert callable(normalize_torch_device)
+assert "torch" not in sys.modules
+assert "omicverse._settings" not in sys.modules
+"""
+    subprocess.run([sys.executable, "-c", code], check=True)
+
+
+def test_normalize_torch_device_adds_current_cuda_index(monkeypatch):
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "current_device", lambda: 0)
+
+    device = normalize_torch_device("cuda")
+
+    assert device == torch.device("cuda:0")
+
+
+def test_normalize_torch_device_preserves_explicit_cuda_index(monkeypatch):
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "current_device", lambda: 0)
+
+    device = normalize_torch_device("cuda:1")
+
+    assert device == torch.device("cuda:1")
+
+
+def test_normalize_torch_device_uses_current_cuda_for_none(monkeypatch):
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "current_device", lambda: 2)
+
+    device = normalize_torch_device()
+
+    assert device == torch.device("cuda:2")
+
+
+def test_normalize_torch_device_integer_selects_cuda_index(monkeypatch):
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+
+    device = normalize_torch_device(1)
+
+    assert device == torch.device("cuda:1")
+
+
+def test_autotune_chunk_receives_indexed_cuda_device(monkeypatch):
+    seen = {}
+
+    def fake_mem_get_info(device):
+        seen["device"] = device
+        return 2 << 30, 4 << 30
+
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "current_device", lambda: 0)
+    monkeypatch.setattr(torch.cuda, "mem_get_info", fake_mem_get_info)
+
+    device = normalize_torch_device("cuda")
+    pyg_knn._autotune_chunk(100, 10, device)
+
+    assert seen["device"] == torch.device("cuda:0")
+
+
+def test_chunked_knn_normalizes_device_before_autotune(monkeypatch):
+    seen = {}
+
+    def fake_autotune(n_samples, n_features, device, headroom_gb=1.0):
+        seen["device"] = device
+        return n_samples
+
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "current_device", lambda: 0)
+    monkeypatch.setattr(pyg_knn, "_autotune_chunk", fake_autotune)
+    monkeypatch.setattr(
+        torch.Tensor,
+        "to",
+        lambda self, *args, **kwargs: self,
+    )
+
+    X = torch.zeros((2, 2), dtype=torch.float32)
+    pyg_knn._chunked_knn_l2(X, k=1, device=torch.device("cuda"))
+
+    assert seen["device"] == torch.device("cuda:0")
+
+
+def test_normalize_torch_device_falls_back_when_cuda_unavailable(monkeypatch):
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+
+    device = normalize_torch_device("cuda", fallback_to_cpu=True)
+
+    assert device == torch.device("cpu")
+
+
+def test_normalize_torch_device_preserves_cuda_without_fallback(monkeypatch):
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+
+    device = normalize_torch_device("cuda")
+
+    assert device == torch.device("cuda")

--- a/tests/pp/test_pyg_knn_implementation.py
+++ b/tests/pp/test_pyg_knn_implementation.py
@@ -70,26 +70,20 @@ def test_autotune_chunk_receives_indexed_cuda_device(monkeypatch):
     assert seen["device"] == torch.device("cuda:0")
 
 
-def test_chunked_knn_normalizes_device_before_autotune(monkeypatch):
-    seen = {}
-
-    def fake_autotune(n_samples, n_features, device, headroom_gb=1.0):
-        seen["device"] = device
-        return n_samples
-
+def test_torch_knn_transformer_auto_resolves_indexed_cuda_device(monkeypatch):
     monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
     monkeypatch.setattr(torch.cuda, "current_device", lambda: 0)
-    monkeypatch.setattr(pyg_knn, "_autotune_chunk", fake_autotune)
-    monkeypatch.setattr(
-        torch.Tensor,
-        "to",
-        lambda self, *args, **kwargs: self,
-    )
+    transformer = pyg_knn.TorchKNNTransformer(device="auto")
 
-    X = torch.zeros((2, 2), dtype=torch.float32)
-    pyg_knn._chunked_knn_l2(X, k=1, device=torch.device("cuda"))
+    assert transformer.device == torch.device("cuda:0")
 
-    assert seen["device"] == torch.device("cuda:0")
+
+def test_torch_knn_transformer_auto_falls_back_to_cpu_if_no_cuda(monkeypatch):
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+
+    transformer = pyg_knn.TorchKNNTransformer(device="auto")
+
+    assert transformer.device == torch.device("cpu")
 
 
 def test_normalize_torch_device_falls_back_when_cuda_unavailable(monkeypatch):


### PR DESCRIPTION
## Summary

- Normalize bare CUDA devices to indexed CUDA devices before PyG KNN calls `torch.cuda.mem_get_info()`.
- Reuse a lightweight helper in `_optional.py` so device normalization does not import settings or trigger settings-side effects.
- Apply the same normalization to related GPU code paths that can receive bare `cuda` devices.

Refs #831.