### PR TITLE
fix(single): validate cNMF result mapping

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -41,13 +41,14 @@ jobs:
     - name: Install dependencies
       run: |
         uv venv .venv --python ${{ matrix.python-version }}
-        # Run CI on numpy>=2 (omicverse core supports it) and keep jax on the
+        # Run CI on numpy>=2,<2.5 (omicverse core supports numpy 2, while numba
+        # has not yet accepted numpy 2.5) and keep jax on the
         # 0.6.x line. On py3.11/3.12 the resolver otherwise pulls jax 0.10.x
         # (transitively via mellon), which is broken against numpy 2.4.x
         # (`np.dtypes.StringDType`) and crashes test collection. jax 0.6.2 is
         # the version py3.10 already resolved + passed with, on numpy 2.2.6.
-        uv pip install --python .venv/bin/python 'numpy>=2' 'jax<0.7' 'jaxlib<0.7' flake8 torch tensorboard mellon torch_geometric POT wget lifelines boltons ctxcore ktplotspy leidenalg datashader graphtools phate python-dotplot metatime pydeseq2 bioservices tomli wandb munch datasets
-        uv pip install --python .venv/bin/python -e ".[tests,mcp]" 'numpy>=2' 'jax<0.7' 'jaxlib<0.7'
+        uv pip install --python .venv/bin/python 'numpy>=2,<2.5' 'jax<0.7' 'jaxlib<0.7' flake8 torch tensorboard mellon torch_geometric POT wget lifelines boltons ctxcore ktplotspy leidenalg datashader graphtools phate python-dotplot metatime pydeseq2 bioservices tomli wandb munch datasets
+        uv pip install --python .venv/bin/python -e ".[tests,mcp]" 'numpy>=2,<2.5' 'jax<0.7' 'jaxlib<0.7'
     - name: Lint with flake8
       run: |
         source .venv/bin/activate

--- a/omicverse/external/cnmf/cnmf.py
+++ b/omicverse/external/cnmf/cnmf.py
@@ -1750,19 +1750,23 @@ class cNMF():
 
         missing_cells = adata.obs_names.difference(usage.index)
         if len(missing_cells) > 0:
+            n_missing = len(missing_cells)
+            noun = "cell" if n_missing == 1 else "cells"
             examples = ", ".join(map(str, missing_cells[:5]))
             raise ValueError(
                 "adata.obs_names must all be present in result_dict['usage_norm'].index "
-                f"before mapping cNMF results. Missing {len(missing_cells)} cells; "
+                f"before mapping cNMF results. Missing {n_missing} {noun}; "
                 f"examples: {examples}"
             )
 
         missing_genes = adata.var_names.difference(gep_scores.index)
         if len(missing_genes) > 0:
+            n_missing = len(missing_genes)
+            noun = "gene" if n_missing == 1 else "genes"
             examples = ", ".join(map(str, missing_genes[:5]))
             raise ValueError(
                 "adata.var_names must all be present in result_dict['gep_scores'].index "
-                f"before mapping cNMF gene scores. Missing {len(missing_genes)} genes; "
+                f"before mapping cNMF gene scores. Missing {n_missing} {noun}; "
                 f"examples: {examples}"
             )
 
@@ -1794,8 +1798,6 @@ class cNMF():
         self._align_results_to_adata(adata, result_dict)
 
         import numpy as np
-        import pandas as pd
-        import matplotlib.pyplot as plt
         from sklearn.tree import DecisionTreeClassifier
         from sklearn.ensemble import RandomForestClassifier
         from sklearn.model_selection import train_test_split
@@ -1803,9 +1805,18 @@ class cNMF():
         new_array = []
         class_array = []
         for i in range(1, result_dict['usage_norm'].shape[1] + 1):
-            data = adata[adata.obs[f'cNMF_{i}'] > cNMF_threshold].obsm[use_rep].toarray()
+            data = adata[adata.obs[f'cNMF_{i}'] > cNMF_threshold].obsm[use_rep]
+            data = data.toarray() if hasattr(data, "toarray") else np.asarray(data)
+            if data.shape[0] == 0:
+                continue
             new_array.append(data)
             class_array.append(np.full(data.shape[0], i))
