### PR TITLE
fix(space): replace legacy rpy2 mclust wrappers

### DIFF
--- a/omicverse/external/BINARY/utils.py
+++ b/omicverse/external/BINARY/utils.py
@@ -9,6 +9,7 @@ import scanpy as sc
 import torch
 from torch_geometric.data import Data
 import anndata as ad
+from .._pymclustr import fit_pymclustr
 
 
 def Count2Binary(adata):
@@ -468,7 +469,7 @@ def Stats_Spatial_Graph(adata):
 
 def mclust_R(adata, num_cluster, add_key = 'mclust', modelNames='EEE', used_obsm='BINARY', random_seed=2020):
     """
-    Cluster an AnnData object using the mclust algorithm from R.
+    Cluster an AnnData object using the pure-Python pymclustR backend.
     
     Parameters:
     ----------
@@ -497,20 +498,13 @@ def mclust_R(adata, num_cluster, add_key = 'mclust', modelNames='EEE', used_obsm
         The input AnnData object with added clustering results in `adata.obs[add_key]`.
     """
     
-    np.random.seed(random_seed)
-    import rpy2.robjects as robjects
-    robjects.r.library("mclust")
-
-    import rpy2.robjects.numpy2ri
-    rpy2.robjects.numpy2ri.activate()
-    r_random_seed = robjects.r['set.seed']
-    r_random_seed(random_seed)
-    rmclust = robjects.r['Mclust']
-
-    res = rmclust(rpy2.robjects.numpy2ri.numpy2rpy(adata.obsm[used_obsm]), num_cluster, modelNames)
-    mclust_res = np.array(res[-2])
-
-    adata.obs[add_key] = mclust_res
+    labels, _ = fit_pymclustr(
+        adata.obsm[used_obsm],
+        n_components=num_cluster,
+        model_names=modelNames,
+        random_state=random_seed,
+    )
+    adata.obs[add_key] = labels
     adata.obs[add_key] = adata.obs[add_key].astype('int')
     adata.obs[add_key] = adata.obs[add_key].astype('category')
     return adata

