### PR TITLE
fix(pl): preserve PDF plot layout

### DIFF
--- a/omicverse/pl/_dotplot.py
+++ b/omicverse/pl/_dotplot.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Sequence, Mapping, Literal, Union, Optional, Tuple, Dict
 import numpy as np
 import pandas as pd
@@ -462,11 +463,19 @@ def dotplot(
     if dendrogram:
         m.add_dendrogram("right", pad=0.1)
     
+    if title:
+        m.add_title(top=title, pad=0.2, fontsize=fontsize + 1, fontweight="bold")
+
     # Add legends
     m.add_legends(box_padding=2)
     
     # Render the plot
-    fig = m.render()
+    m.render()
+    fig = m.figure
+
+    if save not in (None, False):
+        save_path = Path(save) if isinstance(save, str) else Path("dotplot.png")
+        fig.savefig(save_path, bbox_inches="tight", pad_inches=0.1)
     
     if return_fig:
         return fig
@@ -751,23 +760,24 @@ def rank_genes_groups_dotplot(
             title = values_to_plot.replace("_", " ").replace("pvals", "p-value")
 
     # Create the plot
+    if title is not None and "colorbar_title" not in kwds:
+        kwds["colorbar_title"] = title
+
     _pl = dotplot(
         adata,
         var_names,
         groupby,
         dot_color_df=values_df,
+        show=show,
+        save=save,
+        # This wrapper has historically needed the rendered Figure in order
+        # to preserve its default and ``show=False`` return behaviour.
         return_fig=True,
         gene_symbols=gene_symbols,
         preserve_dict_order=True,
         **kwds,
     )
-    
-    if title is not None and "colorbar_title" not in kwds:
-        _pl.legend(colorbar_title=title)
-    
-    if return_fig:
-        return _pl
-    elif not show:
+    if return_fig or not show:
         return _pl
     return None
 

--- a/omicverse/pl/_dotplot.py
+++ b/omicverse/pl/_dotplot.py
@@ -163,7 +163,7 @@ def dotplot(
     
     Returns:
         If `return_fig` is True, returns the figure object.
-        If `show` is False, returns axes dictionary.
+        If `show` is False, returns the rendered Marsilea board.
     """
     marsilea_version = getattr(ma, "__version__", "")
     if marsilea_version.startswith("0.5.6"):
@@ -641,7 +641,7 @@ def rank_genes_groups_dotplot(
     
     Returns:
         If `return_fig` is True, returns the figure object.
-        If `show` is False, returns axes dictionary.
+        If `show` is False, returns the rendered Matplotlib figure.
     
     Examples:
         >>> # Basic usage with top genes

--- a/omicverse/pl/_scatterplot_backend.py
+++ b/omicverse/pl/_scatterplot_backend.py
@@ -2,6 +2,7 @@ import collections.abc as cabc
 from copy import copy
 from numbers import Integral
 from itertools import combinations, product
+from pathlib import Path
 import matplotlib
 from typing import (
     Collection,
@@ -601,17 +602,13 @@ def embedding(
                 multi_panel=bool(grid),
             )
         elif colorbar_loc is not None:
-            # scvelo-style inset colorbar — `inset_axes` puts a 2 %-wide /
-            # 30 %-tall bar at the panel's lower-right corner inside the
-            # axes, so it never widens the panel footprint and the bar
-            # itself stays slim regardless of figure size. Inset children
-            # follow the parent ax automatically when set_position is
-            # called, so we don't need _flow_layout_panels to drag them.
+            # Native Matplotlib inset colorbar. Do not use axes_grid1 here:
+            # its locator interacts badly with PDF tight-bbox export when a
+            # colourbar contains rasterised artists.
             from matplotlib.ticker import MaxNLocator
-            from mpl_toolkits.axes_grid1.inset_locator import inset_axes as _inset_axes
 
-            cax1 = _inset_axes(
-                ax, width="2%", height="30%", loc='lower right', borderpad=0,
+            cax1 = ax.inset_axes(
+                [0.98, 0.0, 0.02, 0.30], transform=ax.transAxes,
             )
             # Register the inset so _flow_layout_panels measures its
             # tightbbox in Pass 1 — ax.get_tightbbox excludes children, so
@@ -633,7 +630,13 @@ def embedding(
     if return_fig is True:
         return fig
     axs = axs if grid else ax
-    savefig_or_show(basis, show=show, save=save)
+    if save not in (None, False):
+        save_path = Path(save) if isinstance(save, str) else Path(f"{basis}.png")
+        bbox_inches = None if save_path.suffix.lower() == ".pdf" else "tight"
+        fig.savefig(save_path, bbox_inches=bbox_inches, pad_inches=0.1)
+    should_show = settings.autoshow if show is None else show
+    if should_show:
+        pl.show()
     if show is False:
         return axs
 
@@ -813,10 +816,10 @@ def _flow_layout_panels(fig, axs, panel_colorbars=None, gap=0.3, margin=0.3):
         ]
         it['ax'].set_position(new_pos_norm)
 
-        # Drag the panel's colorbar along by re-applying the same
-        # (figure-normalised) offset it had from the panel pre-move.
+        # Native inset colorbars follow their parent panel automatically.
+        # Only legacy figure-coordinate axes need their position rewritten.
         cb_ax = it['cb_ax']
-        if cb_ax is not None:
+        if cb_ax is not None and cb_ax.get_axes_locator() is None:
             ap = it['ax_pos_pre']
             cp = it['cb_pos_pre']
             # offset of cb origin from panel origin, normalised by panel size

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ dependencies = [
     'requests>=2.0',
     'transformers>=0.30',
     'marsilea!=0.5.6',
+    'legendkit>=0.5.0',
     #'wandb',
     'openai>=1.0',
     'omicverse-skills>=0.3.0',

--- a/tests/pl/test_dotplot.py
+++ b/tests/pl/test_dotplot.py
@@ -3,6 +3,8 @@ import pandas as pd
 import pytest
 import warnings
 from anndata import AnnData
+from matplotlib.figure import Figure
+import matplotlib.pyplot as plt
 
 import omicverse.pl._dotplot as dotplot_mod
 
@@ -15,9 +17,14 @@ class _StubAnnotation:
 
 
 class _StubSizedHeatmap:
+    instances = []
+
     def __init__(self, *args, **kwargs):
         self.args = args
         self.kwargs = kwargs
+        self.figure = object()
+        self.title_calls = []
+        self.__class__.instances.append(self)
 
     def add_top(self, *args, **kwargs):
         return None
@@ -34,11 +41,16 @@ class _StubSizedHeatmap:
     def add_legends(self, *args, **kwargs):
         return None
 
+    def add_title(self, *args, **kwargs):
+        self.title_calls.append((args, kwargs))
+        return None
+
     def group_cols(self, *args, **kwargs):
         return None
 
     def render(self):
-        return object()
+        # Marsilea renders in place and exposes the result as ``.figure``.
+        return None
 
 
 @pytest.fixture
@@ -91,6 +103,61 @@ def test_dotplot_does_not_warn_for_fixed_marsilea_versions(simple_adata, stub_ma
         )
 
     assert not [w for w in record if "marsilea 0.5.6" in str(w.message)]
+
+
+def test_dotplot_honors_title_and_returns_rendered_figure(simple_adata, stub_marsilea):
+    _StubSizedHeatmap.instances.clear()
+    fig = dotplot_mod.dotplot(
+        simple_adata,
+        ["g1", "g2"],
+        groupby="cell_type",
+        title="Marker genes",
+        return_fig=True,
+    )
+
+    assert fig is _StubSizedHeatmap.instances[0].figure
+    assert _StubSizedHeatmap.instances[0].title_calls == [
+        ((), {"top": "Marker genes", "pad": 0.2, "fontsize": 13, "fontweight": "bold"})
+    ]
+
+
+def test_dotplot_pdf_export(simple_adata, tmp_path):
+    output = tmp_path / "dotplot.pdf"
+    fig = dotplot_mod.dotplot(
+        simple_adata,
+        ["g1", "g2"],
+        groupby="cell_type",
+        title="Marker genes",
+        save=str(output),
+        return_fig=True,
+    )
+
+    assert isinstance(fig, Figure)
+    assert output.read_bytes().startswith(b"%PDF")
+    assert any(text.get_text() == "Marker genes" for ax in fig.axes for text in ax.texts)
+    plt.close(fig)
+
+
+def test_rank_dotplot_preserves_figure_return(simple_adata, monkeypatch):
+    rendered_figure = object()
+    captured = {}
+
+    def fake_dotplot(*args, **kwargs):
+        captured.update(kwargs)
+        return rendered_figure
+
+    monkeypatch.setattr(dotplot_mod, "dotplot", fake_dotplot)
+
+    result = dotplot_mod.rank_genes_groups_dotplot(
+        simple_adata,
+        var_names=["g1", "g2"],
+        groups=["cell_type"],
+        groupby="cell_type",
+        show=False,
+    )
+
+    assert result is rendered_figure
+    assert captured["return_fig"] is True
 
 
 def test_rank_genes_groups_df_drops_unaligned_long_statistics():

--- a/tests/pl/test_plot_export.py
+++ b/tests/pl/test_plot_export.py
@@ -1,0 +1,31 @@
+import matplotlib.pyplot as plt
+import numpy as np
+from anndata import AnnData
+
+from omicverse.pl import _scatterplot_backend as scatterplot
+def test_continuous_embedding_does_not_use_axes_grid1_inset_axes(monkeypatch):
+    import mpl_toolkits.axes_grid1.inset_locator as inset_locator
+
+    adata = AnnData(np.ones((5, 2)))
+    adata.obsm["X_umap"] = np.array([[0, 0], [1, 0], [0, 1], [1, 1], [0.5, 0.5]])
+    adata.obs["score"] = np.linspace(0, 1, adata.n_obs)
+
+    def forbidden(*args, **kwargs):
+        raise AssertionError("axes_grid1.inset_axes must not be used for continuous embeddings")
+
+    monkeypatch.setattr(inset_locator, "inset_axes", forbidden)
+    fig = scatterplot.embedding(adata, "umap", color="score", return_fig=True)
+
+    assert len(fig.axes[0].child_axes) == 1
+    plt.close(fig)
+
+
+def test_continuous_embedding_public_save_writes_pdf_on_its_own_canvas(tmp_path):
+    adata = AnnData(np.ones((5, 2)))
+    adata.obsm["X_umap"] = np.array([[0, 0], [1, 0], [0, 1], [1, 1], [0.5, 0.5]])
+    adata.obs["score"] = np.linspace(0, 1, adata.n_obs)
+    output = tmp_path / "umap.pdf"
+
+    scatterplot.embedding(adata, "umap", color="score", show=False, save=str(output))
+
+    assert output.read_bytes().startswith(b"%PDF")

--- a/tests/pl/test_plot_export.py
+++ b/tests/pl/test_plot_export.py
@@ -3,6 +3,8 @@ import numpy as np
 from anndata import AnnData
 
 from omicverse.pl import _scatterplot_backend as scatterplot
+
+
 def test_continuous_embedding_does_not_use_axes_grid1_inset_axes(monkeypatch):
     import mpl_toolkits.axes_grid1.inset_locator as inset_locator
 


### PR DESCRIPTION
Refs #881

## Summary

This PR fixes PDF-export layout problems affecting Marsilea dot plots and continuous embedding plots.

With affected dependency combinations, dot-plot legends could be positioned inside the heatmap in PDF output. Continuous embedding colour bars could also shift when `axes_grid1.inset_axes` interacted with tight PDF bounding-box calculation.

## Changes

- add a direct `legendkit>=0.5.0` requirement for the Marsilea plotting stack;
- render dot plots in place and return/save their actual Matplotlib Figure;
- restore support for dot-plot titles and explicit `save=`;
- preserve the historical Figure-return contract of `rank_genes_groups_dotplot`;
- replace the continuous embedding colour bar with native `Axes.inset_axes`;
- prevent flow-layout code from manually moving native inset colour bars;
- save embedding PDFs from their owning Figure without a second tight-bbox relayout.

## Result

PDF exports now retain the expected title, legend placement, colour-bar placement, and panel geometry. PNG behaviour and existing public plotting APIs are preserved.

## Tests

- `python -m pytest tests/pl/test_dotplot.py tests/pl/test_plot_export.py -q` — 10 passed
- `python -m compileall -q omicverse/pl`
- `git diff --check`

The regression tests cover dot-plot PDF export, title and Figure handling, rank-dotplot return compatibility, and continuous-embedding PDF export without `axes_grid1.inset_axes`.