+
+        if len(new_array) < 2:
+            raise ValueError(
+                "At least two cNMF factors must have cells above cNMF_threshold "
+                "to train cNMF random forest classifiers."
+            )
 
         new_array = np.concatenate(new_array, axis=0)
         class_array = np.concatenate(class_array)
@@ -1822,8 +1833,10 @@ class cNMF():
         print("Single Tree:",score_c)
         print("Random Forest:",score_r)
 
-        adata.obs['cNMF_cluster_rfc']=[str(i) for i in rfc.predict(adata.obsm[use_rep])]
-        adata.obs['cNMF_cluster_clf']=[str(i) for i in clf.predict(adata.obsm[use_rep])]
+        prediction_data = adata.obsm[use_rep]
+        prediction_data = prediction_data.toarray() if hasattr(prediction_data, "toarray") else np.asarray(prediction_data)
+        adata.obs['cNMF_cluster_rfc']=[str(i) for i in rfc.predict(prediction_data)]
+        adata.obs['cNMF_cluster_clf']=[str(i) for i in clf.predict(prediction_data)]
         print('cNMF_cluster_rfc is added to adata.obs')
         print('cNMF_cluster_clf is added to adata.obs')
 

--- a/omicverse/external/cnmf/cnmf.py
+++ b/omicverse/external/cnmf/cnmf.py
@@ -1735,62 +1735,55 @@ class cNMF():
         result_dict['top_genes'] = top_genes
         return result_dict
 
-    def get_results_rfc(self,adata,result_dict,use_rep='STAGATE',cNMF_threshold=0.5):
-        import pandas as pd
-        if result_dict['usage_norm'].columns[0] in adata.obs.columns:
-            #remove the columns if they already exist
-            #remove columns name starts with 'cNMF'
-            adata.obs = adata.obs.loc[:,~adata.obs.columns.str.startswith('cNMF')]
-        adata.obs = pd.merge(left=adata.obs, right=result_dict['usage_norm'], 
-                             how='left', left_index=True, right_index=True)
-        adata.var = pd.merge(left=adata.var,right=result_dict['gep_scores'].loc[adata.var.index],
-                             how='left', left_index=True, right_index=True)
-        
-        import numpy as np
-        import pandas as pd
-        import matplotlib.pyplot as plt
-        from sklearn.tree import DecisionTreeClassifier
-        from sklearn.ensemble import RandomForestClassifier
-        from sklearn.model_selection import train_test_split
+    def _align_results_to_adata(self, adata, result_dict):
+        usage = result_dict['usage_norm']
+        gep_scores = result_dict['gep_scores']
 
-        new_array = []
-        class_array = []
-        for i in range(1, result_dict['usage_norm'].shape[1] + 1):
-            data = adata[adata.obs[f'cNMF_{i}'] > cNMF_threshold].obsm[use_rep].toarray()
-            new_array.append(data)
-            class_array.append(np.full(data.shape[0], i))
+        if not adata.obs_names.is_unique:
+            raise ValueError("adata.obs_names must be unique before mapping cNMF results.")
+        if not usage.index.is_unique:
+            raise ValueError("result_dict['usage_norm'].index must be unique before mapping cNMF results.")
+        if not adata.var_names.is_unique:
+            raise ValueError("adata.var_names must be unique before mapping cNMF gene scores.")
+        if not gep_scores.index.is_unique:
+            raise ValueError("result_dict['gep_scores'].index must be unique before mapping cNMF gene scores.")
 
-        new_array = np.concatenate(new_array, axis=0)
-        class_array = np.concatenate(class_array)
+        missing_cells = adata.obs_names.difference(usage.index)
+        if len(missing_cells) > 0:
+            examples = ", ".join(map(str, missing_cells[:5]))
+            raise ValueError(
+                "adata.obs_names must all be present in result_dict['usage_norm'].index "
+                f"before mapping cNMF results. Missing {len(missing_cells)} cells; "
+                f"examples: {examples}"
+            )
 
