### PR TITLE
fix(pp): filter unsupported RAPIDS UMAP options

### DIFF
--- a/omicverse/pp/_preprocess.py
+++ b/omicverse/pp/_preprocess.py
@@ -1915,14 +1915,19 @@ def umap(
             try:
                 print(f"{EMOJI['gpu']} Using RAPIDS GPU UMAP...")
                 import rapids_singlecell as rsc
-                rsc.tl.umap(adata, **kwargs)
+                rapids_kwargs = kwargs.copy()
+                rapids_kwargs.pop('gamma', None)
+                rapids_kwargs.pop('method', None)
+                rsc.tl.umap(adata, **rapids_kwargs)
                 add_reference(adata, 'umap', 'UMAP with RAPIDS')
                 note(backend=f"omicverse({settings.mode}) · rapids")
             except Exception as e:
                 print(f"{EMOJI['error']} RAPIDS GPU UMAP failed: {e}")
                 print(f"{EMOJI['error']} Using GPU non-parametric UMAP instead...")
                 from ._umap import umap as _umap
-                _umap(adata, method='umap-gpu', **kwargs)
+                fallback_kwargs = kwargs.copy()
+                fallback_kwargs.pop('method', None)
+                _umap(adata, method='umap-gpu', **fallback_kwargs)
                 note(backend=f"omicverse({settings.mode}) · umap-gpu")
         note(viz=[{"function": "ov.pl.embedding",
                     "kwargs": {"basis": "X_umap",

--- a/omicverse/pp/_preprocess.py
+++ b/omicverse/pp/_preprocess.py
@@ -1908,7 +1908,9 @@ def umap(
             print(f"{EMOJI['gpu']} Using torch GPU to calculate UMAP (non-parametric)...")
             print_gpu_usage_color()
             from ._umap import umap as _umap
-            _umap(adata, method='umap-gpu', **kwargs)
+            mixed_kwargs = kwargs.copy()
+            mixed_kwargs.pop('method', None)
+            _umap(adata, method='umap-gpu', **mixed_kwargs)
             add_reference(adata, 'umap', 'UMAP with gpuex (non-parametric)')
             note(backend=f"omicverse({settings.mode}) · umap-gpu")
         else:

--- a/tests/pp/test_umap_rapids.py
+++ b/tests/pp/test_umap_rapids.py
@@ -49,7 +49,10 @@ def test_umap_falls_back_from_rapids(monkeypatch):
     monkeypatch.setattr(preprocess, "note", lambda **kwargs: None)
     monkeypatch.setattr(preprocess, "pick_color_key", lambda adata: None)
 
-    preprocess.umap(AnnData(np.ones((2, 2))), method="rapids", gamma=2.0)
+    preprocess.umap(
+        AnnData(np.ones((2, 2))), method="rapids", gamma=2.0, min_dist=0.2
+    )
 
     assert captured["method"] == "umap-gpu"
     assert captured["gamma"] == 2.0
+    assert captured["min_dist"] == 0.2

--- a/tests/pp/test_umap_rapids.py
+++ b/tests/pp/test_umap_rapids.py
@@ -56,3 +56,28 @@ def test_umap_falls_back_from_rapids(monkeypatch):
     assert captured["method"] == "umap-gpu"
     assert captured["gamma"] == 2.0
     assert captured["min_dist"] == 0.2
+
+
+def test_umap_mixed_mode_overrides_dispatcher_method(monkeypatch):
+    preprocess = importlib.import_module("omicverse.pp._preprocess")
+    umap_backend = importlib.import_module("omicverse.pp._umap")
+    captured = {}
+
+    def fake_backend(adata, **kwargs):
+        del adata
+        captured.update(kwargs)
+
+    monkeypatch.setattr(umap_backend, "umap", fake_backend)
+    monkeypatch.setattr(preprocess.settings, "mode", "cpu-gpu-mixed")
+    monkeypatch.setattr(preprocess, "print_gpu_usage_color", lambda: None)
+    monkeypatch.setattr(preprocess, "add_reference", lambda *args, **kwargs: None)
+    monkeypatch.setattr(preprocess, "note", lambda **kwargs: None)
+    monkeypatch.setattr(preprocess, "pick_color_key", lambda adata: None)
+
+    preprocess.umap(
+        AnnData(np.ones((2, 2))), method="rapids", gamma=2.0, min_dist=0.2
+    )
+
+    assert captured["method"] == "umap-gpu"
+    assert captured["gamma"] == 2.0
+    assert captured["min_dist"] == 0.2

--- a/tests/pp/test_umap_rapids.py
+++ b/tests/pp/test_umap_rapids.py
@@ -1,0 +1,55 @@
+import importlib
+import sys
+import types
+
+import numpy as np
+from anndata import AnnData
+
+
+def test_umap_filters_unsupported_rapids_options(monkeypatch):
+    import omicverse.pp._preprocess as preprocess
+
+    captured = {}
+
+    def fake_umap(adata, **kwargs):
+        del adata
+        captured.update(kwargs)
+
+    fake_rsc = types.SimpleNamespace(tl=types.SimpleNamespace(umap=fake_umap))
+    monkeypatch.setitem(sys.modules, "rapids_singlecell", fake_rsc)
+    monkeypatch.setattr(preprocess.settings, "mode", "gpu")
+    monkeypatch.setattr(preprocess, "add_reference", lambda *args, **kwargs: None)
+    monkeypatch.setattr(preprocess, "note", lambda **kwargs: None)
+    monkeypatch.setattr(preprocess, "pick_color_key", lambda adata: None)
+
+    preprocess.umap(AnnData(np.ones((2, 2))), method="rapids", gamma=2.0)
+
+    assert "gamma" not in captured
+    assert "method" not in captured
+    assert captured["min_dist"] == 0.5
+
+
+def test_umap_falls_back_from_rapids(monkeypatch):
+    preprocess = importlib.import_module("omicverse.pp._preprocess")
+    umap_backend = importlib.import_module("omicverse.pp._umap")
+    captured = {}
+
+    def fail_rapids(adata, **kwargs):
+        del adata, kwargs
+        raise RuntimeError("RAPIDS unavailable")
+
+    def fake_fallback(adata, **kwargs):
+        del adata
+        captured.update(kwargs)
+
+    fake_rsc = types.SimpleNamespace(tl=types.SimpleNamespace(umap=fail_rapids))
+    monkeypatch.setitem(sys.modules, "rapids_singlecell", fake_rsc)
+    monkeypatch.setattr(umap_backend, "umap", fake_fallback)
+    monkeypatch.setattr(preprocess.settings, "mode", "gpu")
+    monkeypatch.setattr(preprocess, "note", lambda **kwargs: None)
+    monkeypatch.setattr(preprocess, "pick_color_key", lambda adata: None)
+
+    preprocess.umap(AnnData(np.ones((2, 2))), method="rapids", gamma=2.0)
+
+    assert captured["method"] == "umap-gpu"
+    assert captured["gamma"] == 2.0


### PR DESCRIPTION
## Summary

Prevents OmicVerse dispatcher options from reaching RAPIDS SingleCell UMAP.

## Changes

- Removes unsupported gamma and dispatcher-only method options from RAPIDS UMAP calls.
- Preserves gamma for the OmicVerse GPU UMAP fallback.
- Removes the conflicting dispatcher method before fallback execution.

## Validation

- 2 RAPIDS dispatch and fallback regression tests passed.
- Tests use a fake RAPIDS backend because CUDA and RAPIDS are not available locally.

Refs #869