### PR TITLE
fix(synbio): keep rs3 z-scores off the heuristic efficiency scale

### DIFF
--- a/omicverse/synbio/_crispr.py
+++ b/omicverse/synbio/_crispr.py
@@ -54,13 +54,15 @@ class Guide:
     start: int            # 0-based position of protospacer start on the input
     strand: str           # '+' | '-'
     gc: float
-    efficiency: float     # on-target score (heuristic 0..1, or rs3 z-score)
+    efficiency: float     # heuristic on-target score, always in [0,1]
     poly_t: bool          # contains TTTT (Pol III terminator)
     context: str = ""     # 30-mer context (4nt + 20nt spacer + PAM + 3nt) for rs3
+    rs3_score: Optional[float] = None   # Rule Set 3 z-score; None if not scored
 
     def __repr__(self) -> str:  # pragma: no cover
+        tail = "" if self.rs3_score is None else f" rs3={self.rs3_score:+.2f}"
         return (f"Guide({self.spacer} {self.pam} {self.strand}@{self.start} "
-                f"GC={self.gc:.2f} eff={self.efficiency:.2f})")
+                f"GC={self.gc:.2f} eff={self.efficiency:.2f}{tail})")
 
 
 def _efficiency(spacer: str) -> float:
@@ -83,10 +85,11 @@ def _efficiency(spacer: str) -> float:
     aliases=["design_grnas", "gRNA设计", "向导RNA", "sgRNA设计", "crispr_guides",
              "guide_design", "CRISPR", "向导设计"],
     category="synthetic_biology",
-    description="CRISPR gRNA 设计:扫描 PAM(SpCas9/SaCas9/Cas12a)提取原型间隔序列并排序。method='heuristic'(GC/poly-T,默认,无额外依赖)或 method='rs3'(真实 Rule Set 3 on-target 模型,Azimuth 继任者;首用自动下载 ~20MB 模型)。Design & rank CRISPR guide RNAs (heuristic or Rule Set 3).",
+    description="CRISPR gRNA 设计:扫描 PAM(SpCas9/SaCas9/Cas12a)提取原型间隔序列并排序。method='heuristic'(默认,无额外依赖)按 efficiency([0,1] GC/poly-T 启发式)排序;method='rs3' 额外填 rs3_score(真实 Rule Set 3 z 分数,Azimuth 继任者;首用自动下载 ~20MB 模型)并按它排序,efficiency 语义不变。Design & rank CRISPR guide RNAs (heuristic or Rule Set 3).",
     examples=[
         "guides = ov.synbio.design_grnas(target_dna, enzyme='SpCas9')",
         "guides[0].spacer, guides[0].efficiency",
+        "rs3 = ov.synbio.design_grnas(target_dna, method='rs3'); rs3[0].rs3_score",
     ],
     related=["synbio.offtarget_search", "synbio.base_editor_window", "synbio.hdr_arms"],
     requires={},
