### PR TITLE
fix(wgcna): restore SciPy 1.18 compatibility and serialization

### DIFF
--- a/omicverse/_registry.py
+++ b/omicverse/_registry.py
@@ -1218,24 +1218,26 @@ def register_function(aliases: List[str],
             produces=produces,
             auto_fix=auto_fix
         )
-        
-        @wraps(func)
-        def wrapper(*args, **kwargs):
-            return func(*args, **kwargs)
 
-        # Add registry info to function
-        wrapper._registry_info = {
+        registry_info = {
             'aliases': aliases,
             'category': category,
             'description': description
         }
 
-        # If func is a class, copy over class methods and static methods
-        import inspect
+        # Classes must remain bound to their original module-level name.
+        # Replacing a class with a function wrapper breaks class identity and
+        # makes its instances impossible to pickle.
         if inspect.isclass(func):
-            for name, value in inspect.getmembers(func):
-                if isinstance(inspect.getattr_static(func, name), (classmethod, staticmethod)):
-                    setattr(wrapper, name, value)
+            func._registry_info = registry_info
+            return func
+
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            return func(*args, **kwargs)
+
+        # Add registry info to function
+        wrapper._registry_info = registry_info
 
         return wrapper
     

--- a/omicverse/bulk/_dynamicTree.py
+++ b/omicverse/bulk/_dynamicTree.py
@@ -317,7 +317,7 @@ def cutreeHybrid(link, distM,
                 clusts = IndMergeToBranch[dendro_merge[merge,] - 1]
                 sizes = branch_size[clusts - 1]
                 # Note: for 2 elements, rank and order are the same.
-                rnk = rankdata(sizes, method = "ordinal")
+                rnk = np.asarray(rankdata(sizes, method = "ordinal"), dtype=np.intp)
                 small = clusts[rnk[0] - 1]
                 large = clusts[rnk[1] - 1]
                 sizes = sizes[rnk - 1]
@@ -776,7 +776,13 @@ def cutreeHybrid(link, distM,
 
     if UnlabeledExist:
         if len(Sizes) > 1:
-            SizeRank = np.append(1, rankdata(-Sizes[1:len(Sizes)], method="ordinal")+1)
+            SizeRank = np.append(
+                1,
+                np.asarray(
+                    rankdata(-Sizes[1:len(Sizes)], method="ordinal"),
+                    dtype=np.intp,
+                ) + 1,
+            )
         else:
             # Only one label (every gene unassigned / grey). SizeRank must stay
             # an array so the SizeRank[NumLabs - 1] gather below works — a bare
@@ -784,7 +790,10 @@ def cutreeHybrid(link, distM,
             SizeRank = np.array([1])
         OrdNumLabs = SizeRank[NumLabs - 1]
     else:
-        SizeRank = rankdata(-Sizes[np.arange(len(Sizes))], method="ordinal")
+        SizeRank = np.asarray(
+            rankdata(-Sizes[np.arange(len(Sizes))], method="ordinal"),
+            dtype=np.intp,
+        )
         OrdNumLabs = SizeRank[NumLabs - 2]
     ordCoreLabels = OrdNumLabs - UnlabeledExist
     ordCoreLabels[coreLabels == 0] = 0
@@ -945,7 +954,6 @@ def table(vector):
         results.iloc[i] = np.sum(vector == k)
         
     return(results)
-
 
 
 

--- a/omicverse/external/PyWGCNA/wgcna.py
+++ b/omicverse/external/PyWGCNA/wgcna.py
@@ -2109,7 +2109,7 @@ class pyWGCNA(GeneExp):
                 else:
                     clusts = IndMergeToBranch[dendro_merge[merge, :].astype(int) - 1]
                     sizes = branch_size[clusts - 1]
-                    rnk = rankdata(sizes, method="ordinal")
+                    rnk = np.asarray(rankdata(sizes, method="ordinal"), dtype=np.intp)
                     small = clusts[rnk[0] - 1]
                     large = clusts[rnk[1] - 1]
                     sizes = sizes[rnk - 1]
@@ -2506,13 +2506,23 @@ class pyWGCNA(GeneExp):
 
         if UnlabeledExist:
             if len(Sizes) > 1:
-                SizeRank = np.insert(stats.rankdata(-1 * Sizes[1:len(Sizes)], method='ordinal') + 1, 0, 1)
+                SizeRank = np.insert(
+                    np.asarray(
+                        stats.rankdata(-1 * Sizes[1:len(Sizes)], method='ordinal'),
+                        dtype=np.intp,
+                    ) + 1,
+                    0,
+                    1,
+                )
             else:
                 SizeRank = [1]
             for i in range(len(NumLabs)):
                 OrdNumLabs.Value[i] = SizeRank[NumLabs[i] - 1]
         else:
-            SizeRank = stats.rankdata(-1 * Sizes, method='ordinal')
+            SizeRank = np.asarray(
+                stats.rankdata(-1 * Sizes, method='ordinal'),
+                dtype=np.intp,
+            )
             for i in range(len(NumLabs)):
                 OrdNumLabs.Value[i] = SizeRank[NumLabs[i] - 1]
 
@@ -2544,20 +2554,29 @@ class pyWGCNA(GeneExp):
             colorSeq = create_custom_color_seq(colors, naColor)
             colorSeq = interleave_colors(colorSeq)
 
-        if all(isinstance(x, int) for x in labels.Value):
-            if zeroIsGrey:
-                minLabel = 0
-            else:
-                minLabel = 1
-            if np.any(labels.Value < 0):
-                minLabel = np.min(labels.Value)
-            nLabels = labels.copy()
+        if isinstance(labels, pd.DataFrame):
+            if "Value" not in labels.columns:
+                raise ValueError("labels DataFrame must contain a 'Value' column")
+            label_values = labels["Value"].to_numpy()
+        elif isinstance(labels, pd.Series):
+            label_values = labels.to_numpy()
         else:
-            factors = pd.Categorical(labels.Value)
-            nLabels = factors.codes
+            label_values = np.asarray(labels)
 
-        if np.max(nLabels.Value) > len(colorSeq):
-            nRepeats = int((np.max(labels.Value) - 1) / len(colorSeq)) + 1
+        label_values = np.asarray(label_values).reshape(-1)
+        fin = np.asarray(pd.notna(label_values), dtype=bool)
+
+        if is_numeric_dtype(label_values) and np.all(
+            label_values[fin] == np.floor(label_values[fin])
+        ):
+            nLabels = np.zeros(label_values.shape[0], dtype=np.intp)
+            nLabels[fin] = label_values[fin].astype(np.intp, copy=False)
+        else:
+            nLabels = pd.Categorical(label_values).codes.astype(np.intp, copy=False)
+
+        maxLabel = int(np.max(nLabels[fin])) if np.any(fin) else -1
+        if maxLabel >= len(colorSeq):
+            nRepeats = int((maxLabel - 1) / len(colorSeq)) + 1
             print(f"{WARNING}labels2colors: Number of labels exceeds number of avilable colors.\n"
                   f"Some colors will be repeated {str(nRepeats)} times.{ENDC}")
             extColorSeq = colorSeq
@@ -2569,11 +2588,8 @@ class pyWGCNA(GeneExp):
             extColorSeq = colorSeq
 
         colors = np.empty(nLabels.shape[0], dtype=object)
-        fin = [v is not None for v in nLabels.Value]
-        fin = np.atleast_1d(fin)
         colors[~fin] = naColor
-        finLabels = nLabels.loc[fin, :]
-        colors[fin] = [extColorSeq[x] for x in finLabels.Value]
+        colors[fin] = [extColorSeq[x] for x in nLabels[fin]]
 
         return colors
 

--- a/tests/bulk/test_wgcna_compat.py
+++ b/tests/bulk/test_wgcna_compat.py
@@ -1,0 +1,73 @@
+import inspect
+
+import numpy as np
+import pandas as pd
+from scipy.cluster.hierarchy import linkage
+from scipy.spatial.distance import pdist
+
+
+def test_float_ranks(monkeypatch):
+    import omicverse.bulk._dynamicTree as dynamic_tree
+
+    points = np.array(
+        [[0.0], [0.01], [0.2], [0.21], [1.0], [1.01], [1.2], [1.21]]
+    )
+    distances = pdist(points)
+    gene_tree = linkage(distances, method="average")
+    rankdata = dynamic_tree.rankdata
+
+    def float_rankdata(*args, **kwargs):
+        return np.asarray(rankdata(*args, **kwargs), dtype=float)
+
+    monkeypatch.setattr(dynamic_tree, "rankdata", float_rankdata)
+
+    result = dynamic_tree.cutreeHybrid(
+        gene_tree,
+        distM=distances,
+        minClusterSize=2,
+        deepSplit=2,
+        pamStage=False,
+    )
+
+    assert np.issubdtype(np.asarray(result["labels"]).dtype, np.integer)
+
+
+def test_float_labels():
+    from omicverse.external.PyWGCNA.wgcna import pyWGCNA
+
+    labels = pd.DataFrame(
+        {
+            "Name": [0.0, 1.0, 2.0],
+            "Value": [0.0, 1.0, 2.0],
+        }
+    )
+
+    colors = pyWGCNA.labels2colors(
+        labels,
+        colorSeq=["grey", "blue", "brown"],
+    )
+
+    assert colors.tolist() == ["grey", "blue", "brown"]
+
+
+def test_save_roundtrip(tmp_path):
+    import omicverse as ov
+
+    expression = pd.DataFrame(
+        [[1.0, 2.0], [3.0, 4.0]],
+        index=["sample-1", "sample-2"],
+        columns=["gene-1", "gene-2"],
+    )
+    wgcna = ov.bulk.pyWGCNA(
+        name="pickle-smoke",
+        species="mus musculus",
+        geneExp=expression,
+        outputPath=f"{tmp_path}/",
+        save=False,
+    )
+
+    wgcna.saveWGCNA()
+    restored = ov.bulk.readWGCNA(tmp_path / "pickle-smoke.p")
+
+    assert inspect.isclass(ov.bulk.pyWGCNA)
+    assert type(restored) is type(wgcna)


### PR DESCRIPTION
## Summary

Fixes #868.

The PyWGCNA tutorial workflow could fail at multiple consecutive stages with SciPy 1.18:

1. `calculate_dynamicMods()` used floating-point ordinal ranks as NumPy indices, raising an `IndexError`.
2. After casting the first rank array, floating-point module labels propagated into `labels2colors()`, whose categorical branch created an ndarray but continued to access it through the DataFrame-only `.Value` attribute.
3. `saveWGCNA()` failed with a `PicklingError` because `register_function` replaced decorated classes with function wrappers, so the instance class no longer matched the class exposed under its module-qualified name.

This PR fixes the complete failure chain and adds deterministic regression coverage for dynamic module detection, label conversion, and WGCNA serialization.

## Root cause

SciPy 1.18 returns floating-point arrays from `scipy.stats.rankdata(..., method="ordinal")`. The dynamic-tree implementations assumed that these ranks were always integer arrays and used them directly for indexing and module-label construction.

The resulting integral floating-point labels entered the categorical branch of `labels2colors()`. That branch assigned `Categorical.codes`, an ndarray, to `nLabels`, while the remaining code still expected a DataFrame with a `Value` column.

Separately, the registry decorator registered the original class but returned a function wrapper. Pickle resolves classes through their module and class name, so instances of the original class could not be matched to the wrapper stored under `omicverse.external.PyWGCNA.wgcna.pyWGCNA`.

## Changes

- Convert ordinal rank results to `np.intp` before they are used as array indices or module labels.
- Apply the rank conversion consistently in both the canonical bulk dynamic-tree implementation and the mirrored PyWGCNA implementation.
- Normalize DataFrame, Series, and array-like label inputs to a one-dimensional array in `labels2colors()`.
- Preserve integral floating-point module labels as numeric labels instead of incorrectly converting them through categorical codes.
- Use a consistent ndarray-based path for label bounds, missing values, and color lookup.
- Extend repeated color sequences when the highest label equals the original sequence length, preventing an off-by-one index error at the palette boundary.
- Preserve decorated classes as classes in `register_function` while retaining their registry metadata. Existing function-decoration behavior is unchanged.
- Add regression tests for SciPy 1.18-style floating-point ordinal ranks, integral floating-point module labels, and public `saveWGCNA()`/`readWGCNA()` round-trip serialization.

## Results

- Dynamic module detection accepts SciPy 1.18 ordinal rank output without invalid NumPy indexing.
- Generated module labels retain an integer dtype.
- `labels2colors()` converts the reported floating-point labels without raising `AttributeError`.
- Color-sequence extension handles labels exactly at the palette-length boundary without indexing past the original sequence.
- Public `ov.bulk.pyWGCNA` remains a class.
- WGCNA objects can be saved and loaded through the documented public API.

## Validation

- Exact compatibility environment: Python 3.12, NumPy 2.2.6, SciPy 1.18.0, and Pandas 2.3.3: `3 passed`.
- Bulk, lazy WGCNA wiring, and registry class tests: `83 passed, 1 skipped`.
- Independent subagent review: no blocking findings; `90 passed` across focused WGCNA, registry, and MCP class tests.
- `git diff --check`.

Five unrelated cases in `tests/bulk/test_deg_backends.py` require the optional `pydeseq2` dependency, which was not installed in the local development environment. All other selected bulk tests passed.
