### PR TITLE
fix(space): enable GPU defaults for cell2location

### DIFF
--- a/omicverse/space/_deconvolution.py
+++ b/omicverse/space/_deconvolution.py
@@ -107,6 +107,24 @@ class Deconvolution(object):
         if log1p_50_warning:   
             print(f"{Colors.WARNING}⚠️ 50*1e4 is the standardized target sum for `omicverse`{Colors.ENDC}")
 
+    @staticmethod
+    def _default_cell2location_device_kwargs():
+        try:
+            import torch
+        except ImportError:
+            return {}
+
+        if torch.cuda.is_available():
+            return {"accelerator": "gpu", "device": 1}
+        return {}
+
+    def _with_cell2location_device_defaults(self, train_kwargs):
+        train_kwargs = {} if train_kwargs is None else dict(train_kwargs)
+        device_keys = {"accelerator", "device", "devices", "use_gpu"}
+        if not any(key in train_kwargs for key in device_keys):
+            train_kwargs.update(self._default_cell2location_device_kwargs())
+        return train_kwargs
+
     def preprocess_sc(self,mode='shiftlog|pearson',n_HVGs=3000,target_sum=1e4,**kwargs):
         """
         Preprocess the scRNA-seq reference before spatial mapping.
@@ -313,6 +331,7 @@ class Deconvolution(object):
             # Use all data for training (validation not implemented yet, train_size=1)
             if cell2location_scrna_kwargs is None:
                 cell2location_scrna_kwargs={'max_epochs':250,'batch_size':2500,'train_size':1,'lr':0.002}
+            cell2location_scrna_kwargs = self._with_cell2location_device_defaults(cell2location_scrna_kwargs)
             self.mod_sc.train(
                 **cell2location_scrna_kwargs
             )
@@ -361,6 +380,7 @@ class Deconvolution(object):
 
             if cell2location_spatial_kwargs is None:
                 cell2location_spatial_kwargs={'max_epochs':30000,'batch_size':None,'train_size':1}
+            cell2location_spatial_kwargs = self._with_cell2location_device_defaults(cell2location_spatial_kwargs)
 
             self.mod_sp.train(
                 **cell2location_spatial_kwargs

--- a/tests/space/test_deconvolution_cell2location.py
+++ b/tests/space/test_deconvolution_cell2location.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import sys
+import types
+
+import numpy as np
+import pandas as pd
+from anndata import AnnData
+
+
+def _synthetic_pair():
+    ad_sc = AnnData(X=np.array([[1, 0], [0, 2], [3, 1]], dtype=np.float32))
+    ad_sc.var_names = ["g0", "g1"]
+    ad_sc.obs["cell_type"] = ["A", "B", "A"]
+    ad_sc.layers["counts"] = ad_sc.X.copy()
+
+    ad_sp = AnnData(X=np.array([[2, 1], [1, 3]], dtype=np.float32))
+    ad_sp.var_names = ["g0", "g1"]
+    ad_sp.obs["sample"] = ["s0", "s0"]
+    ad_sp.layers["counts"] = ad_sp.X.copy()
+    return ad_sp, ad_sc
+
+
+def _install_fake_cell2location(monkeypatch, seen: dict):
+    fake_root = types.ModuleType("omicverse.external.space.cell2location")
+    fake_root.__path__ = []
+
+    fake_models = types.ModuleType("omicverse.external.space.cell2location.models")
+    fake_plt = types.ModuleType("omicverse.external.space.cell2location.plt")
+    fake_utils = types.ModuleType("omicverse.external.space.cell2location.utils")
+    fake_filtering = types.ModuleType("omicverse.external.space.cell2location.utils.filtering")
+
+    factors = ["A", "B"]
+
+    class FakeRegressionModel:
+        @classmethod
+        def setup_anndata(cls, **kwargs):
+            seen["regression_setup"] = kwargs
+
+        def __init__(self, adata):
+            seen["regression_init_adata"] = adata
+
+        def train(self, **kwargs):
+            seen["regression_train"] = kwargs
+
+        def export_posterior(self, adata, sample_kwargs=None):
+            seen["regression_sample_kwargs"] = sample_kwargs
+            adata = adata.copy()
+            adata.uns["mod"] = {"factor_names": factors}
+            for factor in factors:
+                adata.var[f"means_per_cluster_mu_fg_{factor}"] = [1.0, 2.0]
+            return adata
+
+    class FakeCell2location:
+        @classmethod
+        def setup_anndata(cls, **kwargs):
+            seen["spatial_setup"] = kwargs
+
+        def __init__(self, adata, **kwargs):
+            seen["spatial_init_adata"] = adata
+            seen["spatial_init_kwargs"] = kwargs
+
+        def train(self, **kwargs):
+            seen["spatial_train"] = kwargs
+
+        def export_posterior(self, adata, sample_kwargs=None):
+            seen["spatial_sample_kwargs"] = sample_kwargs
+            adata = adata.copy()
+            adata.uns["mod"] = {"factor_names": factors}
+            adata.obsm["q05_cell_abundance_w_sf"] = pd.DataFrame(
+                [[2.0, 1.0], [1.0, 3.0]],
+                index=adata.obs_names,
+                columns=factors,
+            )
+            return adata
+
+    fake_models.RegressionModel = FakeRegressionModel
+    fake_models.Cell2location = FakeCell2location
+    fake_plt.plot_spatial = lambda *args, **kwargs: None
+    fake_utils.select_slide = lambda *args, **kwargs: None
+    fake_filtering.filter_genes = lambda adata, **kwargs: np.ones(adata.n_vars, dtype=bool)
+
+    monkeypatch.setitem(sys.modules, "omicverse.external.space.cell2location", fake_root)
+    monkeypatch.setitem(sys.modules, "omicverse.external.space.cell2location.models", fake_models)
+    monkeypatch.setitem(sys.modules, "omicverse.external.space.cell2location.plt", fake_plt)
+    monkeypatch.setitem(sys.modules, "omicverse.external.space.cell2location.utils", fake_utils)
+    monkeypatch.setitem(
+        sys.modules,
+        "omicverse.external.space.cell2location.utils.filtering",
+        fake_filtering,
+    )
+
+
+def test_cell2location_uses_cuda_defaults(monkeypatch):
+    import torch
+    import omicverse as ov
+
+    seen: dict = {}
+    _install_fake_cell2location(monkeypatch, seen)
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+
+    ad_sp, ad_sc = _synthetic_pair()
+    decov = ov.space.Deconvolution(adata_sp=ad_sp, adata_sc=ad_sc)
+    decov.deconvolution(
+        method="cell2location",
+        celltype_key_sc="cell_type",
+        batch_key_sp="sample",
+        cell2location_scrna_kwargs={"max_epochs": 1, "batch_size": 2, "train_size": 1},
+        cell2location_spatial_kwargs={"max_epochs": 2, "batch_size": None, "train_size": 1},
+        sample_kwargs={"num_samples": 1, "batch_size": 2},
+    )
+
+    assert seen["regression_train"]["accelerator"] == "gpu"
+    assert seen["regression_train"]["device"] == 1
+    assert seen["spatial_train"]["accelerator"] == "gpu"
+    assert seen["spatial_train"]["device"] == 1
+
+
+def test_cell2location_keeps_explicit_device(monkeypatch):
+    import torch
+    import omicverse as ov
+
+    seen: dict = {}
+    _install_fake_cell2location(monkeypatch, seen)
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+
+    ad_sp, ad_sc = _synthetic_pair()
+    decov = ov.space.Deconvolution(adata_sp=ad_sp, adata_sc=ad_sc)
+    decov.deconvolution(
+        method="cell2location",
+        celltype_key_sc="cell_type",
+        cell2location_scrna_kwargs={
+            "max_epochs": 1,
+            "batch_size": 2,
+            "train_size": 1,
+            "accelerator": "cpu",
+            "device": "auto",
+        },
+        cell2location_spatial_kwargs={
+            "max_epochs": 2,
+            "batch_size": None,
+            "train_size": 1,
+            "accelerator": "cpu",
+            "device": "auto",
+        },
+        sample_kwargs={"num_samples": 1, "batch_size": 2},
+    )
+
+    assert seen["regression_train"]["accelerator"] == "cpu"
+    assert seen["regression_train"]["device"] == "auto"
+    assert seen["spatial_train"]["accelerator"] == "cpu"
+    assert seen["spatial_train"]["device"] == "auto"


### PR DESCRIPTION
Fixes `ov.space.Deconvolution(...).deconvolution(method="cell2location")` so that GPU training arguments are passed explicitly when CUDA is available.

The cell2location scRNA reference and spatial training stages now receive `accelerator="gpu", device=1` when the user has not provided explicit device settings. User-provided `accelerator`, `device`, `devices`, or `use_gpu` settings are preserved.

Regression tests cover default GPU argument injection and preservation of explicit device arguments.

Refs #844