### PR TITLE
feat(pl): clinical statistics and publication figure assembly

### DIFF
--- a/omicverse/pl/__init__.py
+++ b/omicverse/pl/__init__.py
@@ -12,7 +12,10 @@ Visualization categories:
     Multi-omics plots: Factor plots, integration visualizations
     Network plots: Protein-protein interactions, pathway networks
     General plots: Heatmaps, scatter plots, bar plots
-    
+    Clinical plots: Kaplan-Meier survival, competing-risk incidence, forest
+    Model evaluation: ROC curves with DeLong CIs, confusion matrices
+    Figure assembly: journal-sized canvases, labelled panels, editable-text export
+
 Key modules:
     _single: Single-cell specific plotting functions
     _bulk: Bulk RNA-seq plotting functions
@@ -25,6 +28,10 @@ Key modules:
     _flowsig: Flow cytometry-style visualizations
     _embedding: Dimensionality reduction visualizations
     _density: Density and distribution plots
+    _survival: Kaplan-Meier and Aalen-Johansen curves, log-rank / Gray's test
+    _classification: ROC curves and confusion matrices
+    _forest: forest plots and fixed/random-effects meta-analysis
+    _layout: figure(), multipanel(), savefig() with Illustrator-editable text
     _funkyheatmap: dynbenchmark-style benchmark / multi-metric heatmaps
         (funky rectangles + circles + bars + pies + text + image glyphs,
         wraps the pyfunkyheatmap PyPI package)
@@ -254,6 +261,26 @@ from ._funkyheatmap import (
     position_arguments as funky_position_arguments,
     scale_minmax as funky_scale_minmax,
 )
+from ._layout import (
+    EDITABLE_TEXT_RCPARAMS,
+    JOURNAL_WIDTH_MM,
+    add_panel_label,
+    figure,
+    multipanel,
+    savefig,
+    set_editable_text,
+    take_legend_out,
+)
+from ._survival import (
+    aalen_johansen,
+    cumulative_incidence,
+    grays_test,
+    kaplan_meier,
+    logrank_test,
+    survival,
+)
+from ._classification import confusion, roc, roc_auc_ci
+from ._forest import forest, meta_analysis
 
 
 def curved_graph(*args, **kwargs):
@@ -473,4 +500,27 @@ __all__ = [
     "perturb_development_layout",
     "perturb_celloracle_layout",
     "perturb_markov_endpoints",
+    # @ _layout — figure geometry, panels, publication export
+    "JOURNAL_WIDTH_MM",
+    "EDITABLE_TEXT_RCPARAMS",
+    "figure",
+    "multipanel",
+    "add_panel_label",
+    "savefig",
+    "set_editable_text",
+    "take_legend_out",
+    # @ _survival — time-to-event
+    "survival",
+    "cumulative_incidence",
+    "kaplan_meier",
+    "logrank_test",
+    "aalen_johansen",
+    "grays_test",
+    # @ _classification — classifier evaluation
+    "roc",
+    "confusion",
+    "roc_auc_ci",
+    # @ _forest — effect sizes and meta-analysis
+    "forest",
+    "meta_analysis",
 ]

