### PR TITLE
release: omicverse 2.2.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "omicverse"
-version = "2.2.4rc1"
+version = "2.2.4"
 description = "OmicVerse: A single pipeline for exploring the entire transcriptome universe"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Bump version `2.2.4rc1` → `2.2.4` for the 2.2.4 release. Tagging `v2.2.4` after merge triggers the PyPI publish.

Highlights since v2.2.3 (66 commits): the new **`ov.synbio`** three-layer synthetic-biology module (metabolism / protein·enzyme / DNA) plus its advanced-SOTA layer (LinearDesign, Boltz-2, RFdiffusion de-novo binders, PrimeDesign, dynamic FBA, minimal cut sets, SBOL, evaluate_design scorecard), cross-species integration (orthologs + SAMap + SATURN), Seurat RPCA integration, and GPU/perf fixes in pp (sccomposite / scdblfinder / doubletfinder).

🤖 Generated with [Claude Code](https://claude.com/claude-code)