--- a/omicverse/external/BINARY/utils.py
+++ b/omicverse/external/BINARY/utils.py
@@ -471,6 +471,10 @@ def mclust_R(adata, num_cluster, add_key = 'mclust', modelNames='EEE', used_obsm
     """
     Cluster an AnnData object using the pure-Python pymclustR backend.
     
+    The name is kept for backward compatibility; nothing here calls R any
+    more. See :func:`omicverse.external._pymclustr.fit_pymclustr` for where
+    the substitution is and is not numerically transparent.
+    
     Parameters:
     ----------
     adata : AnnData

--- a/omicverse/external/GraphST/utils.py
+++ b/omicverse/external/GraphST/utils.py
@@ -8,7 +8,12 @@ from .._pymclustr import fit_pymclustr
 
 
 def mclust_R(adata, num_cluster, modelNames='EEE', used_obsm='emb_pca', random_seed=2020):
-    """Cluster an AnnData embedding with the pure-Python pymclustR backend."""
+    """Cluster an AnnData embedding with the pure-Python pymclustR backend.
+
+    The name is kept for backward compatibility; nothing here calls R any
+    more. See :func:`omicverse.external._pymclustr.fit_pymclustr` for where
+    the substitution is and is not numerically transparent.
+    """
     labels, _ = fit_pymclustr(
         adata.obsm[used_obsm],
         n_components=num_cluster,

--- a/omicverse/external/GraphST/utils.py
+++ b/omicverse/external/GraphST/utils.py
@@ -4,28 +4,18 @@ from sklearn import metrics
 import scanpy as sc
 
 from sklearn.decomposition import PCA
+from .._pymclustr import fit_pymclustr
 
 
 def mclust_R(adata, num_cluster, modelNames='EEE', used_obsm='emb_pca', random_seed=2020):
-    """\
-    Clustering using the mclust algorithm.
-    The parameters are the same as those in the R package mclust.
-    """
-    
-    np.random.seed(random_seed)
-    import rpy2.robjects as robjects
-    robjects.r.library("mclust")
-
-    import rpy2.robjects.numpy2ri
-    rpy2.robjects.numpy2ri.activate()
-    r_random_seed = robjects.r['set.seed']
-    r_random_seed(random_seed)
-    rmclust = robjects.r['Mclust']
-    
-    res = rmclust(rpy2.robjects.numpy2ri.numpy2rpy(adata.obsm[used_obsm]), num_cluster, modelNames)
-    mclust_res = np.array(res[-2])
-
-    adata.obs['mclust'] = mclust_res
+    """Cluster an AnnData embedding with the pure-Python pymclustR backend."""
+    labels, _ = fit_pymclustr(
+        adata.obsm[used_obsm],
+        n_components=num_cluster,
+        model_names=modelNames,
+        random_state=random_seed,
+    )
+    adata.obs['mclust'] = labels
     adata.obs['mclust'] = adata.obs['mclust'].astype('int')
     adata.obs['mclust'] = adata.obs['mclust'].astype('category')
     return adata

--- a/omicverse/external/PROST/utils.py
+++ b/omicverse/external/PROST/utils.py
@@ -384,7 +384,11 @@ def cluster_post_process(adata, platform, k_neighbors = None, min_distance = Non
 
 
 def mclust(data, num_cluster, modelNames = 'EEE', random_seed = 818):
-    """Cluster data with pymclustR while preserving R's 1-based labels."""
+    """Cluster data with pymclustR while preserving R's 1-based labels.
+
+    See :func:`omicverse.external._pymclustr.fit_pymclustr` for where the
+    substitution for R ``mclust`` is and is not numerically transparent.
+    """
     labels, _ = fit_pymclustr(
         data,
         n_components=num_cluster,

--- a/omicverse/external/PROST/utils.py
+++ b/omicverse/external/PROST/utils.py
@@ -15,6 +15,7 @@ from scipy.interpolate import griddata
 from statsmodels.stats.multitest import fdrcorrection
 import multiprocessing as mp
 from tqdm import trange, tqdm
+from .._pymclustr import fit_pymclustr
 
 
 
@@ -383,19 +384,14 @@ def cluster_post_process(adata, platform, k_neighbors = None, min_distance = Non
 
 
 def mclust(data, num_cluster, modelNames = 'EEE', random_seed = 818):
-    """
-    Mclust algorithm from R, similar to https://mclust-org.github.io/mclust/
-    """ 
-    np.random.seed(random_seed)
-    import rpy2.robjects as robjects
-    robjects.r.library("mclust")
-    import rpy2.robjects.numpy2ri
-    rpy2.robjects.numpy2ri.activate()  
-    r_random_seed = robjects.r['set.seed']
-    r_random_seed(random_seed)
-    rmclust = robjects.r['Mclust']
-    res = rmclust(data, num_cluster, modelNames)
-    return np.array(res[-2])
+    """Cluster data with pymclustR while preserving R's 1-based labels."""
+    labels, _ = fit_pymclustr(
+        data,
+        n_components=num_cluster,
+        model_names=modelNames,
+        random_state=random_seed,
+    )
+    return labels
 
 
 def calc_I(y, w):

--- a/omicverse/external/STAGATE_pyG/utils.py
+++ b/omicverse/external/STAGATE_pyG/utils.py
@@ -202,7 +202,12 @@ def Stats_Spatial_Net(adata):
     ax.bar(plot_df.index, plot_df)
 
 def mclust_R(adata, num_cluster, modelNames='EEE', used_obsm='STAGATE', random_seed=2020):
-    """Cluster an AnnData embedding with the pure-Python pymclustR backend."""
+    """Cluster an AnnData embedding with the pure-Python pymclustR backend.
+
+    The name is kept for backward compatibility; nothing here calls R any
+    more. See :func:`omicverse.external._pymclustr.fit_pymclustr` for where
+    the substitution is and is not numerically transparent.
+    """
     labels, _ = fit_pymclustr(
         adata.obsm[used_obsm],
         n_components=num_cluster,

--- a/omicverse/external/STAGATE_pyG/utils.py
+++ b/omicverse/external/STAGATE_pyG/utils.py
@@ -6,6 +6,7 @@ import seaborn as sns
 import matplotlib.pyplot as plt
 
 import torch
+from .._pymclustr import fit_pymclustr
 
 
 def Transfer_pytorch_Data(adata):
@@ -201,25 +202,14 @@ def Stats_Spatial_Net(adata):
     ax.bar(plot_df.index, plot_df)
 
 def mclust_R(adata, num_cluster, modelNames='EEE', used_obsm='STAGATE', random_seed=2020):
-    """\
-    Clustering using the mclust algorithm.
-    The parameters are the same as those in the R package mclust.
-    """
-    
-    np.random.seed(random_seed)
-    import rpy2.robjects as robjects
-    robjects.r.library("mclust")
-
-    import rpy2.robjects.numpy2ri
-    rpy2.robjects.numpy2ri.activate()
-    r_random_seed = robjects.r['set.seed']
-    r_random_seed(random_seed)
-    rmclust = robjects.r['Mclust']
-
-    res = rmclust(rpy2.robjects.numpy2ri.numpy2rpy(adata.obsm[used_obsm]), num_cluster, modelNames)
-    mclust_res = np.array(res[-2])
-
-    adata.obs['mclust'] = mclust_res
+    """Cluster an AnnData embedding with the pure-Python pymclustR backend."""
+    labels, _ = fit_pymclustr(
+        adata.obsm[used_obsm],
+        n_components=num_cluster,
+        model_names=modelNames,
+        random_state=random_seed,
+    )
+    adata.obs['mclust'] = labels
     adata.obs['mclust'] = adata.obs['mclust'].astype('int')
     adata.obs['mclust'] = adata.obs['mclust'].astype('category')
     return adata

--- a/omicverse/external/STAligner/ST_utils.py
+++ b/omicverse/external/STAligner/ST_utils.py
@@ -124,7 +124,12 @@ def Stats_Spatial_Net(adata):
 
 
 def mclust_R(adata, num_cluster, modelNames='EEE', used_obsm='STAGATE', random_seed=666):
-    """Cluster an AnnData embedding with the pure-Python pymclustR backend."""
+    """Cluster an AnnData embedding with the pure-Python pymclustR backend.
+
+    The name is kept for backward compatibility; nothing here calls R any
+    more. See :func:`omicverse.external._pymclustr.fit_pymclustr` for where
+    the substitution is and is not numerically transparent.
+    """
     labels, _ = fit_pymclustr(
         adata.obsm[used_obsm],
         n_components=num_cluster,

--- a/omicverse/external/STAligner/ST_utils.py
+++ b/omicverse/external/STAligner/ST_utils.py
@@ -4,6 +4,7 @@ import numpy as np
 import sklearn.neighbors
 import networkx as nx
 from .mnn_utils import create_dictionary_mnn
+from .._pymclustr import fit_pymclustr
 
 def match_cluster_labels(true_labels,est_labels):
     true_labels_arr = np.array(list(true_labels))
@@ -123,25 +124,14 @@ def Stats_Spatial_Net(adata):
 
 
 def mclust_R(adata, num_cluster, modelNames='EEE', used_obsm='STAGATE', random_seed=666):
-    """\
-    Clustering using the mclust algorithm.
-    The parameters are the same as those in the R package mclust.
-    """
-
-    np.random.seed(random_seed)
-    import rpy2.robjects as robjects
-    robjects.r.library("mclust")
-
-    import rpy2.robjects.numpy2ri
-    rpy2.robjects.numpy2ri.activate()
-    r_random_seed = robjects.r['set.seed']
-    r_random_seed(random_seed)
-    rmclust = robjects.r['Mclust']
-
-    res = rmclust(adata.obsm[used_obsm], num_cluster, modelNames)
-    mclust_res = np.array(res[-2])
-
-    adata.obs['mclust'] = mclust_res
+    """Cluster an AnnData embedding with the pure-Python pymclustR backend."""
+    labels, _ = fit_pymclustr(
+        adata.obsm[used_obsm],
+        n_components=num_cluster,
+        model_names=modelNames,
+        random_state=random_seed,
+    )
+    adata.obs['mclust'] = labels
     adata.obs['mclust'] = adata.obs['mclust'].astype('int')
     adata.obs['mclust'] = adata.obs['mclust'].astype('category')
     return adata

--- a/omicverse/external/_pymclustr.py
+++ b/omicverse/external/_pymclustr.py
@@ -1,4 +1,20 @@
-"""Shared adapter for the optional :mod:`pymclustR` backend."""
+"""Shared adapter for the optional :mod:`pymclustR` backend.
+
+This replaces the ``rpy2`` bridge the spatial wrappers used to embed, so an R
+installation is no longer required. For the ``EEE`` model those wrappers all
+default to, the substitution is numerically transparent: on a real 700-cell
+PCA embedding, ``pymclustR`` and R ``mclust`` 6.1.2 agree on log-likelihood
+and BIC to six decimals and place every cell in the same cluster (ARI 1.0) at
+both G=5 and G=7.
+
+That does not hold for every covariance model. ``pymclustR``'s own R-parity
+suite holds ``EVE`` and ``VVE`` only to a 50% log-likelihood tolerance and a
+55% label-agreement floor, because those two share one orientation matrix
+across components and their likelihood surface has several stationary points —
+R's Browne-McNicholas MM optimiser and ``pymclustR``'s Stiefel gradient
+descent can converge to different maxima. Callers who pass ``EVE`` or ``VVE``
+through ``model_names`` should not expect their previous R-derived labels.
+"""
 
 from __future__ import annotations
 

--- a/omicverse/external/_pymclustr.py
+++ b/omicverse/external/_pymclustr.py
@@ -1,0 +1,83 @@
+"""Shared adapter for the optional :mod:`pymclustR` backend."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any, Optional, Union
+
+import numpy as np
+
+
+def fit_pymclustr(
+    data: Any,
+    n_components: int,
+    model_names: Union[str, Sequence[str]] = "EEE",
+    random_state: Optional[int] = None,
+    **kwargs: Any,
+):
+    """Fit pymclustR and return its 1-based classifications and fit object."""
+    if isinstance(n_components, bool) or not isinstance(
+        n_components, (int, np.integer)
+    ):
+        raise TypeError("n_components must be a positive integer")
+    n_components = int(n_components)
+    if n_components < 1:
+        raise ValueError("n_components must be a positive integer")
+
+    values = np.asarray(data)
+    if values.ndim != 2:
+        raise ValueError("pymclustR input data must be a two-dimensional matrix")
+    if values.shape[0] < n_components:
+        raise ValueError(
+            "n_components cannot exceed the number of observations"
+        )
+    if not np.issubdtype(values.dtype, np.number):
+        raise TypeError("pymclustR input data must contain numeric values")
+    values = values.astype(float, copy=False)
+    if not np.isfinite(values).all():
+        raise ValueError("pymclustR input data must contain only finite values")
+
+    if isinstance(model_names, str):
+        normalized_models = [model_names]
+    else:
+        normalized_models = list(model_names)
+    if not normalized_models or not all(
+        isinstance(model, str) and model for model in normalized_models
+    ):
+        raise ValueError("model_names must contain at least one model name")
+
+    try:
+        from mclust_py import Mclust
+    except ImportError as exc:
+        raise ImportError(
+            "pymclustR>=0.2.1 is required for this clustering backend. "
+            "Install it with `pip install pymclustR>=0.2.1`."
+        ) from exc
+
+    random_state_snapshot = np.random.get_state()
+    try:
+        if random_state is not None:
+            np.random.seed(random_state)
+        fit = Mclust(
+            values,
+            G=[n_components],
+            model_names=normalized_models,
+            **kwargs,
+        )
+    finally:
+        np.random.set_state(random_state_snapshot)
+
+    raw_labels = np.asarray(fit.classification)
+    if raw_labels.shape != (values.shape[0],):
+        raise RuntimeError(
+            "pymclustR returned classifications with an unexpected shape"
+        )
+    labels = raw_labels.astype(int)
+    if not np.array_equal(raw_labels, labels):
+        raise RuntimeError("pymclustR returned non-integer classifications")
+    if labels.size and (labels.min() < 1 or labels.max() > int(fit.G)):
+        raise RuntimeError(
+            "pymclustR returned classifications outside its 1-based range"
+        )
+
+    return labels, fit

--- a/omicverse/utils/_cluster.py
+++ b/omicverse/utils/_cluster.py
@@ -7,6 +7,7 @@ import numpy as np
 import anndata
 from .._settings import add_reference
 from .._registry import register_function
+from ..external._pymclustr import fit_pymclustr
 
 mira_install=False
 def global_imports(modulename,shortname = None, asfunction = False):
@@ -153,7 +154,9 @@ def cluster(adata:anndata.AnnData,method:str='leiden',
         Number of clusters/components for ``'kmeans'``, ``'GMM'``, and
         ``'mclust'``.
     **kwargs
-        Extra keyword arguments forwarded to the selected backend.
+        Extra keyword arguments forwarded to the selected backend. For
+        ``method='pymclustR'``, ``key_added`` selects the output column;
+        the legacy spelling ``add_key`` is also accepted.
 
     Returns
     -------
@@ -211,31 +214,31 @@ def cluster(adata:anndata.AnnData,method:str='leiden',
         schist.inference.nested_model(adata, **kwargs)
         add_reference(adata,'schist','clustering with schist')
     elif method=='pymclustR':
-        # Pure-Python re-implementation of CRAN mclust — same 14
-        # covariance parameterisations, same EM, same BIC. Replaces
-        # the legacy ``method='mclust_R'`` (rpy2 bridge) so omicverse
-        # no longer needs an R install.
-        try:
-            from mclust_py import Mclust as _PyMclust
-        except ImportError as e:
-            raise ImportError(
-                "pymclustR is required for method='pymclustR'. "
-                "Install with: pip install pymclustR"
-            ) from e
         if n_components is None:
             raise ValueError("n_components must be provided for method='pymclustR'")
-        np.random.seed(random_state)
-        modelNames = kwargs.pop('modelNames', 'EEE')
-        if isinstance(modelNames, str):
-            modelNames = [modelNames]
-        fit = _PyMclust(
+        key_added = kwargs.pop('key_added', None)
+        add_key = kwargs.pop('add_key', None)
+        if key_added is not None and add_key is not None and key_added != add_key:
+            raise ValueError(
+                "key_added and add_key must match when both are provided"
+            )
+        output_key = (
+            key_added
+            if key_added is not None
+            else add_key if add_key is not None else method
+        )
+        if not isinstance(output_key, str) or not output_key:
+            raise ValueError("key_added must be a non-empty string")
+        model_names = kwargs.pop('modelNames', 'EEE')
+        labels, fit = fit_pymclustr(
             adata.obsm[use_rep],
-            G=[int(n_components)],
-            model_names=list(modelNames),
+            n_components=n_components,
+            model_names=model_names,
+            random_state=random_state,
             **kwargs,
         )
-        adata.obs[method] = fit.classification.astype(int)
-        adata.obs[method] = adata.obs[method].astype('category')
+        adata.obs[output_key] = labels
+        adata.obs[output_key] = adata.obs[output_key].astype('category')
         adata.uns.setdefault('pymclustR', {})[use_rep] = {
             'modelName': fit.model_name,
             'G': fit.G,
@@ -243,7 +246,7 @@ def cluster(adata:anndata.AnnData,method:str='leiden',
             'bic': fit.bic,
         }
         print(f"""finished: found {n_components} clusters and added
-    'pymclustR', the cluster labels (adata.obs, categorical)
+    '{output_key}', the cluster labels (adata.obs, categorical)
     [model={fit.model_name}, loglik={fit.loglik:.4f}, BIC={fit.bic:.4f}]""")
         add_reference(adata, 'pymclustR',
                       'clustering with pymclustR (Python re-implementation of CRAN mclust)')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,6 +142,7 @@ full = [
   'gdown>=4.6',
   'wandb',
   'pygam>=0.8.0',
+  'pymclustR>=0.2.1',
 ]
 
 easy=[
@@ -222,6 +223,7 @@ jarvis = [
 tests = [
   "pytest>=7.0",
   "pytest-asyncio>=0.23",
+  "pymclustR>=0.2.1",
   "python-telegram-bot>=21.3",
   "discord.py>=2.5",
   "requests>=2.0",

--- a/tests/external/test_spatial_pymclustr.py
+++ b/tests/external/test_spatial_pymclustr.py
@@ -1,0 +1,435 @@
+"""Regression tests for the shared spatial pymclustR integration."""
+
+from __future__ import annotations
+
+import importlib.util
+import inspect
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+import anndata
+import numpy as np
+import pandas as pd
+import pytest
+
+from omicverse.external._pymclustr import fit_pymclustr
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _fake_fit(labels):
+    return SimpleNamespace(
+        classification=np.asarray(labels),
+        model_name="EEE",
+        G=len(np.unique(labels)),
+        loglik=-12.5,
+        bic=-31.0,
+    )
+
+
+def _load_source_module(monkeypatch, module_name, relative_path):
+    if "torch_geometric.data" not in sys.modules:
+        torch_geometric = types.ModuleType("torch_geometric")
+        torch_geometric_data = types.ModuleType("torch_geometric.data")
+        torch_geometric_data.Data = object
+        torch_geometric.data = torch_geometric_data
+        monkeypatch.setitem(sys.modules, "torch_geometric", torch_geometric)
+        monkeypatch.setitem(
+            sys.modules, "torch_geometric.data", torch_geometric_data
+        )
+
+    if "omicverse.external.STAligner.mnn_utils" not in sys.modules:
+        mnn_utils = types.ModuleType("omicverse.external.STAligner.mnn_utils")
+        mnn_utils.create_dictionary_mnn = lambda *args, **kwargs: {}
+        monkeypatch.setitem(
+            sys.modules, "omicverse.external.STAligner.mnn_utils", mnn_utils
+        )
+
+    spec = importlib.util.spec_from_file_location(
+        module_name, ROOT / relative_path
+    )
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, module_name, module)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_adapter_matches_direct_pymclustr_and_preserves_one_based_labels():
+    from mclust_py import Mclust
+
+    data = np.random.default_rng(42).normal(size=(80, 4))
+    labels, fit = fit_pymclustr(
+        data, n_components=3, model_names="EEE", random_state=17
+    )
+    direct = Mclust(data, G=[3], model_names=["EEE"])
+
+    np.testing.assert_array_equal(labels, direct.classification)
+    assert labels.min() == 1
+    assert labels.max() == 3
+    assert fit.model_name == direct.model_name
+    assert fit.G == direct.G
+    assert fit.loglik == direct.loglik
+    assert fit.bic == direct.bic
+
+
+def test_adapter_restores_numpy_random_state(monkeypatch):
+    class FakeMclust:
+        def __init__(self, data, G, model_names, **kwargs):
+            np.random.random(5)
+            self.classification = np.ones(len(data), dtype=int)
+            self.model_name = model_names[0]
+            self.G = G[0]
+
+    monkeypatch.setitem(
+        sys.modules, "mclust_py", SimpleNamespace(Mclust=FakeMclust)
+    )
+    data = np.arange(12, dtype=float).reshape(6, 2)
+
+    np.random.seed(123)
+    expected = np.random.random(4)
+    np.random.seed(123)
+    fit_pymclustr(data, 1, random_state=999)
+    observed = np.random.random(4)
+
+    np.testing.assert_array_equal(observed, expected)
+
+
+@pytest.mark.parametrize(
+    ("data", "n_components", "error", "message"),
+    [
+        (np.ones(5), 2, ValueError, "two-dimensional"),
+        (np.ones((2, 2)), 3, ValueError, "cannot exceed"),
+        (np.array([[1.0, np.nan], [2.0, 3.0]]), 2, ValueError, "finite"),
+        (np.ones((4, 2)), 0, ValueError, "positive integer"),
+        (np.ones((4, 2)), 1.5, TypeError, "positive integer"),
+    ],
+)
+def test_adapter_validates_inputs(data, n_components, error, message):
+    with pytest.raises(error, match=message):
+        fit_pymclustr(data, n_components)
+
+
+def test_adapter_reports_missing_optional_dependency(monkeypatch):
+    monkeypatch.setitem(sys.modules, "mclust_py", None)
+    with pytest.raises(ImportError, match=r"pip install pymclustR>=0\.2\.1"):
+        fit_pymclustr(np.ones((4, 2)), 2)
+
+
+@pytest.mark.parametrize(
+    ("module_name", "relative_path", "function_name", "embedding_key"),
+    [
+        (
+            "omicverse.external.GraphST._utils_pymclustr_test",
+            "omicverse/external/GraphST/utils.py",
+            "mclust_R",
+            "emb_pca",
+        ),
+        (
+            "omicverse.external.STAGATE_pyG._utils_pymclustr_test",
+            "omicverse/external/STAGATE_pyG/utils.py",
+            "mclust_R",
+            "STAGATE",
+        ),
+        (
+            "omicverse.external.STAligner._utils_pymclustr_test",
+            "omicverse/external/STAligner/ST_utils.py",
+            "mclust_R",
+            "STAGATE",
+        ),
+    ],
+)
+def test_anndata_wrappers_preserve_contract(
+    monkeypatch, module_name, relative_path, function_name, embedding_key
+):
+    module = _load_source_module(monkeypatch, module_name, relative_path)
+    labels = np.array([1, 1, 2, 2, 3, 3])
+    calls = {}
+
+    def fake_adapter(data, **kwargs):
+        calls.update(kwargs)
+        np.testing.assert_array_equal(data, adata.obsm[embedding_key])
+        return labels, _fake_fit(labels)
+
+    monkeypatch.setattr(module, "fit_pymclustr", fake_adapter)
+    adata = anndata.AnnData(np.ones((6, 2)))
+    adata.obsm[embedding_key] = np.arange(18, dtype=float).reshape(6, 3)
+
+    result = getattr(module, function_name)(
+        adata,
+        num_cluster=3,
+        modelNames="EEE",
+        used_obsm=embedding_key,
+        random_seed=27,
+    )
+
+    assert result is adata
+    np.testing.assert_array_equal(adata.obs["mclust"].astype(int), labels)
+    assert isinstance(adata.obs["mclust"].dtype, pd.CategoricalDtype)
+    assert calls == {
+        "n_components": 3,
+        "model_names": "EEE",
+        "random_state": 27,
+    }
+
+
+def test_prost_wrapper_returns_one_based_label_array(monkeypatch):
+    module = _load_source_module(
+        monkeypatch,
+        "omicverse.external.PROST._utils_pymclustr_test",
+        "omicverse/external/PROST/utils.py",
+    )
+    labels = np.array([1, 1, 2, 3])
+    monkeypatch.setattr(
+        module,
+        "fit_pymclustr",
+        lambda data, **kwargs: (labels, _fake_fit(labels)),
+    )
+
+    result = module.mclust(
+        np.ones((4, 2)), num_cluster=3, modelNames="EEE", random_seed=818
+    )
+
+    np.testing.assert_array_equal(result, labels)
+
+
+def test_binary_wrapper_respects_custom_add_key(monkeypatch):
+    module = _load_source_module(
+        monkeypatch,
+        "omicverse.external.BINARY._utils_pymclustr_test",
+        "omicverse/external/BINARY/utils.py",
+    )
+    labels = np.array([1, 1, 2, 2])
+    monkeypatch.setattr(
+        module,
+        "fit_pymclustr",
+        lambda data, **kwargs: (labels, _fake_fit(labels)),
+    )
+    adata = anndata.AnnData(np.ones((4, 2)))
+    adata.obsm["BINARY"] = np.ones((4, 3))
+
+    result = module.mclust_R(adata, 2, add_key="domain")
+
+    assert result is adata
+    np.testing.assert_array_equal(adata.obs["domain"].astype(int), labels)
+    assert isinstance(adata.obs["domain"].dtype, pd.CategoricalDtype)
+
+
+@pytest.mark.parametrize(
+    ("module_name", "relative_path", "function_name", "embedding_key"),
+    [
+        (
+            "omicverse.external.GraphST._real_pymclustr_test",
+            "omicverse/external/GraphST/utils.py",
+            "mclust_R",
+            "emb_pca",
+        ),
+        (
+            "omicverse.external.STAGATE_pyG._real_pymclustr_test",
+            "omicverse/external/STAGATE_pyG/utils.py",
+            "mclust_R",
+            "STAGATE",
+        ),
+        (
+            "omicverse.external.STAligner._real_pymclustr_test",
+            "omicverse/external/STAligner/ST_utils.py",
+            "mclust_R",
+            "STAGATE",
+        ),
+        (
+            "omicverse.external.BINARY._real_pymclustr_test",
+            "omicverse/external/BINARY/utils.py",
+            "mclust_R",
+            "BINARY",
+        ),
+    ],
+)
+def test_anndata_wrappers_match_real_adapter(
+    monkeypatch, module_name, relative_path, function_name, embedding_key
+):
+    module = _load_source_module(monkeypatch, module_name, relative_path)
+    embedding = np.random.default_rng(18).normal(size=(30, 3))
+    expected, _ = fit_pymclustr(
+        embedding, n_components=3, model_names="EEE", random_state=29
+    )
+    adata = anndata.AnnData(np.ones((30, 2)))
+    adata.obsm[embedding_key] = embedding
+
+    kwargs = {
+        "num_cluster": 3,
+        "modelNames": "EEE",
+        "used_obsm": embedding_key,
+        "random_seed": 29,
+    }
+    if "BINARY" in module_name:
+        kwargs["add_key"] = "domain"
+    result = getattr(module, function_name)(adata, **kwargs)
+    output_key = "domain" if "BINARY" in module_name else "mclust"
+
+    assert result is adata
+    np.testing.assert_array_equal(
+        adata.obs[output_key].astype(int).to_numpy(), expected
+    )
+
+
+def test_prost_wrapper_matches_real_adapter(monkeypatch):
+    module = _load_source_module(
+        monkeypatch,
+        "omicverse.external.PROST._real_pymclustr_test",
+        "omicverse/external/PROST/utils.py",
+    )
+    data = np.random.default_rng(21).normal(size=(30, 3))
+    expected, _ = fit_pymclustr(
+        data, n_components=3, model_names="EEE", random_state=818
+    )
+
+    observed = module.mclust(data, num_cluster=3)
+
+    np.testing.assert_array_equal(observed, expected)
+
+
+def test_utils_cluster_supports_output_key_aliases_without_leaking(monkeypatch):
+    from omicverse.utils import _cluster
+
+    calls = []
+    labels = np.array([1, 1, 2, 2])
+    fit = _fake_fit(labels)
+
+    def fake_adapter(data, **kwargs):
+        calls.append(kwargs)
+        return labels, fit
+
+    monkeypatch.setattr(_cluster, "fit_pymclustr", fake_adapter)
+    adata = anndata.AnnData(np.ones((4, 2)))
+    adata.obsm["X_pca"] = np.ones((4, 3))
+
+    assert (
+        _cluster.cluster(
+            adata,
+            method="pymclustR",
+            n_components=2,
+            key_added="domain",
+            modelNames="EEE",
+        )
+        is None
+    )
+    np.testing.assert_array_equal(adata.obs["domain"].astype(int), labels)
+    assert calls == [
+        {
+            "n_components": 2,
+            "model_names": "EEE",
+            "random_state": 1024,
+        }
+    ]
+    assert adata.uns["pymclustR"]["X_pca"] == {
+        "modelName": "EEE",
+        "G": 2,
+        "loglik": -12.5,
+        "bic": -31.0,
+    }
+
+    second = anndata.AnnData(np.ones((4, 2)))
+    second.obsm["X_pca"] = np.ones((4, 3))
+    _cluster.cluster(
+        second,
+        method="pymclustR",
+        n_components=2,
+        add_key="legacy_domain",
+    )
+    assert "legacy_domain" in second.obs
+
+    default = anndata.AnnData(np.ones((4, 2)))
+    default.obsm["X_pca"] = np.ones((4, 3))
+    _cluster.cluster(default, method="pymclustR", n_components=2)
+    assert "pymclustR" in default.obs
+
+
+def test_utils_cluster_rejects_conflicting_output_keys():
+    from omicverse.utils import _cluster
+
+    adata = anndata.AnnData(np.ones((4, 2)))
+    adata.obsm["X_pca"] = np.ones((4, 3))
+    with pytest.raises(ValueError, match="must match"):
+        _cluster.cluster(
+            adata,
+            method="pymclustR",
+            n_components=2,
+            key_added="one",
+            add_key="two",
+        )
+
+    with pytest.raises(ValueError, match="non-empty string"):
+        _cluster.cluster(
+            adata,
+            method="pymclustR",
+            n_components=2,
+            key_added="",
+        )
+
+
+def test_target_wrappers_no_longer_execute_rpy2_mclust():
+    paths = [
+        ROOT / "omicverse/external/PROST/utils.py",
+        ROOT / "omicverse/external/GraphST/utils.py",
+        ROOT / "omicverse/external/STAGATE_pyG/utils.py",
+        ROOT / "omicverse/external/STAligner/ST_utils.py",
+        ROOT / "omicverse/external/BINARY/utils.py",
+    ]
+    for path in paths:
+        source = path.read_text(encoding="utf-8")
+        assert "import rpy2" not in source
+        assert 'library("mclust")' not in source
+
+
+def test_spatial_wrapper_signatures_remain_compatible(monkeypatch):
+    expected = {
+        "PROST": "(data, num_cluster, modelNames='EEE', random_seed=818)",
+        "GraphST": (
+            "(adata, num_cluster, modelNames='EEE', used_obsm='emb_pca', "
+            "random_seed=2020)"
+        ),
+        "STAGATE": (
+            "(adata, num_cluster, modelNames='EEE', used_obsm='STAGATE', "
+            "random_seed=2020)"
+        ),
+        "STAligner": (
+            "(adata, num_cluster, modelNames='EEE', used_obsm='STAGATE', "
+            "random_seed=666)"
+        ),
+        "BINARY": (
+            "(adata, num_cluster, add_key='mclust', modelNames='EEE', "
+            "used_obsm='BINARY', random_seed=2020)"
+        ),
+    }
+    modules = {
+        "PROST": (
+            "omicverse.external.PROST._signature_test",
+            "omicverse/external/PROST/utils.py",
+            "mclust",
+        ),
+        "GraphST": (
+            "omicverse.external.GraphST._signature_test",
+            "omicverse/external/GraphST/utils.py",
+            "mclust_R",
+        ),
+        "STAGATE": (
+            "omicverse.external.STAGATE_pyG._signature_test",
+            "omicverse/external/STAGATE_pyG/utils.py",
+            "mclust_R",
+        ),
+        "STAligner": (
+            "omicverse.external.STAligner._signature_test",
+            "omicverse/external/STAligner/ST_utils.py",
+            "mclust_R",
+        ),
+        "BINARY": (
+            "omicverse.external.BINARY._signature_test",
+            "omicverse/external/BINARY/utils.py",
+            "mclust_R",
+        ),
+    }
+    for name, (module_name, path, function_name) in modules.items():
+        module = _load_source_module(monkeypatch, module_name, path)
+        assert str(inspect.signature(getattr(module, function_name))) == expected[name]


### PR DESCRIPTION
## Summary

- add a shared, lazy `pymclustR` adapter with input/result validation and NumPy RNG-state restoration
- replace legacy embedded `rpy2`/R `mclust` calls in PROST, GraphST, STAGATE, STAligner, and BINARY while preserving their public contracts and 1-based labels
- fix `ov.utils.cluster(method="pymclustR")` so `key_added` and legacy `add_key` select the output column instead of leaking into `Mclust()`; conflicting values fail clearly
- add `pymclustR>=0.2.1` to the `full` and `tests` extras while keeping it lazy and optional for base installations

## Root cause and compatibility

PR #638 introduced the Python mclust backend for the generic clustering utility, but five spatial wrappers still embedded separate `rpy2`/R implementations. Reusing the generic entry point directly would also have changed established spatial output-key behavior and exposed the `add_key` parameter leak.

This PR centralizes only the backend mechanics. Existing spatial APIs remain unchanged:

- PROST still returns the label array
- GraphST, STAGATE, and STAligner still write categorical `adata.obs["mclust"]`
- BINARY still respects arbitrary `add_key`
- `ov.utils.cluster()` still modifies AnnData in place, returns `None`, defaults to `adata.obs["pymclustR"]`, and stores fit metadata under `adata.uns["pymclustR"]`
- labels retain R mclust's 1-based semantics

`tradeSeq` is intentionally out of scope; it should be handled separately only after real R-to-Python numerical parity validation.

## Validation

- focused spatial/pymclustR suite: 22 passed
- focused suite plus import/architecture tests: 429 passed
- exact parity against direct `mclust_py.Mclust` for classification, model name, G, log-likelihood, and BIC
- all five wrappers exercised with the real Python backend
- global NumPy RNG restoration, missing dependency, invalid input, key alias/conflict, and no-parameter-leak coverage
- fatal flake8 syntax gate (`E9,F63,F7`): passed
- wheel build and installed-wheel smoke test: passed
- wheel metadata contains the optional dependency in both extras
- diff whitespace check: passed