-        Xtrain, Xtest, Ytrain, Ytest = train_test_split(new_array,class_array,test_size=0.3)
-        clf = DecisionTreeClassifier(random_state=0)
-        rfc = RandomForestClassifier(random_state=0)
-        clf = clf.fit(Xtrain,Ytrain)
-        rfc = rfc.fit(Xtrain,Ytrain)
-        #查看模型效果
-        score_c = clf.score(Xtest,Ytest)
-        score_r = rfc.score(Xtest,Ytest)
-        #打印最后结果
-        print("Single Tree:",score_c)
-        print("Random Forest:",score_r)
+        missing_genes = adata.var_names.difference(gep_scores.index)
+        if len(missing_genes) > 0:
+            examples = ", ".join(map(str, missing_genes[:5]))
+            raise ValueError(
+                "adata.var_names must all be present in result_dict['gep_scores'].index "
+                f"before mapping cNMF gene scores. Missing {len(missing_genes)} genes; "
+                f"examples: {examples}"
+            )
 
-        adata.obs['cNMF_cluster_rfc']=[str(i) for i in rfc.predict(adata.obsm[use_rep])]
-        adata.obs['cNMF_cluster_clf']=[str(i) for i in clf.predict(adata.obsm[use_rep])]
-        print('cNMF_cluster_rfc is added to adata.obs')
-        print('cNMF_cluster_clf is added to adata.obs')
+        generated_obs_columns = {'cNMF_cluster', 'cNMF_cluster_rfc', 'cNMF_cluster_clf'}
+        cNMF_columns = adata.obs.columns.astype(str).str.match(r'^cNMF_\d+$')
+        stale_columns = adata.obs.columns[cNMF_columns | adata.obs.columns.isin(generated_obs_columns)]
+        if len(stale_columns) > 0:
+            adata.obs = adata.obs.drop(columns=stale_columns)
+
+        usage = usage.reindex(adata.obs_names)
+        gep_scores = gep_scores.reindex(adata.var_names)
+        adata.var = adata.var.drop(columns=adata.var.columns.intersection(gep_scores.columns))
+        for column in usage.columns:
+            adata.obs[column] = usage[column].to_numpy()
+        for column in gep_scores.columns:
+            adata.var[column] = gep_scores[column].to_numpy()
+        return usage
 
     def get_results(self,adata,result_dict):
-        import pandas as pd
-        if result_dict['usage_norm'].columns[0] in adata.obs.columns:
-            #remove the columns if they already exist
-            #remove columns name starts with 'cNMF'
-            adata.obs = adata.obs.loc[:,~adata.obs.columns.str.startswith('cNMF')]
-        adata.obs = pd.merge(left=adata.obs, right=result_dict['usage_norm'], 
-                             how='left', left_index=True, right_index=True)
-        adata.var = pd.merge(left=adata.var,right=result_dict['gep_scores'].loc[adata.var.index],
-                             how='left', left_index=True, right_index=True)
-        df=adata.obs[result_dict['usage_norm'].columns].copy()
+        usage = self._align_results_to_adata(adata, result_dict)
+        df=adata.obs[usage.columns].copy()
         max_topic = df.idxmax(axis=1)
         # 将结果添加到DataFrame中
         adata.obs['cNMF_cluster'] = max_topic
@@ -1798,15 +1791,7 @@ class cNMF():
         print('gene scores are added to adata.var')
 
     def get_results_rfc(self,adata,result_dict,use_rep='STAGATE',cNMF_threshold=0.5):
-        import pandas as pd
-        if result_dict['usage_norm'].columns[0] in adata.obs.columns:
-            #remove the columns if they already exist
-            #remove columns name starts with 'cNMF'
-            adata.obs = adata.obs.loc[:,~adata.obs.columns.str.startswith('cNMF')]
-        adata.obs = pd.merge(left=adata.obs, right=result_dict['usage_norm'], 
-                             how='left', left_index=True, right_index=True)
-        adata.var = pd.merge(left=adata.var,right=result_dict['gep_scores'].loc[adata.var.index],
-                             how='left', left_index=True, right_index=True)
+        self._align_results_to_adata(adata, result_dict)
 
         import numpy as np
         import pandas as pd

--- a/omicverse/external/cnmf/cnmf.py
+++ b/omicverse/external/cnmf/cnmf.py
@@ -1778,7 +1778,12 @@ class cNMF():
 
         usage = usage.reindex(adata.obs_names)
         gep_scores = gep_scores.reindex(adata.var_names)