--- a/omicverse/pl/_classification.py
+++ b/omicverse/pl/_classification.py
@@ -1,0 +1,538 @@
+r"""Classifier-evaluation plots: ROC curves and confusion matrices.
+
+``ov.pl`` had no way to draw the two figures that every classification result
+ends up needing. Both functions here are data-first — arrays, a ``DataFrame``,
+or an ``AnnData`` (``.obs``) all work — and both handle the multi-model and
+multi-class cases that come up when comparing annotation methods.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple, Union
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+from .._registry import register_function
+from ._stats_common import as_frame
+
+__all__ = ["roc_auc_ci", "roc", "confusion"]
+
+
+# --------------------------------------------------------------------------
+# statistics
+# --------------------------------------------------------------------------
+
+
+def _midrank(x: np.ndarray) -> np.ndarray:
+    """Ranks with ties averaged — the ``tiedrank`` of the DeLong papers."""
+    order = np.argsort(x, kind="mergesort")
+    sorted_x = x[order]
+    n = len(x)
+    ranks = np.empty(n, dtype=float)
+    i = 0
+    while i < n:
+        j = i
+        while j < n - 1 and sorted_x[j + 1] == sorted_x[i]:
+            j += 1
+        ranks[i:j + 1] = 0.5 * (i + j) + 1
+        i = j + 1
+    out = np.empty(n, dtype=float)
+    out[order] = ranks
+    return out
+
+
+def roc_auc_ci(y_true: Sequence[Any],
+               y_score: Sequence[float],
+               *,
+               alpha: float = 0.05,
+               pos_label: Any = None) -> Dict[str, float]:
+    r"""AUC with a DeLong confidence interval.
+
+    Uses the fast midrank formulation of DeLong's variance estimator
+    (Sun & Xu 2014), which is what R's ``pROC::ci.auc(method='delong')``
+    computes — and is validated against it in the test suite.
+
+    Returns ``{'auc', 'se', 'lower', 'upper'}``.
+    """
+    from scipy.stats import norm
+
+    y = np.asarray(y_true)
+    s = np.asarray(y_score, dtype=float)
+    if pos_label is None:
+        classes = np.unique(y)
+        if classes.size != 2:
+            raise ValueError(
+                f"AUC needs exactly two classes, found {classes.size}. "
+                "Pass `pos_label=` to pick one against the rest."
+            )
+        pos_label = classes[1]
+    positive = y == pos_label
+
+    pos, neg = s[positive], s[~positive]
+    m, n = pos.size, neg.size
+    if m == 0 or n == 0:
+        raise ValueError("Both classes must be present to compute an AUC.")
+
+    tx = _midrank(pos)
+    ty = _midrank(neg)
+    tz = _midrank(np.concatenate([pos, neg]))
+    auc = (tz[:m].sum() / m - (m + 1) / 2.0) / n
+    v01 = (tz[:m] - tx) / n
+    v10 = 1.0 - (tz[m:] - ty) / m
+    s01 = np.var(v01, ddof=1) / m if m > 1 else 0.0
+    s10 = np.var(v10, ddof=1) / n if n > 1 else 0.0
+    se = float(np.sqrt(s01 + s10))
+    z = norm.ppf(1.0 - alpha / 2.0)
+    return {
+        "auc": float(auc),
+        "se": se,
+        "lower": float(np.clip(auc - z * se, 0.0, 1.0)),
+        "upper": float(np.clip(auc + z * se, 0.0, 1.0)),
+    }
+
+
+def _resolve_scores(data, y_true, y_score, score_names=None):
+    """Normalise the many ways of passing (labels, scores) into one shape.
+
+    Returns ``(y, {name: scores}, mode)`` where ``mode`` is ``'binary'`` or
+    ``'multiclass'``.
+    """
+    frame = as_frame(data)
+
+    if isinstance(y_score, Mapping):
+        scores = {str(k): np.asarray(v, dtype=float) for k, v in y_score.items()}
+    elif isinstance(y_score, str):
+        if frame is None:
+            raise TypeError("`y_score` names a column but no table was given.")
+        scores = {y_score: frame[y_score].to_numpy(dtype=float)}
+    elif isinstance(y_score, (list, tuple)) and all(isinstance(v, str) for v in y_score):
+        if frame is None:
+            raise TypeError("`y_score` names columns but no table was given.")
+        scores = {c: frame[c].to_numpy(dtype=float) for c in y_score}
+    else:
+        arr = np.asarray(y_score, dtype=float)
+        if arr.ndim == 1:
+            scores = {"score": arr}
+        elif arr.ndim == 2:
+            names = (list(score_names) if score_names is not None
+                     else [f"class {i}" for i in range(arr.shape[1])])
+            scores = {str(nm): arr[:, i] for i, nm in enumerate(names)}
+        else:
+            raise ValueError("`y_score` must be 1- or 2-dimensional.")
+
+    if isinstance(y_true, str):
+        if frame is None:
+            raise TypeError("`y_true` names a column but no table was given.")
+        y = frame[y_true].to_numpy()
+    else:
+        y = np.asarray(y_true)
+
+    for name, values in scores.items():
+        if len(values) != len(y):
+            raise ValueError(
+                f"`y_score[{name!r}]` has {len(values)} values but `y_true` "
+                f"has {len(y)}."
+            )
+    return y, scores
+
+
+# --------------------------------------------------------------------------
+# plots
+# --------------------------------------------------------------------------
+
+
+@register_function(
+    aliases=["ROC曲线", "roc", "roc_curve", "AUC", "auc_plot", "受试者工作特征"],
+    category="pl",
+    description=(
+        "ROC curves with AUC and DeLong confidence intervals; overlays several "
+        "models, or expands a multi-class problem into one-vs-rest curves"
+    ),
+    examples=[
+        "# One model",
+        "ax = ov.pl.roc(y_true=y_test, y_score=probabilities)",
+        "# Several models on one axes",
+        "ax = ov.pl.roc(y_true=y_test, y_score={'RF': p_rf, 'SVM': p_svm})",
+        "# From a DataFrame of predictions",
+        "ax = ov.pl.roc(pred_df, 'label', ['rf_prob', 'svm_prob'])",
+        "# Multi-class, one-vs-rest plus the macro average",
+        "ax = ov.pl.roc(y_true=y, y_score=proba_matrix, score_names=clf.classes_)",
+    ],
+    related=["pl.confusion", "pl.forest", "pl.savefig"],
+)
+def roc(data: Any = None,
+        y_true: Any = None,
+        y_score: Any = None,
+        *,
+        score_names: Optional[Sequence[str]] = None,
+        pos_label: Any = None,
+        multiclass: bool = False,
+        average: Optional[str] = "macro",
+        ax=None,
+        figsize: Tuple[float, float] = (4.0, 4.0),
+        palette=None,
+        ci: Optional[str] = "delong",
+        ci_alpha: float = 0.05,
+        n_boot: int = 500,
+        random_state: int = 0,
+        chance_line: bool = True,
+        xlabel: str = "False positive rate",
+        ylabel: str = "True positive rate",
+        title: Optional[str] = None,
+        legend: bool = True,
+        legend_loc: str = "lower right",
+        fontsize: float = 9,
+        linewidth: float = 1.6,
+        return_stats: bool = False):
+    r"""Plot one or more ROC curves.
+
+    Arguments
+    ---------
+    data
+        Optional table; ``y_true`` / ``y_score`` may then be column names.
+        Calling ``roc(y_true, y_score)`` with two arrays also works.
+    y_true
+        Ground-truth labels.
+    y_score
+        Continuous scores. One of: a 1-D array; a dict ``{model: scores}``;
+        a list of column names; or a 2-D array of per-class probabilities
+        (set ``multiclass=True``, or pass ``score_names`` matching the
+        classes).
+    pos_label
+        Which label counts as positive in the binary case. Defaults to the
+        greater of the two labels after sorting, matching scikit-learn — so
+        ``{0, 1}`` gives 1 and ``{'control', 'tumour'}`` gives ``'tumour'``,
+        regardless of row order.
+    multiclass
+        Treat a 2-D ``y_score`` as class probabilities and draw one-vs-rest
+        curves. Inferred automatically when ``y_true`` has more than two
+        levels and the score matrix is aligned to them.
+    average
+        With ``multiclass``, also draw ``'macro'`` (unweighted mean of the
+        per-class curves) and/or ``'micro'``. Pass ``None`` to skip, or
+        ``'both'``.
+    ci
+        ``'delong'`` (default) puts an analytic 95% CI on each AUC in the
+        legend; ``'bootstrap'`` additionally shades a band around the curve;
+        ``None`` reports the point estimate only.
+    n_boot
+        Bootstrap resamples when ``ci='bootstrap'``.
+    return_stats
+        Return ``(ax, stats)`` with the AUC, CI and curve of every model.
+
+    Returns
+    -------
+    The ``Axes`` (or ``(Axes, dict)``).
+    """
+    from sklearn.metrics import roc_curve
+
+    # roc(y_true, y_score) with two bare arrays
+    if data is not None and as_frame(data) is None:
+        data, y_true, y_score = None, data, y_true
+    if y_true is None or y_score is None:
+        raise TypeError("Both `y_true` and `y_score` are required.")
+
+    y, scores = _resolve_scores(data, y_true, y_score, score_names)
+    classes = list(pd.unique(pd.Series(y).dropna()))
+    is_multiclass = multiclass or (len(classes) > 2 and len(scores) == len(classes))
+    if len(classes) > 2 and not is_multiclass:
+        raise ValueError(
+            f"`y_true` has {len(classes)} classes but only {len(scores)} score "
+            "column(s). Pass a probability matrix with one column per class, "
+            "or binarise the labels first."
+        )
+
+    if ax is None:
+        _, ax = plt.subplots(figsize=figsize)
+
+    curves: Dict[str, Dict[str, Any]] = {}
+    if is_multiclass:
+        names = list(scores.keys())
+        ordered = names if score_names is None else [str(c) for c in score_names]
+        for name in ordered:
+            binary = (pd.Series(y).astype(str) == str(name)).to_numpy()
+            if binary.sum() == 0:
+                continue
+            fpr, tpr, _ = roc_curve(binary.astype(int), scores[name])
+            curves[str(name)] = {"fpr": fpr, "tpr": tpr,
+                                 **roc_auc_ci(binary.astype(int), scores[name],
+                                              alpha=ci_alpha, pos_label=1)}
+        if average in {"macro", "both"} and curves:
+            grid = np.unique(np.concatenate([c["fpr"] for c in curves.values()]))
+            mean_tpr = np.mean(
+                [np.interp(grid, c["fpr"], c["tpr"]) for c in curves.values()],
+                axis=0,
+            )
+            from sklearn.metrics import auc as _auc
+
+            curves["macro-average"] = {"fpr": grid, "tpr": mean_tpr,
+                                       "auc": float(_auc(grid, mean_tpr)),
+                                       "se": np.nan, "lower": np.nan,
+                                       "upper": np.nan}
+        if average in {"micro", "both"} and curves:
+            flat_y = np.concatenate(
+                [(pd.Series(y).astype(str) == str(n)).to_numpy().astype(int)
+                 for n in ordered if str(n) in scores]
+            )
+            flat_s = np.concatenate([scores[str(n)] for n in ordered
+                                     if str(n) in scores])
+            fpr, tpr, _ = roc_curve(flat_y, flat_s)
+            curves["micro-average"] = {"fpr": fpr, "tpr": tpr,
+                                       **roc_auc_ci(flat_y, flat_s,
+                                                    alpha=ci_alpha, pos_label=1)}
+    else:
+        if pos_label is None and len(classes) == 2:
+            # sorted, not order-of-appearance: the positive class must not
+            # depend on which row happens to come first (scikit-learn's rule)
+            try:
+                pos_label = sorted(classes)[-1]
+            except TypeError:
+                pos_label = classes[-1]
+        for name, values in scores.items():
+            fpr, tpr, _ = roc_curve(y, values, pos_label=pos_label)
+            curves[name] = {"fpr": fpr, "tpr": tpr,
+                            **roc_auc_ci(y, values, alpha=ci_alpha,
+                                         pos_label=pos_label)}
+
+    from ._survival import _default_palette
+
+    colors = _default_palette(len(curves), palette)
+    rng = np.random.default_rng(random_state)
+    for (name, curve), color in zip(curves.items(), colors):
+        label = f"{name} (AUC {curve['auc']:.3f}"
+        if ci and np.isfinite(curve.get("lower", np.nan)):
+            label += f", {100 * (1 - ci_alpha):.0f}% CI {curve['lower']:.3f}-{curve['upper']:.3f}"
+        label += ")"
+        dashed = name.endswith("-average")
+        ax.plot(curve["fpr"], curve["tpr"], color=color, linewidth=linewidth,
+                linestyle="--" if dashed else "-", label=label)
+
+        if ci == "bootstrap" and not dashed:
+            grid = np.linspace(0, 1, 101)
+            boots = []
+            source = scores.get(name)
+            if source is None:
+                continue
+            binary = (y == pos_label).astype(int) if not is_multiclass else \
+                (pd.Series(y).astype(str) == str(name)).to_numpy().astype(int)
+            for _ in range(n_boot):
+                idx = rng.integers(0, len(binary), len(binary))
+                if binary[idx].sum() in (0, len(idx)):
+                    continue
+                f, t, _ = roc_curve(binary[idx], source[idx])
+                boots.append(np.interp(grid, f, t))
+            if boots:
+                arr = np.vstack(boots)
+                lo = np.percentile(arr, 100 * ci_alpha / 2, axis=0)
+                hi = np.percentile(arr, 100 * (1 - ci_alpha / 2), axis=0)
+                ax.fill_between(grid, lo, hi, color=color, alpha=0.15,
+                                linewidth=0)
+                curve["band"] = (grid, lo, hi)
+
+    if chance_line:
+        ax.plot([0, 1], [0, 1], color="0.6", linewidth=0.9, linestyle=":",
+                zorder=0)
+
+    ax.set_xlim(-0.01, 1.01)
+    ax.set_ylim(-0.01, 1.01)
+    ax.set_aspect("equal", adjustable="box")
+    ax.set_xlabel(xlabel, fontsize=fontsize + 1)
+    ax.set_ylabel(ylabel, fontsize=fontsize + 1)
+    if title:
+        ax.set_title(title, fontsize=fontsize + 2)
+    ax.tick_params(labelsize=fontsize)
+    ax.spines[["right", "top"]].set_visible(False)
+    if legend:
+        ax.legend(loc=legend_loc, frameon=False, fontsize=fontsize - 1)
+
+    return (ax, {"curves": curves}) if return_stats else ax
+
+
+@register_function(
+    aliases=["混淆矩阵", "confusion", "confusion_matrix", "分类矩阵", "confusionplot"],
+    category="pl",
+    description=(
+        "Confusion-matrix heatmap with counts and/or row percentages, plus "
+        "accuracy, balanced accuracy, Cohen's kappa and per-class F1"
+    ),
+    examples=[
+        "ax = ov.pl.confusion(y_true=truth, y_pred=predicted)",
+        "# Row-normalised, so class imbalance does not hide the errors",
+        "ax = ov.pl.confusion(y_true=truth, y_pred=predicted, normalize='true')",
+        "# Compare an annotation method against manual labels in .obs",
+        "ax = ov.pl.confusion(adata, 'manual_celltype', 'scsa_celltype',",
+        "                     normalize='true', metrics=True)",
+    ],
+    related=["pl.roc", "pl.heatmap", "pl.savefig"],
+)
+def confusion(data: Any = None,
+              y_true: Any = None,
+              y_pred: Any = None,
+              *,
+              labels: Optional[Sequence[Any]] = None,
+              normalize: Optional[str] = None,
+              ax=None,
+              figsize: Optional[Tuple[float, float]] = None,
+              cmap: str = "Blues",
+              annot: bool = True,
+              annot_fmt: Optional[str] = None,
+              counts_and_percent: bool = False,
+              metrics: bool = False,
+              colorbar: bool = True,
+              grid: bool = True,
+              xlabel: str = "Predicted",
+              ylabel: str = "True",
+              title: Optional[str] = None,
+              fontsize: float = 9,
+              return_stats: bool = False):
+    r"""Plot a confusion matrix.
+
+    Arguments
+    ---------
+    data, y_true, y_pred
+        A table plus column names, two bare arrays, or an ``AnnData`` plus two
+        ``.obs`` keys.
+    labels
+        Class order. Defaults to the sorted union of the two label sets, so
+        the diagonal is meaningful even when a class is never predicted.
+    normalize
+        ``None`` for raw counts, ``'true'`` for row-wise (recall) fractions,
+        ``'pred'`` for column-wise (precision), ``'all'`` for the whole matrix.
+        ``'true'`` is usually the honest choice with imbalanced classes.
+    counts_and_percent
+        Annotate each cell with the count *and* the row percentage.
+    metrics
+        Append a right-hand strip with per-class precision / recall / F1.
+    return_stats
+        Return ``(ax, stats)`` with the matrix and the summary metrics.
+
+    Returns
+    -------
+    The ``Axes`` (or ``(Axes, dict)``).
+    """
+    from sklearn.metrics import (accuracy_score, balanced_accuracy_score,
+                                 cohen_kappa_score, confusion_matrix,
+                                 precision_recall_fscore_support)
+
+    if data is not None and as_frame(data) is None:
+        data, y_true, y_pred = None, data, y_true
+    if y_true is None or y_pred is None:
+        raise TypeError("Both `y_true` and `y_pred` are required.")
+
+    frame = as_frame(data)
+    yt = frame[y_true].to_numpy() if isinstance(y_true, str) else np.asarray(y_true)
+    yp = frame[y_pred].to_numpy() if isinstance(y_pred, str) else np.asarray(y_pred)
+    if len(yt) != len(yp):
+        raise ValueError(f"`y_true` has {len(yt)} entries, `y_pred` {len(yp)}.")
+    yt = pd.Series(yt).astype(str).to_numpy()
+    yp = pd.Series(yp).astype(str).to_numpy()
+
+    if labels is None:
+        labels = sorted(set(yt) | set(yp))
+    else:
+        labels = [str(v) for v in labels]
+
+    counts = confusion_matrix(yt, yp, labels=labels)
+    matrix = counts.astype(float)
+    if normalize == "true":
+        totals = matrix.sum(axis=1, keepdims=True)
+        matrix = np.divide(matrix, totals, out=np.zeros_like(matrix),
+                           where=totals > 0)
+    elif normalize == "pred":
+        totals = matrix.sum(axis=0, keepdims=True)
+        matrix = np.divide(matrix, totals, out=np.zeros_like(matrix),
+                           where=totals > 0)
+    elif normalize == "all":
+        matrix = matrix / matrix.sum() if matrix.sum() else matrix
+    elif normalize is not None:
+        raise ValueError(
+            f"`normalize` must be None, 'true', 'pred' or 'all', got {normalize!r}."
+        )
+
+    n = len(labels)
+    if ax is None:
+        if figsize is None:
+            side = max(3.0, 0.45 * n + 1.8)
+            figsize = (side + (2.2 if metrics else 0.0), side)
+        _, ax = plt.subplots(figsize=figsize)
+
+    image = ax.imshow(matrix, cmap=cmap, aspect="equal",
+                      vmin=0, vmax=matrix.max() if matrix.size else 1)
+    ax.set_xticks(range(n), labels, rotation=45, ha="right", fontsize=fontsize)
+    ax.set_yticks(range(n), labels, fontsize=fontsize)
+    ax.set_xlabel(xlabel, fontsize=fontsize + 1)
+    ax.set_ylabel(ylabel, fontsize=fontsize + 1)
+
+    if annot:
+        if annot_fmt is None:
+            annot_fmt = "{:.0f}" if normalize is None else "{:.2f}"
+        threshold = matrix.max() * 0.6 if matrix.size else 0
+        row_totals = counts.sum(axis=1)
+        for i in range(n):
+            for j in range(n):
+                value = matrix[i, j]
+                text = annot_fmt.format(value)
+                if counts_and_percent:
+                    pct = counts[i, j] / row_totals[i] * 100 if row_totals[i] else 0
+                    text = f"{counts[i, j]:d}\n{pct:.1f}%"
+                ax.text(j, i, text, ha="center", va="center",
+                        fontsize=fontsize - 1,
+                        color="white" if value > threshold else "black")
+
+    if grid:
+        ax.set_xticks(np.arange(-0.5, n, 1), minor=True)
+        ax.set_yticks(np.arange(-0.5, n, 1), minor=True)
+        ax.grid(which="minor", color="white", linewidth=1.0)
+        ax.tick_params(which="minor", length=0)
+    for spine in ax.spines.values():
+        spine.set_visible(False)
+
+    precision, recall, f1, support = precision_recall_fscore_support(
+        yt, yp, labels=labels, zero_division=0
+    )
+    stats = {
+        "matrix": pd.DataFrame(counts, index=labels, columns=labels),
+        "normalized": pd.DataFrame(matrix, index=labels, columns=labels),
+        "accuracy": float(accuracy_score(yt, yp)),
+        "balanced_accuracy": float(balanced_accuracy_score(yt, yp)),
+        "kappa": float(cohen_kappa_score(yt, yp)),
+        "per_class": pd.DataFrame(
+            {"precision": precision, "recall": recall, "f1": f1,
+             "support": support}, index=labels),
+    }
+
+    if metrics:
+        strip = ax.inset_axes([1.04, 0.0, 0.34, 1.0])
+        values = np.column_stack([precision, recall, f1])
+        strip.imshow(values, cmap="Greys", vmin=0, vmax=1, aspect="auto")
+        strip.set_xticks(range(3), ["Prec", "Rec", "F1"], rotation=45,
+                         ha="right", fontsize=fontsize - 1)
+        strip.set_yticks([])
+        for i in range(n):
+            for j in range(3):
+                strip.text(j, i, f"{values[i, j]:.2f}", ha="center",
+                           va="center", fontsize=fontsize - 2,
+                           color="white" if values[i, j] > 0.6 else "black")
+        for spine in strip.spines.values():
+            spine.set_visible(False)
+        strip.tick_params(length=0)
+
+    if colorbar:
+        if metrics:
+            # place it explicitly beyond the metrics strip — the default
+            # `pad=` puts it straight on top of the strip
+            cbar = ax.figure.colorbar(image, cax=ax.inset_axes(
+                [1.48, 0.0, 0.045, 1.0]))
+        else:
+            cbar = ax.figure.colorbar(image, ax=ax, fraction=0.046, pad=0.04)
+        cbar.ax.tick_params(labelsize=fontsize - 1)
+        cbar.set_label("fraction" if normalize else "count", fontsize=fontsize)
+
+    if title is None:
+        title = (f"accuracy {stats['accuracy']:.3f} | balanced "
+                 f"{stats['balanced_accuracy']:.3f} | kappa {stats['kappa']:.3f}")
+    ax.set_title(title, fontsize=fontsize, pad=8)
+
+    return (ax, stats) if return_stats else ax

--- a/omicverse/pl/_forest.py
+++ b/omicverse/pl/_forest.py
@@ -1,0 +1,427 @@
+r"""Forest plots — effect sizes with confidence intervals, and meta-analysis.
+
+A forest plot is the natural display for any list of "effect ± CI" rows:
+odds/hazard ratios per cohort, per-gene coefficients from a regression, Cox
+results across subgroups, or the studies of a meta-analysis. ``ov.pl`` had one
+only inside the Mendelian-randomisation code (``ov.genetics.mr_forest``); this
+is the general version.
+
+When ``meta=`` is given the function also pools the rows — fixed effect
+(inverse variance) and/or DerSimonian-Laird random effects — and draws the
+summary diamond with Q, I² and tau².
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+from .._registry import register_function
+from ._stats_common import as_frame, resolve_columns
+
+__all__ = ["meta_analysis", "forest"]
+
+
+def meta_analysis(estimate: Sequence[float],
+                  se: Sequence[float],
+                  *,
+                  method: str = "random",
+                  ci_level: float = 0.95) -> Dict[str, float]:
+    r"""Pool effect estimates by inverse variance.
+
+    Arguments
+    ---------
+    estimate
+        Effect sizes on the scale they are to be pooled on — log(OR),
+        log(HR), mean difference, ...
+    se
+        Standard errors of ``estimate``.
+    method
+        ``'fixed'`` for inverse-variance fixed effect, ``'random'`` for
+        DerSimonian-Laird random effects (the default, and the safer choice
+        whenever the studies are not exact replicates).
+    ci_level
+        Confidence level of the pooled interval.
+
+    Returns
+    -------
+    dict with ``estimate``, ``se``, ``lower``, ``upper``, ``zvalue``,
+    ``pvalue``, and the heterogeneity statistics ``Q``, ``df``, ``Q_pvalue``,
+    ``tau2`` and ``I2``.
+
+    Notes
+    -----
+    Matches ``statsmodels.stats.meta_analysis.combine_effects`` with
+    ``method_re='dl'``; that agreement is asserted in the test suite.
+    """
+    from scipy.stats import chi2 as chi2_dist
+    from scipy.stats import norm
+
+    y = np.asarray(estimate, dtype=float)
+    v = np.asarray(se, dtype=float) ** 2
+    if y.size != v.size:
+        raise ValueError("`estimate` and `se` must have the same length.")
+    if np.any(v <= 0):
+        raise ValueError("Standard errors must be positive.")
+
+    w = 1.0 / v
+    theta_f = float(np.sum(w * y) / np.sum(w))
+    var_f = float(1.0 / np.sum(w))
+
+    Q = float(np.sum(w * (y - theta_f) ** 2))
+    df = int(y.size - 1)
+    C = float(np.sum(w) - np.sum(w ** 2) / np.sum(w))
+    tau2 = max(0.0, (Q - df) / C) if C > 0 and df > 0 else 0.0
+    I2 = max(0.0, (Q - df) / Q) if Q > 0 and df > 0 else 0.0
+
+    if method == "fixed":
+        theta, var = theta_f, var_f
+    elif method == "random":
+        w_star = 1.0 / (v + tau2)
+        theta = float(np.sum(w_star * y) / np.sum(w_star))
+        var = float(1.0 / np.sum(w_star))
+    else:
+        raise ValueError(f"`method` must be 'fixed' or 'random', got {method!r}.")
+
+    se_pooled = float(np.sqrt(var))
+    z = norm.ppf(0.5 + ci_level / 2.0)
+    zval = theta / se_pooled if se_pooled > 0 else np.nan
+    return {
+        "estimate": theta,
+        "se": se_pooled,
+        "lower": theta - z * se_pooled,
+        "upper": theta + z * se_pooled,
+        "zvalue": float(zval),
+        "pvalue": float(2 * norm.sf(abs(zval))) if np.isfinite(zval) else np.nan,
+        "Q": Q,
+        "df": df,
+        "Q_pvalue": float(chi2_dist.sf(Q, df)) if df > 0 else np.nan,
+        "tau2": tau2,
+        "I2": I2,
+        "method": method,
+    }
+
+
+def _format_effect(value: float, lo: float, hi: float, digits: int) -> str:
+    return f"{value:.{digits}f} ({lo:.{digits}f}, {hi:.{digits}f})"
+
+
+def _format_p(p: float) -> str:
+    if not np.isfinite(p):
+        return ""
+    if p < 1e-4:
+        return "<1e-4"
+    return f"{p:.3g}"
+
+
+@register_function(
+    aliases=["森林图", "forest", "forest_plot", "森林", "meta分析图", "effect_plot"],
+    category="pl",
+    description=(
+        "Forest plot of effect sizes with confidence intervals, optional "
+        "subgroups, and fixed/random-effects meta-analysis with I-squared"
+    ),
+    examples=[
+        "# Hazard ratios per cohort, on a log axis",
+        "ax = ov.pl.forest(res, 'HR', lower='HR_low', upper='HR_high',",
+        "                  label='cohort', log_scale=True)",
+        "# From coefficients and standard errors",
+        "ax = ov.pl.forest(res, 'beta', se='se', label='gene')",
+        "# Pool the studies and show the diamond",
+        "ax, stats = ov.pl.forest(studies, 'logOR', se='se', label='study',",
+        "                         meta='random', log_scale=True,",
+        "                         return_stats=True)",
+        "print(stats['meta']['I2'])",
+    ],
+    related=["pl.survival", "pl.volcano", "pl.savefig"],
+)
+def forest(data: Any = None,
+           estimate: Any = None,
+           *,
+           lower: Any = None,
+           upper: Any = None,
+           se: Any = None,
+           label: Any = None,
+           group: Any = None,
+           weight: Any = None,
+           pvalue: Any = None,
+           ci_level: float = 0.95,
+           log_scale: bool = False,
+           already_log: bool = False,
+           ref_line: Optional[float] = None,
+           meta: Optional[str] = None,
+           sort: Optional[str] = None,
+           ax=None,
+           figsize: Optional[Tuple[float, float]] = None,
+           color: str = "#1F577B",
+           summary_color: str = "#CB3E35",
+           marker: str = "s",
+           markersize: float = 40.0,
+           scale_marker: bool = True,
+           annotate: bool = True,
+           annotate_x: float = 1.04,
+           digits: int = 2,
+           xlabel: Optional[str] = None,
+           title: Optional[str] = None,
+           xlim: Optional[Tuple[float, float]] = None,
+           fontsize: float = 9,
+           return_stats: bool = False):
+    r"""Draw a forest plot.
+
+    Arguments
+    ---------
+    data, estimate
+        A table plus the column holding the effect size, or a bare array.
+    lower, upper
+        Confidence-interval bounds. Give these **or** ``se``.
+    se
+        Standard error; the interval is then built at ``ci_level``.
+    label
+        Row labels (column name or array). Defaults to the table index.
+    group
+        Optional subgroup column — rows are blocked under a bold header, and
+        with ``meta`` each subgroup gets its own summary.
+    weight
+        Marker area weights. Defaults to inverse variance when ``se`` is
+        available, which is the convention in meta-analysis figures.
+    pvalue
+        Optional column shown in the right-hand annotation.
+    log_scale
+        Effects are ratios (OR/HR/RR): plot on a log x-axis and centre the
+        reference line on 1. Pooling is then done in log space and converted
+        back.
+    already_log
+        Set with ``log_scale`` when the *input* is already log-transformed —
+        the axis is then exponentiated for display only.
+    ref_line
+        Null-effect line. Defaults to 1 for ``log_scale``, else 0.
+    meta
+        ``'fixed'``, ``'random'`` or ``'both'`` to pool the rows and draw the
+        summary diamond(s).
+    sort
+        ``'estimate'`` or ``'label'`` to reorder rows; ``None`` keeps input
+        order (top row first).
+    annotate
+        Print ``effect (low, high)`` — and the P value when given — to the
+        right of the axes.
+    return_stats
+        Return ``(ax, stats)`` including the pooled result and heterogeneity.
+
+    Returns
+    -------
+    The ``Axes`` (or ``(Axes, dict)``).
+    """
+    from scipy.stats import norm
+
+    if data is not None and as_frame(data) is None:
+        data, estimate = None, data
+    if estimate is None:
+        raise TypeError("`estimate` is required.")
+    if lower is None and upper is None and se is None:
+        raise TypeError("Give either `lower`/`upper` or `se`.")
+
+    frame_in = as_frame(data)
+    if label is None and frame_in is not None:
+        label = np.asarray(frame_in.index).astype(str)
+
+    frame, names = resolve_columns(data, estimate=estimate, lower=lower,
+                                   upper=upper, se=se, label=label,
+                                   group=group, weight=weight, pvalue=pvalue,
+                                   dropna=False, require=("estimate",))
+
+    est = frame["estimate"].to_numpy(dtype=float)
+    z = norm.ppf(0.5 + ci_level / 2.0)
+
+    # everything is computed on the additive scale, then displayed
+    work = np.log(est) if (log_scale and not already_log) else est
+    if "se" in frame:
+        se_work = frame["se"].to_numpy(dtype=float)
+        lo_work, hi_work = work - z * se_work, work + z * se_work
+    else:
+        lo_raw = frame["lower"].to_numpy(dtype=float)
+        hi_raw = frame["upper"].to_numpy(dtype=float)
+        lo_work = np.log(lo_raw) if (log_scale and not already_log) else lo_raw
+        hi_work = np.log(hi_raw) if (log_scale and not already_log) else hi_raw
+        se_work = (hi_work - lo_work) / (2.0 * z)
+
+    labels = (frame["label"].astype(str).to_numpy() if "label" in frame
+              else np.array([str(i + 1) for i in range(len(est))]))
+    groups = frame["group"].astype(str).to_numpy() if "group" in frame else None
+    pvals = frame["pvalue"].to_numpy(dtype=float) if "pvalue" in frame else None
+
+    if "weight" in frame:
+        weights = frame["weight"].to_numpy(dtype=float)
+    elif np.all(np.isfinite(se_work)) and np.all(se_work > 0):
+        weights = 1.0 / se_work ** 2
+    else:
+        weights = np.ones_like(work)
+
+    order = np.arange(len(work))
+    if sort == "estimate":
+        order = np.argsort(work)
+    elif sort == "label":
+        order = np.argsort(labels)
+    elif sort is not None:
+        raise ValueError("`sort` must be 'estimate', 'label' or None.")
+    if groups is not None:
+        order = order[np.argsort(pd.Categorical(groups[order],
+                                                categories=pd.unique(groups),
+                                                ordered=True).codes,
+                                 kind="stable")]
+
+    # ---- build the row layout (data rows, group headers, summary rows) ----
+    rows: List[Dict[str, Any]] = []
+    stats: Dict[str, Any] = {}
+    current_group = None
+    for idx in order:
+        if groups is not None and groups[idx] != current_group:
+            current_group = groups[idx]
+            rows.append({"kind": "header", "label": current_group})
+        rows.append({
+            "kind": "study", "label": labels[idx], "value": work[idx],
+            "lower": lo_work[idx], "upper": hi_work[idx], "se": se_work[idx],
+            "weight": weights[idx],
+            "pvalue": pvals[idx] if pvals is not None else np.nan,
+        })
+
+    methods = {"fixed": ["fixed"], "random": ["random"],
+               "both": ["fixed", "random"], None: []}
+    if meta not in methods:
+        raise ValueError("`meta` must be 'fixed', 'random', 'both' or None.")
+    for method in methods[meta]:
+        if not np.all(np.isfinite(se_work)) or np.any(se_work <= 0):
+            raise ValueError(
+                "Meta-analysis needs a usable standard error for every row; "
+                "pass `se=` or finite `lower`/`upper`."
+            )
+        pooled = meta_analysis(work, se_work, method=method, ci_level=ci_level)
+        stats.setdefault("meta", {})[method] = pooled
+        rows.append({
+            "kind": "summary", "label": f"{method.capitalize()} effect",
+            "value": pooled["estimate"], "lower": pooled["lower"],
+            "upper": pooled["upper"], "pvalue": pooled["pvalue"],
+        })
+
+    n_rows = len(rows)
+    if ax is None:
+        if figsize is None:
+            figsize = (6.4, max(2.2, 0.34 * n_rows + 1.0))
+        _, ax = plt.subplots(figsize=figsize)
+
+    if scale_marker:
+        w = np.array([r.get("weight", np.nan) for r in rows], dtype=float)
+        finite = np.isfinite(w)
+        if finite.sum() and np.nanmax(w) > np.nanmin(w[finite]):
+            scaled = (w - np.nanmin(w[finite])) / (np.nanmax(w) - np.nanmin(w[finite]))
+        else:
+            scaled = np.full(n_rows, 0.5)
+    else:
+        scaled = np.full(n_rows, 0.5)
+
+    # Rows live on the additive (log) scale; ratios are drawn on a log axis so
+    # matplotlib picks readable ticks instead of exp() of evenly spaced ones.
+    def _x(value):
+        return float(np.exp(value)) if log_scale else float(value)
+
+    yticks, yticklabels = [], []
+    for i, row in enumerate(rows):
+        y = n_rows - 1 - i
+        yticks.append(y)
+        if row["kind"] == "header":
+            yticklabels.append(row["label"])
+            continue
+        yticklabels.append(row["label"])
+        is_summary = row["kind"] == "summary"
+        row_color = summary_color if is_summary else color
+        lo_x, hi_x, mid_x = _x(row["lower"]), _x(row["upper"]), _x(row["value"])
+        ax.plot([lo_x, hi_x], [y, y], color=row_color,
+                linewidth=1.4, solid_capstyle="butt", zorder=2)
+        if is_summary:
+            # diamond spanning the pooled interval
+            ax.fill(
+                [lo_x, mid_x, hi_x, mid_x],
+                [y, y + 0.32, y, y - 0.32],
+                color=row_color, zorder=3,
+            )
+        else:
+            size = markersize * (0.5 + 1.5 * scaled[i])
+            ax.scatter([mid_x], [y], s=size, marker=marker,
+                       color=row_color, zorder=3, edgecolors="none")
+    if log_scale:
+        ax.set_xscale("log")
+
+    ax.set_yticks(yticks)
+    ax.set_yticklabels(yticklabels, fontsize=fontsize)
+    for tick, row in zip(ax.get_yticklabels(), rows):
+        if row["kind"] == "header":
+            tick.set_fontweight("bold")
+        elif row["kind"] == "summary":
+            tick.set_fontstyle("italic")
+    ax.set_ylim(-0.8, n_rows - 0.2)
+
+    if ref_line is None:
+        ref_line = 1.0 if log_scale else 0.0
+    ax.axvline(float(ref_line), color="0.5", linewidth=0.9, linestyle="--",
+               zorder=1)
+
+    if annotate:
+        transform = ax.get_yaxis_transform()
+        for i, row in enumerate(rows):
+            if row["kind"] == "header":
+                continue
+            y = n_rows - 1 - i
+            value, lo, hi = row["value"], row["lower"], row["upper"]
+            if log_scale:
+                # rows are held on the log scale internally; report ratios
+                value, lo, hi = np.exp(value), np.exp(lo), np.exp(hi)
+            text = _format_effect(value, lo, hi, digits)
+            p_text = _format_p(row.get("pvalue", np.nan))
+            if p_text:
+                text += f"   P={p_text}"
+            ax.text(annotate_x, y, text, transform=transform, va="center",
+                    ha="left", fontsize=fontsize - 0.5,
+                    fontstyle="italic" if row["kind"] == "summary" else "normal")
+
+    if meta and "meta" in stats:
+        first = next(iter(stats["meta"].values()))
+        het = (f"Q = {first['Q']:.2f} (df={first['df']}, "
+               f"P={_format_p(first['Q_pvalue'])});  "
+               f"I$^2$ = {100 * first['I2']:.0f}%;  "
+               f"$\\tau^2$ = {first['tau2']:.3f}")
+        # placed in the blank strip below the last row, inside the axes, so it
+        # can never collide with the tick labels however tall the figure is
+        ax.text(0.005, -0.62, het, transform=ax.get_yaxis_transform(),
+                va="center", ha="left", fontsize=fontsize - 1, color="0.35")
+
+    if xlim is not None:
+        ax.set_xlim(*xlim)
+    if log_scale:
+        from matplotlib.ticker import FuncFormatter, LogLocator
+
+        ax.xaxis.set_major_locator(
+            LogLocator(base=10, subs=(1.0, 1.5, 2.0, 3.0, 5.0, 7.0),
+                       numticks=10)
+        )
+        # ScalarFormatter picks one decimal count for the whole axis and so
+        # renders 0.7 and 1.5 as "1"; %g keeps each tick readable instead
+        ax.xaxis.set_major_formatter(FuncFormatter(lambda v, _: f"{v:g}"))
+        ax.xaxis.set_minor_formatter(plt.NullFormatter())
+    ax.tick_params(axis="x", labelsize=fontsize)
+
+    if xlabel is None:
+        xlabel = names.get("estimate", "Effect size")
+        if log_scale:
+            xlabel = f"{xlabel} (ratio scale)"
+    ax.set_xlabel(xlabel, fontsize=fontsize + 1)
+    if title:
+        ax.set_title(title, fontsize=fontsize + 2)
+    ax.spines[["right", "top", "left"]].set_visible(False)
+    ax.tick_params(axis="y", length=0)
+
+    stats["rows"] = pd.DataFrame(
+        [r for r in rows if r["kind"] != "header"]
+    )
+    return (ax, stats) if return_stats else ax

