### PR TITLE
fix(pp): qc_gpu final filter uses cells/genes not counts (#862)

### DIFF
--- a/omicverse/pp/_qc.py
+++ b/omicverse/pp/_qc.py
@@ -1766,10 +1766,16 @@ def qc_gpu(adata, mode='seurat',
     cells_before_final = adata.shape[0]
     genes_before_final = adata.shape[1]
     
-    rsc.pp.filter_cells(adata, min_counts=min_genes)
-    rsc.pp.filter_cells(adata, max_counts=max_genes_ratio*adata.shape[1])
-    rsc.pp.filter_genes(adata, min_counts=min_cells)
-    rsc.pp.filter_genes(adata, max_counts=max_cells_ratio*adata.shape[0])
+    # NB: filter on *cells-per-gene* / *genes-per-cell*, not total UMI counts.
+    # Using min_counts/max_counts here (the old bug, #862) dropped highly
+    # expressed marker genes — e.g. with max_cells_ratio=1 any gene whose total
+    # UMIs exceed n_cells (S100A8, LYZ, FCGR3B, ...) was removed. rapids-singlecell
+    # exposes min_genes/max_genes/min_cells/max_cells separately, matching the CPU
+    # path's _filter_cells_impl / _filter_genes_impl.
+    rsc.pp.filter_cells(adata, min_genes=min_genes)
+    rsc.pp.filter_cells(adata, max_genes=int(max_genes_ratio*adata.shape[1]))
+    rsc.pp.filter_genes(adata, min_cells=min_cells)
+    rsc.pp.filter_genes(adata, max_cells=int(max_cells_ratio*adata.shape[0]))
     
     cells_final_filtered = cells_before_final - adata.shape[0]
     genes_final_filtered = genes_before_final - adata.shape[1]


### PR DESCRIPTION
## Summary

Fixes #862. The GPU QC path (`qc_gpu`, Step 3 "Final Filtering") forwarded the cell/gene filter thresholds to RAPIDS-SingleCell using the **wrong keyword arguments** — `min_counts`/`max_counts` instead of `min_genes`/`max_genes`/`min_cells`/`max_cells`.

With the default `max_cells_ratio=1`, the buggy call collapsed to:

```python
rsc.pp.filter_genes(adata, max_counts=n_cells)
```

which removes any gene whose **total UMI count** exceeds `n_cells`. That silently deleted highly expressed canonical markers (`S100A8`, `S100A9`, `LYZ`, `FCGR3B`, `CSF3R`, `CD74`, `HBB`, …), so downstream DotPlot / CellTypist appeared to "miss" common markers. Only the GPU path was affected — the CPU / mixed paths already use `_filter_*_impl(min_genes=…, max_genes=…, min_cells=…, max_cells=…)`.

## Change

The four `rsc.pp.filter_*` calls now use the correct arguments, matching the CPU path and the rapids-singlecell API (which mirrors scanpy's `filter_cells(min_genes=…)` / `filter_genes(min_cells=…)`):

```python
rsc.pp.filter_cells(adata, min_genes=min_genes)
rsc.pp.filter_cells(adata, max_genes=int(max_genes_ratio*adata.shape[1]))
rsc.pp.filter_genes(adata, min_cells=min_cells)
rsc.pp.filter_genes(adata, max_cells=int(max_cells_ratio*adata.shape[0]))
```

`int(...)` matches the CPU path, which passes integer thresholds.

Thanks to @ZHDATA2 for the precise bug report and reproduction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)