@@ -99,14 +102,20 @@ def design_grnas(sequence: str, enzyme: str = "SpCas9",
     """Design guide RNAs targeting *sequence*.
 
     Scans both strands for PAM sites, extracts protospacers of the enzyme's
-    length, filters on GC, and ranks by the heuristic efficiency score.
+    length and filters on GC.
 
-    ``method='rs3'`` re-scores the guides with the real Rule Set 3 model. rs3
-    cannot be a declared dependency (its stale pins would make the whole
-    ``[synbio]`` extra unresolvable), so on first use it is fetched with
-    ``--no-deps`` into ``$OMICOS_SYNBIO_WEIGHTS/rs3`` — ~20 MB, one network
-    round-trip, see :mod:`omicverse.synbio._rs3`. The default
-    ``method='heuristic'`` needs no download at all.
+    ``method='heuristic'`` (the default) ranks by :attr:`Guide.efficiency`, a
+    transparent GC/poly-T score in ``[0,1]`` that needs no download at all.
+
+    ``method='rs3'`` additionally fills :attr:`Guide.rs3_score` with the real
+    Rule Set 3 z-score and ranks by *that*; ``efficiency`` keeps its heuristic
+    meaning in both cases, so the two are never compared on the same scale.
+    Guides too close to the sequence ends to yield a 30-mer context cannot be
+    rs3-scored and are ranked last. rs3 cannot be a declared dependency (its
+    stale pins would make the whole ``[synbio]`` extra unresolvable), so on
+    first use it is fetched with ``--no-deps`` into
+    ``$OMICOS_SYNBIO_WEIGHTS/rs3`` — ~20 MB, one network round-trip, see
+    :mod:`omicverse.synbio._rs3`.
     """
     import re
     if method not in ("heuristic", "rs3"):
@@ -153,15 +162,24 @@ def design_grnas(sequence: str, enzyme: str = "SpCas9",
 
     if method == "rs3":
         _score_rs3(guides)
-
-    guides.sort(key=lambda g: g.efficiency, reverse=True)
+        # rs3 returns a z-score (unbounded, frequently negative) — it lives in
+        # its own field and is *not* comparable to the heuristic [0,1] score.
+        # Guides with no 30-mer context cannot be scored, so they rank last
+        # rather than being mixed in on an incompatible scale.
+        guides.sort(key=lambda g: (g.rs3_score is not None, g.rs3_score or 0.0),
+                    reverse=True)
+    else:
+        guides.sort(key=lambda g: g.efficiency, reverse=True)
     return guides[:top_n] if top_n else guides
 
 
 def _score_rs3(guides: List["Guide"]) -> None:
-    """Replace each guide's efficiency with the real Rule Set 3 score
-    (DeWeirdt *et al.* 2021; the successor to Azimuth/Rule Set 2). Guides that
-    lack a full 30-mer context keep their heuristic score."""
+    """Attach the real Rule Set 3 score (DeWeirdt *et al.* 2021; the successor
+    to Azimuth/Rule Set 2) to each guide's ``rs3_score``.
+
+    The heuristic ``efficiency`` is left untouched — the two scores are on
+    different scales. Guides lacking a full 30-mer context keep
+    ``rs3_score=None``; no flanking sequence is invented to manufacture one."""
     scored = [g for g in guides if len(g.context) == 30]
     if not scored:
         return
@@ -169,7 +187,7 @@ def _score_rs3(guides: List["Guide"]) -> None:
 
     preds = predict_rs3([g.context for g in scored], sequence_tracr="Hsu2013")
     for g, p in zip(scored, preds):
-        g.efficiency = float(p)
+        g.rs3_score = float(p)
 
 
 @dataclass

--- a/tests/test_synbio_crispr.py
+++ b/tests/test_synbio_crispr.py
@@ -166,3 +166,144 @@ def test_load_model_leaves_a_healthy_pickle_alone(monkeypatch):
     monkeypatch.setitem(sys.modules, "rs3.seq", fake_seq)
 
     assert _rs3._load_model()._n_classes == 3
+
+
+# ---------------------------------------------------------------------------
+# Ranking semantics: rs3 is a z-score, ``efficiency`` is a [0,1] heuristic,
+# and the two must never be sorted against each other.
+#
+# ``TARGET`` above carries 10-nt flanks so every guide gets a 30-mer context.
+# These tests need the opposite: a target whose end-adjacent guides *cannot* be
+# scored, because that is where the scales used to collide.
+# ---------------------------------------------------------------------------
+RANKING_TARGET = (
+    "GGCCATGGAGTCTAGGACTTCAGGTACCGGATCAGGCTAACGGTTAGGCCATTAGGACGTTAGG"
+    "ACCTTGGCATGCAGGTTACCGGAATTCAGGCCTTAAGGCATTCAGGTTAACGGCCATTAGGTAC"
+)
+
+
+@pytest.fixture
+def stub_rs3(monkeypatch):
+    """Replace ``_rs3.predict_rs3`` with a stub returning negative z-scores.
+
+    Score = -(index + 1) * 0.5, so the *first* context handed to the model gets
+    the highest (least negative) score. Every value is < 0 — the regime real
+    Rule Set 3 lives in, and the one that used to let unscored heuristic guides
+    float to the top of an rs3 ranking.
+
+    Patching here also keeps ``ensure_rs3()`` out of the test: no ``--no-deps``
+    pip fetch, no ~20 MB model download, no lightgbm import.
+    """
+    calls = {}
+
+    def predict_rs3(contexts, sequence_tracr="Hsu2013"):
+        calls["contexts"] = list(contexts)
+        calls["tracr"] = sequence_tracr
+        return [-(i + 1) * 0.5 for i in range(len(contexts))]
+
+    monkeypatch.setattr(_rs3, "predict_rs3", predict_rs3)
+    return calls
+
+
+def test_heuristic_leaves_rs3_score_unset():
+    guides = ov.synbio.design_grnas(RANKING_TARGET)
+    assert guides
+    assert all(g.rs3_score is None for g in guides)
+
+
+def test_rs3_score_populated_only_where_context_exists(stub_rs3):
+    for g in ov.synbio.design_grnas(RANKING_TARGET, method="rs3"):
+        assert (g.rs3_score is not None) == (len(g.context) == 30)
+
+
+def test_rs3_does_not_clobber_heuristic_efficiency(stub_rs3):
+    """The regression: ``efficiency`` used to *become* the z-score."""
+    heur = {(g.spacer, g.start, g.strand): g.efficiency
+            for g in ov.synbio.design_grnas(RANKING_TARGET)}
+    for g in ov.synbio.design_grnas(RANKING_TARGET, method="rs3"):
+        assert 0.0 <= g.efficiency <= 1.0
+        assert g.efficiency == pytest.approx(heur[(g.spacer, g.start, g.strand)])
+
+
+def test_rs3_ranking_is_by_z_score_and_tolerates_negatives(stub_rs3):
+    guides = ov.synbio.design_grnas(RANKING_TARGET, method="rs3")
+    scored = [g for g in guides if g.rs3_score is not None]
+    assert scored, "stub should have scored at least one guide"
+    assert all(g.rs3_score < 0 for g in scored), "stub returns negative z-scores"
+    zs = [g.rs3_score for g in scored]
+    assert zs == sorted(zs, reverse=True)
+
+
+def test_unscorable_guides_rank_last(stub_rs3):
+    """A top-heuristic guide with no context must not outrank a real rs3 hit.
+
+    ``RANKING_TARGET`` has guides too close to both ends to yield a 30-mer, and
+    one of them carries the *highest* heuristic efficiency in the pool — under
+    the old scale-mixing sort it landed at rank 0, ahead of every guide the
+    model actually scored.
+    """
+    guides = ov.synbio.design_grnas(RANKING_TARGET, method="rs3")
+    unscored = [g for g in guides if g.rs3_score is None]
+    scored = [g for g in guides if g.rs3_score is not None]
+    assert unscored and scored, "target must exercise both cases"
+
+    n = len(scored)
+    assert all(g.rs3_score is not None for g in guides[:n]), "scored guides lead"
+    assert all(g.rs3_score is None for g in guides[n:]), "unscored form the tail"
+
+    # The trap: an unscored guide beats every scored one on the heuristic scale.
+    assert max(g.efficiency for g in unscored) >= max(g.efficiency for g in scored)
+
+
+def test_no_fabricated_flanks_reach_the_model(stub_rs3):
+    """Contexts are real 30-mers taken from the input, never padded out."""
+    ov.synbio.design_grnas(RANKING_TARGET, method="rs3")
+    revcomp = RANKING_TARGET.translate(str.maketrans("ACGTN", "TGCAN"))[::-1]
+    for ctx in stub_rs3["contexts"]:
+        assert len(ctx) == 30
+        assert set(ctx) <= set("ACGT")
+        assert ctx in RANKING_TARGET or ctx in revcomp
+
+
+def test_tracr_passed_through(stub_rs3):
+    ov.synbio.design_grnas(RANKING_TARGET, method="rs3")
+    assert stub_rs3["tracr"] == "Hsu2013"
+
+
+def test_top_n_applies_after_the_rs3_sort(stub_rs3):
+    full = ov.synbio.design_grnas(RANKING_TARGET, method="rs3")
+    top = ov.synbio.design_grnas(RANKING_TARGET, method="rs3", top_n=3)
+    assert len(top) == 3
+    assert [g.spacer for g in top] == [g.spacer for g in full[:3]]
+
+
+def test_rs3_failure_is_not_silently_downgraded(monkeypatch):
+    """An unavailable rs3 raises — it does not quietly fall back to heuristic.
+
+    A silent fallback would hand back a heuristic ranking under the name the
+    caller asked rs3 for: the same scale confusion, just hidden better.
+    """
+    def boom(contexts, sequence_tracr="Hsu2013"):
+        raise ImportError("rs3 install failed")
+
+    monkeypatch.setattr(_rs3, "predict_rs3", boom)
+    with pytest.raises(ImportError, match="rs3"):
+        ov.synbio.design_grnas(RANKING_TARGET, method="rs3")
+
+
+def test_guide_rs3_score_defaults_to_none():
+    from omicverse.synbio._crispr import Guide
+
+    g = Guide(spacer="A" * 20, pam="AGG", start=0, strand="+", gc=0.0,
+              efficiency=0.5, poly_t=False)
+    assert g.rs3_score is None
+
+
+def test_guide_repr_shows_rs3_only_when_scored():
+    from omicverse.synbio._crispr import Guide
+
+    g = Guide(spacer="A" * 20, pam="AGG", start=0, strand="+", gc=0.0,
+              efficiency=0.5, poly_t=False)
+    assert "rs3" not in repr(g)
+    g.rs3_score = -1.25
+    assert "rs3=-1.25" in repr(g)


### PR DESCRIPTION
## The bug

`design_grnas(method='rs3')` overwrote `Guide.efficiency` with the Rule Set 3 prediction.

Those are not the same kind of number. rs3 emits a **z-score** — unbounded, routinely negative. `efficiency` is a bounded `[0,1]` GC/poly-T heuristic. Guides too close to the sequence ends to yield a 30-mer context can't be rs3-scored at all, so they kept their heuristic value — and the single `sort` at the end then ranked the whole pool across two incompatible scales.

Concretely, on the target added in this PR (21 SpCas9 guides, 2 of them end-adjacent):

```
+@  1 eff=0.910 rs3=None
-@  5 eff=0.950 rs3=None     <- highest heuristic score in the pool
... 19 guides with rs3 in [-9.5, -0.5]
```

Every scored guide is negative, so **both unscorable guides sorted to the top** — including the one at `eff=0.950`, which took rank 0 ahead of everything the model actually looked at. Asking for the better model made the ranking worse.

## The fix

- `Guide` gains `rs3_score: Optional[float] = None`.
- `efficiency` now always means the heuristic in `[0,1]` and is never overwritten. `crispr_regulation` already relies on this when it computes `score = window_score * efficiency` (`_editing.py:234`) — with a negative z-score in there the product inverts. It happens not to pass `method='rs3'` today, so it was never hit; the invariant is now explicit rather than incidental.
- `method='rs3'` ranks by `rs3_score`; guides that can't be scored rank **last** instead of being interleaved. `top_n` applies after that sort.
- No flanking sequence is invented to manufacture a 30-mer — an unscorable guide is reported as unscored, not guessed at.
- `__repr__` shows rs3 only when present.

Callers who want the old single-number behaviour read `rs3_score`; callers who want a bounded score read `efficiency`. Neither is silently the other.

## Tests

12 tests added to `tests/test_synbio_crispr.py` (the module #914 created), which the `CRISPR + extra guards` CI step already runs. **21 passed** in that module.

`_rs3.predict_rs3` is stubbed, so `ensure_rs3()` never runs: no `--no-deps` pip fetch, no ~20 MB model download, no lightgbm import. The stub deliberately returns **negative** z-scores — that is the regime real Rule Set 3 produces and the one that broke sorting, so a stub returning `[0,1]` values would not have caught this.

Checking out the pre-fix `_crispr.py` under the new tests gives **7 failed / 14 passed**, and the load-bearing failure is a real assertion rather than a missing attribute:

```
FAILED test_rs3_does_not_clobber_heuristic_efficiency - assert 0.0 <= -0.5
```

Also verified through the public API: `ov.synbio.design_grnas` and `ov.synbio.crispr_regulation` (9 guides, all scores in `[0,1]`).

## Not in this PR

`tests/test_synbio_gpu.py` fails locally with `OSError: [Errno 28] No space left on device` — `OMICOS_SYNBIO_WEIGHTS` defaults under `$HOME/.omicverse/synbio_weights`, which is a 15 GB quota on our cluster, and ESMFold does not fit. Unrelated to this change (layer B, no `_crispr` involvement) and it skips cleanly on CPU CI. Filing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EEdtfKgHr5pRPtCx5UTePa