### PR TITLE
Fix perturbation Sankey ribbon scaling

### DIFF
--- a/omicverse/pl/_perturbation.py
+++ b/omicverse/pl/_perturbation.py
@@ -624,12 +624,12 @@ def perturb_sankey(
         palette = {c: cmap(i % 20) for i, c in enumerate(cats)}
 
     # Equal-height source bars so small clusters (e.g. Mk) stay visible.
-    # Each row of `ct` is already row-stochastic (out-distribution).
+    # Each row of `ct` is already row-stochastic (out-distribution), but
+    # ribbon coordinates must use the same normalized height scale as the bars.
     src_sizes = np.full(n, 1.0 / n, dtype=float)
-    # Destination heights = total inflow probability mass per destination.
-    right_in = ct.sum(axis=0).to_numpy()
-    right_in = right_in / right_in.sum()
-    right_sizes = right_in
+    flow_heights = ct.to_numpy(dtype=float) * src_sizes[:, None]
+    # Destination heights = total inflow mass on the same scale as sources.
+    right_sizes = flow_heights.sum(axis=0)
 
     if ax is None:
         fig, ax = plt.subplots(figsize=figsize)
@@ -666,9 +666,8 @@ def perturb_sankey(
             p = float(ct.iloc[i, j])
             if p < min_flow:
                 continue
-            src_flow = p * src_sizes[i]
-            # destination flow occupies in_p[i,j] / right_in[j] fraction
-            dst_flow = ct.iloc[i, j] / right_in[j] * right_sizes[j] if right_in[j] > 0 else src_flow
+            src_flow = flow_heights[i, j]
+            dst_flow = flow_heights[i, j]
             y0_src = src_y_offsets[i]
             y0_dst = dst_y_offsets[j]
             verts = _make_sankey_ribbon(

--- a/tests/pl/test_perturbation.py
+++ b/tests/pl/test_perturbation.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import importlib.util
+import matplotlib
+import numpy as np
+import pandas as pd
+import sys
+import types
+from pathlib import Path
+
+matplotlib.use("Agg")
+
+
+class _FakePerturbResult:
+    target = "target_gene"
+    mode = "ko"
+    backend = "test_backend"
+
+    def __init__(self, transitions: pd.DataFrame):
+        self._transitions = transitions
+
+    def cluster_transitions(self, *, adata, cluster_col):
+        return self._transitions
+
+
+def _load_perturbation_module(monkeypatch):
+    root = Path(__file__).resolve().parents[2]
+    registry = types.ModuleType("omicverse._registry")
+    registry.register_function = lambda *args, **kwargs: (lambda func: func)
+    monkeypatch.setitem(sys.modules, "omicverse", types.ModuleType("omicverse"))
+    monkeypatch.setitem(sys.modules, "omicverse.pl", types.ModuleType("omicverse.pl"))
+    monkeypatch.setitem(sys.modules, "omicverse._registry", registry)
+
+    spec = importlib.util.spec_from_file_location(
+        "omicverse.pl._perturbation",
+        root / "omicverse" / "pl" / "_perturbation.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_perturb_sankey_ribbons_stay_within_destination_bars(monkeypatch):
+    _perturbation = _load_perturbation_module(monkeypatch)
+
+    clusters = [f"cluster_{i}" for i in range(7)]
+    ct = pd.DataFrame(
+        [
+            [0.996, 0.000, 0.000, 0.000, 0.004, 0.000, 0.000],
+            [0.000, 0.902, 0.046, 0.003, 0.010, 0.039, 0.000],
+            [0.000, 0.065, 0.826, 0.059, 0.000, 0.000, 0.050],
+            [0.000, 0.004, 0.106, 0.885, 0.000, 0.000, 0.005],
+            [0.031, 0.052, 0.000, 0.000, 0.889, 0.028, 0.000],
+            [0.000, 0.257, 0.000, 0.000, 0.133, 0.610, 0.000],
+            [0.000, 0.000, 0.039, 0.005, 0.000, 0.000, 0.956],
+        ],
+        index=clusters,
+        columns=clusters,
+    )
+    ribbons = []
+    real_make_ribbon = _perturbation._make_sankey_ribbon
+
+    def capture_ribbon(**kwargs):
+        ribbons.append(kwargs)
+        return real_make_ribbon(**kwargs)
+
+    monkeypatch.setattr(_perturbation, "_make_sankey_ribbon", capture_ribbon)
+    fig, _ = _perturbation.perturb_sankey(
+        _FakePerturbResult(ct),
+        adata=None,
+        cluster_col="main_cluster",
+        min_flow=0.03,
+    )
+
+    n = len(ct.index)
+    src_sizes = np.full(n, 1.0 / n, dtype=float)
+    expected_right_sizes = (ct.to_numpy(dtype=float) * src_sizes[:, None]).sum(axis=0)
+    y_pad = 0.005
+    right_tops = np.cumsum(expected_right_sizes + y_pad)
+    right_bottoms = right_tops - expected_right_sizes
+
+    assert ribbons
+    for ribbon in ribbons:
+        j = np.flatnonzero(np.isclose(right_bottoms, ribbon["y0_dst"], atol=1e-12) |
+                           ((right_bottoms - 1e-12 <= ribbon["y0_dst"]) &
+                            (ribbon["y0_dst"] <= right_tops + 1e-12)))[0]
+        assert ribbon["y0_dst"] >= right_bottoms[j] - 1e-12
+        assert ribbon["y1_dst"] <= right_tops[j] + 1e-12
+
+    fig.clf()


### PR DESCRIPTION
## Summary

This PR fixes the geometry used by `ov.pl.perturb_sankey`.

The previous implementation used equal-height source bars, but computed destination ribbon heights from raw transition probabilities. That placed the right-side ribbon coordinates on a different vertical scale from the right-side destination bars, so ribbons could extend beyond the target cluster bar in cluster-level perturbation Sankey plots.

The fix computes a single normalized `flow_heights` matrix and uses it consistently across the plot:

- each transition row is scaled by the source bar height
- destination bar heights are derived from the summed incoming flow heights
- source and destination ribbon ends use the same normalized flow height

This keeps source bars, destination bars, and ribbons in one coordinate system, preventing ribbons from overflowing beyond the target bars.

## Changes

- Normalize Sankey flow geometry through `flow_heights = ct * src_sizes[:, None]`
- Use the same flow height for both source and destination ribbon ends
- Add a regression test that checks destination ribbons stay within target bars
- Keep the test fixture generic, with non-biological cluster labels and row-stochastic transition rows

## Validation

- `pytest -q tests/pl/test_perturbation.py`
- `python -m py_compile omicverse/pl/_perturbation.py tests/pl/test_perturbation.py`
- `git diff --check`

A separate review pass also checked that the fix puts the source bars, destination bars, and ribbon endpoints on the same normalized vertical scale.
