### PR TITLE
fix(flow): a quadrant's sub-populations are populations, and can be parents

### DIFF
--- a/omicverse/flow/_strategy.py
+++ b/omicverse/flow/_strategy.py
@@ -152,10 +152,20 @@ class GatingStrategy:
             raise ValueError(f"a gate named {gate.name!r} is already in this strategy")
         if gate.name == ROOT:
             raise ValueError(f"{ROOT!r} is reserved for the ungated population")
-        if parent != ROOT and parent not in self._gates:
+        # Against every known POPULATION, not just the gate names. A quadrant's
+        # sub-populations are populations in their own right -- the comment
+        # below has always said they "must be addressable as a parent" -- but
+        # this check looked only at `_gates`, so gating within CD4+CD8-, the
+        # single most ordinary thing to do after drawing a quadrant, raised.
+        #
+        # `apply()` handled it correctly the whole time. Only the validation
+        # refused, and `to_dict()` happily emitted `"parent": "CD4+CD8-"` for a
+        # strategy built any other way -- which `from_dict()` then rejected, so
+        # the module could not round-trip its own output.
+        if parent != ROOT and parent not in self._parent:
             # Checked here rather than at apply() time so the error names the
             # gate being added, which is the thing the caller can fix.
-            known = [ROOT] + self._order
+            known = [ROOT] + sorted(self._parent)
             raise KeyError(
                 f"gate {gate.name!r} names parent {parent!r}, which is not in this "
                 f"strategy. Known populations: {known}"
@@ -225,7 +235,27 @@ class GatingStrategy:
         for name in self._order:
             gate = self._gates[name]
             parent = self._parent[name]
-            parent_mask = masks.get(parent) if parent != ROOT else None
+            if parent == ROOT:
+                parent_mask = None
+            elif parent in masks:
+                parent_mask = masks[parent]
+            else:
+                # RAISE, do not run unrestricted. `masks.get(parent)` returned
+                # None for a parent that simply had not been evaluated yet, and
+                # None means "no restriction" three lines down -- so a gate
+                # declared before its parent silently reported the whole sample.
+                # Measured: a child of a quadrant octant, placed first, returned
+                # 200 of 200 where its parent held 50. No exception, no warning,
+                # and a plausible number.
+                #
+                # `add_gate` keeps the order right by construction, but
+                # `from_dict` takes whatever order the document lists and
+                # `_order` is reachable directly.
+                raise KeyError(
+                    f"gate {name!r} names parent {parent!r}, which has not been "
+                    f"computed yet. A gate must come after its parent. "
+                    f"Computed so far: {sorted(masks)}"
+                )
 
             if isinstance(gate, BooleanGate):
                 # Booleans compose already-resolved populations, so they are not

--- a/tests/flow/test_gates.py
+++ b/tests/flow/test_gates.py
@@ -322,3 +322,85 @@ def test_ov_flow_is_a_registered_namespace():
     assert hasattr(ov, "flow")
     assert "flowsom" in ov.flow.__all__
     assert callable(ov.flow.make_transform)
+
+
+# ── a quadrant's sub-populations ARE populations ────────────────────────────
+#
+# `add_gate`'s own comment has always said each quadrant "must be addressable
+# as a parent", and `apply()` has always handled it correctly. Only the
+# validation refused, so gating within CD4+CD8- — the most ordinary thing to do
+# after drawing a quadrant — raised KeyError. Meanwhile `to_dict()` emitted
+# `"parent": "CD4+CD8-"` for a strategy built any other way, and `from_dict()`
+# rejected that exact document: the module could not round-trip its own output.
+
+def _quadrant_sample():
+    """Four events, one per quadrant, repeated — so every octant holds 50."""
+    import anndata as ad
+    X = np.array([[0.0, 0.0], [10.0, 0.0], [0.0, 10.0], [10.0, 10.0]] * 50,
+                 dtype=np.float32)
+    return ad.AnnData(X, var=pd.DataFrame(index=["x", "y"]))
+
+
+def _quadrant_strategy():
+    return GatingStrategy().add_gate(
+        QuadrantGate(name="Q", dims=("x", "y"), dividers=(5.0, 5.0),
+                     quadrant_names=("DN", "C4", "C8", "DP")))
+
+
+def test_a_quadrant_sub_population_can_be_a_parent():
+    gs = _quadrant_strategy()
+    gs.add_gate(RectangleGate(name="kid", dims=("x",), bounds=((0.0, None),)),
+                parent="C4")
+    res = gs.apply(_quadrant_sample(), write_obs=False)
+    assert res.masks["C4"].sum() == 50
+    # Restricted to its parent, not to the whole sample.
+    assert res.masks["kid"].sum() == 50
+    assert res.masks["kid"].sum() <= res.masks["C4"].sum()
+
+
+def test_a_strategy_gated_inside_a_quadrant_round_trips_through_its_own_dict():
+    gs = _quadrant_strategy()
+    gs.add_gate(RectangleGate(name="kid", dims=("x",), bounds=((0.0, None),)),
+                parent="C4")
+    d = gs.to_dict()
+    assert any(g.get("parent") == "C4" for g in d["gates"]), d["gates"]
+
+    back = GatingStrategy.from_dict(d)
+    assert back.parent_of("kid") == "C4"
+    a = _quadrant_sample()
+    r1, r2 = gs.apply(a, write_obs=False), back.apply(a, write_obs=False)
+    for name in r1.masks:
+        assert np.array_equal(r1.masks[name], r2.masks[name]), name
+
+
+def test_a_parent_that_does_not_exist_is_still_refused():
+    """Widening the check must not turn a typo into silence — and the message
+    now lists the octants, which is what the caller was reaching for."""
+    gs = _quadrant_strategy()
+    with pytest.raises(KeyError) as e:
+        gs.add_gate(RectangleGate(name="kid", dims=("x",), bounds=((0.0, None),)),
+                    parent="C5")
+    assert "C5" in str(e.value)
+    assert "C4" in str(e.value), "the available octants should be listed"
+
+
+def test_a_gate_before_its_parent_raises_instead_of_running_unrestricted():
+    """The silent one, and why this is a correctness fix and not an ergonomic
+    one.
+
+    `masks.get(parent)` returned None for a parent not yet computed, and None
+    means "no restriction" three lines later. Measured before the fix: a child
+    of an octant, declared first, returned 200 of 200 where its parent held 50.
+    No exception, no warning, and a perfectly plausible number.
+    """
+    gs = GatingStrategy()
+    # Reach past add_gate, which keeps the order right by construction. This is
+    # the state from_dict produces from a reordered document.
+    gs._gates["kid"] = RectangleGate(name="kid", dims=("x",), bounds=((-99.0, None),))
+    gs._parent["kid"] = "C4"
+    gs._order.append("kid")
+    gs.add_gate(QuadrantGate(name="Q", dims=("x", "y"), dividers=(5.0, 5.0),
+                             quadrant_names=("DN", "C4", "C8", "DP")))
+    with pytest.raises(KeyError) as e:
+        gs.apply(_quadrant_sample(), write_obs=False)
+    assert "has not been computed yet" in str(e.value)


### PR DESCRIPTION
`add_gate`'s own comment says each quadrant **"must be addressable as a parent"**, and `apply()` has always handled it correctly. Only the validation refused — so gating within `CD4+CD8-`, the single most ordinary thing to do after drawing a quadrant, raised:

```
KeyError: "gate 'kid' names parent 'C4', which is not in this strategy.
           Known populations: ['root', 'Q']"
```

The check looked at `self._gates`, which holds only the gate objects. The octants live in `self._parent` — the map of every known **population** — and that is what a parent reference means.

### The module could not round-trip its own output

`to_dict()` emits `"parent": "C4"` for such a gate, and `from_dict()` on that exact document raised the same `KeyError`. A strategy that evaluated perfectly could not be saved and reloaded.

### And the silent one

`masks.get(parent)` returned `None` for a parent that had simply not been evaluated yet, and `None` means *"no restriction"* three lines later. A gate declared before its parent therefore reported the **whole sample**:

```
kid declared BEFORE its quadrant parent:
   kid = 200 of 200
   C4  = 50
   -> ran UNRESTRICTED, no exception, no warning
```

A plausible number that is 4× wrong is the worst failure mode this library has, so it now raises and names both the gate and what has been computed so far. `add_gate` keeps the order right by construction; `from_dict` takes whatever order the document lists, and `_order` is reachable directly.

A parent that genuinely does not exist is still refused — and the message now lists the octants, which is what the caller was reaching for.

### Verified

| | |
|---|---|
| gate inside `C4` | `kid` = 50 of `C4`'s 50 — not 200 |
| `to_dict` → `from_dict` → `apply` | byte-identical masks for every population |
| out-of-order | raises, naming the gate and the computed set |
| unknown parent | still raises |

### Tests

Four regression cases in `tests/flow/test_gates.py` (the file whose header is already *"Gate geometry and the gating strategy tree"*). Both fixes mutation-checked — restoring either turns its test red:

- restoring the `self._gates` check → `test_a_strategy_gated_inside_a_quadrant_round_trips_through_its_own_dict` fails
- restoring `masks.get(parent)` → `test_a_gate_before_its_parent_raises_instead_of_running_unrestricted` fails

`tests/flow`: 201 passed before, **205 passed, 0 failed** after.

Found while building the omicOS flow-cytometry tool, where the gating tree needs every population the kernel reports to be selectable and gateable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)