### PR TITLE
fix(latentvelo): restore preprocessing compatibility

### DIFF
--- a/omicverse/external/latentvelo/utils.py
+++ b/omicverse/external/latentvelo/utils.py
@@ -134,7 +134,9 @@ def _select_hvgs_from_log1p(adata, n_top_genes, subset=False):
         selection_X = np.log1p(selection_X)
     hvg_adata = ad.AnnData(X=selection_X, var=adata.var.copy())
 
-    highly_variable_genes(hvg_adata, n_top_genes=n_top_genes, subset=False)
+    highly_variable_genes(
+        hvg_adata, n_top_genes=n_top_genes, flavor='seurat', subset=False
+    )
     for key in (
         'highly_variable', 'means', 'dispersions', 'dispersions_norm',
         'highly_variable_rank', 'variances', 'variances_norm',

--- a/omicverse/external/latentvelo/utils.py
+++ b/omicverse/external/latentvelo/utils.py
@@ -10,7 +10,7 @@ import anndata as ad
 import gc
 from .velocity_genes import compute_velocity_genes
 
-from ...pp import umap,pca,neighbors,scale
+from ...pp import highly_variable_genes, umap, pca, neighbors, scale
 
 from ...pp._normalization import log1p
 
@@ -116,6 +116,38 @@ def _ensure_csr_local(adata):
             adata.obsp[k] = v.tocsr()
     return adata
 
+
+def _normalize_layer_by_size_factor(layer, size_factors):
+    """Scale rows while preserving an AnnData-supported sparse format."""
+    factors = np.asarray(size_factors).reshape(-1)
+    if scp.sparse.issparse(layer):
+        return layer.multiply(1.0 / factors[:, None]).tocsr()
+    return np.asarray(layer) / factors[:, None]
+
+
+def _select_hvgs_from_log1p(adata, n_top_genes, subset=False):
+    """Select HVGs from log1p data without changing the recipe input matrix."""
+    selection_X = adata.X.copy()
+    if scp.sparse.issparse(selection_X):
+        selection_X.data = np.log1p(selection_X.data)
+    else:
+        selection_X = np.log1p(selection_X)
+    hvg_adata = ad.AnnData(X=selection_X, var=adata.var.copy())
+
+    highly_variable_genes(hvg_adata, n_top_genes=n_top_genes, subset=False)
+    for key in (
+        'highly_variable', 'means', 'dispersions', 'dispersions_norm',
+        'highly_variable_rank', 'variances', 'variances_norm',
+        'highly_variable_nbatches', 'highly_variable_intersection',
+    ):
+        if key in hvg_adata.var:
+            adata.var[key] = hvg_adata.var[key]
+    if 'hvg' in hvg_adata.uns:
+        adata.uns['hvg'] = hvg_adata.uns['hvg']
+    if subset:
+        adata._inplace_subset_var(adata.var['highly_variable'].to_numpy())
+
+
 def unique_index(x):
     """
     find the index of the unique times for the ODE solver
@@ -219,8 +251,12 @@ def standard_clean_recipe(adata, spliced_key = 'spliced', unspliced_key = 'unspl
         spliced_all_size_factors = spliced_library_sizes/spliced_median_library_sizes
         unspliced_all_size_factors = unspliced_library_sizes/unspliced_median_library_sizes
         
-        adata.layers[spliced_key] = adata.layers[spliced_key]/spliced_all_size_factors
-        adata.layers[unspliced_key] = adata.layers[unspliced_key]/unspliced_all_size_factors
+        adata.layers[spliced_key] = _normalize_layer_by_size_factor(
+            adata.layers[spliced_key], spliced_all_size_factors
+        )
+        adata.layers[unspliced_key] = _normalize_layer_by_size_factor(
+            adata.layers[unspliced_key], unspliced_all_size_factors
+        )
 
         #adata.layers[spliced_key] = adata.layers[spliced_key].tocsr()
         #adata.layers[unspliced_key] = adata.layers[unspliced_key].tocsr()
@@ -231,7 +267,7 @@ def standard_clean_recipe(adata, spliced_key = 'spliced', unspliced_key = 'unspl
     adata.X = scp.sparse.csr_matrix(adata.layers[spliced_key].copy())
     
     if n_top_genes != None:
-        scv.pp.filter_genes_dispersion(adata, n_top_genes = n_top_genes, subset=False)
+        _select_hvgs_from_log1p(adata, n_top_genes=n_top_genes)
         
         if retain_genes == None and 'highly_variable' in adata.var.columns.values:
             print('Choosing top '+str(n_top_genes) + ' genes')
@@ -445,8 +481,12 @@ def anvi_clean_recipe(adata, spliced_key = 'spliced', unspliced_key = 'unspliced
         spliced_all_size_factors = spliced_library_sizes/spliced_median_library_sizes
         unspliced_all_size_factors = unspliced_library_sizes/unspliced_median_library_sizes
         
-        adata.layers[spliced_key] = adata.layers[spliced_key]/spliced_all_size_factors
-        adata.layers[unspliced_key] = adata.layers[unspliced_key]/unspliced_all_size_factors
+        adata.layers[spliced_key] = _normalize_layer_by_size_factor(
+            adata.layers[spliced_key], spliced_all_size_factors
+        )
+        adata.layers[unspliced_key] = _normalize_layer_by_size_factor(
+            adata.layers[unspliced_key], unspliced_all_size_factors
+        )
         
         adata.obs['spliced_size_factor'] = spliced_library_sizes #spliced_all_size_factors
         adata.obs['unspliced_size_factor'] = unspliced_library_sizes #unspliced_all_size_factors
@@ -455,7 +495,7 @@ def anvi_clean_recipe(adata, spliced_key = 'spliced', unspliced_key = 'unspliced
     adata.X = scp.sparse.csr_matrix(adata.layers[spliced_key].copy())
     
     if n_top_genes != None:
-        scv.pp.filter_genes_dispersion(adata, n_top_genes = n_top_genes, subset=False)
+        _select_hvgs_from_log1p(adata, n_top_genes=n_top_genes)
 
         # Convert COO matrices to CSR before subsetting (COO doesn't support indexing)
         for layer_key in [spliced_key, unspliced_key]:
@@ -639,8 +679,12 @@ def atac_clean_recipe(adata, spliced_key = 'spliced', unspliced_key = 'unspliced
         spliced_all_size_factors = spliced_library_sizes/spliced_median_library_sizes
         unspliced_all_size_factors = unspliced_library_sizes/unspliced_median_library_sizes
         
-        adata.layers[spliced_key] = adata.layers[spliced_key]/spliced_all_size_factors
-        adata.layers[unspliced_key] = adata.layers[unspliced_key]/unspliced_all_size_factors
+        adata.layers[spliced_key] = _normalize_layer_by_size_factor(
+            adata.layers[spliced_key], spliced_all_size_factors
+        )
+        adata.layers[unspliced_key] = _normalize_layer_by_size_factor(
+            adata.layers[unspliced_key], unspliced_all_size_factors
+        )
         
         adata.obs['spliced_size_factor'] = spliced_all_size_factors
         adata.obs['unspliced_size_factor'] = unspliced_all_size_factors
@@ -649,7 +693,7 @@ def atac_clean_recipe(adata, spliced_key = 'spliced', unspliced_key = 'unspliced
     adata.X = scp.sparse.csr_matrix(adata.layers[spliced_key].copy())
     
     if n_top_genes != None:
-        scv.pp.filter_genes_dispersion(adata, n_top_genes = n_top_genes)
+        _select_hvgs_from_log1p(adata, n_top_genes=n_top_genes, subset=True)
 
     adata.layers['mask_spliced'] = ((adata.layers[spliced_key] > 0) )*1
     adata.layers['mask_unspliced'] = ((adata.layers[unspliced_key] > 0))*1

--- a/tests/external/test_latentvelo_preprocessing_compat.py
+++ b/tests/external/test_latentvelo_preprocessing_compat.py
@@ -1,0 +1,47 @@
+import sys
+import types
+
+import numpy as np
+from anndata import AnnData
+from scipy import sparse
+
+# The helpers under test do not call scVelo, which is an optional CI dependency.
+_stubbed_scvelo = 'scvelo' not in sys.modules
+if _stubbed_scvelo:
+    sys.modules['scvelo'] = types.ModuleType('scvelo')
+try:
+    from omicverse.external.latentvelo.utils import (
+        _normalize_layer_by_size_factor,
+        _select_hvgs_from_log1p,
+    )
+finally:
+    if _stubbed_scvelo:
+        sys.modules.pop('scvelo', None)
+
+
+def _counts():
+    return sparse.csr_matrix(np.random.default_rng(864).poisson(2, size=(80, 120)))
+
+
+def test_latentvelo_hvg_selection_preserves_input_and_subsets():
+    counts = _counts()
+    adata = AnnData(X=counts.copy())
+    _select_hvgs_from_log1p(adata, n_top_genes=30)
+
+    assert (adata.X != counts).nnz == 0
+    assert 'highly_variable' in adata.var
+    expected_n_vars = int(adata.var['highly_variable'].sum())
+
+    subset_adata = AnnData(X=counts.copy())
+    _select_hvgs_from_log1p(subset_adata, n_top_genes=30, subset=True)
+
+    assert subset_adata.n_vars == expected_n_vars
+    assert subset_adata.var['highly_variable'].all()
+
+
+def test_latentvelo_sparse_size_normalization_stays_csr():
+    counts = _counts()
+    normalized = _normalize_layer_by_size_factor(counts, counts.sum(axis=1))
+
+    assert sparse.isspmatrix_csr(normalized)
+    np.testing.assert_allclose(normalized.sum(axis=1).A1, 1.0)


### PR DESCRIPTION
## Summary

Restore LatentVelo preprocessing compatibility with current scVelo and AnnData releases.

- Replace the removed `scvelo.preprocessing.filter_genes_dispersion` calls with OmicVerse-native HVG selection.
- Preserve the former HVG-selection semantics by running the `seurat` selector on a temporary log1p-transformed expression matrix.
- Keep the original recipe `X` and layers unchanged during HVG selection, while avoiding a deep copy of the complete AnnData object.
- Preserve CSR output after row-wise library-size normalization so AnnData 0.12+ accepts updated layers.
- Restore `n_top_genes` subsetting in the ATAC recipe.


The removed scVelo selector and OmicVerse’s `seurat` HVG implementation expect equivalent log1p expression semantics for ranking highly variable genes. LatentVelo performs its own log transform later in the recipe, so passing its library-normalized counts directly to `ov.pp.highly_variable_genes` would change the selected genes.

`_select_hvgs_from_log1p` creates a lightweight temporary AnnData containing only a copied `X` matrix and `var` metadata, applies log1p only to that temporary matrix, and transfers the HVG annotations back. This preserves the previous selection behavior without mutating the layers used by downstream velocity preprocessing or duplicating large layers and graphs.

## Validation

- Reproduced the removed scVelo API failure with scVelo 0.3.4.
- Verified CSR-preserving row normalization for sparse layers.
- Ran the LatentVelo standard-recipe compatibility smoke test through HVG selection, PCA, neighbor construction, and moments.
- Verified the temporary HVG selection leaves the original `X` unchanged and restores ATAC gene subsetting.
- Ran `python -m compileall omicverse/external/latentvelo/utils.py` and `git diff --check`.

Fixes #864