### PR TITLE
fix(pp): qc_gpu doublet methods (scdblfinder/etc.) fail on the GPU matrix (#866)

### DIFF
--- a/omicverse/pp/_qc.py
+++ b/omicverse/pp/_qc.py
@@ -1820,6 +1820,14 @@ def qc_gpu(adata, mode='seurat',
                 f"Unknown doublets_method={doublets_method!r}; "
                 "expected 'scrublet', 'sccomposite', 'doubletfinder', or 'scdblfinder'."
             )
+        # scrublet runs on the GPU (rapids-singlecell); the other backends are
+        # CPU/NumPy tools (pyscdblfinder / pydoubletfinder / sccomposite) that
+        # cannot consume the cupy matrix qc_gpu put on the GPU — feeding it in
+        # flips the orientation and returns one value per *gene*, causing
+        # "Length of values (n_genes) does not match length of index (n_cells)"
+        # (issue #866). Move the matrix back to host memory for those.
+        if doublets_method != 'scrublet':
+            rsc.get.anndata_to_CPU(adata)
         if doublets_method=='scrublet':
             print(f"   {Colors.GREEN}{EMOJI['start']} Running GPU-accelerated scrublet...{Colors.ENDC}")
             rsc.pp.scrublet(adata, random_state=1234,batch_key=batch_key)


### PR DESCRIPTION
## Summary

Fixes #866. In GPU mode, `ov.pp.qc(..., doublets_method='scdblfinder')` (the default) crashes with:

```
Length of values (13503) does not match length of index (2695)
```

`13503` ≈ n_genes, `2695` ≈ n_cells.

### Root cause

`qc_gpu` moves the matrix to the GPU (cupy) via `rsc.get.anndata_to_GPU`. **scrublet** runs there natively (rapids-singlecell), so it works — but the other doublet backends are **CPU / NumPy** tools:

- `scdblfinder` → `pyscdblfinder`
- `doubletfinder` → `pydoubletfinder`
- `sccomposite`

Handed a **cupy** matrix, `scipy.sparse.issparse(X)` is `False`, so they misread its orientation and compute one value **per gene**. Writing that back onto the (cells-indexed) `obs` raises the length mismatch. That's why "only `doublets_method='scrublet'` works in GPU mode".

### Fix

Move the matrix back to host memory (`rsc.get.anndata_to_CPU`) before any **non-scrublet** doublet method, so the GPU path matches the already-correct CPU path. scrublet still runs on the GPU.

```python
if doublets_method != 'scrublet':
    rsc.get.anndata_to_CPU(adata)
```

### Note on testing

The GPU path needs `rapids-singlecell` + `cupy` + a GPU, which aren't available in CI, so this can't be exercised by an automated test here. The change is a one-line host-memory transfer that makes the GPU doublet path identical to the working CPU path (where these NumPy tools already run correctly).

Fixes #866