### PR TITLE
fix(pl): restore plotting compatibility APIs

### DIFF
--- a/omicverse/external/STT/pl/_plot_tensor.py
+++ b/omicverse/external/STT/pl/_plot_tensor.py
@@ -208,7 +208,7 @@ def plot_pathway(adata,figsize = (10,10),fontsize = 12,cmp='Set2',size = 20):
     fig, ax = plt.subplots(figsize = figsize)
     c_labels = adata.uns['pathway_labels']
     num_clusters = max(c_labels)+1
-    cmap = plt.cm.get_cmap(cmp, num_clusters)
+    cmap = plt.get_cmap(cmp, num_clusters)
 
     # Map the labels to colors using the colormap
     colors = cmap(c_labels/ num_clusters)

--- a/omicverse/pl/__init__.py
+++ b/omicverse/pl/__init__.py
@@ -245,6 +245,8 @@ from ._plot_backend import (
     geneset_wordcloud,
     plot_pca_variance_ratio,
     plot_pca_variance_ratio1,
+    plot_ConvexHull,
+    stacking_vol,
     gen_mpl_labels,
 )
 from ._funkyheatmap import (
@@ -451,6 +453,8 @@ __all__ = [
     "geneset_wordcloud",
     "plot_pca_variance_ratio",
     "plot_pca_variance_ratio1",
+    "plot_ConvexHull",
+    "stacking_vol",
     "gen_mpl_labels",
     # @ _cnv
     "cnv_heatmap",

--- a/omicverse/pl/_plot_backend.py
+++ b/omicverse/pl/_plot_backend.py
@@ -1047,15 +1047,15 @@ def normalize_to_minus_one_to_one(arr):
         "# Basic stacked volcano plot",
         "data_dict = {'Dataset1': deg_df1, 'Dataset2': deg_df2}",
         "color_dict = {'Dataset1': 'red', 'Dataset2': 'blue'}",
-        "fig, axes = ov.utils.stacking_vol(data_dict, color_dict)",
+        "fig, axes = ov.pl.stacking_vol(data_dict, color_dict)",
         "# Custom thresholds and styling",
-        "fig, axes = ov.utils.stacking_vol(data_dict, color_dict,",
+        "fig, axes = ov.pl.stacking_vol(data_dict, color_dict,",
         "                                 pval_threshold=0.05, log2fc_threshold=1.5,",
         "                                 figsize=(10,6), plot_genes_num=15)",
         "# Three-way comparison",
         "data_dict = {'Control': deg1, 'Treatment1': deg2, 'Treatment2': deg3}",
         "color_dict = {'Control': '#1f77b4', 'Treatment1': '#ff7f0e', 'Treatment2': '#2ca02c'}",
-        "fig, axes = ov.utils.stacking_vol(data_dict, color_dict)"
+        "fig, axes = ov.pl.stacking_vol(data_dict, color_dict)"
     ],
     related=["pl.volcano", "bulk.get_deg", "single.cosg"]
 )
@@ -1165,14 +1165,14 @@ def stacking_vol(data_dict:dict,color_dict:dict,
         "# Basic convex hull for a cluster",
         "fig, ax = plt.subplots()",
         "ov.pl.embedding(adata, basis='X_umap', color='leiden', ax=ax)",
-        "ov.utils.plot_ConvexHull(adata, basis='X_umap', cluster_key='leiden',",
+        "ov.pl.plot_ConvexHull(adata, basis='X_umap', cluster_key='leiden',",
         "                         hull_cluster='0', ax=ax)",
         "# Custom color and transparency",
-        "ov.utils.plot_ConvexHull(adata, basis='X_tsne', cluster_key='celltype',",
+        "ov.pl.plot_ConvexHull(adata, basis='X_tsne', cluster_key='celltype',",
         "                         hull_cluster='T cells', ax=ax, color='red', alpha=0.3)",
         "# Multiple cluster hulls",
         "for cluster in ['0', '1', '2']:",
-        "    ov.utils.plot_ConvexHull(adata, basis='X_umap', cluster_key='leiden',",
+        "    ov.pl.plot_ConvexHull(adata, basis='X_umap', cluster_key='leiden',",
         "                             hull_cluster=cluster, ax=ax)"
     ],
     related=["utils.embedding", "pl.umap", "pl.tsne"]