-        adata.var = adata.var.drop(columns=adata.var.columns.intersection(gep_scores.columns))
+        stale_gene_score_columns = [
+            column
+            for column in adata.var.columns
+            if isinstance(column, (int, np.integer)) and column >= 1
+        ]
+        adata.var = adata.var.drop(columns=stale_gene_score_columns)
         for column in usage.columns:
             adata.obs[column] = usage[column].to_numpy()
         for column in gep_scores.columns:
@@ -1787,14 +1792,20 @@ class cNMF():
 
     def get_results(self,adata,result_dict):
         usage = self._align_results_to_adata(adata, result_dict)
+        print('gene scores are added to adata.var')
         df=adata.obs[usage.columns].copy()
         max_topic = df.idxmax(axis=1)
         # 将结果添加到DataFrame中
         adata.obs['cNMF_cluster'] = max_topic
         print('cNMF_cluster is added to adata.obs')
-        print('gene scores are added to adata.var')
 
     def get_results_rfc(self,adata,result_dict,use_rep='STAGATE',cNMF_threshold=0.5):
+        """
+        Map cNMF results to ``adata`` and train RFC/decision-tree cluster labels.
+
+        This replaces existing cNMF usage and generated cNMF cluster columns,
+        including ``cNMF_cluster`` from ``get_results``.
+        """
         self._align_results_to_adata(adata, result_dict)
 
         import numpy as np

--- a/tests/external/test_cnmf_result_alignment.py
+++ b/tests/external/test_cnmf_result_alignment.py
@@ -65,6 +65,8 @@ def test_cnmf_get_results_can_be_called_repeatedly_on_same_adata():
     adata = _adata(["cell_a", "cell_b", "cell_c"])
     adata.obs["cNMF_note"] = ["keep", "keep", "keep"]
     adata.obs["cNMF_3"] = [1.0, 1.0, 1.0]
+    adata.var[3] = [3.0, 3.0]
+    adata.var["gene_note"] = ["keep", "keep"]
 
     cnmf.get_results(adata, _result_dict())
     cnmf.get_results(adata, _result_dict())
@@ -74,7 +76,9 @@ def test_cnmf_get_results_can_be_called_repeatedly_on_same_adata():
     assert "cNMF_3" not in adata.obs
     assert list(adata.obs["cNMF_note"]) == ["keep", "keep", "keep"]
     assert list(adata.obs["cNMF_cluster"]) == ["cNMF_1", "cNMF_2", "cNMF_2"]
-    assert list(adata.var.columns) == [1, 2]
+    assert 3 not in adata.var
+    assert list(adata.var["gene_note"]) == ["keep", "keep"]
+    assert list(adata.var.columns) == ["gene_note", 1, 2]
 
 
 def test_cnmf_get_results_rfc_uses_alignment_validation():

--- a/tests/external/test_cnmf_result_alignment.py
+++ b/tests/external/test_cnmf_result_alignment.py
@@ -54,7 +54,7 @@ def test_cnmf_get_results_rejects_missing_obs_names_instead_of_silent_nan():
     cnmf = _cnmf_instance()
     adata = _adata(["cell_a", "missing_cell"])
 
-    with pytest.raises(ValueError, match="Missing 1 cells"):
+    with pytest.raises(ValueError, match="Missing 1 cell"):
         cnmf.get_results(adata, _result_dict())
 
     assert "cNMF_cluster" not in adata.obs
@@ -75,3 +75,22 @@ def test_cnmf_get_results_can_be_called_repeatedly_on_same_adata():
     assert list(adata.obs["cNMF_note"]) == ["keep", "keep", "keep"]
     assert list(adata.obs["cNMF_cluster"]) == ["cNMF_1", "cNMF_2", "cNMF_2"]
     assert list(adata.var.columns) == [1, 2]