--- a/omicverse/pl/_layout.py
+++ b/omicverse/pl/_layout.py
@@ -1,0 +1,624 @@
+r"""Figure geometry, multi-panel layout and publication-grade export.
+
+Journals specify figure *width* in millimetres and expect text in a vector
+export to stay text — editable in Illustrator/Inkscape, not outlines. Neither
+is what matplotlib does by default: ``figsize`` is in inches, and the SVG
+backend converts every glyph to a path.
+
+This module closes that gap:
+
+``figure``            a canvas sized in mm / cm / inches / pixels, with the
+                      column widths of common journals available by name
+``multipanel``        a labelled panel grid (or mosaic) in one call
+``add_panel_label``   the ``a`` / ``b`` / ``c`` tags, offset in typographic
+                      points so they do not drift with the axes size
+``savefig``           write one figure to several formats at once, keeping
+                      text as text
+``set_editable_text`` make that the default for plain ``plt.savefig`` too
+``take_legend_out``   move a legend outside the axes without resizing games
+
+Nothing here is specific to omics data — these are the plumbing functions the
+rest of ``ov.pl`` and any user script can share.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple, Union
+
+import matplotlib.pyplot as plt
+from matplotlib.figure import Figure
+
+from .._registry import register_function
+
+__all__ = [
+    "JOURNAL_WIDTH_MM",
+    "EDITABLE_TEXT_RCPARAMS",
+    "figure",
+    "multipanel",
+    "add_panel_label",
+    "savefig",
+    "set_editable_text",
+    "take_legend_out",
+]
+
+
+#: Column widths in millimetres, from the author guidelines of each journal.
+#: Use the key as ``width=`` in :func:`figure` / :func:`multipanel`.
+JOURNAL_WIDTH_MM: Dict[str, float] = {
+    "nature-single": 89.0,
+    "nature-medium": 120.0,
+    "nature-double": 183.0,
+    "science-single": 55.0,
+    "science-double": 120.0,
+    "science-triple": 183.0,
+    "cell-single": 85.0,
+    "cell-medium": 114.0,
+    "cell-double": 174.0,
+    "pnas-single": 87.0,
+    "pnas-medium": 114.0,
+    "pnas-double": 178.0,
+    "elife-single": 85.0,
+    "elife-double": 174.0,
+}
+
+#: rcParams that keep text as text in vector output.
+#: ``svg.fonttype='none'`` stops the SVG backend from converting glyphs to
+#: paths; ``42`` selects TrueType (rather than Type-3) font embedding in
+#: PDF/PS, which Illustrator can edit.
+EDITABLE_TEXT_RCPARAMS: Dict[str, Any] = {
+    "svg.fonttype": "none",
+    "pdf.fonttype": 42,
+    "ps.fonttype": 42,
+}
+
+_UNIT_TO_INCH = {
+    "in": 1.0,
+    "inch": 1.0,
+    "inches": 1.0,
+    "mm": 1.0 / 25.4,
+    "cm": 1.0 / 2.54,
+}
+
+_PANEL_LABEL_ALPHABET = "abcdefghijklmnopqrstuvwxyz"
+
+
+def _resolve_width(value: Union[float, str, None], units: str) -> Optional[float]:
+    """Turn a number or a journal preset name into a value in ``units``."""
+    if value is None:
+        return None
+    if isinstance(value, str):
+        key = value.strip().lower().replace("_", "-").replace(" ", "-")
+        if key not in JOURNAL_WIDTH_MM:
+            raise KeyError(
+                f"Unknown journal width preset {value!r}. Available: "
+                + ", ".join(sorted(JOURNAL_WIDTH_MM))
+            )
+        mm = JOURNAL_WIDTH_MM[key]
+        # The preset is defined in mm; convert into whatever the caller uses.
+        return mm * _UNIT_TO_INCH["mm"] / _to_inch_factor(units)
+    return float(value)
+
+
+def _to_inch_factor(units: str, dpi: float = 100.0) -> float:
+    u = str(units).strip().lower()
+    if u in _UNIT_TO_INCH:
+        return _UNIT_TO_INCH[u]
+    if u in {"px", "pixel", "pixels"}:
+        return 1.0 / float(dpi)
+    raise ValueError(
+        f"Unknown units {units!r}; use one of 'mm', 'cm', 'in' or 'px'."
+    )
+
+
+def _figsize_inches(width, height, units: str, dpi: float,
+                    aspect: Optional[float]) -> Tuple[float, float]:
+    factor = _to_inch_factor(units, dpi)
+    w = _resolve_width(width, units)
+    h = _resolve_width(height, units)
+    if w is None and h is None:
+        raise ValueError("Give at least one of `width` or `height`.")
+    if aspect is not None and float(aspect) <= 0:
+        raise ValueError("`aspect` must be positive (width / height).")
+    if w is None:
+        w = h * float(aspect if aspect is not None else 1.4)
+    if h is None:
+        h = w / float(aspect if aspect is not None else 1.4)
+    w_in, h_in = w * factor, h * factor
+    if w_in <= 0 or h_in <= 0:
+        raise ValueError(f"Figure size must be positive, got {w_in}x{h_in} in.")
+    return w_in, h_in
+
+
+@register_function(
+    aliases=["画布", "figure", "figure_size", "出版尺寸", "期刊尺寸", "journal figure"],
+    category="pl",
+    description=(
+        "Create a figure sized in mm/cm/inches/pixels, or by journal column "
+        "preset (e.g. 'nature-single' = 89 mm), with publication defaults"
+    ),
+    examples=[
+        "# A single-column Nature figure, 60 mm tall",
+        "fig = ov.pl.figure('nature-single', 60)",
+        "ax = fig.add_subplot(111)",
+        "# Explicit units",
+        "fig, ax = ov.pl.figure(89, 60, units='mm', dpi=300, axes=True)",
+        "# Pixel-exact canvas for a slide",
+        "fig = ov.pl.figure(1200, 800, units='px', dpi=150)",
+    ],
+    related=["pl.multipanel", "pl.savefig", "pl.add_panel_label", "pl.plot_set"],
+)
+def figure(width: Union[float, str, None] = None,
+           height: Union[float, str, None] = None,
+           *,
+           units: str = "mm",
+           dpi: float = 300,
+           aspect: Optional[float] = None,
+           axes: bool = False,
+           editable_text: bool = True,
+           constrained: bool = True,
+           **kwargs: Any):
+    r"""Create a figure with an exactly specified physical size.
+
+    Arguments
+    ---------
+    width, height
+        Size in ``units``. ``width`` may instead be a journal preset name —
+        see :data:`JOURNAL_WIDTH_MM` (``'nature-single'``, ``'cell-double'``,
+        ...). If only one of the two is given, the other follows ``aspect``.
+    units
+        ``'mm'`` (default), ``'cm'``, ``'in'`` or ``'px'``. Pixels are
+        converted through ``dpi``, so ``figure(1200, 800, units='px',
+        dpi=150)`` produces exactly a 1200x800 PNG.
+    dpi
+        Figure resolution. 300 is the usual journal minimum for raster
+        panels; it does not affect vector output.
+    aspect
+        Width / height, used only when one dimension is omitted (default 1.4).
+    axes
+        If ``True`` return ``(fig, ax)`` with a single axes already added.
+    editable_text
+        Also set this figure's SVG/PDF font handling so exported text stays
+        editable. Applied globally to rcParams — call
+        :func:`set_editable_text` to control that separately.
+    constrained
+        Use matplotlib's constrained layout, which keeps labels inside the
+        requested physical size instead of letting them overflow.
+
+    Returns
+    -------
+    ``matplotlib.figure.Figure``, or ``(Figure, Axes)`` when ``axes=True``.
+    """
+    if editable_text:
+        set_editable_text(True)
+    w_in, h_in = _figsize_inches(width, height, units, dpi, aspect)
+    kwargs.setdefault("layout", "constrained" if constrained else None)
+    fig = plt.figure(figsize=(w_in, h_in), dpi=dpi, **kwargs)
+    if axes:
+        return fig, fig.add_subplot(111)
+    return fig
+
+
+def _panel_labels(n: int, label: Union[bool, str, Sequence[str]]) -> Optional[List[str]]:
+    """Resolve the ``label=`` argument of :func:`multipanel` into a list."""
+    if label is False or label is None:
+        return None
+    if isinstance(label, str):
+        if label in {"a", "lower", "lowercase"}:
+            base = _PANEL_LABEL_ALPHABET
+        elif label in {"A", "upper", "uppercase"}:
+            base = _PANEL_LABEL_ALPHABET.upper()
+        else:
+            raise ValueError(
+                "`label` as a string must be 'a'/'lower' or 'A'/'upper'; "
+                "pass a list for custom labels."
+            )
+        if n > len(base):
+            raise ValueError(f"Cannot auto-label {n} panels with 26 letters.")
+        return list(base[:n])
+    if label is True:
+        return list(_PANEL_LABEL_ALPHABET[:n])
+    labels = list(label)
+    if len(labels) < n:
+        raise ValueError(f"Got {len(labels)} labels for {n} panels.")
+    return labels[:n]
+
+
+@register_function(
+    aliases=["多面板", "multipanel", "panel_grid", "subplot_mosaic", "组合图", "拼图"],
+    category="pl",
+    description=(
+        "Lay out a labelled multi-panel figure (grid or mosaic) at a physical "
+        "size, with automatic a/b/c panel tags"
+    ),
+    examples=[
+        "# 2x2 grid, 183 mm wide (Nature double column)",
+        "fig, ax = ov.pl.multipanel((2, 2), width='nature-double', height=120)",
+        "ov.pl.volcano(deg, ax=ax['a'])",
+        "# Mosaic: a wide panel on top of two narrow ones",
+        "fig, ax = ov.pl.multipanel('AA\\nBC', width=183, height=110)",
+        "ax['A'].plot(x, y)",
+        "# Uppercase tags, custom ratios",
+        "fig, ax = ov.pl.multipanel((1, 3), width=183, height=55, label='A',",
+        "                           width_ratios=[2, 1, 1])",
+    ],
+    related=["pl.figure", "pl.add_panel_label", "pl.savefig"],
+)
+def multipanel(layout: Union[int, Tuple[int, int], str, Sequence[Sequence[Any]]],
+               *,
+               width: Union[float, str, None] = None,
+               height: Union[float, str, None] = None,
+               units: str = "mm",
+               dpi: float = 300,
+               aspect: Optional[float] = None,
+               label: Union[bool, str, Sequence[str]] = True,
+               label_kw: Optional[Mapping[str, Any]] = None,
+               sharex: bool = False,
+               sharey: bool = False,
+               editable_text: bool = True,
+               constrained: bool = True,
+               **gridspec_kw: Any):
+    r"""Build a multi-panel figure and label the panels.
+
+    Arguments
+    ---------
+    layout
+        One of
+
+        * ``(nrows, ncols)`` — a regular grid;
+        * ``n`` — that many panels in a near-square grid;
+        * a mosaic string such as ``'AA\nBC'`` or a nested list, passed to
+          ``Figure.subplot_mosaic``. ``'.'`` leaves a slot empty.
+    width, height, units, dpi, aspect
+        Figure geometry — identical to :func:`figure`, including the journal
+        width presets.
+    label
+        ``True`` for lowercase ``a, b, c``, ``'A'`` for uppercase, a list for
+        custom text, ``False`` to skip. Panels are labelled in reading order.
+    label_kw
+        Extra keyword arguments forwarded to :func:`add_panel_label`.
+    sharex, sharey
+        Share axes across panels.
+    **gridspec_kw
+        Passed to the gridspec — e.g. ``width_ratios``, ``height_ratios``,
+        ``wspace``, ``hspace``.
+
+    Returns
+    -------
+    ``(fig, axes)`` where ``axes`` is a dict. For a mosaic the keys are the
+    mosaic keys; for a grid they are the panel labels (``'a'``, ``'b'``, ...),
+    or ``(row, col)`` tuples when ``label=False``.
+    """
+    if isinstance(layout, int):
+        import math
+
+        ncols = int(math.ceil(math.sqrt(layout)))
+        nrows = int(math.ceil(layout / ncols))
+        grid: Optional[Tuple[int, int]] = (nrows, ncols)
+        n_panels = layout
+    elif isinstance(layout, tuple) and len(layout) == 2 and all(
+        isinstance(v, int) for v in layout
+    ):
+        grid = (int(layout[0]), int(layout[1]))
+        n_panels = grid[0] * grid[1]
+    else:
+        grid = None
+        n_panels = 0
+
+    if editable_text:
+        set_editable_text(True)
+    w_in, h_in = _figsize_inches(width, height, units, dpi, aspect)
+    fig = plt.figure(figsize=(w_in, h_in), dpi=dpi,
+                     layout="constrained" if constrained else None)
+
+    if grid is not None:
+        nrows, ncols = grid
+        labels = _panel_labels(n_panels, label)
+        keys = labels if labels is not None else [
+            (r, c) for r in range(nrows) for c in range(ncols)
+        ]
+        gs = fig.add_gridspec(nrows, ncols, **gridspec_kw)
+        axes: Dict[Any, Any] = {}
+        first = None
+        for idx in range(n_panels):
+            r, c = divmod(idx, ncols)
+            ax = fig.add_subplot(
+                gs[r, c],
+                sharex=first if sharex else None,
+                sharey=first if sharey else None,
+            )
+            if first is None:
+                first = ax
+            axes[keys[idx]] = ax
+        ordered = list(axes.values())
+    else:
+        mosaic_kw = dict(gridspec_kw)
+        axes = fig.subplot_mosaic(layout, sharex=sharex, sharey=sharey,
+                                  gridspec_kw=mosaic_kw or None)
+        # Reading order: sort by the top-left corner of each panel.
+        ordered_items = sorted(
+            axes.items(),
+            key=lambda kv: (-kv[1].get_position().y1, kv[1].get_position().x0),
+        )
+        axes = dict(ordered_items)
+        ordered = [ax for _, ax in ordered_items]
+        labels = _panel_labels(len(ordered), label)
+
+    if labels is not None:
+        for ax, text in zip(ordered, labels):
+            add_panel_label(ax, text, **(dict(label_kw) if label_kw else {}))
+
+    return fig, axes
+
+
+@register_function(
+    aliases=["面板标签", "add_panel_label", "panel_label", "子图标签", "abc标注"],
+    category="pl",
+    description=(
+        "Add an a/b/c panel tag outside the top-left corner of an axes, "
+        "offset in typographic points so it stays put at any figure size"
+    ),
+    examples=[
+        "ov.pl.add_panel_label(ax, 'a')",
+        "# Nudge further out, larger",
+        "ov.pl.add_panel_label(ax, 'b', dx=-28, dy=8, fontsize=10)",
+        "# Include the label inside the axes instead",
+        "ov.pl.add_panel_label(ax, 'c', dx=4, dy=-4, ha='left', va='top')",
+    ],
+    related=["pl.multipanel", "pl.figure"],
+)
+def add_panel_label(ax,
+                    label: str,
+                    *,
+                    dx: float = -20.0,
+                    dy: float = 4.0,
+                    fontsize: Optional[float] = None,
+                    fontweight: str = "bold",
+                    fontfamily: Optional[str] = None,
+                    ha: str = "right",
+                    va: str = "baseline",
+                    color: str = "black",
+                    **kwargs: Any):
+    r"""Tag an axes with a panel letter.
+
+    The tag is anchored to the axes' top-left corner and displaced by
+    ``(dx, dy)`` **points**, not axes fractions — so the same offset looks the
+    same on a 40 mm and a 180 mm panel, which is not true of the usual
+    ``ax.text(-0.1, 1.05, ...)`` idiom.
+
+    Arguments
+    ---------
+    ax
+        Target axes.
+    label
+        Text of the tag, e.g. ``'a'``.
+    dx, dy
+        Offset from the top-left corner, in points. Negative ``dx`` moves left
+        (into the margin), positive ``dy`` moves up.
+    fontsize
+        Defaults to ``rcParams['axes.titlesize']`` resolved to points.
+
+    Returns
+    -------
+    The created ``matplotlib.text.Annotation``.
+    """
+    if fontsize is None:
+        from matplotlib.font_manager import FontProperties
+
+        fontsize = FontProperties(
+            size=plt.rcParams.get("axes.titlesize", "medium")
+        ).get_size_in_points()
+    return ax.annotate(
+        str(label),
+        xy=(0.0, 1.0),
+        xycoords="axes fraction",
+        xytext=(dx, dy),
+        textcoords="offset points",
+        fontsize=fontsize,
+        fontweight=fontweight,
+        fontfamily=fontfamily,
+        color=color,
+        ha=ha,
+        va=va,
+        annotation_clip=False,
+        **kwargs,
+    )
+
+
+@register_function(
+    aliases=["可编辑文字", "set_editable_text", "editable_svg", "矢量字体", "illustrator"],
+    category="pl",
+    description=(
+        "Keep text as editable text (not outlines) in SVG/PDF/PS exports, "
+        "so figures can be relabelled in Illustrator or Inkscape"
+    ),
+    examples=[
+        "ov.pl.set_editable_text()        # affects every later plt.savefig",
+        "old = ov.pl.set_editable_text(True)",
+        "ov.pl.set_editable_text(False)   # back to outlined glyphs",
+    ],
+    related=["pl.savefig", "pl.figure", "pl.plot_set"],
+)
+def set_editable_text(enable: bool = True) -> Dict[str, Any]:
+    r"""Switch vector text between *editable* and *outlined* globally.
+
+    matplotlib's SVG backend converts glyphs to paths by default, which makes
+    an exported figure impossible to relabel; PDF defaults to Type-3 fonts,
+    which Illustrator refuses to edit. This sets
+    ``svg.fonttype='none'`` and ``pdf/ps.fonttype=42`` (TrueType).
+
+    Note that ``svg.fonttype='none'`` means the SVG *references* the font by
+    name rather than embedding it — whoever opens the file needs that font
+    installed, or the viewer substitutes one. That is the trade for editability.
+
+    Returns the previous values, so they can be restored.
+    """
+    previous = {k: plt.rcParams.get(k) for k in EDITABLE_TEXT_RCPARAMS}
+    if enable:
+        plt.rcParams.update(EDITABLE_TEXT_RCPARAMS)
+    else:
+        plt.rcParams.update({"svg.fonttype": "path", "pdf.fonttype": 3,
+                             "ps.fonttype": 3})
+    return previous
+
+
+@register_function(
+    aliases=["保存图形", "savefig", "save_figure", "导出图形", "export_figure"],
+    category="pl",
+    description=(
+        "Save a figure to one or several formats at once with publication "
+        "defaults and text that stays editable in vector output"
+    ),
+    examples=[
+        "ov.pl.savefig(fig, 'figure1.pdf')",
+        "# One call, three files: figure1.pdf / .svg / .png",
+        "ov.pl.savefig(fig, 'figure1', formats=['pdf', 'svg', 'png'], dpi=600)",
+        "# Current figure, no explicit handle",
+        "ov.pl.savefig('figure1.svg')",
+    ],
+    related=["pl.figure", "pl.multipanel", "pl.set_editable_text"],
+)
+def savefig(fig: Union[Figure, str, "os.PathLike[str]"],
+            path: Union[str, "os.PathLike[str]", None] = None,
+            *,
+            dpi: Union[float, str] = 300,
+            formats: Optional[Iterable[str]] = None,
+            editable_text: bool = True,
+            transparent: bool = False,
+            bbox_inches: Optional[str] = "tight",
+            pad_inches: float = 0.02,
+            verbose: bool = True,
+            **kwargs: Any) -> List[str]:
+    r"""Write a figure to disk, keeping vector text editable.
+
+    Arguments
+    ---------
+    fig
+        The figure. May be omitted by passing the path as the first argument,
+        in which case the current figure (``plt.gcf()``) is used.
+    path
+        Output path. With ``formats`` given, any extension on ``path`` is
+        replaced by each requested format.
+    dpi
+        Raster resolution; ignored for pure-vector formats.
+    formats
+        Write several files from one figure, e.g. ``['pdf', 'svg', 'png']``.
+    editable_text
+        Apply :data:`EDITABLE_TEXT_RCPARAMS` for the duration of the save
+        only, leaving the global rcParams untouched.
+    bbox_inches
+        ``'tight'`` crops to the drawn content. Pass ``None`` to preserve the
+        exact physical size requested from :func:`figure` — which matters when
+        a journal asks for a figure of a specific width.
+
+    Returns
+    -------
+    List of the paths written.
+    """
+    if isinstance(fig, (str, os.PathLike)):
+        if path is not None:
+            raise TypeError(
+                "Pass either savefig(fig, path) or savefig(path), not both."
+            )
+        path, fig = fig, plt.gcf()
+    if path is None:
+        raise TypeError("`path` is required.")
+
+    path = os.fspath(path)
+    directory = os.path.dirname(os.path.abspath(path))
+    if directory:
+        os.makedirs(directory, exist_ok=True)
+
+    if formats:
+        stem = os.path.splitext(path)[0]
+        targets = [f"{stem}.{str(f).lstrip('.').lower()}" for f in formats]
+    else:
+        targets = [path]
+
+    context = EDITABLE_TEXT_RCPARAMS if editable_text else {}
+    written: List[str] = []
+    with plt.rc_context(context):
+        for target in targets:
+            fig.savefig(target, dpi=dpi, transparent=transparent,
+                        bbox_inches=bbox_inches, pad_inches=pad_inches,
+                        **kwargs)
+            written.append(target)
+    if verbose:
+        print("Saved: " + ", ".join(written))
+    return written
+
+
+@register_function(
+    aliases=["图例外移", "take_legend_out", "legend_outside", "移出图例"],
+    category="pl",
+    description=(
+        "Move an axes legend outside the plotting area (right/left/top/bottom) "
+        "without shrinking the data region by hand"
+    ),
+    examples=[
+        "ov.pl.take_legend_out(ax)                  # to the right",
+        "ov.pl.take_legend_out(ax, loc='bottom', ncol=4)",
+        "ov.pl.take_legend_out(ax, loc='top', title='Cell type')",
+    ],
+    related=["pl.multipanel", "pl.figure"],
+)
+def take_legend_out(ax,
+                    loc: str = "right",
+                    *,
+                    pad: float = 0.02,
+                    ncol: Optional[int] = None,
+                    title: Optional[str] = None,
+                    frameon: bool = False,
+                    fontsize: Optional[float] = None,
+                    handles=None,
+                    labels=None,
+                    **kwargs: Any):
+    r"""Re-place an axes legend outside the axes.
+
+    Arguments
+    ---------
+    ax
+        Axes whose legend should move. Its current handles/labels are reused
+        unless ``handles``/``labels`` are given explicitly.
+    loc
+        ``'right'`` (default), ``'left'``, ``'top'`` or ``'bottom'``.
+    pad
+        Gap between axes and legend, in axes fractions.
+    ncol
+        Legend columns. Defaults to 1 for left/right and to the number of
+        entries for top/bottom, which is what usually reads best.
+
+    Returns
+    -------
+    The new ``matplotlib.legend.Legend``.
+    """
+    if handles is None or labels is None:
+        cur_handles, cur_labels = ax.get_legend_handles_labels()
+        handles = cur_handles if handles is None else handles
+        labels = cur_labels if labels is None else labels
+    if not handles:
+        raise ValueError(
+            "No legend entries on this axes — plot with `label=` first, or "
+            "pass `handles=`/`labels=` explicitly."
+        )
+
+    anchors = {
+        "right": ((1.0 + pad, 0.5), "center left"),
+        "left": ((-pad, 0.5), "center right"),
+        "top": ((0.5, 1.0 + pad), "lower center"),
+        "bottom": ((0.5, -pad), "upper center"),
+    }
+    if loc not in anchors:
+        raise ValueError(
+            f"`loc` must be one of {sorted(anchors)}, got {loc!r}."
+        )
+    bbox, legend_loc = anchors[loc]
+    if ncol is None:
+        ncol = len(labels) if loc in {"top", "bottom"} else 1
+
+    existing = ax.get_legend()
+    if existing is not None:
+        existing.remove()
+    return ax.legend(handles, labels, loc=legend_loc, bbox_to_anchor=bbox,
+                     ncol=ncol, title=title, frameon=frameon,
+                     fontsize=fontsize, **kwargs)

--- a/omicverse/pl/_stats_common.py
+++ b/omicverse/pl/_stats_common.py
@@ -1,0 +1,157 @@
+r"""Shared input handling for the data-first plots in ``ov.pl``.
+
+The statistical plots added alongside the omics-specific ones (survival, ROC,
+confusion, forest, ...) deliberately do **not** require an ``AnnData``. They
+accept, interchangeably:
+
+* a ``pandas.DataFrame`` plus column names,
+* bare arrays / Series / lists,
+* an ``AnnData``-like object, in which case ``.obs`` is used as the frame,
+* a plain ``dict`` of columns.
+
+:func:`resolve_columns` normalises all four into one tidy frame, so each
+plotting function only has to deal with arrays.
+"""
+
+from __future__ import annotations
+
+from difflib import get_close_matches
+from typing import Any, Dict, Mapping, Optional, Tuple
+
+import numpy as np
+import pandas as pd
+
+__all__ = ["as_frame", "group_levels", "resolve_columns"]
+
+
+def as_frame(data: Any) -> Optional[pd.DataFrame]:
+    """Return a tabular view of ``data``, or ``None`` if it is not tabular.
+
+    Recognises ``DataFrame``, ``dict``, and anything exposing an ``.obs``
+    frame (``AnnData``, ``MuData``, and the out-of-core equivalents).
+    """
+    if data is None:
+        return None
+    if isinstance(data, pd.DataFrame):
+        return data
+    obs = getattr(data, "obs", None)
+    if isinstance(obs, pd.DataFrame):
+        return obs
+    if isinstance(data, Mapping):
+        return pd.DataFrame({k: np.asarray(v).ravel() for k, v in data.items()})
+    return None
+
+
+def group_levels(group: Any, explicit: Optional[Any] = None) -> list:
+    """Deterministic ordering of the levels of a grouping variable.
+
+    The first level is the reference for a hazard ratio, so its identity must
+    not depend on which row happens to come first in the file. Order is taken
+    from, in priority order: an explicit ``explicit`` list, the categories of a
+    pandas ``Categorical``, or a plain sort of the observed values.
+    """
+    series = pd.Series(group)
+    present = list(pd.unique(series.dropna()))
+    if explicit is not None:
+        missing = [lv for lv in explicit if lv not in present]
+        if missing:
+            raise ValueError(
+                f"`groups={list(explicit)}` names levels that are not present: "
+                f"{missing}. Observed levels: {present}."
+            )
+        return list(explicit)
+    if isinstance(series.dtype, pd.CategoricalDtype):
+        return [c for c in series.cat.categories if c in present]
+    try:
+        return sorted(present)
+    except TypeError:  # mixed types — fall back to order of appearance
+        return present
+
+
+def _lookup(frame: pd.DataFrame, name: str, arg: str):
+    if name in frame.columns:
+        # keep the Series (and therefore its dtype, e.g. Categorical) — the
+        # category order decides which group is the reference downstream
+        return frame[name].reset_index(drop=True)
+    hint = get_close_matches(name, [str(c) for c in frame.columns], n=3, cutoff=0.6)
+    suffix = f" Did you mean: {', '.join(hint)}?" if hint else ""
+    raise KeyError(
+        f"`{arg}={name!r}` is not a column of the input table.{suffix} "
+        f"Available columns: {', '.join(map(str, frame.columns[:20]))}"
+        + (" ..." if frame.shape[1] > 20 else "")
+    )
+
+
+def resolve_columns(data: Any = None,
+                    *,
+                    dropna: bool = True,
+                    require: Tuple[str, ...] = (),
+                    **specs: Any) -> Tuple[pd.DataFrame, Dict[str, str]]:
+    r"""Turn ``data`` + column specs into one aligned frame.
+
+    Each keyword is either a column name in ``data``, an array-like of values,
+    or ``None`` (meaning "not supplied").
+
+    Arguments
+    ---------
+    data
+        Table to read column names from — ``DataFrame``, ``dict``, ``AnnData``
+        (uses ``.obs``), or ``None`` when every spec is already an array.
+    dropna
+        Drop rows where any resolved column is missing. Rows removed this way
+        are reported by the caller, not silently ignored.
+    require
+        Names that must resolve to something; a clear error is raised if not.
+    **specs
+        ``key=column_name_or_array`` pairs.
+
+    Returns
+    -------
+    ``(frame, names)`` — the aligned frame keyed by the spec names, and a map
+    from spec name to a human-readable label (the original column name where
+    one was given), suitable for axis labels.
+    """
+    frame = as_frame(data)
+    columns: Dict[str, np.ndarray] = {}
+    names: Dict[str, str] = {}
+
+    for key, spec in specs.items():
+        if spec is None:
+            continue
+        if isinstance(spec, str):
+            if frame is None:
+                raise TypeError(
+                    f"`{key}={spec!r}` names a column, but no table was passed "
+                    f"as the first argument. Either pass a DataFrame/AnnData, "
+                    f"or give `{key}` as an array of values."
+                )
+            columns[key] = _lookup(frame, spec, key)
+            names[key] = spec
+        elif isinstance(spec, pd.Series):
+            columns[key] = spec.reset_index(drop=True)
+            names[key] = spec.name or key
+        else:
+            values = np.asarray(spec)
+            columns[key] = values.ravel() if values.ndim > 1 and 1 in values.shape else values
+            names[key] = key
+
+    for key in require:
+        if key not in columns:
+            raise TypeError(f"`{key}` is required.")
+
+    if not columns:
+        raise TypeError("No data columns were supplied.")
+
+    lengths = {k: len(v) for k, v in columns.items()}
+    if len(set(lengths.values())) > 1:
+        detail = ", ".join(f"{k}={n}" for k, n in lengths.items())
+        raise ValueError(f"Columns have different lengths: {detail}.")
+
+    out = pd.DataFrame(columns)
+    if dropna:
+        before = len(out)
+        out = out.dropna()
+        if len(out) < before:
+            out.attrs["n_dropped"] = before - len(out)
+    out = out.reset_index(drop=True)
+    return out, names

--- a/omicverse/pl/_survival.py
+++ b/omicverse/pl/_survival.py
@@ -1,0 +1,950 @@
+r"""Time-to-event plots: Kaplan-Meier curves and competing-risk incidence.
+
+Both estimators are implemented here directly on top of NumPy/SciPy rather
+than pulled from ``lifelines``, so survival plotting works in a bare
+``omicverse`` install. The implementations follow the standard references and
+are checked against ``lifelines`` (Kaplan-Meier, log-rank, Aalen-Johansen) and
+R's ``cmprsk`` (Gray's test) in ``tests/pl/test_stats.py``.
+
+Public entry points
+-------------------
+``survival``             Kaplan-Meier curves + confidence band + numbers at
+                         risk + log-rank test + hazard ratio
+``cumulative_incidence`` Aalen-Johansen cumulative incidence under competing
+                         risks + Gray's test
+
+Both take a ``DataFrame`` (or ``AnnData``, or bare arrays) — no ``AnnData`` is
+required anywhere.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple, Union
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+from .._registry import register_function
+from ._stats_common import as_frame, group_levels, resolve_columns
+
+__all__ = [
+    "kaplan_meier",
+    "logrank_test",
+    "aalen_johansen",
+    "grays_test",
+    "survival",
+    "cumulative_incidence",
+]
+
+
+# --------------------------------------------------------------------------
+# estimators
+# --------------------------------------------------------------------------
+
+
+def _event_table(time: np.ndarray, indicator: np.ndarray) -> Dict[str, np.ndarray]:
+    """Risk set / event / censor counts at each distinct observed time."""
+    t = np.asarray(time, dtype=float)
+    times = np.unique(t)
+    n_risk = np.array([(t >= ti).sum() for ti in times], dtype=float)
+    n_event = np.array([((t == ti) & indicator).sum() for ti in times], dtype=float)
+    n_censor = np.array([((t == ti) & ~indicator).sum() for ti in times], dtype=float)
+    return {"times": times, "n_risk": n_risk, "n_event": n_event,
+            "n_censor": n_censor}
+
+
+def kaplan_meier(time: Sequence[float],
+                 event: Sequence[Any],
+                 *,
+                 alpha: float = 0.05) -> Dict[str, np.ndarray]:
+    r"""Kaplan-Meier product-limit estimator with a log-log confidence band.
+
+    Arguments
+    ---------
+    time
+        Follow-up time for each subject.
+    event
+        1 / ``True`` if the event was observed, 0 / ``False`` if censored.
+    alpha
+        Two-sided significance for the confidence band (0.05 -> 95%).
+
+    Returns
+    -------
+    dict with ``timeline`` (starting at 0), ``survival``, ``lower``,
+    ``upper``, ``std_error``, the per-time ``n_risk`` / ``n_event`` /
+    ``n_censor`` counts, ``median`` and ``median_ci``.
+
+    Notes
+    -----
+    The band uses the log-log (``log(-log S)``) transform with Greenwood's
+    variance, which keeps the interval inside :math:`[0, 1]` — unlike the
+    plain linear band, which routinely runs past 1 in the early follow-up
+    where survival is high.
+    """
+    from scipy.stats import norm
+
+    t = np.asarray(time, dtype=float)
+    e = np.asarray(event)
+    if e.dtype == bool:
+        ind = e
+    else:
+        ind = np.asarray(e, dtype=float) > 0
+    if t.size == 0:
+        raise ValueError("No observations passed to kaplan_meier().")
+    if np.any(t < 0):
+        raise ValueError("Negative follow-up times are not allowed.")
+
+    table = _event_table(t, ind)
+    times, n_risk = table["times"], table["n_risk"]
+    n_event, n_censor = table["n_event"], table["n_censor"]
+
+    with np.errstate(divide="ignore", invalid="ignore"):
+        factors = 1.0 - n_event / n_risk
+        surv = np.cumprod(factors)
+        # Greenwood: Var(S) = S^2 * sum d / (n (n - d))
+        denom = n_risk * (n_risk - n_event)
+        increments = np.where(denom > 0, n_event / denom, np.nan)
+        cum = np.nancumsum(np.where(n_event > 0, increments, 0.0))
+        # once the risk set is exhausted by events the variance is undefined
+        broken = np.cumsum((n_event > 0) & (denom <= 0)) > 0
+        cum = np.where(broken, np.nan, cum)
+        var = surv ** 2 * cum
+
+    z = norm.ppf(1.0 - alpha / 2.0)
+    with np.errstate(divide="ignore", invalid="ignore"):
+        # se of log(-log S)
+        se_ll = np.sqrt(cum) / np.abs(np.log(surv))
+        expo = np.exp(np.where(surv > 0, z * se_ll, np.nan))
+        lower = surv ** expo
+        upper = surv ** (1.0 / expo)
+    lower = np.where(surv >= 1.0, 1.0, lower)
+    upper = np.where(surv >= 1.0, 1.0, upper)
+    lower = np.where(surv <= 0.0, 0.0, lower)
+    upper = np.where(surv <= 0.0, 0.0, upper)
+
+    timeline = np.concatenate([[0.0], times])
+    surv_full = np.concatenate([[1.0], surv])
+    lower_full = np.concatenate([[1.0], lower])
+    upper_full = np.concatenate([[1.0], upper])
+
+    median = np.nan
+    below = np.flatnonzero(surv <= 0.5)
+    if below.size:
+        median = float(times[below[0]])
+    # Brookmeyer-Crowley: the interval is the set of times whose confidence
+    # band still covers 0.5. The lower band drops through 0.5 first, so it
+    # gives the *earlier* bound; the upper band gives the later one.
+    med_lo, med_hi = np.nan, np.nan
+    hit = np.flatnonzero(lower <= 0.5)
+    if hit.size:
+        med_lo = float(times[hit[0]])
+    hit = np.flatnonzero(upper <= 0.5)
+    if hit.size:
+        med_hi = float(times[hit[0]])
+
+    return {
+        "timeline": timeline,
+        "survival": surv_full,
+        "lower": lower_full,
+        "upper": upper_full,
+        "std_error": np.concatenate([[0.0], np.sqrt(var)]),
+        "event_times": times,
+        "n_risk": n_risk,
+        "n_event": n_event,
+        "n_censor": n_censor,
+        "median": median,
+        "median_ci": (med_lo, med_hi),
+        "n": int(t.size),
+        "n_events": int(ind.sum()),
+    }
+
+
+def _at_risk(time: np.ndarray, query: np.ndarray) -> np.ndarray:
+    return np.array([(time >= q).sum() for q in query], dtype=int)
+
+
+def logrank_test(time: Sequence[float],
+                 event: Sequence[Any],
+                 group: Sequence[Any],
+                 *,
+                 groups: Optional[Sequence[Any]] = None) -> Dict[str, Any]:
+    r"""Multivariate log-rank (Mantel-Cox) test across two or more groups.
+
+    Arguments
+    ---------
+    time, event
+        Follow-up time and event indicator.
+    group
+        Group label per subject.
+    groups
+        Explicit level order. The **first** level is the numerator of the
+        hazard ratio, so pass this when the direction matters —
+        ``groups=['treated', 'control']`` reports treated vs control.
+        Without it the order comes from the ``Categorical`` categories if
+        there are any, and otherwise from sorting the observed labels.
+
+    Returns
+    -------
+    dict with ``statistic`` (chi-square), ``pvalue``, ``df``, ``groups``,
+    ``observed``, ``expected``, and — for exactly two groups — the log-rank
+    ``hazard_ratio`` with its confidence interval.
+
+    Notes
+    -----
+    The hazard ratio reported is the Mantel-Haenszel / Peto estimate
+    :math:`(O_1/E_1)/(O_2/E_2)` with
+    :math:`\mathrm{SE}(\log \mathrm{HR}) = \sqrt{1/E_1 + 1/E_2}`. It agrees
+    closely with a Cox model for a single binary covariate but is not
+    identical, and it degrades when hazards are strongly non-proportional —
+    exactly the situation where the log-rank test is itself questionable.
+    """
+    from scipy.stats import chi2 as chi2_dist
+    from scipy.stats import norm
+
+    t = np.asarray(time, dtype=float)
+    e = np.asarray(event)
+    ind = e if e.dtype == bool else np.asarray(e, dtype=float) > 0
+    levels = group_levels(group, groups)
+    g = pd.Series(group).to_numpy()
+    k = len(levels)
+    if k < 2:
+        raise ValueError("The log-rank test needs at least two groups.")
+    groups = levels
+
+    event_times = np.unique(t[ind])
+    observed = np.zeros(k)
+    expected = np.zeros(k)
+    V = np.zeros((k, k))
+
+    masks = [g == grp for grp in groups]
+    for ti in event_times:
+        n_i = float((t >= ti).sum())
+        d_i = float(((t == ti) & ind).sum())
+        if n_i <= 1 or d_i == 0:
+            # still accumulate O and E, but the variance term is 0
+            pass
+        n_ij = np.array([float((t[m] >= ti).sum()) for m in masks])
+        d_ij = np.array([float(((t[m] == ti) & ind[m]).sum()) for m in masks])
+        observed += d_ij
+        expected += n_ij * d_i / n_i
+        if n_i > 1:
+            factor = d_i * (n_i - d_i) / (n_i - 1) / (n_i ** 2)
+            V += factor * (np.diag(n_ij * n_i) - np.outer(n_ij, n_ij))
+
+    diff = (observed - expected)[: k - 1]
+    Vk = V[: k - 1, : k - 1]
+    statistic = float(diff @ np.linalg.pinv(Vk) @ diff)
+    df = k - 1
+    pvalue = float(chi2_dist.sf(statistic, df))
+
+    out: Dict[str, Any] = {
+        "statistic": statistic,
+        "pvalue": pvalue,
+        "df": df,
+        "groups": groups,
+        "observed": observed,
+        "expected": expected,
+        "test": "log-rank (Mantel-Cox)",
+    }
+    if k == 2 and np.all(expected > 0):
+        hr = float((observed[0] / expected[0]) / (observed[1] / expected[1]))
+        se = float(np.sqrt(1.0 / expected[0] + 1.0 / expected[1]))
+        z = norm.ppf(0.975)
+        out["hazard_ratio"] = hr
+        out["hazard_ratio_ci"] = (float(hr * np.exp(-z * se)),
+                                  float(hr * np.exp(z * se)))
+        out["hazard_ratio_reference"] = groups[1]
+    return out
+
+
+def aalen_johansen(time: Sequence[float],
+                   event: Sequence[Any],
+                   cause: Any = 1,
+                   *,
+                   alpha: float = 0.05) -> Dict[str, np.ndarray]:
+    r"""Aalen-Johansen cumulative incidence for one cause under competing risks.
+
+    Arguments
+    ---------
+    time
+        Follow-up time.
+    event
+        Cause code per subject: ``0`` (or ``False``) means censored, any other
+        value identifies which event happened.
+    cause
+        The cause whose incidence is estimated. Every other non-zero code is a
+        competing event.
+    alpha
+        Two-sided level of the pointwise confidence band.
+
+    Returns
+    -------
+    dict with ``timeline``, ``cif``, ``lower``, ``upper``, ``variance``,
+    ``n_risk`` and the overall (all-cause) ``survival``.
+
+    Notes
+    -----
+    Treating competing events as censoring and running ``1 - KM`` **over-states**
+    the incidence, sometimes badly, because it implicitly assumes the subjects
+    removed by a competing event could still have had the event of interest.
+    The Aalen-Johansen estimator weights each cause-specific increment by the
+    overall survival just before that time, which is the quantity that actually
+    adds up to the observed proportion of failures.
+
+    The variance follows the standard delta-method expression (Aalen 1978; see
+    Marubini & Valsecchi §10), and the band is built on the log-log scale.
+    """
+    from scipy.stats import norm
+
+    t = np.asarray(time, dtype=float)
+    codes = np.asarray(event)
+    if codes.dtype == bool:
+        codes = codes.astype(int)
+    is_event = codes != 0
+    is_cause = codes == cause
+
+    times = np.unique(t[is_event])
+    if times.size == 0:
+        raise ValueError("No events of any cause were observed.")
+
+    n_risk = np.array([(t >= ti).sum() for ti in times], dtype=float)
+    d_any = np.array([((t == ti) & is_event).sum() for ti in times], dtype=float)
+    d_k = np.array([((t == ti) & is_cause).sum() for ti in times], dtype=float)
+
+    # overall (all-cause) Kaplan-Meier, shifted to give S(t-)
+    surv = np.cumprod(1.0 - d_any / n_risk)
+    surv_prev = np.concatenate([[1.0], surv[:-1]])
+
+    increments = surv_prev * d_k / n_risk
+    cif = np.cumsum(increments)
+
+    # Aalen's delta-method variance
+    m = times.size
+    var = np.zeros(m)
+    with np.errstate(divide="ignore", invalid="ignore"):
+        a = np.where(n_risk > d_any, d_any / (n_risk * (n_risk - d_any)), np.nan)
+        b = surv_prev ** 2 * ((n_risk - d_k) / n_risk) * d_k / (n_risk ** 2)
+        c = surv_prev * d_k / (n_risk ** 2)
+    for i in range(m):
+        d = cif[i] - cif[: i + 1]
+        term1 = np.nansum(d ** 2 * a[: i + 1])
+        term2 = np.nansum(b[: i + 1])
+        term3 = 2.0 * np.nansum(d * c[: i + 1])
+        var[i] = term1 + term2 - term3
+    var = np.clip(var, 0.0, None)
+
+    z = norm.ppf(1.0 - alpha / 2.0)
+    with np.errstate(divide="ignore", invalid="ignore"):
+        # log-log band on the CIF, mirroring cmprsk's default
+        se_ll = np.sqrt(var) / (cif * np.abs(np.log(cif)))
+        expo = np.exp(z * se_ll)
+        lower = cif ** expo
+        upper = cif ** (1.0 / expo)
+    lower = np.where(cif <= 0, 0.0, np.nan_to_num(lower, nan=0.0))
+    upper = np.where(cif <= 0, 0.0, np.clip(np.nan_to_num(upper, nan=0.0), 0.0, 1.0))
+
+    return {
+        "timeline": np.concatenate([[0.0], times]),
+        "cif": np.concatenate([[0.0], cif]),
+        "lower": np.concatenate([[0.0], lower]),
+        "upper": np.concatenate([[0.0], upper]),
+        "variance": np.concatenate([[0.0], var]),
+        "survival": np.concatenate([[1.0], surv]),
+        "event_times": times,
+        "n_risk": n_risk,
+        "n_event": d_k,
+        "n": int(t.size),
+        "n_events": int(is_cause.sum()),
+    }
+
+
+def _left_limit(times: np.ndarray, values: np.ndarray, query: float,
+                initial: float) -> float:
+    """Value of a right-continuous step function just *before* ``query``."""
+    index = int(np.searchsorted(times, query, side="left")) - 1
+    return float(values[index]) if index >= 0 else float(initial)
+
+
+def _subdistribution_curves(t: np.ndarray, codes: np.ndarray, cause: Any):
+    """Per-group overall survival and cause-specific CIF, for Gray's weights."""
+    times = np.unique(t)
+    n_risk = np.array([(t >= x).sum() for x in times], dtype=float)
+    d_any = np.array([((t == x) & (codes != 0)).sum() for x in times], dtype=float)
+    d_k = np.array([((t == x) & (codes == cause)).sum() for x in times], dtype=float)
+    surv = np.cumprod(1.0 - d_any / n_risk)
+    surv_prev = np.concatenate([[1.0], surv[:-1]])
+    cif = np.cumsum(surv_prev * d_k / n_risk)
+    return times, surv, cif
+
+
+def grays_test(time: Sequence[float],
+               event: Sequence[Any],
+               group: Sequence[Any],
+               cause: Any = 1,
+               *,
+               groups: Optional[Sequence[Any]] = None) -> Dict[str, Any]:
+    r"""Gray's test for equality of cumulative incidence functions.
+
+    Compares the *subdistribution* hazard of ``cause`` across groups, which is
+    the test that matches what a cumulative-incidence plot shows. A plain
+    log-rank on the same data answers a different question (the cause-specific
+    hazard) and can point the other way when the competing risk differs between
+    groups.
+
+    Returns a dict with ``statistic`` (chi-square), ``pvalue``, ``df`` and
+    ``groups``.
+
+    Notes
+    -----
+    Implemented as a log-rank statistic over Gray's **subdistribution risk
+    set**: within group :math:`j`,
+
+    .. math::
+        R_j(t) = Y_j(t)\,\frac{1 - \hat F_{kj}(t^-)}{\hat S_j(t^-)}
+
+    where :math:`Y_j` is the ordinary number at risk, :math:`\hat F_{kj}` the
+    Aalen-Johansen incidence of the cause of interest and :math:`\hat S_j` the
+    all-cause survival. The inflation factor is exactly the subjects who left
+    through a competing event and must stay in the denominator.
+
+    The variance uses the log-rank (hypergeometric) estimator rather than
+    Gray's full martingale variance, which also propagates the uncertainty in
+    :math:`\hat F` and :math:`\hat S`. The consequence is that the chi-square
+    lands within a few percent of ``cmprsk::cuminc`` rather than matching it
+    digit for digit — the test suite pins that agreement to 5%. Treat a P
+    value hovering at the significance threshold accordingly.
+    """
+    from scipy.stats import chi2 as chi2_dist
+
+    t = np.asarray(time, dtype=float)
+    codes = np.asarray(event)
+    if codes.dtype == bool:
+        codes = codes.astype(int)
+    is_cause = codes == cause
+
+    levels = group_levels(group, groups)
+    g = pd.Series(group).to_numpy()
+    k = len(levels)
+    if k < 2:
+        raise ValueError("Gray's test needs at least two groups.")
+    groups = levels
+    masks = [g == grp for grp in groups]
+
+    event_times = np.unique(t[is_cause])
+    if event_times.size == 0:
+        raise ValueError(f"No events of cause {cause!r} were observed.")
+
+    curves = [_subdistribution_curves(t[m], codes[m], cause) for m in masks]
+
+    observed = np.zeros(k)
+    expected = np.zeros(k)
+    V = np.zeros((k, k))
+
+    for ti in event_times:
+        risk = np.zeros(k)
+        events = np.zeros(k)
+        for j, mask in enumerate(masks):
+            times_j, surv_j, cif_j = curves[j]
+            at_risk = float((t[mask] >= ti).sum())
+            surv_prev = _left_limit(times_j, surv_j, ti, 1.0)
+            cif_prev = _left_limit(times_j, cif_j, ti, 0.0)
+            risk[j] = at_risk * (1.0 - cif_prev) / surv_prev if surv_prev > 0 else 0.0
+            events[j] = float(((t[mask] == ti) & is_cause[mask]).sum())
+
+        total_risk = risk.sum()
+        total_events = events.sum()
+        if total_risk <= 0:
+            continue
+        observed += events
+        expected += risk * total_events / total_risk
+        if total_risk > 1:
+            factor = (total_events * (total_risk - total_events)
+                      / (total_risk - 1) / (total_risk ** 2))
+            V += factor * (np.diag(risk * total_risk) - np.outer(risk, risk))
+
+    diff = (observed - expected)[: k - 1]
+    Vk = V[: k - 1, : k - 1]
+    statistic = float(diff @ np.linalg.pinv(Vk) @ diff)
+    df = k - 1
+    return {
+        "statistic": statistic,
+        "pvalue": float(chi2_dist.sf(statistic, df)),
+        "df": df,
+        "groups": groups,
+        "observed": observed,
+        "expected": expected,
+        "test": "Gray's test (subdistribution)",
+    }
+
+
+# --------------------------------------------------------------------------
+# plotting helpers
+# --------------------------------------------------------------------------
+
+
+def _default_palette(n: int, palette=None) -> List[str]:
+    if palette is None:
+        from ._palette import sc_color
+
+        base = list(sc_color)
+    elif isinstance(palette, str):
+        cmap = plt.get_cmap(palette)
+        base = [cmap(i / max(n - 1, 1)) for i in range(n)]
+    else:
+        base = list(palette)
+    if len(base) < n:
+        base = (base * (n // len(base) + 1))[:n]
+    return base[:n]
+
+
+def _format_p(p: float) -> str:
+    if not np.isfinite(p):
+        return "P = n/a"
+    if p < 1e-4:
+        return "P < 0.0001"
+    if p < 0.001:
+        return f"P = {p:.1e}"
+    return f"P = {p:.3g}"
+
+
+def _make_axes(ax, figsize, risk_table: bool, n_groups: int):
+    """Return ``(fig, ax, ax_risk)``, creating a risk-table axes if asked."""
+    if ax is None:
+        fig = plt.figure(figsize=figsize)
+        if risk_table:
+            ratio = 0.10 + 0.075 * n_groups
+            gs = fig.add_gridspec(2, 1, height_ratios=[1.0, ratio], hspace=0.10)
+            main = fig.add_subplot(gs[0])
+            table = fig.add_subplot(gs[1], sharex=main)
+        else:
+            main, table = fig.add_subplot(111), None
+        return fig, main, table
+    fig = ax.get_figure()
+    table = None
+    if risk_table:
+        height = 0.08 + 0.065 * n_groups
+        table = ax.inset_axes([0.0, -0.16 - height, 1.0, height])
+        table.sharex(ax)
+    return fig, ax, table
+
+
+def _draw_risk_table(ax_risk, times, labels, counts, colors, fontsize,
+                     xlim, xlabel=None):
+    """Numbers-at-risk table below the curves.
+
+    The main axes hands its x tick labels over to this one, so the time axis
+    is written once, underneath the table — the layout every journal uses.
+    """
+    n = len(labels)
+    span = (xlim[1] - xlim[0]) or 1.0
+    ax_risk.set_ylim(-0.5, n - 0.5)
+    ax_risk.invert_yaxis()
+    ax_risk.set_yticks(range(n))
+    ax_risk.set_yticklabels(labels, fontsize=fontsize)
+    for tick, color in zip(ax_risk.get_yticklabels(), colors):
+        tick.set_color(color)
+    ax_risk.set_xticks(times)
+    ax_risk.set_xticklabels([f"{v:g}" for v in times], fontsize=fontsize + 0.5)
+    ax_risk.tick_params(axis="x", length=0, labelbottom=True)
+    ax_risk.tick_params(axis="y", length=0)
+    for spine in ax_risk.spines.values():
+        spine.set_visible(False)
+    for row, row_counts in enumerate(counts):
+        for x, value in zip(times, row_counts):
+            # a count centred on the very edge would hang outside the axes
+            rel = (x - xlim[0]) / span
+            ha = "left" if rel < 0.02 else ("right" if rel > 0.98 else "center")
+            ax_risk.text(x, row, f"{int(value)}", ha=ha, va="center",
+                         fontsize=fontsize)
+    ax_risk.set_ylabel("")
+    if xlabel:
+        ax_risk.set_xlabel(xlabel, fontsize=fontsize + 1.5)
+    ax_risk.set_title("Number at risk", fontsize=fontsize, loc="left", pad=3)
+
+
+def _step_ci(ax, x, lo, hi, color, alpha):
+    ax.fill_between(x, lo, hi, step="post", color=color, alpha=alpha,
+                    linewidth=0)
+
+
+# --------------------------------------------------------------------------
+# public plots
+# --------------------------------------------------------------------------
+
+
+@register_function(
+    aliases=["生存曲线", "survival", "kaplan_meier", "KM曲线", "km_plot", "生存分析图"],
+    category="pl",
+    description=(
+        "Kaplan-Meier survival curves with confidence band, censoring marks, "
+        "numbers-at-risk table, log-rank test and hazard ratio"
+    ),
+    examples=[
+        "# From a clinical table",
+        "ax = ov.pl.survival(clinical, time='OS_months', event='OS_status',",
+        "                    group='risk_group')",
+        "# Bare arrays, no DataFrame needed",
+        "ax = ov.pl.survival(time=t, event=e, group=labels)",
+        "# From AnnData .obs, and keep the statistics",
+        "ax, stats = ov.pl.survival(adata, time='days', event='dead',",
+        "                           group='cluster', return_stats=True)",
+        "print(stats['pvalue'], stats['hazard_ratio'])",
+    ],
+    related=["pl.cumulative_incidence", "pl.forest", "pl.savefig"],
+)
+def survival(data: Any = None,
+             time: Any = None,
+             event: Any = None,
+             group: Any = None,
+             *,
+             groups: Optional[Sequence[Any]] = None,
+             ax=None,
+             figsize: Tuple[float, float] = (4.2, 4.2),
+             palette=None,
+             ci: bool = True,
+             ci_alpha: float = 0.05,
+             ci_opacity: float = 0.15,
+             censor_marks: bool = True,
+             risk_table: bool = True,
+             risk_table_times: Optional[Sequence[float]] = None,
+             test: bool = True,
+             hazard_ratio: bool = True,
+             median_line: bool = False,
+             percent: bool = False,
+             xlabel: Optional[str] = None,
+             ylabel: Optional[str] = None,
+             title: Optional[str] = None,
+             xlim: Optional[Tuple[float, float]] = None,
+             ylim: Optional[Tuple[float, float]] = None,
+             legend: bool = True,
+             legend_loc: str = "best",
+             fontsize: float = 9,
+             linewidth: float = 1.6,
+             return_stats: bool = False):
+    r"""Plot Kaplan-Meier survival curves.
+
+    Arguments
+    ---------
+    data
+        ``DataFrame``, ``dict``, or ``AnnData`` (its ``.obs`` is used). May be
+        ``None`` when ``time``/``event``/``group`` are given as arrays.
+    time
+        Column name or array of follow-up times.
+    event
+        Column name or array; ``1``/``True`` = event observed, ``0``/``False``
+        = censored.
+    group
+        Optional column name or array splitting the cohort into strata. With
+        no ``group`` a single curve is drawn and no test is run.
+    groups
+        Explicit order of the strata. The first one is the **reference** of
+        the hazard ratio, so ``groups=['advanced', 'early']`` reports advanced
+        vs early. Left out, the order is the ``Categorical`` category order if
+        the column has one, and otherwise the sorted labels — never the order
+        rows happen to appear in the file.
+    ci
+        Draw the pointwise log-log confidence band at level ``1 - ci_alpha``.
+    censor_marks
+        Mark censoring times with a vertical tick on the curve — without them
+        a flat tail is indistinguishable from "everyone still at risk".
+    risk_table
+        Draw the numbers-at-risk table underneath. Reviewers ask for it; it is
+        also the only way to see that a late plateau rests on three patients.
+    risk_table_times
+        Times to tabulate. Defaults to the x-axis ticks.
+    test
+        Annotate the log-rank P value (needs ``group`` with >= 2 levels).
+    hazard_ratio
+        With exactly two groups, also annotate the log-rank hazard ratio and
+        its 95% CI.
+    median_line
+        Drop guide lines from ``S = 0.5`` to each group's median survival.
+    percent
+        Label the y-axis 0-100% instead of 0-1.
+    return_stats
+        Return ``(ax, stats)`` where ``stats`` holds the per-group fits and
+        the test result.
+
+    Returns
+    -------
+    The main ``Axes`` (or ``(Axes, dict)`` when ``return_stats=True``).
+    """
+    if data is not None and as_frame(data) is None:
+        # survival(time_array, event_array, group_array) without a table
+        data, time, event, group = None, data, time, event
+    frame, names = resolve_columns(data, time=time, event=event, group=group,
+                                   require=("time", "event"))
+    dropped = frame.attrs.get("n_dropped", 0)
+    if dropped:
+        print(f"survival: dropped {dropped} rows with missing values.")
+    t = frame["time"].to_numpy(dtype=float)
+    e = frame["event"].to_numpy()
+
+    if "group" in frame:
+        levels = group_levels(frame["group"], groups)
+        g = frame["group"].to_numpy()
+    else:
+        g = np.zeros(len(t), dtype=int)
+        levels = [0]
+
+    colors = _default_palette(len(levels), palette)
+    fig, ax, ax_risk = _make_axes(ax, figsize, risk_table, len(levels))
+
+    fits: Dict[Any, Dict[str, np.ndarray]] = {}
+    for level, color in zip(levels, colors):
+        mask = g == level
+        fit = kaplan_meier(t[mask], e[mask], alpha=ci_alpha)
+        fits[level] = fit
+        label = str(level) if "group" in frame else (names.get("time", "cohort"))
+        if "group" not in frame:
+            label = "all"
+        ax.step(fit["timeline"], fit["survival"], where="post", color=color,
+                linewidth=linewidth, label=f"{label} (n={fit['n']})")
+        if ci:
+            _step_ci(ax, fit["timeline"], fit["lower"], fit["upper"], color,
+                     ci_opacity)
+        if censor_marks:
+            cens_times = fit["event_times"][fit["n_censor"] > 0]
+            if cens_times.size:
+                idx = np.searchsorted(fit["timeline"], cens_times, side="right") - 1
+                ax.plot(cens_times, fit["survival"][idx], linestyle="none",
+                        marker="|", markersize=6, markeredgewidth=1.2,
+                        color=color)
+        if median_line and np.isfinite(fit["median"]):
+            ax.plot([0, fit["median"], fit["median"]], [0.5, 0.5, 0.0],
+                    color=color, linewidth=0.8, linestyle=":", zorder=0)
+
+    stats: Dict[str, Any] = {"fits": fits}
+    annotation: List[str] = []
+    if "group" in frame and len(levels) >= 2 and (test or hazard_ratio):
+        result = logrank_test(t, e, g, groups=levels)
+        stats.update(result)
+        if test:
+            annotation.append(f"Log-rank {_format_p(result['pvalue'])}")
+        if hazard_ratio and "hazard_ratio" in result:
+            lo, hi = result["hazard_ratio_ci"]
+            annotation.append(
+                f"HR = {result['hazard_ratio']:.2f} ({lo:.2f}-{hi:.2f})"
+            )
+            annotation.append(
+                f"{levels[0]} vs {result['hazard_ratio_reference']}"
+            )
+    if annotation:
+        ax.text(0.98, 0.98, "\n".join(annotation), transform=ax.transAxes,
+                ha="right", va="top", fontsize=fontsize,
+                bbox=dict(boxstyle="round,pad=0.3", facecolor="white",
+                          edgecolor="0.8", alpha=0.85))
+
+    ax.set_xlim(xlim if xlim is not None else (0, float(np.max(t)) * 1.02))
+    ax.set_ylim(ylim if ylim is not None else (0.0, 1.02))
+    if percent:
+        ax.set_yticks(np.linspace(0, 1, 6))
+        ax.set_yticklabels([f"{v:.0f}" for v in np.linspace(0, 100, 6)])
+    time_label = xlabel if xlabel is not None else names.get("time", "Time")
+    if ax_risk is None:
+        ax.set_xlabel(time_label, fontsize=fontsize + 1)
+    else:
+        # the risk table below carries the time axis instead
+        ax.tick_params(axis="x", labelbottom=False)
+    ax.set_ylabel(
+        ylabel if ylabel is not None
+        else ("Survival probability (%)" if percent else "Survival probability"),
+        fontsize=fontsize + 1,
+    )
+    if title:
+        ax.set_title(title, fontsize=fontsize + 2)
+    ax.tick_params(labelsize=fontsize)
+    ax.spines[["right", "top"]].set_visible(False)
+    if legend and "group" in frame:
+        ax.legend(loc=legend_loc, frameon=False, fontsize=fontsize)
+
+    if ax_risk is not None:
+        ticks = (np.asarray(risk_table_times, dtype=float)
+                 if risk_table_times is not None
+                 else np.asarray([v for v in ax.get_xticks()
+                                  if ax.get_xlim()[0] <= v <= ax.get_xlim()[1]]))
+        counts = [_at_risk(t[g == level], ticks) for level in levels]
+        _draw_risk_table(ax_risk, ticks, [str(lv) for lv in levels], counts,
+                         colors, fontsize - 0.5, ax.get_xlim(), time_label)
+        ax_risk.set_xlim(ax.get_xlim())
+
+    return (ax, stats) if return_stats else ax
+
+
+@register_function(
+    aliases=["累积发病率", "cumulative_incidence", "竞争风险", "competing_risks",
+             "CIF", "aalen_johansen"],
+    category="pl",
+    description=(
+        "Aalen-Johansen cumulative incidence curves under competing risks, "
+        "with Gray's test — the correct alternative to 1 - Kaplan-Meier"
+    ),
+    examples=[
+        "# 0 = censored, 1 = relapse, 2 = death without relapse",
+        "ax = ov.pl.cumulative_incidence(clinical, time='months', event='status',",
+        "                                group='arm', cause=1)",
+        "# Show every cause at once for one cohort",
+        "ax = ov.pl.cumulative_incidence(clinical, time='months', event='status',",
+        "                                cause=[1, 2])",
+        "# Compare against the naive 1 - KM curve",
+        "ax = ov.pl.cumulative_incidence(clinical, time='months', event='status',",
+        "                                cause=1, show_naive_km=True)",
+    ],
+    related=["pl.survival", "pl.forest"],
+)
+def cumulative_incidence(data: Any = None,
+                         time: Any = None,
+                         event: Any = None,
+                         group: Any = None,
+                         *,
+                         groups: Optional[Sequence[Any]] = None,
+                         cause: Union[Any, Sequence[Any]] = 1,
+                         cause_labels: Optional[Mapping[Any, str]] = None,
+                         ax=None,
+                         figsize: Tuple[float, float] = (4.2, 4.0),
+                         palette=None,
+                         ci: bool = False,
+                         ci_alpha: float = 0.05,
+                         ci_opacity: float = 0.15,
+                         test: bool = True,
+                         show_naive_km: bool = False,
+                         risk_table: bool = False,
+                         risk_table_times: Optional[Sequence[float]] = None,
+                         percent: bool = False,
+                         xlabel: Optional[str] = None,
+                         ylabel: Optional[str] = None,
+                         title: Optional[str] = None,
+                         xlim: Optional[Tuple[float, float]] = None,
+                         ylim: Optional[Tuple[float, float]] = None,
+                         legend: bool = True,
+                         legend_loc: str = "best",
+                         fontsize: float = 9,
+                         linewidth: float = 1.6,
+                         return_stats: bool = False):
+    r"""Plot cumulative incidence functions under competing risks.
+
+    Arguments
+    ---------
+    data, time, group, groups
+        As in :func:`survival`.
+    event
+        Cause code per subject: ``0`` = censored, other values identify which
+        event occurred.
+    cause
+        Which cause to plot. Pass a list to overlay several causes; combining
+        a multi-cause list with ``group`` is refused, because the resulting
+        curve set is unreadable.
+    cause_labels
+        Display names for the cause codes.
+    ci
+        Draw the pointwise confidence band (off by default — with several
+        groups the bands overlap into mud).
+    test
+        Annotate Gray's test P value when ``group`` has >= 2 levels.
+    show_naive_km
+        Also draw the ``1 - KM`` curve that treats competing events as
+        censoring, as a dashed line. It is always at or above the correct
+        curve; showing both makes the size of the bias visible.
+    return_stats
+        Return ``(ax, stats)``.
+
+    Returns
+    -------
+    The ``Axes`` (or ``(Axes, dict)`` when ``return_stats=True``).
+    """
+    if data is not None and as_frame(data) is None:
+        data, time, event, group = None, data, time, event
+    frame, names = resolve_columns(data, time=time, event=event, group=group,
+                                   require=("time", "event"))
+    dropped = frame.attrs.get("n_dropped", 0)
+    if dropped:
+        print(f"cumulative_incidence: dropped {dropped} rows with missing values.")
+    t = frame["time"].to_numpy(dtype=float)
+    e = frame["event"].to_numpy()
+
+    causes = list(cause) if isinstance(cause, (list, tuple, np.ndarray)) else [cause]
+    has_group = "group" in frame
+    if has_group and len(causes) > 1:
+        raise ValueError(
+            "Plot either several causes for one cohort, or one cause across "
+            "groups — not both. Call this once per cause instead."
+        )
+
+    if has_group:
+        levels = group_levels(frame["group"], groups)
+        g = frame["group"].to_numpy()
+        series = [(lv, g == lv, causes[0], str(lv)) for lv in levels]
+    else:
+        g = None
+        levels = [0]
+        series = [
+            (c, np.ones(len(t), dtype=bool), c,
+             (cause_labels or {}).get(c, f"cause {c}"))
+            for c in causes
+        ]
+
+    colors = _default_palette(len(series), palette)
+    fig, ax, ax_risk = _make_axes(ax, figsize, risk_table, len(series))
+
+    fits: Dict[Any, Dict[str, np.ndarray]] = {}
+    for (key, mask, this_cause, label), color in zip(series, colors):
+        fit = aalen_johansen(t[mask], e[mask], this_cause, alpha=ci_alpha)
+        fits[key] = fit
+        ax.step(fit["timeline"], fit["cif"], where="post", color=color,
+                linewidth=linewidth, label=f"{label} (n={fit['n']})")
+        if ci:
+            _step_ci(ax, fit["timeline"], fit["lower"], fit["upper"], color,
+                     ci_opacity)
+        if show_naive_km:
+            km = kaplan_meier(t[mask], np.asarray(e[mask]) == this_cause)
+            ax.step(km["timeline"], 1.0 - km["survival"], where="post",
+                    color=color, linewidth=linewidth * 0.8, linestyle="--",
+                    alpha=0.75, label=f"{label}, 1 - KM")
+
+    stats: Dict[str, Any] = {"fits": fits}
+    if has_group and test and len(levels) >= 2:
+        result = grays_test(t, e, g, causes[0], groups=levels)
+        stats.update(result)
+        ax.text(0.02, 0.98, f"Gray's test {_format_p(result['pvalue'])}",
+                transform=ax.transAxes, ha="left", va="top", fontsize=fontsize,
+                bbox=dict(boxstyle="round,pad=0.3", facecolor="white",
+                          edgecolor="0.8", alpha=0.85))
+
+    ax.set_xlim(xlim if xlim is not None else (0, float(np.max(t)) * 1.02))
+    if ylim is not None:
+        ax.set_ylim(ylim)
+    else:
+        ax.set_ylim(0.0, None)
+    if percent:
+        ticks = ax.get_yticks()
+        ax.set_yticks(ticks)
+        ax.set_yticklabels([f"{v * 100:.0f}" for v in ticks])
+    time_label = xlabel if xlabel is not None else names.get("time", "Time")
+    if ax_risk is None:
+        ax.set_xlabel(time_label, fontsize=fontsize + 1)
+    else:
+        ax.tick_params(axis="x", labelbottom=False)
+    ax.set_ylabel(
+        ylabel if ylabel is not None
+        else ("Cumulative incidence (%)" if percent else "Cumulative incidence"),
+        fontsize=fontsize + 1,
+    )
+    if title:
+        ax.set_title(title, fontsize=fontsize + 2)
+    ax.tick_params(labelsize=fontsize)
+    ax.spines[["right", "top"]].set_visible(False)
+    if legend:
+        ax.legend(loc=legend_loc, frameon=False, fontsize=fontsize)
+
+    if ax_risk is not None:
+        ticks = (np.asarray(risk_table_times, dtype=float)
+                 if risk_table_times is not None
+                 else np.asarray([v for v in ax.get_xticks()
+                                  if ax.get_xlim()[0] <= v <= ax.get_xlim()[1]]))
+        counts = [_at_risk(t[mask], ticks) for _, mask, _, _ in series]
+        _draw_risk_table(ax_risk, ticks, [lab for *_, lab in series], counts,
+                         colors, fontsize - 0.5, ax.get_xlim(), time_label)
+        ax_risk.set_xlim(ax.get_xlim())
+
+    return (ax, stats) if return_stats else ax

--- a/tests/pl/test_stats_layout.py
+++ b/tests/pl/test_stats_layout.py
@@ -1,0 +1,767 @@
+"""Tests for the data-first statistical plots and the layout/export layer.
+
+Two kinds of assertion live here.
+
+1. **Numerical parity.** The estimators are re-implementations, so each one is
+   pinned to a value produced by the reference implementation on a fixed
+   dataset: Kaplan-Meier / log-rank / Aalen-Johansen against ``lifelines``
+   0.30.0, DeLong's AUC interval against R ``pROC`` 1.18, Gray's test against
+   R ``cmprsk`` 2.2-12, and the meta-analysis against
+   ``statsmodels.stats.meta_analysis`` (which is a hard dependency, so that
+   one is checked live rather than pinned).
+
+   The reference packages are *not* required to run these tests — the expected
+   numbers are baked in as constants.
+
+2. **Contract.** Every plotting function returns an ``Axes``, accepts a
+   DataFrame / bare arrays / an AnnData-like object interchangeably, and the
+   export path really does keep text as text.
+"""
+from __future__ import annotations
+
+import os
+
+import matplotlib
+import numpy as np
+import pandas as pd
+import pytest
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt  # noqa: E402
+
+from omicverse.pl._classification import confusion, roc, roc_auc_ci  # noqa: E402
+from omicverse.pl._forest import forest, meta_analysis  # noqa: E402
+from omicverse.pl._layout import (  # noqa: E402
+    JOURNAL_WIDTH_MM,
+    add_panel_label,
+    figure,
+    multipanel,
+    savefig,
+    set_editable_text,
+    take_legend_out,
+)
+from omicverse.pl._stats_common import resolve_columns  # noqa: E402
+from omicverse.pl._survival import (  # noqa: E402
+    aalen_johansen,
+    cumulative_incidence,
+    grays_test,
+    kaplan_meier,
+    logrank_test,
+    survival,
+)
+
+# --------------------------------------------------------------------------
+# fixed datasets — `default_rng` is stream-stable across NumPy versions
+# --------------------------------------------------------------------------
+
+
+def make_survival():
+    rng = np.random.default_rng(20260727)
+    n = 200
+    grp = np.where(np.arange(n) < n // 2, "A", "B")
+    lam = np.where(grp == "A", 0.05, 0.10)
+    T = rng.exponential(1.0 / lam)
+    C = rng.exponential(20.0, n)
+    return np.minimum(T, C), (T <= C).astype(int), grp
+
+
+def make_competing():
+    rng = np.random.default_rng(20260728)
+    n = 240
+    grp = np.where(np.arange(n) < n // 2, "A", "B")
+    h1 = np.where(grp == "A", 0.04, 0.09)
+    T1 = rng.exponential(1.0 / h1)
+    T2 = rng.exponential(1.0 / 0.05, n)
+    C = rng.exponential(30.0, n)
+    t = np.minimum(np.minimum(T1, T2), C)
+    code = np.where((T1 <= T2) & (T1 <= C), 1,
+                    np.where((T2 < T1) & (T2 <= C), 2, 0))
+    return t, code, grp
+
+
+def make_scores():
+    rng = np.random.default_rng(20260729)
+    n = 300
+    y = (np.arange(n) % 2).astype(int)
+    return y, rng.normal(y * 0.9, 1.0)
+
+
+# Reference values, computed once against the packages named above.
+KM_A_MEDIAN = 13.642009585218469          # lifelines KaplanMeierFitter
+KM_A_SURV_AT_10 = 0.6445304290957725
+KM_A_MEDIAN_CI = (10.935559444422825,     # lifelines median_survival_times()
+                  32.84643671835402)
+LOGRANK_CHI2 = 24.2660158656954           # lifelines multivariate_logrank_test
+LOGRANK_P = 8.390647599419126e-07
+AJ_CIF1_AT_10 = 0.34813048741651814       # lifelines AalenJohansenFitter
+AJ_CIF1_AT_25 = 0.512018609133357
+AJ_VAR1_AT_25 = 0.0015224199800410285
+GRAY_CHI2 = 7.790932                      # R cmprsk::cuminc()$Tests, cause 1
+GRAY_P = 0.005251
+GRAY_CHI2_CAUSE2 = 1.309497
+PROC_AUC = 0.731688888889                 # R pROC roc()/ci.auc(method='delong')
+PROC_LO = 0.675718603199
+PROC_HI = 0.787659174578
+
+
+def _step_value(timeline, values, query):
+    """Right-continuous step lookup, the convention of both estimators."""
+    idx = np.searchsorted(timeline, query, side="right") - 1
+    return float(values[idx])
+
+
+# --------------------------------------------------------------------------
+# survival estimators
+# --------------------------------------------------------------------------
+
+
+class TestSurvivalEstimators:
+    def test_kaplan_meier_matches_lifelines(self):
+        t, e, g = make_survival()
+        fit = kaplan_meier(t[g == "A"], e[g == "A"])
+        assert fit["median"] == pytest.approx(KM_A_MEDIAN, rel=1e-12)
+        assert _step_value(fit["timeline"], fit["survival"], 10.0) == pytest.approx(
+            KM_A_SURV_AT_10, rel=1e-12
+        )
+
+    def test_median_confidence_interval_matches_lifelines(self):
+        t, e, g = make_survival()
+        fit = kaplan_meier(t[g == "A"], e[g == "A"])
+        low, high = fit["median_ci"]
+        assert low == pytest.approx(KM_A_MEDIAN_CI[0], rel=1e-12)
+        assert high == pytest.approx(KM_A_MEDIAN_CI[1], rel=1e-12)
+        # Brookmeyer-Crowley: the interval must bracket the point estimate
+        assert low <= fit["median"] <= high
+
+    def test_confidence_band_stays_inside_zero_one(self):
+        t, e, _ = make_survival()
+        fit = kaplan_meier(t, e)
+        finite = np.isfinite(fit["lower"]) & np.isfinite(fit["upper"])
+        assert np.all(fit["lower"][finite] >= 0.0)
+        assert np.all(fit["upper"][finite] <= 1.0)
+        assert np.all(fit["lower"][finite] <= fit["survival"][finite] + 1e-12)
+        assert np.all(fit["upper"][finite] >= fit["survival"][finite] - 1e-12)
+
+    def test_survival_is_monotone_non_increasing(self):
+        t, e, _ = make_survival()
+        fit = kaplan_meier(t, e)
+        assert np.all(np.diff(fit["survival"]) <= 1e-12)
+
+    def test_no_censoring_gives_empirical_survival(self):
+        t = np.array([1.0, 2.0, 3.0, 4.0])
+        fit = kaplan_meier(t, np.ones(4))
+        assert _step_value(fit["timeline"], fit["survival"], 2.0) == pytest.approx(0.5)
+        assert _step_value(fit["timeline"], fit["survival"], 4.0) == pytest.approx(0.0)
+
+    def test_logrank_matches_lifelines(self):
+        t, e, g = make_survival()
+        res = logrank_test(t, e, g)
+        assert res["statistic"] == pytest.approx(LOGRANK_CHI2, rel=1e-10)
+        assert res["pvalue"] == pytest.approx(LOGRANK_P, rel=1e-8)
+        assert res["df"] == 1
+
+    def test_logrank_hazard_ratio_direction(self):
+        t, e, g = make_survival()
+        res = logrank_test(t, e, g)
+        # group B has twice the hazard of A, and A is the reference here
+        assert res["hazard_ratio"] < 1.0
+        lo, hi = res["hazard_ratio_ci"]
+        assert lo < res["hazard_ratio"] < hi
+        assert hi < 1.0
+
+    def test_reference_group_does_not_depend_on_row_order(self):
+        """Regression: the HR direction must not flip when rows are shuffled.
+
+        Deriving the level order from ``pd.unique`` (order of appearance) made
+        the reference group depend on which patient happened to be first in
+        the file, so a per-cohort forest plot came out with half the hazard
+        ratios inverted.
+        """
+        t, e, g = make_survival()
+        forward = logrank_test(t, e, g)
+        order = np.argsort(g)[::-1]  # now group "B" appears first
+        shuffled = logrank_test(t[order], e[order], g[order])
+        assert forward["groups"] == shuffled["groups"] == ["A", "B"]
+        assert forward["hazard_ratio"] == pytest.approx(shuffled["hazard_ratio"])
+
+    def test_explicit_group_order_sets_the_reference(self):
+        t, e, g = make_survival()
+        default = logrank_test(t, e, g)
+        flipped = logrank_test(t, e, g, groups=["B", "A"])
+        assert flipped["groups"] == ["B", "A"]
+        assert flipped["hazard_ratio"] == pytest.approx(
+            1.0 / default["hazard_ratio"], rel=1e-12)
+        assert flipped["statistic"] == pytest.approx(default["statistic"])
+
+    def test_categorical_order_is_respected(self):
+        t, e, g = make_survival()
+        categorical = pd.Categorical(g, categories=["B", "A"], ordered=True)
+        res = logrank_test(t, e, categorical)
+        assert res["groups"] == ["B", "A"]
+
+    def test_unknown_explicit_level_is_reported(self):
+        t, e, g = make_survival()
+        with pytest.raises(ValueError, match="not present"):
+            logrank_test(t, e, g, groups=["A", "Z"])
+
+    def test_logrank_needs_two_groups(self):
+        t, e, _ = make_survival()
+        with pytest.raises(ValueError, match="at least two groups"):
+            logrank_test(t, e, np.zeros(len(t)))
+
+
+class TestCompetingRisks:
+    def test_aalen_johansen_matches_lifelines(self):
+        t, code, _ = make_competing()
+        fit = aalen_johansen(t, code, 1)
+        assert _step_value(fit["timeline"], fit["cif"], 10.0) == pytest.approx(
+            AJ_CIF1_AT_10, rel=1e-10
+        )
+        assert _step_value(fit["timeline"], fit["cif"], 25.0) == pytest.approx(
+            AJ_CIF1_AT_25, rel=1e-10
+        )
+
+    def test_aalen_johansen_variance_matches_lifelines(self):
+        t, code, _ = make_competing()
+        fit = aalen_johansen(t, code, 1)
+        assert _step_value(fit["timeline"], fit["variance"], 25.0) == pytest.approx(
+            AJ_VAR1_AT_25, rel=1e-8
+        )
+
+    def test_cif_never_exceeds_one_minus_km(self):
+        """The whole point of Aalen-Johansen: 1 - KM over-states incidence."""
+        t, code, _ = make_competing()
+        aj = aalen_johansen(t, code, 1)
+        km = kaplan_meier(t, code == 1)
+        for query in (5.0, 10.0, 20.0, 40.0):
+            naive = 1.0 - _step_value(km["timeline"], km["survival"], query)
+            assert _step_value(aj["timeline"], aj["cif"], query) <= naive + 1e-12
+
+    def test_cifs_of_all_causes_sum_to_one_minus_survival(self):
+        t, code, _ = make_competing()
+        f1 = aalen_johansen(t, code, 1)
+        f2 = aalen_johansen(t, code, 2)
+        for query in (5.0, 15.0, 30.0):
+            total = (_step_value(f1["timeline"], f1["cif"], query)
+                     + _step_value(f2["timeline"], f2["cif"], query))
+            surv = _step_value(f1["timeline"], f1["survival"], query)
+            assert total == pytest.approx(1.0 - surv, abs=1e-10)
+
+    def test_grays_test_tracks_cmprsk(self):
+        """Agreement with ``cmprsk::cuminc`` to within a few percent.
+
+        Not an exact match: the statistic uses Gray's subdistribution risk set
+        but the log-rank variance rather than Gray's martingale variance. On
+        the four simulated cohorts checked against R the gap never exceeded
+        2.3% of the chi-square, so 5% is the contract.
+        """
+        t, code, g = make_competing()
+        res = grays_test(t, code, g, 1)
+        assert res["df"] == 1
+        assert res["statistic"] == pytest.approx(GRAY_CHI2, rel=0.05)
+        assert res["pvalue"] == pytest.approx(GRAY_P, rel=0.15)
+
+        competing = grays_test(t, code, g, 2)
+        assert competing["statistic"] == pytest.approx(GRAY_CHI2_CAUSE2, rel=0.05)
+
+    def test_grays_test_beats_a_plain_logrank_here(self):
+        """The cause-specific log-rank answers a different question."""
+        t, code, g = make_competing()
+        gray = grays_test(t, code, g, 1)
+        naive = logrank_test(t, code == 1, g)
+        assert gray["pvalue"] < 0.05
+        # both point the same way on this cohort, but the statistics differ
+        assert gray["statistic"] != pytest.approx(naive["statistic"], rel=1e-3)
+
+    def test_grays_test_null_case(self):
+        """With groups assigned at random the test must not fire."""
+        rng = np.random.default_rng(4)
+        t, code, _ = make_competing()
+        g = rng.integers(0, 2, len(t))
+        res = grays_test(t, code, g, 1)
+        assert res["pvalue"] > 0.05
+
+    def test_unknown_cause_is_reported(self):
+        t, code, g = make_competing()
+        with pytest.raises(ValueError, match="No events of cause"):
+            grays_test(t, code, g, 9)
+
+
+# --------------------------------------------------------------------------
+# classifier evaluation
+# --------------------------------------------------------------------------
+
+
+class TestROC:
+    def test_auc_matches_sklearn(self):
+        from sklearn.metrics import roc_auc_score
+
+        y, s = make_scores()
+        assert roc_auc_ci(y, s)["auc"] == pytest.approx(roc_auc_score(y, s),
+                                                        rel=1e-12)
+
+    def test_delong_interval_matches_proc(self):
+        y, s = make_scores()
+        res = roc_auc_ci(y, s)
+        assert res["auc"] == pytest.approx(PROC_AUC, abs=1e-11)
+        assert res["lower"] == pytest.approx(PROC_LO, abs=1e-11)
+        assert res["upper"] == pytest.approx(PROC_HI, abs=1e-11)
+
+    def test_delong_handles_ties(self):
+        y = np.array([0, 0, 1, 1, 0, 1])
+        s = np.array([1.0, 1.0, 1.0, 2.0, 0.0, 2.0])
+        res = roc_auc_ci(y, s)
+        assert 0.0 <= res["auc"] <= 1.0
+        assert res["se"] > 0
+
+    def test_positive_class_does_not_depend_on_row_order(self):
+        """Regression: AUC came out as 1 - AUC when label 1 appeared first.
+
+        ``roc`` picked ``pos_label`` from ``pd.unique`` (order of appearance)
+        while ``roc_auc_ci`` used the sorted classes, so the same model scored
+        0.79 in one call and 0.21 in another.
+        """
+        y, s = make_scores()
+        order = np.argsort(y)[::-1]  # label 1 now comes first
+        _, forward = roc(y_true=y, y_score=s, return_stats=True)
+        _, shuffled = roc(y_true=y[order], y_score=s[order], return_stats=True)
+        plt.close("all")
+        assert forward["curves"]["score"]["auc"] > 0.5
+        assert forward["curves"]["score"]["auc"] == pytest.approx(
+            shuffled["curves"]["score"]["auc"])
+
+    def test_plot_auc_agrees_with_the_estimator(self):
+        y, s = make_scores()
+        _, stats = roc(y, s, return_stats=True)
+        plt.close("all")
+        assert stats["curves"]["score"]["auc"] == pytest.approx(
+            roc_auc_ci(y, s)["auc"], rel=1e-12)
+
+    def test_single_class_is_rejected(self):
+        with pytest.raises(ValueError, match="two classes"):
+            roc_auc_ci(np.ones(10), np.arange(10.0))
+
+    def test_plot_accepts_arrays_dict_and_frame(self):
+        y, s = make_scores()
+        frame = pd.DataFrame({"label": y, "p1": s, "p2": -s})
+
+        ax = roc(y, s)
+        assert ax.get_ylabel() == "True positive rate"
+        plt.close("all")
+
+        ax = roc(y_true=y, y_score={"a": s, "b": -s})
+        assert len(ax.get_legend().get_texts()) == 2
+        plt.close("all")
+
+        ax, stats = roc(frame, "label", ["p1", "p2"], return_stats=True)
+        assert set(stats["curves"]) == {"p1", "p2"}
+        plt.close("all")
+
+    def test_multiclass_one_vs_rest(self):
+        rng = np.random.default_rng(11)
+        labels = np.array(["a", "b", "c"])[rng.integers(0, 3, 150)]
+        proba = rng.random((150, 3))
+        proba /= proba.sum(axis=1, keepdims=True)
+        ax, stats = roc(y_true=labels, y_score=proba,
+                        score_names=["a", "b", "c"], average="both",
+                        return_stats=True)
+        assert {"a", "b", "c", "macro-average", "micro-average"} <= set(stats["curves"])
+        plt.close("all")
+
+    def test_mismatched_class_count_is_reported(self):
+        rng = np.random.default_rng(3)
+        labels = np.array(["a", "b", "c"])[rng.integers(0, 3, 60)]
+        with pytest.raises(ValueError, match="classes but only"):
+            roc(y_true=labels, y_score=rng.random(60))
+
+
+class TestConfusion:
+    def test_matrix_and_metrics(self):
+        truth = np.array(["a"] * 5 + ["b"] * 5)
+        pred = np.array(["a"] * 4 + ["b"] + ["b"] * 4 + ["a"])
+        ax, stats = confusion(y_true=truth, y_pred=pred, return_stats=True)
+        assert stats["matrix"].loc["a", "a"] == 4
+        assert stats["matrix"].loc["b", "a"] == 1
+        assert stats["accuracy"] == pytest.approx(0.8)
+        assert stats["per_class"].loc["a", "recall"] == pytest.approx(0.8)
+        plt.close("all")
+
+    def test_row_normalisation_sums_to_one(self):
+        rng = np.random.default_rng(5)
+        truth = rng.integers(0, 4, 200)
+        pred = np.where(rng.random(200) < 0.7, truth, rng.integers(0, 4, 200))
+        _, stats = confusion(y_true=truth, y_pred=pred, normalize="true",
+                             return_stats=True)
+        assert np.allclose(stats["normalized"].sum(axis=1), 1.0)
+        plt.close("all")
+
+    def test_unseen_class_keeps_a_row(self):
+        truth = np.array(["a", "b", "c"])
+        pred = np.array(["a", "b", "b"])
+        _, stats = confusion(y_true=truth, y_pred=pred, return_stats=True)
+        assert list(stats["matrix"].index) == ["a", "b", "c"]
+        plt.close("all")
+
+    def test_bad_normalize_is_reported(self):
+        with pytest.raises(ValueError, match="normalize"):
+            confusion(y_true=[0, 1], y_pred=[0, 1], normalize="rows")
+
+
+# --------------------------------------------------------------------------
+# forest / meta-analysis
+# --------------------------------------------------------------------------
+
+
+EST = np.array([0.32, 0.11, 0.55, -0.05, 0.41, 0.28, 0.62])
+SE = np.array([0.12, 0.19, 0.15, 0.22, 0.10, 0.17, 0.25])
+
+
+class TestMetaAnalysis:
+    def test_matches_statsmodels(self):
+        from statsmodels.stats.meta_analysis import combine_effects
+
+        res = combine_effects(EST, SE ** 2, method_re="dl")
+        frame = res.summary_frame()
+        fixed = meta_analysis(EST, SE, method="fixed")
+        random = meta_analysis(EST, SE, method="random")
+
+        assert fixed["estimate"] == pytest.approx(
+            frame.loc["fixed effect", "eff"], rel=1e-12)
+        assert fixed["se"] == pytest.approx(
+            frame.loc["fixed effect", "sd_eff"], rel=1e-12)
+        assert random["estimate"] == pytest.approx(
+            frame.loc["random effect", "eff"], rel=1e-12)
+        assert random["se"] == pytest.approx(
+            frame.loc["random effect", "sd_eff"], rel=1e-12)
+        assert random["tau2"] == pytest.approx(res.tau2, rel=1e-10)
+        assert random["Q"] == pytest.approx(res.q, rel=1e-10)
+
+    def test_random_interval_is_wider_under_heterogeneity(self):
+        fixed = meta_analysis(EST, SE, method="fixed")
+        random = meta_analysis(EST, SE, method="random")
+        assert random["tau2"] > 0
+        assert (random["upper"] - random["lower"]) > (fixed["upper"] - fixed["lower"])
+
+    def test_homogeneous_studies_collapse_to_fixed(self):
+        est = np.full(5, 0.4)
+        se = np.full(5, 0.1)
+        random = meta_analysis(est, se, method="random")
+        fixed = meta_analysis(est, se, method="fixed")
+        assert random["tau2"] == 0.0
+        assert random["estimate"] == pytest.approx(fixed["estimate"])
+
+    def test_zero_standard_error_is_rejected(self):
+        with pytest.raises(ValueError, match="positive"):
+            meta_analysis(EST, np.zeros_like(SE))
+
+
+class TestForestPlot:
+    def test_from_se_and_from_bounds_agree(self):
+        frame = pd.DataFrame({"beta": EST, "se": SE,
+                              "label": [f"S{i}" for i in range(len(EST))]})
+        _, a = forest(frame, "beta", se="se", label="label", return_stats=True)
+        z = 1.959963984540054
+        frame["lo"], frame["hi"] = EST - z * SE, EST + z * SE
+        _, b = forest(frame, "beta", lower="lo", upper="hi", label="label",
+                      return_stats=True)
+        assert np.allclose(a["rows"]["lower"], b["rows"]["lower"])
+        assert np.allclose(a["rows"]["upper"], b["rows"]["upper"])
+        plt.close("all")
+
+    def test_meta_row_is_appended(self):
+        frame = pd.DataFrame({"beta": EST, "se": SE})
+        _, stats = forest(frame, "beta", se="se", meta="both", return_stats=True)
+        assert set(stats["meta"]) == {"fixed", "random"}
+        assert (stats["rows"]["kind"] == "summary").sum() == 2
+        plt.close("all")
+
+    def test_log_scale_uses_a_log_axis(self):
+        frame = pd.DataFrame({"HR": np.exp(EST), "se": SE})
+        ax = forest(frame, "HR", se="se", log_scale=True)
+        assert ax.get_xscale() == "log"
+        plt.close("all")
+
+    def test_needs_an_interval(self):
+        with pytest.raises(TypeError, match="lower.*upper.*se|se"):
+            forest(pd.DataFrame({"beta": EST}), "beta")
+
+    def test_meta_without_se_is_refused(self):
+        frame = pd.DataFrame({"beta": EST, "lo": EST - 1, "hi": EST + 1})
+        ax = forest(frame, "beta", lower="lo", upper="hi")
+        assert ax is not None
+        plt.close("all")
+
+
+# --------------------------------------------------------------------------
+# input handling shared by the group
+# --------------------------------------------------------------------------
+
+
+class TestInputHandling:
+    def test_dataframe_arrays_and_anndata_agree(self):
+        t, e, g = make_survival()
+        frame = pd.DataFrame({"months": t, "status": e, "arm": g})
+
+        ax_frame, s_frame = survival(frame, "months", "status", "arm",
+                                     return_stats=True)
+        plt.close("all")
+        ax_array, s_array = survival(time=t, event=e, group=g,
+                                     return_stats=True)
+        plt.close("all")
+        assert s_frame["pvalue"] == pytest.approx(s_array["pvalue"])
+
+        anndata = pytest.importorskip("anndata")
+        adata = anndata.AnnData(np.zeros((len(t), 2), dtype=np.float32),
+                                obs=frame)
+        _, s_adata = survival(adata, "months", "status", "arm",
+                              return_stats=True)
+        plt.close("all")
+        assert s_adata["pvalue"] == pytest.approx(s_frame["pvalue"])
+
+    def test_unknown_column_suggests_a_close_match(self):
+        frame = pd.DataFrame({"months": [1.0, 2.0], "status": [1, 0]})
+        with pytest.raises(KeyError, match="month"):
+            resolve_columns(frame, time="monthss", event="status")
+
+    def test_length_mismatch_is_reported(self):
+        with pytest.raises(ValueError, match="different lengths"):
+            resolve_columns(None, time=[1.0, 2.0], event=[1])
+
+    def test_missing_values_are_dropped_and_reported(self, capsys):
+        frame = pd.DataFrame({"months": [1.0, np.nan, 3.0],
+                              "status": [1, 1, 0]})
+        survival(frame, "months", "status", risk_table=False)
+        assert "dropped 1 rows" in capsys.readouterr().out
+        plt.close("all")
+
+    def test_column_name_without_a_table_is_reported(self):
+        with pytest.raises(TypeError, match="names a column"):
+            resolve_columns(None, time="months", event=[1, 0])
+
+
+# --------------------------------------------------------------------------
+# plots return axes and carry the right furniture
+# --------------------------------------------------------------------------
+
+
+class TestSurvivalPlot:
+    def test_risk_table_moves_the_time_axis_down(self):
+        t, e, g = make_survival()
+        ax = survival(time=t, event=e, group=g, risk_table=True)
+        # the curve axes hands its tick labels to the table below it
+        assert not any(lbl.get_text() for lbl in ax.get_xticklabels())
+        assert len(ax.get_figure().axes) == 2
+        plt.close("all")
+
+    def test_without_risk_table_the_axes_keeps_its_label(self):
+        t, e, _ = make_survival()
+        ax = survival(time=t, event=e, risk_table=False)
+        assert ax.get_xlabel() == "time"
+        plt.close("all")
+
+    def test_censor_marks_are_drawn(self):
+        t, e, _ = make_survival()
+        ax = survival(time=t, event=e, risk_table=False, censor_marks=True)
+        markers = [ln for ln in ax.get_lines() if ln.get_marker() == "|"]
+        assert markers
+        plt.close("all")
+
+    def test_percent_axis(self):
+        t, e, _ = make_survival()
+        ax = survival(time=t, event=e, risk_table=False, percent=True)
+        assert "100" in [lbl.get_text() for lbl in ax.get_yticklabels()]
+        plt.close("all")
+
+
+class TestCumulativeIncidencePlot:
+    def test_group_comparison_annotates_grays_test(self):
+        t, code, g = make_competing()
+        ax, stats = cumulative_incidence(time=t, event=code, group=g, cause=1,
+                                         return_stats=True)
+        assert stats["test"].startswith("Gray")
+        assert any("Gray" in txt.get_text() for txt in ax.texts)
+        plt.close("all")
+
+    def test_several_causes_for_one_cohort(self):
+        t, code, _ = make_competing()
+        ax = cumulative_incidence(time=t, event=code, cause=[1, 2],
+                                  cause_labels={1: "relapse", 2: "death"})
+        labels = [txt.get_text() for txt in ax.get_legend().get_texts()]
+        assert any("relapse" in lbl for lbl in labels)
+        plt.close("all")
+
+    def test_groups_and_multiple_causes_are_refused(self):
+        t, code, g = make_competing()
+        with pytest.raises(ValueError, match="one cause across"):
+            cumulative_incidence(time=t, event=code, group=g, cause=[1, 2])
+
+    def test_naive_km_overlay_sits_above(self):
+        t, code, _ = make_competing()
+        ax = cumulative_incidence(time=t, event=code, cause=1,
+                                  show_naive_km=True)
+        dashed = [ln for ln in ax.get_lines() if ln.get_linestyle() == "--"]
+        assert dashed
+        plt.close("all")
+
+
+# --------------------------------------------------------------------------
+# layout and export
+# --------------------------------------------------------------------------
+
+
+class TestLayout:
+    def test_millimetre_size_is_exact(self):
+        fig = figure(89, 60, units="mm", dpi=300)
+        width, height = fig.get_size_inches()
+        assert width == pytest.approx(89 / 25.4, rel=1e-12)
+        assert height == pytest.approx(60 / 25.4, rel=1e-12)
+        plt.close(fig)
+
+    def test_pixel_size_is_exact(self):
+        fig = figure(1200, 800, units="px", dpi=150)
+        assert tuple(np.round(fig.get_size_inches() * 150).astype(int)) == (1200, 800)
+        plt.close(fig)
+
+    def test_journal_preset(self):
+        fig = figure("nature-single", 60)
+        assert fig.get_size_inches()[0] == pytest.approx(
+            JOURNAL_WIDTH_MM["nature-single"] / 25.4, rel=1e-12)
+        plt.close(fig)
+
+    def test_unknown_preset_lists_the_options(self):
+        with pytest.raises(KeyError, match="nature-single"):
+            figure("nature-quadruple", 60)
+
+    def test_aspect_fills_the_missing_side(self):
+        fig = figure(width=100, aspect=2.0)
+        w, h = fig.get_size_inches()
+        assert w / h == pytest.approx(2.0, rel=1e-12)
+        plt.close(fig)
+
+    def test_grid_panels_are_labelled_in_reading_order(self):
+        fig, axes = multipanel((2, 2), width=180, height=120)
+        assert list(axes) == ["a", "b", "c", "d"]
+        for key, ax in axes.items():
+            assert any(txt.get_text() == key for txt in ax.texts)
+        plt.close(fig)
+
+    def test_mosaic_keys_are_preserved(self):
+        fig, axes = multipanel("AAB\nCCB", width=180, height=90, label="A")
+        assert set(axes) == {"A", "B", "C"}
+        plt.close(fig)
+
+    def test_label_can_be_switched_off(self):
+        fig, axes = multipanel((1, 2), width=180, height=60, label=False)
+        assert list(axes) == [(0, 0), (0, 1)]
+        assert not any(ax.texts for ax in axes.values())
+        plt.close(fig)
+
+    def test_panel_label_uses_point_offsets(self):
+        fig, ax = figure(100, 60, axes=True)
+        note = add_panel_label(ax, "a", dx=-18, dy=5)
+        assert note.get_position() == (-18, 5)
+        assert note.xycoords == "axes fraction"
+        plt.close(fig)
+
+    def test_take_legend_out_moves_the_legend(self):
+        fig, ax = figure(100, 60, axes=True)
+        ax.plot([0, 1], [0, 1], label="x")
+        legend = take_legend_out(ax, loc="right")
+        assert legend.get_bbox_to_anchor() is not None
+        assert legend.get_frame_on() is False
+        plt.close(fig)
+
+    def test_take_legend_out_without_entries_is_reported(self):
+        fig, ax = figure(100, 60, axes=True)
+        with pytest.raises(ValueError, match="No legend entries"):
+            take_legend_out(ax)
+        plt.close(fig)
+
+
+class TestExport:
+    def test_svg_keeps_text_as_text(self, tmp_path):
+        fig, ax = figure(80, 60, axes=True)
+        ax.set_xlabel("editable label")
+        target = tmp_path / "fig.svg"
+        savefig(fig, target, verbose=False)
+        content = target.read_text()
+        assert "<text" in content
+        assert "editable label" in content
+        plt.close(fig)
+
+    def test_outlined_mode_drops_the_text_elements(self, tmp_path):
+        previous = set_editable_text(False)
+        try:
+            fig, ax = figure(80, 60, axes=True, editable_text=False)
+            ax.set_xlabel("outlined label")
+            target = tmp_path / "fig.svg"
+            savefig(fig, target, editable_text=False, verbose=False)
+            content = target.read_text()
+            # glyphs become <path>/<use>; matplotlib still leaves the string in
+            # an XML comment, so the real check is that no <text> node exists
+            assert "<text" not in content
+            plt.close(fig)
+        finally:
+            plt.rcParams.update(previous)
+
+    def test_several_formats_from_one_call(self, tmp_path):
+        fig, ax = figure(80, 60, axes=True)
+        ax.plot([0, 1], [0, 1])
+        written = savefig(fig, tmp_path / "panel", formats=["png", "svg", "pdf"],
+                          verbose=False)
+        assert [os.path.basename(p) for p in written] == [
+            "panel.png", "panel.svg", "panel.pdf"]
+        assert all(os.path.getsize(p) > 0 for p in written)
+        plt.close(fig)
+
+    def test_path_only_call_uses_the_current_figure(self, tmp_path):
+        fig, ax = figure(80, 60, axes=True)
+        ax.plot([0, 1], [0, 1])
+        target = tmp_path / "current.png"
+        savefig(str(target), verbose=False)
+        assert target.exists()
+        plt.close(fig)
+
+    def test_editable_rcparams_are_not_leaked(self, tmp_path):
+        set_editable_text(False)
+        before = dict(plt.rcParams)
+        fig, ax = figure(60, 40, axes=True, editable_text=False)
+        savefig(fig, tmp_path / "x.svg", editable_text=True, verbose=False)
+        assert plt.rcParams["svg.fonttype"] == before["svg.fonttype"]
+        plt.close(fig)
+        set_editable_text(True)
+
+
+class TestRegistry:
+    def test_new_functions_are_registered(self):
+        import omicverse.pl  # noqa: F401  — runs the decorators
+
+        from omicverse._registry import get_registry
+
+        names = {entry.get("full_name")
+                 for entry in get_registry().get_by_category("pl")}
+        for expected in (
+            "omicverse.pl._survival.survival",
+            "omicverse.pl._survival.cumulative_incidence",
+            "omicverse.pl._classification.roc",
+            "omicverse.pl._classification.confusion",
+            "omicverse.pl._forest.forest",
+            "omicverse.pl._layout.figure",
+            "omicverse.pl._layout.multipanel",
+            "omicverse.pl._layout.add_panel_label",
+            "omicverse.pl._layout.savefig",
+            "omicverse.pl._layout.set_editable_text",
+            "omicverse.pl._layout.take_legend_out",
+        ):
+            assert expected in names, f"{expected} missing from the registry"
+
+    def test_functions_are_reachable_from_the_public_namespace(self):
+        import omicverse.pl as pl
+
+        for name in ("survival", "cumulative_incidence", "roc", "confusion",
+                     "forest", "figure", "multipanel", "add_panel_label",
+                     "savefig", "set_editable_text", "take_legend_out",
+                     "kaplan_meier", "logrank_test", "aalen_johansen",
+                     "grays_test", "roc_auc_ci", "meta_analysis"):
+            assert hasattr(pl, name), f"ov.pl.{name} is not exported"
+            assert name in pl.__all__, f"ov.pl.{name} is missing from __all__"


### PR DESCRIPTION
`ov.pl` can draw an embedding but could not draw a survival curve. This adds the plots a clinical or benchmarking result actually needs, plus the plumbing to get them out of matplotlib at the size and in the format a journal asks for.

All of it is **data-first**: a `DataFrame` + column names, bare arrays, or an `AnnData` (its `.obs`) are interchangeable. Nothing here requires an `AnnData`.

## What's new

| Function | Draws |
| --- | --- |
| `ov.pl.survival` | Kaplan-Meier + log-log band + censoring ticks + numbers at risk + log-rank + hazard ratio |
| `ov.pl.cumulative_incidence` | Aalen-Johansen under competing risks + Gray's test, with an opt-in `1 - KM` overlay so the naive estimator's bias is visible |
| `ov.pl.roc` | ROC with DeLong intervals, multi-model overlay, one-vs-rest multiclass + macro/micro |
| `ov.pl.confusion` | Confusion matrix + accuracy / balanced accuracy / kappa / per-class P-R-F1 |
| `ov.pl.forest` | Effect sizes with CIs, subgroups, fixed or DerSimonian-Laird random-effects pooling |
| `ov.pl.figure` | Canvas in mm / cm / in / px, or by journal column preset (`'nature-single'` = 89 mm) |
| `ov.pl.multipanel` | Labelled panel grid or mosaic |
| `ov.pl.add_panel_label` | a/b/c tags offset in **points**, not axes fractions |
| `ov.pl.savefig` | Several formats per call, text stays text |
| `ov.pl.set_editable_text` | `svg.fonttype='none'` + `pdf/ps.fonttype=42` globally |
| `ov.pl.take_legend_out` | Legend outside the axes |

The estimators are public on their own too — `kaplan_meier`, `logrank_test`, `aalen_johansen`, `grays_test`, `roc_auc_ci`, `meta_analysis` — and return plain dicts.

**No new dependencies.** The survival estimators are implemented on NumPy/SciPy rather than pulling in `lifelines`.

## Numerical parity

Pinned in `tests/pl/test_stats_layout.py`. The reference packages are **not** needed to run the tests — the expected values are baked in as constants.

| Quantity | Reference | Agreement |
| --- | --- | --- |
| KM survival, log-log band, median + Brookmeyer-Crowley CI | lifelines 0.30.0 | ~1e-12 |
| Multivariate log-rank chi-square | lifelines 0.30.0 | ~1e-10 |
| Aalen-Johansen CIF **and its variance** | lifelines 0.30.0 | ~1e-10 |
| DeLong AUC interval | R pROC 1.18 | 1e-11 |
| Fixed/random pooling, tau², Q, I² | `statsmodels.stats.meta_analysis` | ~1e-12 (checked live) |
| Gray's test | R cmprsk 2.2-12 | **within 2.3%**, see below |

Gray's test uses the subdistribution risk set with the log-rank variance rather than Gray's full martingale variance. Across four simulated cohorts (8 cause/cohort comparisons) the chi-square never differed from `cmprsk::cuminc` by more than 2.3%. That limit is documented in the docstring and asserted at 5% in the test, rather than being papered over.

## Two defects found by running it on real data

Both are regression-tested. Found while building the tutorial against the TCGA Pan-Cancer Clinical Data Resource:

1. **Reference group came from `pd.unique`** — i.e. whichever patient happened to be first in the file. A per-cancer-type forest plot came out with half its hazard ratios inverted (KIRC 0.28, BLCA 2.19, for the same comparison). Level order is now the `Categorical` category order, else sorted, and `groups=` sets it explicitly.
2. **`roc` picked `pos_label` by order of appearance** while `roc_auc_ci` used the sorted classes, so the same model scored AUC 0.79 in one call and 0.21 in another. Both now follow scikit-learn's rule.

## Testing

`tests/pl/test_stats_layout.py` — 73 tests, all passing. Covers the parity table above, the two regressions, input-form equivalence (DataFrame / arrays / AnnData give identical statistics), error messages, and the export contract (an SVG saved with the defaults really does still contain `<text>` nodes; with `editable_text=False` it does not).

## Tutorial

omicverse/omicverse-tutorials#97 — executed end to end on real TCGA data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VVqVNig3oV6wz42YiQ9obZ
