### PR TITLE
chore(via): remove unused AdjlstGraph import

### DIFF
--- a/omicverse/external/VIA/core.py
+++ b/omicverse/external/VIA/core.py
@@ -138,9 +138,6 @@ def _rw2_walks(A: ndarray, root: int, memory: float = 0.8, weighted: bool = True
     :param walk_length: default None (walk_length = num_nodes *2)
     :return: implicit_ids
     '''
-    from pecanpy.graph import AdjlstGraph
-    # initialize SparseGraph object
-    # g = AdjlstGraph()
     # setting up the lazy-teleporting behaviour
     n_states = A.shape[0]
     P = A / A.sum(axis=1).reshape((n_states, 1))


### PR DESCRIPTION
## Summary

Removes the unused AdjlstGraph import from VIA random-walk generation.

## Notes

The random-walk implementation continues to use PecanPy through SparseOTF. This cleanup does not remove or change the active PecanPy dependency.

## Validation

- A minimal _rw2_walks() smoke run completed successfully.

Refs #869