@@ -1201,7 +1201,7 @@ def plot_ConvexHull(adata:anndata.AnnData,basis:str,cluster_key:str,
         >>> # Create embedding plot with convex hull
         >>> fig, ax = plt.subplots()
         >>> ov.pl.embedding(adata, basis='X_umap', color='leiden', ax=ax)
-        >>> ov.utils.plot_ConvexHull(adata, basis='X_umap', cluster_key='leiden',
+        >>> ov.pl.plot_ConvexHull(adata, basis='X_umap', cluster_key='leiden',
         ...                          hull_cluster='0', ax=ax)
     """
     

--- a/omicverse/utils/__init__.py
+++ b/omicverse/utils/__init__.py
@@ -77,7 +77,7 @@ from ._plot import (
     plot_set,plotset,ov_plot_set,pyomic_palette,palette,blue_palette,orange_palette,
     red_palette,green_palette,plot_text_set,ticks_range,plot_boxplot,plot_network,
     plot_cellproportion,plot_embedding_celltype,geneset_wordcloud,
-    plot_pca_variance_ratio,gen_mpl_labels
+    plot_pca_variance_ratio,plot_ConvexHull,stacking_vol,gen_mpl_labels
 )
 #from ._genomics import *
 from ._mde import mde
@@ -252,6 +252,8 @@ __all__ = [
     "plot_embedding_celltype",
     "geneset_wordcloud",
     "plot_pca_variance_ratio",
+    "plot_ConvexHull",
+    "stacking_vol",
     "gen_mpl_labels",
     # @ _mde
     "mde",

--- a/omicverse/utils/_heatmap.py
+++ b/omicverse/utils/_heatmap.py
@@ -183,10 +183,10 @@ def make_dense(X):
         Dense numpy array
     """
     if issparse(X):
-        XA = X.A if X.ndim == 2 else X.A1
-    else:
-        XA = X.A1 if isinstance(X, np.matrix) else X
-    return np.array(XA)
+        return np.asarray(X.toarray())
+    if isinstance(X, np.matrix):
+        return np.asarray(X).ravel()
+    return np.asarray(X)
 
 # TODO: Add docstrings
 def default_palette(palette=None):
@@ -327,7 +327,7 @@ def interpret_colorkey(adata, c=None, layer=None, perc=None, use_raw=None):
                 if adata.raw is None and use_raw:
                     raise ValueError("AnnData object does not have `raw` counts.")
                 c = adata.raw.obs_vector(c) if use_raw else adata.obs_vector(c)
-            c = c.A.flatten() if issparse(c) else c
+            c = make_dense(c).flatten() if issparse(c) else c
         elif c in adata.var.keys():  # color by observation key
             c = adata.var[c]
         elif np.any([var_key in c for var_key in adata.var.keys()]):

--- a/omicverse/utils/_heatmap.py
+++ b/omicverse/utils/_heatmap.py
@@ -5,6 +5,7 @@ from matplotlib.colors import cnames, is_color_like, ListedColormap, to_rgb
 from matplotlib import patheffects, rcParams
 import scanpy as sc
 import anndata
+from collections.abc import Sequence as SequenceABC
 from typing import Union, Sequence
 
 #from scvelo import logging as logg
@@ -73,7 +74,7 @@ def plot_heatmap(
         else adata[:, var_names].X
     )
     if issparse(X):
-        X = X.A
+        X = X.toarray()
     df = pd.DataFrame(X[np.argsort(time)], columns=var_names)
 
     if n_convolve is not None:
@@ -594,7 +595,7 @@ def set_colors_for_categorical_obs(adata, value_to_plot, palette=None):
             if isinstance(palette, dict):
                 palette = [palette[c] for c in categories]
             # check if palette is a list and convert it to a cycler
-            if isinstance(palette, abc.Sequence):
+            if isinstance(palette, SequenceABC):
                 if len(palette) < length:
                     print(
                         "Length of palette colors is smaller than the number of "
@@ -656,4 +657,3 @@ def set_colors_for_categorical_obs(adata, value_to_plot, palette=None):
                 )
 
         adata.uns[f"{value_to_plot}_colors"] = palette[:length]
-

--- a/omicverse/utils/_plot.py
+++ b/omicverse/utils/_plot.py
@@ -46,6 +46,8 @@ _FUNCTION_REPLACEMENTS = {
     "geneset_wordcloud": "ov.pl.geneset_wordcloud",
     "plot_pca_variance_ratio": "ov.pl.plot_pca_variance_ratio",
     "plot_pca_variance_ratio1": "ov.pl.plot_pca_variance_ratio1",
+    "plot_ConvexHull": "ov.pl.plot_ConvexHull",
+    "stacking_vol": "ov.pl.stacking_vol",
     "gen_mpl_labels": "ov.pl.gen_mpl_labels",
 }
 

--- a/tests/external/test_stt_plot_tensor.py
+++ b/tests/external/test_stt_plot_tensor.py
@@ -1,0 +1,28 @@
+import types
+import warnings
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+def test_plot_pathway_avoids_deprecated_get_cmap():
+    from matplotlib import MatplotlibDeprecationWarning
+
+    from omicverse.external.STT.pl._plot_tensor import plot_pathway
+
+    adata = types.SimpleNamespace(
+        uns={
+            "pathway_select": {"p1": [], "p2": []},
+            "pathway_embedding": np.array([[0.0, 0.0], [1.0, 1.0]]),
+            "pathway_labels": np.array([0, 1]),
+        }
+    )
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", MatplotlibDeprecationWarning)
+        plot_pathway(adata)
+    plt.close("all")

--- a/tests/others/test_pl_public_api_scanpy_compat.py
+++ b/tests/others/test_pl_public_api_scanpy_compat.py
@@ -55,6 +55,32 @@ def test_public_plot_set_smoke():
     assert plt.rcParams["figure.dpi"] == 60
 
 
+def test_plot_convex_hull_is_exported():
+    assert callable(ov.pl.plot_ConvexHull)
+
+
+def test_stacking_vol_is_exported():
+    assert callable(ov.pl.stacking_vol)
+
+
+def test_stacking_vol_legacy_wrapper(monkeypatch):
+    import omicverse.pl._plot_backend as backend
+
+    calls = []
+
+    def fake_stacking_vol(*args, **kwargs):
+        calls.append((args, kwargs))
+        return "stacked"
+
+    monkeypatch.setattr(backend, "stacking_vol", fake_stacking_vol)
+
+    with pytest.warns(DeprecationWarning, match="ov.pl.stacking_vol"):
+        result = ov.utils.stacking_vol("data", alpha=0.5)
+
+    assert result == "stacked"
+    assert calls == [(('data',), {"alpha": 0.5})]
+
+
 def test_public_embedding_smoke(toy_adata):
     with warnings.catch_warnings(record=True) as captured:
         warnings.simplefilter("always")

--- a/tests/utils/test_agent_initialization.py
+++ b/tests/utils/test_agent_initialization.py
@@ -54,7 +54,8 @@ def test_utils_exports_agent_entrypoints(monkeypatch):
             "blue_palette", "orange_palette", "red_palette", "green_palette",
             "plot_text_set", "ticks_range", "plot_boxplot", "plot_network",
             "plot_cellproportion", "plot_embedding_celltype", "geneset_wordcloud",
-            "plot_pca_variance_ratio", "gen_mpl_labels"
+            "plot_pca_variance_ratio", "plot_ConvexHull", "stacking_vol",
+            "gen_mpl_labels",
         ],
         "_mde": ["mde"],
         "_syn": ["logger", "pancreas", "synthetic_iid", "url_datadir"],

--- a/tests/utils/test_heatmap.py
+++ b/tests/utils/test_heatmap.py
@@ -31,6 +31,47 @@ def test_plot_heatmap_accepts_sparse_view():
     plt.close(grid.fig)
 
 
+def test_make_dense_accepts_sparse_matrix_without_matrix_shortcuts():
+    """SciPy sparse matrices no longer expose the ``.A`` and ``.A1`` aliases."""
+    from omicverse.utils._heatmap import make_dense
+
+    matrix = sparse.csr_matrix([[1.0, 2.0], [3.0, 4.0]])
+
+    result = make_dense(matrix)
+
+    assert isinstance(result, np.ndarray)
+    np.testing.assert_array_equal(result, [[1.0, 2.0], [3.0, 4.0]])
+
+
+def test_make_dense_preserves_matrix_vector_semantics():
+    from omicverse.utils._heatmap import make_dense
+
+    result = make_dense(np.matrix([[1.0, 2.0]]))
+
+    np.testing.assert_array_equal(result, [1.0, 2.0])
+
+
+def test_interpret_colorkey_densifies_sparse_gene_vector():
+    from omicverse.utils._heatmap import interpret_colorkey
+
+    class SparseExpressionAdata:
+        var_names = ["g1"]
+        layers = {}
+        raw = None
+        obs = pd.DataFrame()
+
+        @staticmethod
+        def obs_vector(key, layer=None):
+            assert key == "g1"
+            assert layer is None
+            return sparse.csr_matrix([[1.0], [2.0], [3.0]])
+
+    result = interpret_colorkey(SparseExpressionAdata(), "g1")
+
+    assert isinstance(result, np.ndarray)
+    np.testing.assert_array_equal(result, [1.0, 2.0, 3.0])
+
+
 def test_set_colors_accepts_sequence_palette():
     from omicverse.utils._heatmap import set_colors_for_categorical_obs
 

--- a/tests/utils/test_heatmap.py
+++ b/tests/utils/test_heatmap.py
@@ -1,0 +1,47 @@
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from anndata import AnnData
+from scipy import sparse
+
+
+def test_plot_heatmap_accepts_sparse_view():
+    from omicverse.utils._heatmap import plot_heatmap
+
+    matrix = sparse.csr_matrix([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
+    adata = AnnData(matrix)
+    adata.var_names = ["g1", "g2"]
+    adata.obs["latent_time"] = [0.0, 1.0, 2.0]
+    adata.layers["Ms"] = matrix.copy()
+
+    grid = plot_heatmap(
+        adata,
+        ["g1", "g2"],
+        n_convolve=None,
+        row_cluster=False,
+        col_cluster=False,
+        show=False,
+    )
+
+    assert grid is not None
+    plt.close(grid.fig)
+
+
+def test_set_colors_accepts_sequence_palette():
+    from omicverse.utils._heatmap import set_colors_for_categorical_obs
+
+    adata = AnnData(
+        np.ones((2, 1)),
+        obs=pd.DataFrame(
+            {"group": pd.Categorical(["A", "B"])},
+            index=["c1", "c2"],
+        ),
+    )
+
+    set_colors_for_categorical_obs(adata, "group", ("red", "blue"))
+
+    assert list(adata.uns["group_colors"]) == ["#ff0000", "#0000ff"]

--- a/tests/utils/test_plotting_deprecation_wrappers.py
+++ b/tests/utils/test_plotting_deprecation_wrappers.py
@@ -8,32 +8,32 @@ from pathlib import Path
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 
 
-def _load_module(module_name: str, relative_path: str):
+def _load_module(monkeypatch, module_name: str, relative_path: str):
     path = PROJECT_ROOT / relative_path
     spec = importlib.util.spec_from_file_location(module_name, path)
     module = importlib.util.module_from_spec(spec)
     assert spec.loader is not None
-    sys.modules[module_name] = module
+    monkeypatch.setitem(sys.modules, module_name, module)
     spec.loader.exec_module(module)
     return module
 
 
-def _seed_packages():
+def _seed_packages(monkeypatch):
     omicverse_pkg = types.ModuleType("omicverse")
     omicverse_pkg.__path__ = [str(PROJECT_ROOT / "omicverse")]
-    sys.modules["omicverse"] = omicverse_pkg
+    monkeypatch.setitem(sys.modules, "omicverse", omicverse_pkg)
 
     pl_pkg = types.ModuleType("omicverse.pl")
     pl_pkg.__path__ = [str(PROJECT_ROOT / "omicverse" / "pl")]
-    sys.modules["omicverse.pl"] = pl_pkg
+    monkeypatch.setitem(sys.modules, "omicverse.pl", pl_pkg)
 
     utils_pkg = types.ModuleType("omicverse.utils")
     utils_pkg.__path__ = [str(PROJECT_ROOT / "omicverse" / "utils")]
-    sys.modules["omicverse.utils"] = utils_pkg
+    monkeypatch.setitem(sys.modules, "omicverse.utils", utils_pkg)
 
 
 def test_utils_plot_wrapper_warns_and_delegates(monkeypatch):
-    _seed_packages()
+    _seed_packages(monkeypatch)
     calls = []
 
     backend = types.ModuleType("omicverse.pl._plot_backend")
@@ -78,7 +78,7 @@ def test_utils_plot_wrapper_warns_and_delegates(monkeypatch):
     backend.pastel_palette = []
     monkeypatch.setitem(sys.modules, "omicverse.pl._plot_backend", backend)
 
-    module = _load_module("omicverse.utils._plot", "omicverse/utils/_plot.py")
+    module = _load_module(monkeypatch, "omicverse.utils._plot", "omicverse/utils/_plot.py")
 
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
@@ -91,8 +91,50 @@ def test_utils_plot_wrapper_warns_and_delegates(monkeypatch):
     assert any("ov.pl.plot_set" in message for message in messages)
 
 
+def test_stacking_vol_wrapper_warns_and_delegates(monkeypatch):
+    _seed_packages(monkeypatch)
+    calls = []
+    backend = types.ModuleType("omicverse.pl._plot_backend")
+
+    def stacking_vol(*args, **kwargs):
+        calls.append((args, kwargs))
+        return "stacked"
+
+    backend.stacking_vol = stacking_vol
+    monkeypatch.setitem(sys.modules, "omicverse.pl._plot_backend", backend)
+    module = _load_module(monkeypatch, "omicverse.utils._plot", "omicverse/utils/_plot.py")
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        assert module.stacking_vol("data", alpha=0.5) == "stacked"
+
+    assert calls == [(('data',), {"alpha": 0.5})]
+    assert any("ov.pl.stacking_vol" in str(warning.message) for warning in caught)
+
+
+def test_plot_convex_hull_wrapper_warns_and_delegates(monkeypatch):
+    _seed_packages(monkeypatch)
+    calls = []
+    backend = types.ModuleType("omicverse.pl._plot_backend")
+
+    def plot_convex_hull(*args, **kwargs):
+        calls.append((args, kwargs))
+        return "hull"
+
+    backend.plot_ConvexHull = plot_convex_hull
+    monkeypatch.setitem(sys.modules, "omicverse.pl._plot_backend", backend)
+    module = _load_module(monkeypatch, "omicverse.utils._plot", "omicverse/utils/_plot.py")
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        assert module.plot_ConvexHull("adata", alpha=0.2) == "hull"
+
+    assert calls == [(('adata',), {"alpha": 0.2})]
+    assert any("ov.pl.plot_ConvexHull" in str(warning.message) for warning in caught)
+
+
 def test_utils_scatterplot_wrapper_warns_and_delegates(monkeypatch):
-    _seed_packages()
+    _seed_packages(monkeypatch)
     calls = []
 
     backend = types.ModuleType("omicverse.pl._scatterplot_backend")
@@ -123,7 +165,7 @@ def test_utils_scatterplot_wrapper_warns_and_delegates(monkeypatch):
         setattr(backend, name, embedding)
     monkeypatch.setitem(sys.modules, "omicverse.pl._scatterplot_backend", backend)
 
-    module = _load_module("omicverse.utils._scatterplot", "omicverse/utils/_scatterplot.py")
+    module = _load_module(monkeypatch, "omicverse.utils._scatterplot", "omicverse/utils/_scatterplot.py")
 
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
@@ -135,7 +177,7 @@ def test_utils_scatterplot_wrapper_warns_and_delegates(monkeypatch):
 
 
 def test_utils_venn_wrapper_warns_and_delegates(monkeypatch):
-    _seed_packages()
+    _seed_packages(monkeypatch)
     calls = []
 
     backend = types.ModuleType("omicverse.pl._venn_backend")
@@ -149,7 +191,7 @@ def test_utils_venn_wrapper_warns_and_delegates(monkeypatch):
     backend.venny4py = venny4py
     monkeypatch.setitem(sys.modules, "omicverse.pl._venn_backend", backend)
 
-    module = _load_module("omicverse.utils._venn", "omicverse/utils/_venn.py")
+    module = _load_module(monkeypatch, "omicverse.utils._venn", "omicverse/utils/_venn.py")
 
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")


### PR DESCRIPTION
## Summary

Restores plotting compatibility for current SciPy, AnnData, and Matplotlib versions.

## Changes

- Replaces removed sparse-matrix .A access with .toarray() in plot_heatmap.
- Restores ov.pl.plot_ConvexHull and ov.pl.stacking_vol.
- Keeps legacy ov.utils entry points through deprecation-warning wrappers.
- Updates plotting registry examples and docstrings to use canonical ov.pl APIs.
- Fixes categorical palette handling for sequence inputs.
- Replaces the deprecated STT colormap accessor.
- Makes plotting wrapper tests isolate sys.modules correctly.

## Validation

- 1402 plotting, API, wrapper, and architecture tests passed.
- The real ov.utils.stacking_vol compatibility path is covered.

Refs #869