### PR TITLE
fix(space): guard svg(mode='pearsonr') against all-zero spots (#860)

### DIFF
--- a/omicverse/space/_svg.py
+++ b/omicverse/space/_svg.py
@@ -646,6 +646,23 @@ def svg(adata,mode='prost',n_svgs=3000,target_sum=50*1e4,platform="visium",
     elif mode=='pearsonr':
         from ..pp import preprocess
         bdata=adata.copy()
+        # Pearson-residual HVG selection normalizes each spot by its total count,
+        # so all-zero spots (common in Visium HD nucleus/cell segmentation, where
+        # some segments capture no reads) trigger a `division by zero` (issue #860).
+        # `bdata` is a throwaway copy used only to pick genes — its result is mapped
+        # back to `adata` by gene name — so dropping empty spots here does not touch
+        # the returned object's cells.
+        import numpy as _np
+        import scipy.sparse as _spp
+        _counts = bdata.X
+        _cell_sums = _np.asarray(
+            _counts.sum(axis=1)).ravel() if _spp.issparse(_counts) else _np.asarray(_counts).sum(axis=1)
+        _nonzero = _cell_sums > 0
+        if not _nonzero.all():
+            n_drop = int((~_nonzero).sum())
+            print(f"   ⚠️ Dropping {n_drop} all-zero spot(s) before Pearson-residual "
+                  f"SVG selection (issue #860); returned AnnData is unchanged.")
+            bdata = bdata[_nonzero].copy()
         bdata=preprocess(bdata,mode='shiftlog|pearson',n_HVGs=n_svgs,target_sum=target_sum)
         adata.var['space_variable_features'] = False
         both_genes = list(set(adata.var_names) & set(bdata.var_names))


### PR DESCRIPTION
## Summary

Fixes #860 — `ov.space.svg(adata, mode='pearsonr', n_svgs=3000)` raises `ZeroDivisionError: division by zero` on Visium HD segmented data.

Pearson-residual HVG selection normalizes each spot by its total UMI count. Visium HD nucleus/cell **segmentation** produces segments that capture no reads (all-zero spots); dividing by their zero total count blows up inside scanpy's `_highly_variable_pearson_residuals` — raised as an error on the rapids-singlecell GPU path, and silently producing NaN residuals on CPU.

## Fix

Filter out all-zero spots from the throwaway `bdata` copy **before** calling `preprocess(..., mode='shiftlog|pearson')` — exactly the location suggested by the reporter (@hufanglq): *"we need to filter out all zero cells before call `_highly_variable_pearson_residuals`"*.

`bdata` exists only to pick genes; its `highly_variable` flags are mapped back to `adata` **by gene name**, so dropping empty spots there leaves the **returned AnnData's cells completely unchanged**. A short message reports how many spots were dropped.

## Verification

- Synthetic Visium-like data with all-zero spots (sparse **and** dense `X`): `svg(mode='pearsonr')` now completes, selects SVGs, and returns the full cell count (200 → 200) with 15 empty spots dropped only from the internal gene-selection copy.
- `flake8 --select=E9,F63,F7 omicverse/space/_svg.py` clean.

Thanks to @hufanglq for the precise diagnosis and suggested fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)