### PR TITLE
feat(synbio): bring Rule Set 3 back via a --no-deps runtime fetch

### DIFF
--- a/omicverse/synbio/_crispr.py
+++ b/omicverse/synbio/_crispr.py
@@ -83,7 +83,7 @@ def _efficiency(spacer: str) -> float:
     aliases=["design_grnas", "gRNA设计", "向导RNA", "sgRNA设计", "crispr_guides",
              "guide_design", "CRISPR", "向导设计"],
     category="synthetic_biology",
-    description="CRISPR gRNA 设计:扫描 PAM(SpCas9/SaCas9/Cas12a)提取原型间隔序列并排序。method='heuristic'(GC/poly-T,默认,无额外依赖)或 method='rs3'(真实 Rule Set 3 on-target 模型,Azimuth 继任者;rs3 与 omicverse 的 scikit-learn 版本冲突,须在独立环境安装)。Design & rank CRISPR guide RNAs (heuristic or Rule Set 3).",
+    description="CRISPR gRNA 设计:扫描 PAM(SpCas9/SaCas9/Cas12a)提取原型间隔序列并排序。method='heuristic'(GC/poly-T,默认,无额外依赖)或 method='rs3'(真实 Rule Set 3 on-target 模型,Azimuth 继任者;首用自动下载 ~20MB 模型)。Design & rank CRISPR guide RNAs (heuristic or Rule Set 3).",
     examples=[
         "guides = ov.synbio.design_grnas(target_dna, enzyme='SpCas9')",
         "guides[0].spacer, guides[0].efficiency",
@@ -101,12 +101,12 @@ def design_grnas(sequence: str, enzyme: str = "SpCas9",
     Scans both strands for PAM sites, extracts protospacers of the enzyme's
     length, filters on GC, and ranks by the heuristic efficiency score.
 
-    ``method='rs3'`` re-scores the guides with the real Rule Set 3 model, but
-    ``rs3`` is **not** part of ``omicverse[synbio]`` and cannot be installed
-    alongside omicverse (it pins ``scikit-learn<=1.0.2``; omicverse needs
-    ``>=1.2``). Use it from a separate environment — see the ImportError raised
-    by ``_score_rs3`` for the exact recipe. The default ``method='heuristic'``
-    needs no extra dependency.
+    ``method='rs3'`` re-scores the guides with the real Rule Set 3 model. rs3
+    cannot be a declared dependency (its stale pins would make the whole
+    ``[synbio]`` extra unresolvable), so on first use it is fetched with
+    ``--no-deps`` into ``$OMICOS_SYNBIO_WEIGHTS/rs3`` — ~20 MB, one network
+    round-trip, see :mod:`omicverse.synbio._rs3`. The default
+    ``method='heuristic'`` needs no download at all.
     """
     import re
     if method not in ("heuristic", "rs3"):
@@ -162,25 +162,12 @@ def _score_rs3(guides: List["Guide"]) -> None:
     """Replace each guide's efficiency with the real Rule Set 3 score
     (DeWeirdt *et al.* 2021; the successor to Azimuth/Rule Set 2). Guides that
     lack a full 30-mer context keep their heuristic score."""
-    try:
-        from rs3.seq import predict_seq
-    except ImportError as exc:
-        raise ImportError(
-            "design_grnas(method='rs3') 需要 rs3(Rule Set 3 on-target 模型),"
-            "它不随 omicverse[synbio] 一起安装,且不能装进当前环境:"
-            "rs3 钉死 scikit-learn<=1.0.2,而 omicverse 需要 scikit-learn>=1.2 —— "
-            "在本环境 pip install rs3 会把 scikit-learn 降级,从而弄坏 omicverse。\n"
-            "  · 留在本环境:用 method='heuristic'(默认),无需额外安装。\n"
-            "  · 一定要 Rule Set 3:在独立环境里跑,例如\n"
-            "      python -m venv /tmp/rs3env\n"
-            "      /tmp/rs3env/bin/pip install rs3 sglearn 'lightgbm==3.3.5'\n"
-            "    再把 design_grnas(...) 每个 guide 的 .context(30-mer)喂给那个环境的 "
-            "rs3.seq.predict_seq。"
-        ) from exc
     scored = [g for g in guides if len(g.context) == 30]
     if not scored:
         return
-    preds = predict_seq([g.context for g in scored], sequence_tracr="Hsu2013")
+    from ._rs3 import predict_rs3
+
+    preds = predict_rs3([g.context for g in scored], sequence_tracr="Hsu2013")
     for g, p in zip(scored, preds):
         g.efficiency = float(p)
 

--- a/omicverse/synbio/_rs3.py
+++ b/omicverse/synbio/_rs3.py
@@ -1,0 +1,150 @@
+r"""Runtime access to `Rule Set 3 <https://github.com/gpp-rnd/rs3>`_ — the real
+on-target sgRNA activity model (DeWeirdt *et al.* 2021, *Nature Biotechnology*;
+the maintained successor to Azimuth / Rule Set 2).
+
+``rs3`` cannot be a declared dependency of ``omicverse[synbio]``. Its metadata
+pins ``scikit-learn<=1.0.2``, ``numpy<=1.26.4`` and ``lightgbm<=3.3.5``, all of
+which contradict omicverse's own floors — and ``rs3 0.0.18`` is its only release
+satisfying ``rs3>=0.0.18``, so no resolver can back off. Listing it made the
+whole extra unsatisfiable (see the note in ``pyproject.toml``).
+
+Those pins are, however, **stale rather than real**: ``RuleSet3.pkl`` unpickles
+to a plain ``lightgbm.sklearn.LGBMRegressor`` — no scikit-learn estimator is
+stored in it at all, scikit-learn is merely lightgbm's own dependency. Verified
+by running the same 30-mers through rs3's pinned stack (numpy 1.26.4 /
+scikit-learn 1.0.2 / lightgbm 3.3.5 / pandas 1.5.3) and through a modern one
+(numpy 2.4.6 / scikit-learn 1.9.0 / lightgbm 4.7.0 / pandas 3.0.5): the
+predictions are bit-identical.
+
+So on first use we install rs3 + sglearn with ``--no-deps`` into
+``$OMICOS_SYNBIO_WEIGHTS/rs3`` (default ``~/.omicverse/synbio_weights/rs3``,
+~20 MB, mostly the 17 MB ``RuleSet3.pkl``) and import them from there, letting
+the host environment provide modern lightgbm/pandas/joblib. ``--no-deps`` is
+what makes this safe: a plain ``pip install rs3`` into an omicverse env would
+try to downgrade scikit-learn to 1.0.2 and break omicverse.
+
+rs3 is Apache-2.0, sglearn is MIT; both are fetched from PyPI at runtime, not
+redistributed here.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from typing import List, Optional, Sequence
+
+from ._esm_common import weights_dir
+
+# pinned so a silent upstream change can't move the model under us
+_RS3_SPEC = "rs3==0.0.18"
+_SGLEARN_SPEC = "sglearn==1.2.5"
+
+
+def _install_root() -> str:
+    return os.path.join(weights_dir(), "rs3")
+
+
+def _install_commands(root: str) -> List[List[str]]:
+    """Installers to try, in order.
+
+    ``--no-deps`` is load-bearing in both: it skips rs3's stale scikit-learn /
+    numpy / lightgbm ceilings, which would otherwise downgrade — and break —
+    the omicverse environment. ``--target`` keeps the whole thing out of
+    site-packages.
+
+    pip is tried first but is not always there: environments created by ``uv
+    venv`` (which is how the omicOS kernel env is built) ship without pip, so
+    ``python -m pip`` fails with "No module named pip". uv itself is the
+    fallback for exactly that case.
+    """
+    specs = [_RS3_SPEC, _SGLEARN_SPEC]
+    return [
+        [sys.executable, "-m", "pip", "install", "--quiet",
+         "--no-deps", "--target", root, *specs],
+        ["uv", "pip", "install", "--quiet", "--python", sys.executable,
+         "--no-deps", "--target", root, *specs],
+    ]
+
+
+def _rs3_importable() -> bool:
+    try:
+        import rs3.seq  # noqa: F401
+        import sglearn  # noqa: F401
+    except Exception:
+        return False
+    return True
+
+
+def ensure_rs3() -> Optional[str]:
+    """Make ``rs3`` and ``sglearn`` importable; return the install dir if we own it.
+
+    Returns ``None`` when the host environment already provides them (nothing
+    was installed). Raises an actionable ``ImportError`` if the install fails.
+    """
+    if _rs3_importable():
+        return None
+
+    root = _install_root()
+    if os.path.isdir(root) and root not in sys.path:
+        sys.path.insert(0, root)
+        if _rs3_importable():
+            return root
+
+    os.makedirs(root, exist_ok=True)
+    errors = []
+    for cmd in _install_commands(root):
+        try:
+            subprocess.run(cmd, check=True, capture_output=True, text=True)
+            break
+        except (subprocess.CalledProcessError, FileNotFoundError) as exc:
+            errors.append(f"{cmd[0]}: {getattr(exc, 'stderr', None) or exc}")
+    else:
+        raise ImportError(
+            "design_grnas(method='rs3') 需要 Rule Set 3 模型,自动安装失败。请手动:\n"
+            f"    pip install --no-deps --target {root} {_RS3_SPEC} {_SGLEARN_SPEC}\n"
+            "  (--no-deps 必须加 —— rs3 钉死 scikit-learn<=1.0.2,直接 pip install rs3 "
+            "会把 scikit-learn 降级从而弄坏 omicverse。)\n"
+            "  也可以改用 method='heuristic'(默认),无需任何额外安装。\n"
+            "  (尝试过: " + " | ".join(errors) + ")"
+        ) from None
+
+    if root not in sys.path:
+        sys.path.insert(0, root)
+    if not _rs3_importable():  # pragma: no cover
+        raise ImportError(
+            f"rs3 已安装到 {root},但仍然导入失败。它需要宿主环境提供 lightgbm 与 "
+            "seqfold:请 pip install 'omicverse[synbio]',或 pip install lightgbm seqfold。"
+        )
+    return root
+
+
+def _load_model():
+    """Load ``RuleSet3.pkl``, repairing the one attribute lightgbm 4.x needs.
+
+    The pickle was written by lightgbm 3.x, whose ``LGBMRegressor`` had no
+    ``_n_classes``; 4.x reads it in ``_process_params`` and trips over ``None``.
+    For a regressor the value is 1.
+    """
+    from rs3.seq import load_seq_model
+
+    model = load_seq_model()
+    if getattr(model, "_n_classes", None) is None:
+        model._n_classes = 1
+    return model
+
+
+def predict_rs3(contexts: Sequence[str], sequence_tracr: str = "Hsu2013") -> List[float]:
+    """Rule Set 3 on-target scores for 30-mer *contexts* (4nt + 20nt + PAM + 3nt).
+
+    Mirrors ``rs3.seq.predict_seq``, but goes through :func:`ensure_rs3` and the
+    patched loader. Feature columns are passed in the featurizer's own order —
+    do **not** reorder them by ``booster_.feature_name()``, which reports
+    lightgbm-normalised names (``Hsu2013_tracr`` for ``"Hsu2013 tracr"``) and
+    would raise ``KeyError``.
+    """
+    ensure_rs3()
+    from rs3.seq import featurize_context
+
+    model = _load_model()
+    features = featurize_context(list(contexts), sequence_tracr=sequence_tracr)
+    return [float(v) for v in model.predict(features)]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -407,17 +407,21 @@ synbio = [
   "gdown>=4.6",                                 # enzyme_function(method='clean') — fetch CLEAN weights
   "equilibrator-api>=0.6",                      # reaction_dg(method='equilibrator') — component-contribution ΔG
   "rdkit>=2024.3",                              # enzyme_kcat(method='dlkcat') substrate graphs (NumPy-2 compatible)
-  # NOTE: rs3 (design_grnas(method='rs3'), Rule Set 3) is deliberately NOT listed
-  # here and must not be re-added. rs3 0.0.18 — its only release satisfying
-  # >=0.0.18, so a resolver cannot back off — pins scikit-learn<=1.0.2, while
-  # omicverse itself requires scikit-learn>=1.2. Listing it made the whole extra
-  # unsatisfiable: `pip install "omicverse[synbio]"` failed with
-  # ResolutionImpossible on every Python version, under both pip and uv, so none
-  # of the other 19 dependencies could be installed either. Installing rs3 into
-  # an existing omicverse env is equally unsafe — it downgrades scikit-learn to
-  # 1.0.2 and breaks omicverse. Use it from a separate environment; design_grnas
-  # raises an actionable ImportError explaining this, and method='heuristic'
-  # (the default) needs no extra install.
+  "lightgbm>=4.0",                              # design_grnas(method='rs3') — runs the Rule Set 3 booster
+  "seqfold>=0.7.7",                             # sglearn's folding features for the rs3 featuriser
+  # NOTE: rs3 itself (design_grnas(method='rs3'), Rule Set 3) is deliberately
+  # NOT listed here and must not be re-added. rs3 0.0.18 — its only release
+  # satisfying >=0.0.18, so a resolver cannot back off — pins
+  # scikit-learn<=1.0.2, while omicverse itself requires scikit-learn>=1.2.
+  # Listing it made the whole extra unsatisfiable: `pip install
+  # "omicverse[synbio]"` failed with ResolutionImpossible on every Python
+  # version, under both pip and uv, so none of the other dependencies could be
+  # installed either. Those pins are stale rather than real (RuleSet3.pkl holds
+  # a plain lightgbm regressor, no scikit-learn estimator), so omicverse/synbio/
+  # _rs3.py installs rs3 + sglearn with --no-deps into $OMICOS_SYNBIO_WEIGHTS on
+  # first use and lets lightgbm/seqfold above satisfy it at runtime. A plain
+  # `pip install rs3` into an omicverse env is still unsafe — it downgrades
+  # scikit-learn to 1.0.2 and breaks omicverse.
   # NOTE: equilibrator-api pulls pyarrow>=21 + libcst; if pip tries to build them
   # from source, install with a Rust toolchain on PATH and force wheels:
   #   pip install --only-binary=pyarrow,libcst equilibrator-api

--- a/tests/test_synbio_crispr.py
+++ b/tests/test_synbio_crispr.py
@@ -4,19 +4,36 @@
 ``>=1.2``, and 0.0.18 is its only release satisfying ``>=0.0.18`` — so a
 resolver cannot back off. Listing it in the ``synbio`` extra made
 ``pip install "omicverse[synbio]"`` fail with ResolutionImpossible on every
-Python version, taking all 19 sibling dependencies down with it. These tests
-keep it out and keep the fallback path honest.
+Python version, taking all its sibling dependencies down with it. It is now
+fetched at runtime with ``--no-deps`` instead (see ``omicverse/synbio/_rs3.py``).
+These tests keep it out of the extra, keep the runtime path honest, and keep
+the dependency-free fallback working.
+
+Nothing here touches the network: the install step is always monkeypatched.
 """
 import re
+import sys
+import types
 from pathlib import Path
 
 import pytest
 
 import omicverse as ov
+from omicverse.synbio import _rs3
 
 
 # A short target with 10-nt flanks so guides get a full 30-mer rs3 context.
 TARGET = "GCATGCATGC" + "ATGGCTAGCTAGGATCCATCGATCGGGCTAAACCGGTTAGCTAGCTTGACC" + "GCATGCATGC"
+
+
+def _synbio_extra_requirements():
+    pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    if not pyproject.is_file():
+        pytest.skip("running against an installed omicverse, no pyproject.toml")
+    extra = pyproject.read_text(encoding="utf-8").split("synbio = [", 1)[1].split("\n]", 1)[0]
+    reqs = re.findall(r'^\s*"([^"]+)"', extra, re.M)
+    assert reqs, "failed to parse the synbio extra — did the block move?"
+    return reqs
 
 
 def test_design_grnas_heuristic_needs_no_optional_dependency():
@@ -34,48 +51,118 @@ def test_design_grnas_rejects_unknown_method():
         ov.synbio.design_grnas(TARGET, method="azimuth")
 
 
-def test_rs3_method_raises_actionable_error(monkeypatch):
-    """``method='rs3'`` must explain the conflict, not just say 'pip install rs3'.
-
-    Naively installing rs3 into an omicverse env downgrades scikit-learn to
-    1.0.2 and breaks omicverse, so the message has to steer users to a separate
-    environment and to the dependency-free default.
-    """
-    import builtins
-
-    real_import = builtins.__import__
-
-    def _no_rs3(name, *args, **kwargs):
-        if name == "rs3" or name.startswith("rs3."):
-            raise ImportError("blocked import: rs3")
-        return real_import(name, *args, **kwargs)
-
-    monkeypatch.setattr(builtins, "__import__", _no_rs3)
-
-    with pytest.raises(ImportError) as excinfo:
-        ov.synbio.design_grnas(TARGET, method="rs3")
-
-    msg = str(excinfo.value)
-    assert "scikit-learn<=1.0.2" in msg, "must name the pin that causes the conflict"
-    assert "method='heuristic'" in msg, "must offer the dependency-free fallback"
-    assert "venv" in msg, "must point at a separate environment, not the current one"
-
-
 def test_rs3_stays_out_of_the_synbio_extra():
     """Regression guard: re-adding rs3 makes the whole extra uninstallable."""
-    pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
-    if not pyproject.is_file():
-        pytest.skip("running against an installed omicverse, no pyproject.toml")
-
-    body = pyproject.read_text(encoding="utf-8")
-    extra = body.split("synbio = [", 1)[1].split("\n]", 1)[0]
-    requirements = re.findall(r'^\s*"([^"]+)"', extra, re.M)
-
-    assert requirements, "failed to parse the synbio extra — did the block move?"
-    offenders = [r for r in requirements if re.match(r"rs3\b", r)]
+    offenders = [r for r in _synbio_extra_requirements() if re.match(r"rs3\b", r)]
     assert not offenders, (
         f"rs3 is back in the synbio extra ({offenders}). It pins "
         "scikit-learn<=1.0.2 against omicverse's >=1.2, which makes "
         '`pip install "omicverse[synbio]"` unresolvable for every dependency in '
-        "the extra. Keep it out; design_grnas raises an actionable ImportError."
+        "the extra. It is fetched at runtime by omicverse/synbio/_rs3.py instead."
     )
+
+
+def test_extra_carries_what_the_runtime_fetch_needs():
+    """``--no-deps`` means the host env must supply rs3/sglearn's real deps."""
+    reqs = _synbio_extra_requirements()
+    for pkg in ("lightgbm", "seqfold"):
+        assert any(re.match(rf"{pkg}\b", r) for r in reqs), (
+            f"{pkg} missing from the synbio extra — _rs3.py installs rs3/sglearn "
+            "with --no-deps, so nothing else will pull it in and method='rs3' "
+            "would fail at import time."
+        )
+
+
+def test_install_commands_cover_pip_and_uv_and_always_pass_no_deps():
+    """uv-created venvs (including the omicOS kernel env) ship without pip.
+
+    Found the hard way: with only the ``python -m pip`` path, method='rs3'
+    died with "No module named pip" on any uv-built environment.
+    """
+    cmds = _rs3._install_commands("/tmp/whatever")
+    assert len(cmds) >= 2, "need a fallback installer, not just pip"
+    assert cmds[0][1:4] == ["-m", "pip", "install"], "pip should be tried first"
+    assert cmds[1][0] == "uv", "uv is the fallback for pip-less environments"
+    for cmd in cmds:
+        assert "--no-deps" in cmd, (
+            "--no-deps must never be dropped: without it the installer "
+            "downgrades scikit-learn to 1.0.2 and breaks omicverse"
+        )
+        assert "--target" in cmd, "must install out-of-tree, not into site-packages"
+
+
+def test_ensure_rs3_falls_back_to_uv_when_pip_is_missing(monkeypatch):
+    monkeypatch.setattr(_rs3, "_rs3_importable", lambda: False)
+    import subprocess
+
+    attempted = []
+
+    def _fake_run(cmd, **kwargs):
+        attempted.append(cmd[0] if cmd[0] == "uv" else "pip")
+        if attempted[-1] == "pip":
+            raise subprocess.CalledProcessError(1, cmd, stderr="No module named pip")
+        return types.SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    # the post-install import check would fail with a fake installer; skip past it
+    monkeypatch.setattr(_rs3, "_rs3_importable", lambda: len(attempted) >= 2)
+
+    _rs3.ensure_rs3()
+    assert attempted == ["pip", "uv"], f"expected pip then uv, got {attempted}"
+
+
+def test_ensure_rs3_failure_is_actionable(monkeypatch):
+    """A failed install must not leave the user guessing (or wrecking their env)."""
+    import subprocess
+
+    monkeypatch.setattr(_rs3, "_rs3_importable", lambda: False)
+
+    def _boom(*args, **kwargs):
+        raise subprocess.CalledProcessError(1, "pip", stderr="network unreachable")
+
+    monkeypatch.setattr(subprocess, "run", _boom)
+
+    with pytest.raises(ImportError) as excinfo:
+        _rs3.ensure_rs3()
+
+    msg = str(excinfo.value)
+    assert "--no-deps" in msg, "the manual recipe must keep --no-deps or it breaks the env"
+    assert "method='heuristic'" in msg, "must offer the dependency-free fallback"
+    assert "scikit-learn<=1.0.2" in msg, "must say why --no-deps is mandatory"
+
+
+def test_ensure_rs3_is_a_noop_when_host_already_has_it(monkeypatch):
+    import subprocess
+
+    monkeypatch.setattr(_rs3, "_rs3_importable", lambda: True)
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: pytest.fail("must not install"))
+    assert _rs3.ensure_rs3() is None
+
+
+def test_load_model_repairs_the_lightgbm_3_pickle(monkeypatch):
+    """RuleSet3.pkl was written by lightgbm 3.x; 4.x trips over _n_classes=None."""
+    class _FakeRegressor:
+        _n_classes = None
+
+    fake_seq = types.ModuleType("rs3.seq")
+    fake_seq.load_seq_model = lambda: _FakeRegressor()
+    fake_rs3 = types.ModuleType("rs3")
+    fake_rs3.seq = fake_seq
+    monkeypatch.setitem(sys.modules, "rs3", fake_rs3)
+    monkeypatch.setitem(sys.modules, "rs3.seq", fake_seq)
+
+    assert _rs3._load_model()._n_classes == 1
+
+
+def test_load_model_leaves_a_healthy_pickle_alone(monkeypatch):
+    class _FakeRegressor:
+        _n_classes = 3          # would be wrong to clobber
+
+    fake_seq = types.ModuleType("rs3.seq")
+    fake_seq.load_seq_model = lambda: _FakeRegressor()
+    fake_rs3 = types.ModuleType("rs3")
+    fake_rs3.seq = fake_seq
+    monkeypatch.setitem(sys.modules, "rs3", fake_rs3)
+    monkeypatch.setitem(sys.modules, "rs3.seq", fake_seq)
+
+    assert _rs3._load_model()._n_classes == 3


### PR DESCRIPTION
Follow-up to #912, which had to drop `rs3` from the `[synbio]` extra to make the extra installable at all. That left `design_grnas(method='rs3')` reachable only by hand-building a separate environment. This brings it back properly.

## The pins were stale, not real

`rs3` pins `scikit-learn<=1.0.2`, `numpy<=1.26.4`, `lightgbm<=3.3.5`. But `RuleSet3.pkl` unpickles to a plain `lightgbm.sklearn.LGBMRegressor` — **there is no scikit-learn estimator in it at all**; scikit-learn is only lightgbm's own dependency. So I ran identical 30-mers through both stacks:

| stack | numpy / scikit-learn / lightgbm / pandas | `predict_seq` |
|---|---|---|
| rs3's own pins | 1.26.4 / **1.0.2** / **3.3.5** / 1.5.3 | `-0.11693749033657669` |
| modern | **2.4.6** / **1.9.0** / **4.7.0** / **3.0.5** | `-0.11693749033657669` |

Bit-identical.

## Approach

`omicverse/synbio/_rs3.py` installs `rs3` + `sglearn` with `--no-deps` into `$OMICOS_SYNBIO_WEIGHTS/rs3` (~20 MB, mostly the 17 MB `RuleSet3.pkl`) on first use — the same runtime-fetch pattern ProteinMPNN / CLEAN / DLKcat / PrimeDesign / LinearDesign already use — and lets the host env supply modern lightgbm/pandas/joblib.

`--no-deps` is the load-bearing flag: a plain `pip install rs3` into an omicverse env downgrades scikit-learn to 1.0.2 and breaks omicverse. Vendoring into `synbio/external/` was the alternative but would add 17 MB to every wheel and put a third-party Apache-2.0 tree under maintenance; rs3 is fetched from PyPI at runtime, not redistributed.

Adds `lightgbm>=4.0` + `seqfold>=0.7.7` to the extra — with `--no-deps`, nothing else pulls them in. `rs3` itself stays out, still guarded by a test.

## Two bugs only a real run surfaced

Both are now regression-tested. Neither was reachable from mocked tests.

1. **uv-built venvs have no pip.** `python -m pip` died with `No module named pip` — and that is exactly how the omicOS kernel env is built. uv is now the fallback installer; both commands are asserted to carry `--no-deps`.
2. **The pickle predates lightgbm 4.x.** `predict()` hit `'>' not supported between instances of 'NoneType' and 'int'` — 3.x had no `_n_classes`. Repaired on load (1 for a regressor), leaving a healthy value alone.

Also worth recording: do **not** reorder feature columns by `booster_.feature_name()`. lightgbm normalises `"Hsu2013 tracr"` to `"Hsu2013_tracr"`, so reindexing raises `KeyError`. The featuriser's own column order *is* the training order. I hit this while exploring and nearly shipped it.

## Verification

Full end-to-end on a clean weights dir, no mocks:

```
host python has pip? NO — so this exercises the uv fallback
design_grnas(method='rs3'): 1.3s, 5 guides
  GCTAGCTAGGATCCATCGAT CGG  rs3=-0.131428
installed: ['rs3', 'rs3-0.0.18.dist-info', 'sglearn', 'sglearn-1.2.5.dist-info']
cross-check vs rs3's own pinned stack: identical: True
```

- second call reinstalls nothing (0 installer invocations, cached)
- the pip path works too (verified in a pip-equipped venv)
- **host env untouched after a full run**: scikit-learn 1.7.2 / numpy 2.2.6, no downgrade
- extra resolves: **189 / 186 / 188** packages on 3.10 / 3.12 / 3.11
- `tests/test_synbio_crispr.py`: **10 passed**

## Pre-existing issue this makes visible (not fixed here)

`_score_rs3` only re-scores guides that have a full 30-mer context; the rest keep their heuristic score. Those two scores are different quantities — heuristic is 0..1, rs3 is a z-score — and `design_grnas` then sorts the mixed list by `efficiency`, so a heuristic 0.91 outranks an rs3 0.25 meaninglessly. Visible in the run above. This predates both PRs and needs its own decision (separate field? refuse to mix? pad the context?), so I left it alone.