### PR TITLE
Include scMulan metadata file in package builds

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,6 +7,7 @@ include requirements.txt
 include requirements-latest.txt
 
 recursive-include omicverse *.py *.pyi *.json *.txt *.yaml *.yml *.csv *.tsv *.md *.ipynb *.html *.css *.js *.png *.jpg *.jpeg *.svg *.ico *.db *.npz *.gz
+include omicverse/external/scMulan/utils/meta_info.pt
 
 prune .git
 prune .github


### PR DESCRIPTION
## Summary

Fixes #855.

Fresh PyPI installs of `omicverse==2.2.3` are missing `omicverse/external/scMulan/utils/meta_info.pt`, even though the file exists in the source tree and is required by scMulan at runtime.

The packaging manifest included many data-file extensions but did not include this required `.pt` metadata file. As a result, source/wheel distributions did not contain it, and `model_inference()` could fail with `FileNotFoundError` when loading the default `meta_info_path`.

This PR explicitly includes only the required scMulan metadata file:

`omicverse/external/scMulan/utils/meta_info.pt`

I intentionally did not add a global `*.pt` include pattern, because future `.pt` model weights could be much larger and should not be accidentally bundled into PyPI distributions.

## Validation

- Subagent review completed with no blocking findings
- Built sdist and wheel locally with `python -m build --sdist --wheel`
- Verified `meta_info.pt` is present in both artifacts:
  - `dist/omicverse-2.2.4rc1.tar.gz`
  - `dist/omicverse-2.2.4rc1-py3-none-any.whl`
- Installed the built wheel into a temporary venv with `pip install --no-deps`
- Verified `site-packages/omicverse/external/scMulan/utils/meta_info.pt` exists and has the expected size: 56307 bytes
- Ran `git diff --check`