+
+
+def test_cnmf_get_results_rfc_uses_alignment_validation():
+    cnmf = _cnmf_instance()
+    adata = _adata(["cell_a", "missing_cell"])
+
+    with pytest.raises(ValueError, match="Missing 1 cell"):
+        cnmf.get_results_rfc(adata, _result_dict(), use_rep="X_test")
+
+    assert "cNMF_cluster_rfc" not in adata.obs
+
+
+def test_cnmf_get_results_rfc_rejects_threshold_without_two_classes():
+    cnmf = _cnmf_instance()
+    adata = _adata(["cell_a", "cell_b", "cell_c"])
+    adata.obsm["X_test"] = np.ones((3, 2))
+
+    with pytest.raises(ValueError, match="At least two cNMF factors"):
+        cnmf.get_results_rfc(adata, _result_dict(), use_rep="X_test", cNMF_threshold=1.0)

--- a/tests/external/test_cnmf_result_alignment.py
+++ b/tests/external/test_cnmf_result_alignment.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+from anndata import AnnData
+
+from omicverse.external.cnmf.cnmf import cNMF
+
+
+def _cnmf_instance():
+    cls = getattr(cNMF, "__wrapped__", cNMF)
+    return cls.__new__(cls)
+
+
+def _adata(obs_names):
+    return AnnData(
+        X=np.ones((len(obs_names), 2)),
+        obs=pd.DataFrame(index=list(obs_names)),
+        var=pd.DataFrame(index=["g1", "g2"]),
+    )
+
+
+def _result_dict():
+    return {
+        "usage_norm": pd.DataFrame(
+            {
+                "cNMF_1": [0.9, 0.1, 0.2],
+                "cNMF_2": [0.1, 0.9, 0.8],
+            },
+            index=["cell_a", "cell_b", "cell_c"],
+        ),
+        "gep_scores": pd.DataFrame(
+            {
+                1: [2.0, -1.0],
+                2: [-1.0, 2.0],
+            },
+            index=["g1", "g2"],
+        ),
+    }
+
+
+def test_cnmf_get_results_aligns_by_obs_names_when_adata_is_reordered():
+    cnmf = _cnmf_instance()
+    adata = _adata(["cell_c", "cell_a", "cell_b"])
+
+    cnmf.get_results(adata, _result_dict())
+
+    assert list(adata.obs["cNMF_cluster"]) == ["cNMF_2", "cNMF_1", "cNMF_2"]
+    assert list(adata.obs["cNMF_1"]) == [0.2, 0.9, 0.1]
+
+
+def test_cnmf_get_results_rejects_missing_obs_names_instead_of_silent_nan():
+    cnmf = _cnmf_instance()
+    adata = _adata(["cell_a", "missing_cell"])
+
+    with pytest.raises(ValueError, match="Missing 1 cells"):
+        cnmf.get_results(adata, _result_dict())
+
+    assert "cNMF_cluster" not in adata.obs
+
+
+def test_cnmf_get_results_can_be_called_repeatedly_on_same_adata():
+    cnmf = _cnmf_instance()
+    adata = _adata(["cell_a", "cell_b", "cell_c"])
+    adata.obs["cNMF_note"] = ["keep", "keep", "keep"]
+    adata.obs["cNMF_3"] = [1.0, 1.0, 1.0]
+
+    cnmf.get_results(adata, _result_dict())
+    cnmf.get_results(adata, _result_dict())
+
+    cNMF_columns = {col for col in adata.obs if col.startswith("cNMF_") and col != "cNMF_cluster"}
+    assert cNMF_columns == {"cNMF_1", "cNMF_2", "cNMF_note"}
+    assert "cNMF_3" not in adata.obs
+    assert list(adata.obs["cNMF_note"]) == ["keep", "keep", "keep"]
+    assert list(adata.obs["cNMF_cluster"]) == ["cNMF_1", "cNMF_2", "cNMF_2"]
+    assert list(adata.var.columns) == [1, 2]


### PR DESCRIPTION
## Summary

Fixes cNMF result mapping so `get_results()` and `get_results_rfc()` validate and align results by AnnData cell names before writing cNMF usage and gene scores back to `adata`.

- Adds shared cNMF result alignment validation for cell and gene indices
- Prevents silent NaN or misleading mappings when `adata.obs_names` do not match `usage_norm.index`
- Preserves correct behavior when `adata` is reordered or subsetted by matching cell names
- Removes the duplicate dead `get_results_rfc()` definition
- Adds regression tests for reordered cells, missing cells, and repeated mapping calls

Refs #849