### PR TITLE
fix(synbio): drop rs3 from the [synbio] extra — it made the extra uninstallable

### DIFF
--- a/omicverse/synbio/_crispr.py
+++ b/omicverse/synbio/_crispr.py
@@ -83,7 +83,7 @@ def _efficiency(spacer: str) -> float:
     aliases=["design_grnas", "gRNA设计", "向导RNA", "sgRNA设计", "crispr_guides",
              "guide_design", "CRISPR", "向导设计"],
     category="synthetic_biology",
-    description="CRISPR gRNA 设计:扫描 PAM(SpCas9/SaCas9/Cas12a)提取原型间隔序列并排序。method='heuristic'(GC/poly-T)或 method='rs3'(真实 Rule Set 3 on-target 模型,Azimuth 继任者)。Design & rank CRISPR guide RNAs (heuristic or Rule Set 3).",
+    description="CRISPR gRNA 设计:扫描 PAM(SpCas9/SaCas9/Cas12a)提取原型间隔序列并排序。method='heuristic'(GC/poly-T,默认,无额外依赖)或 method='rs3'(真实 Rule Set 3 on-target 模型,Azimuth 继任者;rs3 与 omicverse 的 scikit-learn 版本冲突,须在独立环境安装)。Design & rank CRISPR guide RNAs (heuristic or Rule Set 3).",
     examples=[
         "guides = ov.synbio.design_grnas(target_dna, enzyme='SpCas9')",
         "guides[0].spacer, guides[0].efficiency",
@@ -100,6 +100,13 @@ def design_grnas(sequence: str, enzyme: str = "SpCas9",
 
     Scans both strands for PAM sites, extracts protospacers of the enzyme's
     length, filters on GC, and ranks by the heuristic efficiency score.
+
+    ``method='rs3'`` re-scores the guides with the real Rule Set 3 model, but
+    ``rs3`` is **not** part of ``omicverse[synbio]`` and cannot be installed
+    alongside omicverse (it pins ``scikit-learn<=1.0.2``; omicverse needs
+    ``>=1.2``). Use it from a separate environment — see the ImportError raised
+    by ``_score_rs3`` for the exact recipe. The default ``method='heuristic'``
+    needs no extra dependency.
     """
     import re
     if method not in ("heuristic", "rs3"):
@@ -159,8 +166,16 @@ def _score_rs3(guides: List["Guide"]) -> None:
         from rs3.seq import predict_seq
     except ImportError as exc:
         raise ImportError(
-            "design_grnas(method='rs3') 需要 rs3(Rule Set 3 on-target 模型)。请 "
-            "pip install rs3 sglearn 'lightgbm==3.3.5'(rs3 的模型需 lightgbm 3.x)。"
+            "design_grnas(method='rs3') 需要 rs3(Rule Set 3 on-target 模型),"
+            "它不随 omicverse[synbio] 一起安装,且不能装进当前环境:"
+            "rs3 钉死 scikit-learn<=1.0.2,而 omicverse 需要 scikit-learn>=1.2 —— "
+            "在本环境 pip install rs3 会把 scikit-learn 降级,从而弄坏 omicverse。\n"
+            "  · 留在本环境:用 method='heuristic'(默认),无需额外安装。\n"
+            "  · 一定要 Rule Set 3:在独立环境里跑,例如\n"
+            "      python -m venv /tmp/rs3env\n"
+            "      /tmp/rs3env/bin/pip install rs3 sglearn 'lightgbm==3.3.5'\n"
+            "    再把 design_grnas(...) 每个 guide 的 .context(30-mer)喂给那个环境的 "
+            "rs3.seq.predict_seq。"
         ) from exc
     scored = [g for g in guides if len(g.context) == 30]
     if not scored:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -407,7 +407,17 @@ synbio = [
   "gdown>=4.6",                                 # enzyme_function(method='clean') — fetch CLEAN weights
   "equilibrator-api>=0.6",                      # reaction_dg(method='equilibrator') — component-contribution ΔG
   "rdkit>=2024.3",                              # enzyme_kcat(method='dlkcat') substrate graphs (NumPy-2 compatible)
-  "rs3>=0.0.18",                                # design_grnas(method='rs3') — Rule Set 3 on-target (needs lightgbm==3.3.5)
+  # NOTE: rs3 (design_grnas(method='rs3'), Rule Set 3) is deliberately NOT listed
+  # here and must not be re-added. rs3 0.0.18 — its only release satisfying
+  # >=0.0.18, so a resolver cannot back off — pins scikit-learn<=1.0.2, while
+  # omicverse itself requires scikit-learn>=1.2. Listing it made the whole extra
+  # unsatisfiable: `pip install "omicverse[synbio]"` failed with
+  # ResolutionImpossible on every Python version, under both pip and uv, so none
+  # of the other 19 dependencies could be installed either. Installing rs3 into
+  # an existing omicverse env is equally unsafe — it downgrades scikit-learn to
+  # 1.0.2 and breaks omicverse. Use it from a separate environment; design_grnas
+  # raises an actionable ImportError explaining this, and method='heuristic'
+  # (the default) needs no extra install.
   # NOTE: equilibrator-api pulls pyarrow>=21 + libcst; if pip tries to build them
   # from source, install with a Rust toolchain on PATH and force wheels:
   #   pip install --only-binary=pyarrow,libcst equilibrator-api

--- a/tests/test_synbio_crispr.py
+++ b/tests/test_synbio_crispr.py
@@ -1,0 +1,81 @@
+"""Guard rails around ``ov.synbio.design_grnas`` and the ``[synbio]`` extra.
+
+``rs3`` (Rule Set 3) pins ``scikit-learn<=1.0.2`` while omicverse requires
+``>=1.2``, and 0.0.18 is its only release satisfying ``>=0.0.18`` — so a
+resolver cannot back off. Listing it in the ``synbio`` extra made
+``pip install "omicverse[synbio]"`` fail with ResolutionImpossible on every
+Python version, taking all 19 sibling dependencies down with it. These tests
+keep it out and keep the fallback path honest.
+"""
+import re
+from pathlib import Path
+
+import pytest
+
+import omicverse as ov
+
+
+# A short target with 10-nt flanks so guides get a full 30-mer rs3 context.
+TARGET = "GCATGCATGC" + "ATGGCTAGCTAGGATCCATCGATCGGGCTAAACCGGTTAGCTAGCTTGACC" + "GCATGCATGC"
+
+
+def test_design_grnas_heuristic_needs_no_optional_dependency():
+    """The default path must work on a bare install — no synbio extra at all."""
+    guides = ov.synbio.design_grnas(TARGET)
+    assert guides, "expected at least one SpCas9 guide in the target"
+    top = guides[0]
+    assert len(top.spacer) == 20
+    assert 0.0 <= top.efficiency <= 1.0
+    assert guides == sorted(guides, key=lambda g: g.efficiency, reverse=True)
+
+
+def test_design_grnas_rejects_unknown_method():
+    with pytest.raises(ValueError, match="heuristic"):
+        ov.synbio.design_grnas(TARGET, method="azimuth")
+
+
+def test_rs3_method_raises_actionable_error(monkeypatch):
+    """``method='rs3'`` must explain the conflict, not just say 'pip install rs3'.
+
+    Naively installing rs3 into an omicverse env downgrades scikit-learn to
+    1.0.2 and breaks omicverse, so the message has to steer users to a separate
+    environment and to the dependency-free default.
+    """
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _no_rs3(name, *args, **kwargs):
+        if name == "rs3" or name.startswith("rs3."):
+            raise ImportError("blocked import: rs3")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _no_rs3)
+
+    with pytest.raises(ImportError) as excinfo:
+        ov.synbio.design_grnas(TARGET, method="rs3")
+
+    msg = str(excinfo.value)
+    assert "scikit-learn<=1.0.2" in msg, "must name the pin that causes the conflict"
+    assert "method='heuristic'" in msg, "must offer the dependency-free fallback"
+    assert "venv" in msg, "must point at a separate environment, not the current one"
+
+
+def test_rs3_stays_out_of_the_synbio_extra():
+    """Regression guard: re-adding rs3 makes the whole extra uninstallable."""
+    pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    if not pyproject.is_file():
+        pytest.skip("running against an installed omicverse, no pyproject.toml")
+
+    body = pyproject.read_text(encoding="utf-8")
+    extra = body.split("synbio = [", 1)[1].split("\n]", 1)[0]
+    requirements = re.findall(r'^\s*"([^"]+)"', extra, re.M)
+
+    assert requirements, "failed to parse the synbio extra — did the block move?"
+    offenders = [r for r in requirements if re.match(r"rs3\b", r)]
+    assert not offenders, (
+        f"rs3 is back in the synbio extra ({offenders}). It pins "
+        "scikit-learn<=1.0.2 against omicverse's >=1.2, which makes "
+        '`pip install "omicverse[synbio]"` unresolvable for every dependency in '
+        "the extra. Keep it out; design_grnas raises an actionable ImportError."
+    )


### PR DESCRIPTION
## The bug

`pip install "omicverse[synbio]"` has **never worked**. It fails with `ResolutionImpossible` on every Python version, under both pip and uv:

```
The conflict is caused by:
    omicverse 2.2.4 depends on scikit-learn>=1.2
    rs3 0.0.18 depends on scikit-learn<=1.0.2 and >=0.24.2
ERROR: ResolutionImpossible
```

`rs3 0.0.18` is the **only** release satisfying `rs3>=0.0.18`, so no resolver can back off. One unsatisfiable requirement took the entire extra down with it — none of the other 19 dependencies (`cobra`, `dnachisel`, `straindesign`, `fair-esm`, `ViennaRNA`, `sbol2`, `rdkit`, …) could be installed either, so **no `ov.synbio` function had a working install path**.

`git log -S rs3 -- pyproject.toml` shows the pin arrived in #887, the initial commit of the module — this has been broken for the module's entire lifetime.

## Why nobody noticed

`ov.synbio` has no pytest coverage. The two existing scripts — `tests/synbio_coupling_demo.py` and `tests/synbio_gpu_smoke.py` — are not named `test_*.py`, and `[tool.pytest.ini_options] python_files = ["test_*.py"]`, so pytest never collected them. CI never installs `[synbio]` either.

## The fix

Drop `rs3>=0.0.18` from the extra, with a comment explaining why it must not come back.

`design_grnas(method='rs3')` already lazy-imported rs3 behind a `try/except`, so the function keeps working — but the old error message told users to `pip install rs3 sglearn 'lightgbm==3.3.5'`, which is **actively harmful**: in an omicverse env that downgrades scikit-learn to 1.0.2 and breaks omicverse (on macOS it fails outright, trying to build scikit-learn 1.0.2 from source — `clang: error: unsupported option '-fopenmp'`). The message now names the conflict, points at a separate environment, and offers `method='heuristic'` (the default, dependency-free) as the in-place alternative.

## Verification

Resolution after the fix, via `uv pip compile` against the real extra:

| Python | before | after |
|---|---|---|
| 3.10 | `No solution found` | Resolved **187** packages |
| 3.11 | `No solution found` | Resolved **184** packages |
| 3.12 | `No solution found` | Resolved **186** packages |

New `tests/test_synbio_crispr.py` (4 passed) — the first pytest-collected tests for `ov.synbio`:
- the default heuristic path works with **zero** optional dependencies
- unknown `method=` still raises `ValueError`
- `method='rs3'` raises an `ImportError` that names the `scikit-learn<=1.0.2` pin, offers the fallback, and points at a separate env (rs3 import blocked via monkeypatch so it holds on machines that do have rs3)
- regression guard: `rs3` is absent from the `synbio` extra in `pyproject.toml`

`tests/architecture/` is unchanged by this PR: `test_pl_canonical_aliases.py` fails identically on `master` (verified before/after).

## Not in this PR

- CI that actually installs `[synbio]` and runs a smoke test — the real reason this went unseen. Worth a follow-up.
- The tutorial `t_synbio_03_crispr_library.ipynb` (in the `omicverse_guide` submodule) calls `method='rs3'` with no note that it needs a separate environment. Needs a matching PR in the tutorials repo.