### PR TITLE
fix(pp): coerce Leiden resolution to a scalar float (#877)

### DIFF
--- a/omicverse/pp/_leiden_gpu.py
+++ b/omicverse/pp/_leiden_gpu.py
@@ -278,6 +278,38 @@ def _choose_graph_local(adata, obsp_key, neighbors_key):
     return adata.obsp[obsp_name]
 
 
+def _coerce_resolution(resolution):
+    """Return ``resolution`` as a plain Python ``float``.
+
+    Programmatic / agent-generated callers sometimes pass a length-1
+    container (e.g. ``resolution=[1.0]``). Left as-is, the downstream
+    ``resolution * tensor`` in the local-move becomes Python **list
+    repetition**, which calls ``tensor.__index__()`` and raises the opaque
+    ``TypeError: only integer tensors of a single element can be converted
+    to an index`` (issue #877). Unwrap single-element containers; reject
+    multi-element ones with a clear message.
+    """
+    if isinstance(resolution, bool):  # avoid True/False sneaking through as 1/0
+        raise ValueError(f"ov.pp.leiden resolution must be a number, got {resolution!r}")
+    if isinstance(resolution, (int, float)):
+        return float(resolution)
+    if isinstance(resolution, (list, tuple)):
+        if len(resolution) != 1:
+            raise ValueError(
+                "ov.pp.leiden expects a single resolution value, got a "
+                f"{type(resolution).__name__} of length {len(resolution)}: "
+                f"{resolution!r}"
+            )
+        return _coerce_resolution(resolution[0])
+    # numpy / torch scalar or single-element array → float() handles these
+    try:
+        return float(resolution)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"ov.pp.leiden resolution must be a single number, got {resolution!r}"
+        ) from exc
+
+
 def leiden_gpu_sparse_multilevel(
     adata,
     resolution: float = 1.0,
@@ -322,6 +354,7 @@ def leiden_gpu_sparse_multilevel(
     -------
     None (modifies ``adata`` in place; see ``key_added``).
     """
+    resolution = _coerce_resolution(resolution)
     dev = _pick_device(device)
 
     # Small-N fast path: at small N the multilevel loop's thousands of

--- a/omicverse/pp/_leiden_gpu.py
+++ b/omicverse/pp/_leiden_gpu.py
@@ -301,7 +301,18 @@ def _coerce_resolution(resolution):
                 f"{resolution!r}"
             )
         return _coerce_resolution(resolution[0])
-    # numpy / torch scalar or single-element array → float() handles these
+    # numpy / torch scalar or single-element array/tensor. ``.item()`` unwraps
+    # a single element on numpy 1.x AND 2.x (numpy 2 removed the implicit
+    # float(size-1 array) conversion) and on torch; multi-element raises.
+    item = getattr(resolution, "item", None)
+    if callable(item):
+        try:
+            return float(item())
+        except Exception as exc:  # multi-element array/tensor, or non-numeric
+            raise ValueError(
+                "ov.pp.leiden expects a single resolution value, got "
+                f"{resolution!r}"
+            ) from exc
     try:
         return float(resolution)
     except (TypeError, ValueError) as exc:

--- a/omicverse/pp/_preprocess.py
+++ b/omicverse/pp/_preprocess.py
@@ -2102,6 +2102,17 @@ def leiden(
     leiden clustering
     '''
     random_state = resolve_random_state(random_state)
+    # A length-1 list/tuple resolution (seen from agent-generated code) would
+    # otherwise crash the torch GPU path with an opaque index TypeError
+    # (issue #877) and confuse scanpy / RAPIDS too. Normalise to a scalar.
+    if isinstance(resolution, (list, tuple)):
+        if len(resolution) != 1:
+            raise ValueError(
+                "ov.pp.leiden expects a single resolution value, got a "
+                f"{type(resolution).__name__} of length {len(resolution)}: "
+                f"{resolution!r}"
+            )
+        resolution = resolution[0]
     if settings.mode == 'cpu':
         print(f"{EMOJI['cpu']} Using Scanpy CPU Leiden...")
         from ._leiden import leiden as _leiden

--- a/tests/pp/test_leiden_resolution.py
+++ b/tests/pp/test_leiden_resolution.py
@@ -1,0 +1,52 @@
+"""Regression tests for issue #877 — a list/tuple ``resolution`` crashed the
+torch GPU Leiden path with an opaque
+``TypeError: only integer tensors of a single element can be converted to an
+index`` (``resolution * tensor`` became Python list-repetition inside the
+local-move). ``resolution`` must be coerced to a scalar float.
+"""
+import numpy as np
+import pytest
+
+
+def test_coerce_resolution_unwraps_scalars_and_containers():
+    from omicverse.pp._leiden_gpu import _coerce_resolution
+
+    assert _coerce_resolution(1.0) == 1.0
+    assert _coerce_resolution(2) == 2.0
+    assert _coerce_resolution([0.5]) == 0.5          # length-1 list
+    assert _coerce_resolution((0.8,)) == 0.8         # length-1 tuple
+    assert _coerce_resolution(np.float64(1.5)) == 1.5
+    assert _coerce_resolution(np.array([0.3])) == pytest.approx(0.3)
+
+
+def test_coerce_resolution_rejects_multi_element_and_junk():
+    from omicverse.pp._leiden_gpu import _coerce_resolution
+
+    for bad in ([1.0, 2.0], (0.5, 1.0), np.array([1.0, 2.0]), True, "x"):
+        with pytest.raises((ValueError, TypeError)):
+            _coerce_resolution(bad)
+
+
+def _small_adata_with_graph(n=200, seed=0):
+    import scanpy as sc
+    from anndata import AnnData
+
+    rng = np.random.default_rng(seed)
+    X = rng.normal(size=(n, 30)).astype(np.float32)
+    adata = AnnData(X)
+    sc.pp.pca(adata, n_comps=10)
+    sc.pp.neighbors(adata, n_neighbors=15, use_rep="X_pca")
+    return adata
+
+
+def test_leiden_gpu_multilevel_accepts_list_resolution():
+    """The exact #877 trigger: resolution=[1.0]. On a CPU-only box this
+    falls back to igraph Leiden, but the coercion runs first — the point is
+    it must NOT raise the index TypeError."""
+    from omicverse.pp._leiden_gpu import leiden_gpu_sparse_multilevel
+
+    adata = _small_adata_with_graph()
+    # would previously raise "only integer tensors ... converted to an index"
+    leiden_gpu_sparse_multilevel(adata, resolution=[1.0], key_added="leiden")
+    assert "leiden" in adata.obs
+    assert adata.obs["leiden"].nunique() >= 1


### PR DESCRIPTION
## Problem — closes #877
On the `cpu-gpu-mixed` torch Leiden path, a **length-1 list/tuple** `resolution` (e.g. `resolution=[1.0]`, as produced by some agent-generated code) crashed with an opaque error:
```
File ".../pp/_leiden_gpu.py", line 160, in _local_move
    gains = k_ic - resolution * ki * sig_eff / two_m
TypeError: only integer tensors of a single element can be converted to an index
```

**Root cause:** with a *list* `resolution`, `resolution * ki` is Python **list-repetition** (`list.__mul__`), which calls `ki.__index__()` on a multi-element tensor. Reproduced exactly: `[1.0] * torch.arange(5)` → this error (`1.0` / `np.float64(1.0)` are fine).

## Fix
- `leiden_gpu_sparse_multilevel` coerces `resolution` via a new `_coerce_resolution()` at entry — unwraps length-1 `list`/`tuple`, accepts numpy/torch scalars & single-element arrays, and rejects multi-element input with a clear message.
- `ov.pp.leiden` wrapper also normalises a length-1 list/tuple (torch-free) so the `cpu` (scanpy) and `gpu` (RAPIDS) backends are protected too.

## Tests
`tests/pp/test_leiden_resolution.py` — unit-tests the coercion (unwrap + reject), and an integration test running `leiden_gpu_sparse_multilevel(adata, resolution=[1.0])` end-to-end (3/3 pass; previously raised the index TypeError).

🤖 Generated with [Claude Code](https://claude.com/claude-code)