### PR TITLE
feat(pl): table-first statistical plots and an AnnData adapter

### DIFF
--- a/omicverse/pl/__init__.py
+++ b/omicverse/pl/__init__.py
@@ -28,6 +28,11 @@ Key modules:
     _flowsig: Flow cytometry-style visualizations
     _embedding: Dimensionality reduction visualizations
     _density: Density and distribution plots
+    _categorical: barplot/stripplot/violinplot/stackplot/pie/donut/slope (table in)
+    _distribution: histplot/kdeplot/ridgeplot/qqplot
+    _relational: scatterplot/lineplot/regplot
+    _stats_tests: compare_groups + significance brackets
+    _plotdata: as_plotdata / accepts_frame — AnnData plots that also take a table
     _survival: Kaplan-Meier and Aalen-Johansen curves, log-rank / Gray's test
     _classification: ROC curves and confusion matrices
     _forest: forest plots and fixed/random-effects meta-analysis
@@ -281,6 +286,20 @@ from ._survival import (
 )
 from ._classification import confusion, roc, roc_auc_ci
 from ._forest import forest, meta_analysis
+from ._stats_tests import add_stat_annotation, compare_groups, format_pvalue
+from ._categorical import (
+    barplot,
+    donutplot,
+    lollipopplot,
+    pieplot,
+    slopeplot,
+    stackplot,
+    stripplot,
+    violinplot,
+)
+from ._distribution import histplot, kdeplot, qqplot, ridgeplot
+from ._relational import lineplot, regplot, scatterplot
+from ._plotdata import ObsView, PlotData, accepts_frame, as_plotdata
 
 
 def curved_graph(*args, **kwargs):
@@ -523,4 +542,31 @@ __all__ = [
     # @ _forest — effect sizes and meta-analysis
     "forest",
     "meta_analysis",
+    # @ _stats_tests — group comparison and significance brackets
+    "compare_groups",
+    "add_stat_annotation",
+    "format_pvalue",
+    # @ _categorical — generic categorical plots (table in, no AnnData)
+    "barplot",
+    "stripplot",
+    "violinplot",
+    "stackplot",
+    "lollipopplot",
+    "pieplot",
+    "donutplot",
+    "slopeplot",
+    # @ _distribution
+    "histplot",
+    "kdeplot",
+    "ridgeplot",
+    "qqplot",
+    # @ _relational
+    "scatterplot",
+    "lineplot",
+    "regplot",
+    # @ _plotdata — let AnnData-shaped plots take a table
+    "as_plotdata",
+    "accepts_frame",
+    "PlotData",
+    "ObsView",
 ]

--- a/omicverse/pl/_categorical.py
+++ b/omicverse/pl/_categorical.py
@@ -1,0 +1,1224 @@
+r"""Categorical plots that take a table, not an ``AnnData``.
+
+``ov.pl`` has a violin plot and a stacked-proportion plot, but both start from
+an ``AnnData``. These are the container-free versions, in the shape a
+statistician expects: a long-form table plus the names of the category column
+and the value column.
+
+All of them accept ``test=`` and route it through
+:func:`~omicverse.pl.compare_groups`, so the significance brackets are drawn
+from the same numbers you get back — the annotation cannot drift away from the
+statistics.
+
+The ``...plot`` suffix marks this generic layer and keeps it clear of the
+existing omics-specific names (``ov.pl.violin`` still takes an ``AnnData``;
+``ov.pl.violinplot`` takes a frame).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple, Union
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+from .._registry import register_function
+from ._stats_common import as_frame, default_palette, group_levels, resolve_columns
+
+__all__ = [
+    "barplot", "stripplot", "violinplot", "stackplot", "lollipopplot",
+    "pieplot", "donutplot", "slopeplot",
+]
+
+
+# --------------------------------------------------------------------------
+# shared layout helpers
+# --------------------------------------------------------------------------
+
+
+def _long_frame(data, x, y, hue, order, hue_order, *, require_y=True):
+    """Normalise (data, x, y, hue) into a tidy frame plus level orders."""
+    if data is not None and as_frame(data) is None:
+        data, x, y, hue = None, data, x, y
+    if x is None:
+        raise TypeError("`x` (the category) is required.")
+    if require_y and y is None:
+        raise TypeError("`y` (the value) is required.")
+
+    frame, names = resolve_columns(data, x=x, y=y, hue=hue, require=("x",))
+    dropped = frame.attrs.get("n_dropped", 0)
+    levels = group_levels(frame["x"], order)
+    hues = group_levels(frame["hue"], hue_order) if "hue" in frame else [None]
+    return frame, levels, hues, names, dropped
+
+
+def _offsets(n_hue: int, width: float) -> np.ndarray:
+    """Dodge offsets for ``n_hue`` sub-categories inside one slot."""
+    if n_hue <= 1:
+        return np.array([0.0])
+    step = width / n_hue
+    return (np.arange(n_hue) - (n_hue - 1) / 2.0) * step
+
+
+def _finish(ax, *, levels, names, xlabel, ylabel, title, fontsize, orient,
+            rotation=0, categorical_axis=True):
+    labels = [str(level) for level in levels]
+    if categorical_axis:
+        if orient == "v":
+            ax.set_xticks(range(len(levels)))
+            ax.set_xticklabels(labels, fontsize=fontsize,
+                               rotation=rotation,
+                               ha="right" if rotation else "center")
+        else:
+            ax.set_yticks(range(len(levels)))
+            ax.set_yticklabels(labels, fontsize=fontsize)
+    cat_label = xlabel if xlabel is not None else names.get("x", "")
+    val_label = ylabel if ylabel is not None else names.get("y", "")
+    if orient == "v":
+        ax.set_xlabel(cat_label, fontsize=fontsize + 1)
+        ax.set_ylabel(val_label, fontsize=fontsize + 1)
+    else:
+        ax.set_ylabel(cat_label, fontsize=fontsize + 1)
+        ax.set_xlabel(val_label, fontsize=fontsize + 1)
+    if title:
+        ax.set_title(title, fontsize=fontsize + 2)
+    ax.tick_params(labelsize=fontsize)
+    ax.spines[["right", "top"]].set_visible(False)
+
+
+def _hue_legend(ax, hues, colors, title, fontsize, show):
+    if not show or len(hues) <= 1 or hues[0] is None:
+        return
+    from matplotlib.patches import Patch
+
+    ax.legend(handles=[Patch(facecolor=c, label=str(h))
+                       for h, c in zip(hues, colors)],
+              title=title, frameon=False, fontsize=fontsize,
+              title_fontsize=fontsize)
+
+
+def _maybe_annotate(ax, frame, levels, test, correction, style, hide_ns,
+                    orient, fontsize):
+    """Run the requested comparison and draw brackets. Returns the table."""
+    if not test or test in ("none", False):
+        return None
+    from ._stats_tests import add_stat_annotation
+
+    _, results = add_stat_annotation(
+        ax, value=frame["y"].to_numpy(dtype=float),
+        group=frame["x"].to_numpy(), order=levels, test=test,
+        correction=correction, style=style, hide_ns=hide_ns, orient=orient,
+        fontsize=fontsize, return_stats=True,
+    )
+    return results
+
+
+def _series_colors(levels, hues, palette):
+    """One colour per hue level, or — with no hue — one per category.
+
+    Colouring by category when there is nothing else to encode is what makes a
+    four-group violin readable at a glance, and it is what the ov palettes
+    exist for.
+    """
+    if len(hues) > 1 or hues[0] is not None:
+        return default_palette(len(hues), palette), False
+    return default_palette(len(levels), palette), True
+
+
+def _new_axes(ax, figsize, default):
+    if ax is not None:
+        return ax
+    _, ax = plt.subplots(figsize=figsize or default)
+    return ax
+
+
+# --------------------------------------------------------------------------
+# bar / strip / violin
+# --------------------------------------------------------------------------
+
+
+_ESTIMATORS = {"mean": np.mean, "median": np.median, "sum": np.sum,
+               "count": len, "max": np.max, "min": np.min}
+
+
+def _error(values: np.ndarray, kind, ci_level: float) -> Tuple[float, float]:
+    if kind in (None, "none") or values.size < 2:
+        return 0.0, 0.0
+    if kind == "sd":
+        half = float(np.std(values, ddof=1))
+        return half, half
+    if kind == "se":
+        half = float(np.std(values, ddof=1) / np.sqrt(values.size))
+        return half, half
+    if kind == "ci":
+        from scipy import stats
+
+        se = np.std(values, ddof=1) / np.sqrt(values.size)
+        half = float(stats.t.ppf(0.5 + ci_level / 2, values.size - 1) * se)
+        return half, half
+    if kind == "pi":  # percentile interval of the raw values
+        lo, hi = np.percentile(values, [(1 - ci_level) * 50,
+                                        100 - (1 - ci_level) * 50])
+        centre = np.mean(values)
+        return float(centre - lo), float(hi - centre)
+    raise ValueError(
+        f"`errorbar` must be 'sd', 'se', 'ci', 'pi' or None, got {kind!r}."
+    )
+
+
+@register_function(
+    aliases=["柱状图", "barplot", "条形图", "bar_chart", "均值柱图"],
+    category="pl",
+    description=(
+        "Bar plot of a summary statistic per category with error bars, "
+        "optional dodged groups, raw-point overlay and significance brackets"
+    ),
+    examples=[
+        "ax = ov.pl.barplot(df, 'cell_type', 'score')",
+        "# Dodged by condition, with the raw points on top",
+        "ax = ov.pl.barplot(df, 'cell_type', 'score', hue='condition', dots=True)",
+        "# Median with a bootstrap-free percentile interval, and a test",
+        "ax = ov.pl.barplot(df, 'arm', 'value', estimator='median',",
+        "                   errorbar='pi', test='mannwhitney')",
+    ],
+    related=["pl.stripplot", "pl.violinplot", "pl.compare_groups", "pl.boxplot"],
+)
+def barplot(data: Any = None,
+            x: Any = None,
+            y: Any = None,
+            *,
+            hue: Any = None,
+            order: Optional[Sequence[Any]] = None,
+            hue_order: Optional[Sequence[Any]] = None,
+            estimator: str = "mean",
+            errorbar: Optional[str] = "se",
+            ci_level: float = 0.95,
+            dots: bool = False,
+            dot_size: float = 12,
+            dot_jitter: float = 0.12,
+            dot_alpha: float = 0.7,
+            orient: str = "v",
+            width: float = 0.8,
+            palette=None,
+            edgecolor: str = "none",
+            ax=None,
+            figsize: Optional[Tuple[float, float]] = None,
+            test: Optional[str] = None,
+            correction: Optional[str] = "holm",
+            annot_style: str = "star",
+            hide_ns: bool = False,
+            xlabel: Optional[str] = None,
+            ylabel: Optional[str] = None,
+            title: Optional[str] = None,
+            legend: bool = True,
+            legend_title: Optional[str] = None,
+            rotation: float = 0,
+            fontsize: float = 9,
+            random_state: int = 0,
+            return_stats: bool = False):
+    r"""Bars of a per-category summary, with error bars.
+
+    Arguments
+    ---------
+    data, x, y
+        Long-form table plus the category and value columns; or bare arrays.
+    hue
+        Optional second factor — bars are dodged within each category.
+    estimator
+        ``'mean'`` (default), ``'median'``, ``'sum'``, ``'count'``, ``'max'``,
+        ``'min'``.
+    errorbar
+        ``'se'`` (default), ``'sd'``, ``'ci'`` (t-based at ``ci_level``),
+        ``'pi'`` (percentile interval of the raw values), or ``None``.
+    dots
+        Draw the raw observations over the bars. Worth turning on: a bar with
+        n=3 looks exactly like a bar with n=300 until you can see the points.
+    test
+        Run a comparison and draw brackets — any test accepted by
+        :func:`~omicverse.pl.compare_groups`, e.g. ``'mannwhitney'``,
+        ``'welch'``, or ``'auto'``. Ignored when ``hue`` is set.
+    return_stats
+        Return ``(ax, results)`` with the summary table and, if a test ran,
+        its results.
+
+    Returns
+    -------
+    ``Axes``, or ``(Axes, dict)``.
+    """
+    frame, levels, hues, names, dropped = _long_frame(data, x, y, hue, order,
+                                                      hue_order)
+    if dropped:
+        print(f"barplot: dropped {dropped} rows with missing values.")
+    if estimator not in _ESTIMATORS:
+        raise ValueError(
+            f"`estimator` must be one of {sorted(_ESTIMATORS)}, got {estimator!r}."
+        )
+    reduce = _ESTIMATORS[estimator]
+
+    ax = _new_axes(ax, figsize, (max(3.2, 0.7 * len(levels) + 1.2), 3.4))
+    colors, by_category = _series_colors(levels, hues, palette)
+    offsets = _offsets(len(hues), width)
+    bar_width = width / max(len(hues), 1) * 0.9
+    rng = np.random.default_rng(random_state)
+
+    summary = []
+    for h_index, hue_level in enumerate(hues):
+        for x_index, level in enumerate(levels):
+            mask = frame["x"].to_numpy() == level
+            if hue_level is not None:
+                mask &= frame["hue"].to_numpy() == hue_level
+            values = frame.loc[mask, "y"].to_numpy(dtype=float)
+            if values.size == 0:
+                continue
+            centre = float(reduce(values))
+            low, high = _error(values, errorbar, ci_level)
+            position = x_index + offsets[h_index]
+            summary.append({"x": level, "hue": hue_level, "n": values.size,
+                            estimator: centre, "err_low": low, "err_high": high})
+            colour = colors[x_index if by_category else h_index]
+            if orient == "v":
+                ax.bar(position, centre, width=bar_width, color=colour,
+                       edgecolor=edgecolor, zorder=2)
+                if low or high:
+                    ax.errorbar(position, centre, yerr=[[low], [high]],
+                                fmt="none", ecolor="0.25", elinewidth=1.0,
+                                capsize=2.5, zorder=3)
+            else:
+                ax.barh(position, centre, height=bar_width, color=colour,
+                        edgecolor=edgecolor, zorder=2)
+                if low or high:
+                    ax.errorbar(centre, position, xerr=[[low], [high]],
+                                fmt="none", ecolor="0.25", elinewidth=1.0,
+                                capsize=2.5, zorder=3)
+            if dots:
+                jitter = rng.uniform(-dot_jitter, dot_jitter, values.size)
+                if orient == "v":
+                    ax.scatter(position + jitter, values, s=dot_size,
+                               color="0.2", alpha=dot_alpha, linewidths=0,
+                               zorder=4)
+                else:
+                    ax.scatter(values, position + jitter, s=dot_size,
+                               color="0.2", alpha=dot_alpha, linewidths=0,
+                               zorder=4)
+
+    _finish(ax, levels=levels, names=names, xlabel=xlabel, ylabel=ylabel,
+            title=title, fontsize=fontsize, orient=orient, rotation=rotation)
+    _hue_legend(ax, hues, colors, legend_title or names.get("hue"), fontsize,
+                legend and not by_category)
+
+    results = None
+    if test and len(hues) == 1:
+        results = _maybe_annotate(ax, frame, levels, test, correction,
+                                  annot_style, hide_ns, orient, fontsize)
+    elif test:
+        print("barplot: `test=` is ignored when `hue` is set — call "
+              "ov.pl.compare_groups() per hue level instead.")
+
+    if return_stats:
+        return ax, {"summary": pd.DataFrame(summary), "test": results}
+    return ax
+
+
+@register_function(
+    aliases=["散点分布图", "stripplot", "抖动散点", "jitter_plot", "点图"],
+    category="pl",
+    description=(
+        "Strip plot: every observation as a jittered point per category, "
+        "optionally over a summary line, with significance brackets"
+    ),
+    examples=[
+        "ax = ov.pl.stripplot(df, 'cell_type', 'score')",
+        "# Show the median as a crossbar and test the groups",
+        "ax = ov.pl.stripplot(df, 'arm', 'value', summary='median',",
+        "                     test='mannwhitney')",
+        "# Split by a second factor",
+        "ax = ov.pl.stripplot(df, 'cell_type', 'score', hue='batch')",
+    ],
+    related=["pl.barplot", "pl.violinplot", "pl.compare_groups"],
+)
+def stripplot(data: Any = None,
+              x: Any = None,
+              y: Any = None,
+              *,
+              hue: Any = None,
+              order: Optional[Sequence[Any]] = None,
+              hue_order: Optional[Sequence[Any]] = None,
+              jitter: float = 0.18,
+              size: float = 14,
+              alpha: float = 0.75,
+              summary: Optional[str] = "mean",
+              summary_width: float = 0.5,
+              orient: str = "v",
+              width: float = 0.8,
+              palette=None,
+              ax=None,
+              figsize: Optional[Tuple[float, float]] = None,
+              test: Optional[str] = None,
+              correction: Optional[str] = "holm",
+              annot_style: str = "star",
+              hide_ns: bool = False,
+              xlabel: Optional[str] = None,
+              ylabel: Optional[str] = None,
+              title: Optional[str] = None,
+              legend: bool = True,
+              legend_title: Optional[str] = None,
+              rotation: float = 0,
+              fontsize: float = 9,
+              random_state: int = 0,
+              return_stats: bool = False):
+    r"""Every observation as a jittered point.
+
+    Arguments
+    ---------
+    jitter
+        Half-width of the horizontal scatter, in category units.
+    summary
+        Draw a crossbar at the ``'mean'`` (default), ``'median'``, or ``None``.
+    test, correction, annot_style, hide_ns
+        As in :func:`barplot`.
+
+    Returns
+    -------
+    ``Axes``, or ``(Axes, dict)`` when ``return_stats=True``.
+    """
+    frame, levels, hues, names, dropped = _long_frame(data, x, y, hue, order,
+                                                      hue_order)
+    if dropped:
+        print(f"stripplot: dropped {dropped} rows with missing values.")
+
+    ax = _new_axes(ax, figsize, (max(3.2, 0.7 * len(levels) + 1.2), 3.4))
+    colors, by_category = _series_colors(levels, hues, palette)
+    offsets = _offsets(len(hues), width)
+    rng = np.random.default_rng(random_state)
+
+    for h_index, hue_level in enumerate(hues):
+        for x_index, level in enumerate(levels):
+            mask = frame["x"].to_numpy() == level
+            if hue_level is not None:
+                mask &= frame["hue"].to_numpy() == hue_level
+            values = frame.loc[mask, "y"].to_numpy(dtype=float)
+            if values.size == 0:
+                continue
+            position = x_index + offsets[h_index]
+            noise = rng.uniform(-jitter, jitter, values.size)
+            if orient == "v":
+                ax.scatter(position + noise, values, s=size, alpha=alpha,
+                           color=colors[x_index if by_category else h_index],
+                           linewidths=0, zorder=2)
+            else:
+                ax.scatter(values, position + noise, s=size, alpha=alpha,
+                           color=colors[x_index if by_category else h_index],
+                           linewidths=0, zorder=2)
+            if summary:
+                if summary not in {"mean", "median"}:
+                    raise ValueError(
+                        f"`summary` must be 'mean', 'median' or None, got "
+                        f"{summary!r}."
+                    )
+                centre = float(np.mean(values) if summary == "mean"
+                               else np.median(values))
+                half = summary_width / 2 / max(len(hues), 1)
+                if orient == "v":
+                    ax.plot([position - half, position + half], [centre] * 2,
+                            color="0.1", linewidth=1.6, zorder=3,
+                            solid_capstyle="butt")
+                else:
+                    ax.plot([centre] * 2, [position - half, position + half],
+                            color="0.1", linewidth=1.6, zorder=3,
+                            solid_capstyle="butt")
+
+    _finish(ax, levels=levels, names=names, xlabel=xlabel, ylabel=ylabel,
+            title=title, fontsize=fontsize, orient=orient, rotation=rotation)
+    _hue_legend(ax, hues, colors, legend_title or names.get("hue"), fontsize,
+                legend and not by_category)
+
+    results = None
+    if test and len(hues) == 1:
+        results = _maybe_annotate(ax, frame, levels, test, correction,
+                                  annot_style, hide_ns, orient, fontsize)
+    return (ax, {"test": results}) if return_stats else ax
+
+
+def _kde_profile(values: np.ndarray, grid: np.ndarray, bw_method):
+    from scipy.stats import gaussian_kde
+
+    if values.size < 2 or np.allclose(values, values[0]):
+        return np.zeros_like(grid)
+    return gaussian_kde(values, bw_method=bw_method)(grid)
+
+
+@register_function(
+    aliases=["小提琴图", "violinplot", "violin_plot", "分布小提琴"],
+    category="pl",
+    description=(
+        "Violin plot from a table (no AnnData): kernel density per category, "
+        "optional split by a two-level factor, inner box/points, and brackets"
+    ),
+    examples=[
+        "ax = ov.pl.violinplot(df, 'cell_type', 'score')",
+        "# Two conditions mirrored in one violin",
+        "ax = ov.pl.violinplot(df, 'cell_type', 'score', hue='condition',",
+        "                      split=True)",
+        "# With a Kruskal-Wallis omnibus and corrected pairwise brackets",
+        "ax, res = ov.pl.violinplot(df, 'arm', 'value', test='auto',",
+        "                           return_stats=True)",
+    ],
+    related=["pl.violin", "pl.stripplot", "pl.barplot", "pl.compare_groups"],
+)
+def violinplot(data: Any = None,
+               x: Any = None,
+               y: Any = None,
+               *,
+               hue: Any = None,
+               order: Optional[Sequence[Any]] = None,
+               hue_order: Optional[Sequence[Any]] = None,
+               split: bool = False,
+               inner: Optional[str] = "box",
+               cut: float = 2.0,
+               bw_method: Any = None,
+               gridsize: int = 200,
+               scale: str = "area",
+               orient: str = "v",
+               width: float = 0.8,
+               palette=None,
+               alpha: float = 0.9,
+               linewidth: float = 0.8,
+               ax=None,
+               figsize: Optional[Tuple[float, float]] = None,
+               test: Optional[str] = None,
+               correction: Optional[str] = "holm",
+               annot_style: str = "star",
+               hide_ns: bool = False,
+               xlabel: Optional[str] = None,
+               ylabel: Optional[str] = None,
+               title: Optional[str] = None,
+               legend: bool = True,
+               legend_title: Optional[str] = None,
+               rotation: float = 0,
+               fontsize: float = 9,
+               random_state: int = 0,
+               return_stats: bool = False):
+    r"""Kernel-density violins per category.
+
+    Arguments
+    ---------
+    split
+        With exactly two hue levels, mirror them in one violin instead of
+        dodging — half the width for twice the comparison.
+    inner
+        ``'box'`` (quartile box + median dot, the default), ``'point'`` (raw
+        observations), ``'stick'`` (a tick per observation), or ``None``.
+    cut
+        How far past the extreme observations the density is drawn, in
+        bandwidths. ``cut=0`` clips at the data range, which is what you want
+        for a bounded quantity like a proportion.
+    scale
+        ``'area'`` (equal area, default), ``'width'`` (equal maximum width) or
+        ``'count'`` (width proportional to n).
+
+    Returns
+    -------
+    ``Axes``, or ``(Axes, dict)``.
+    """
+    frame, levels, hues, names, dropped = _long_frame(data, x, y, hue, order,
+                                                      hue_order)
+    if dropped:
+        print(f"violinplot: dropped {dropped} rows with missing values.")
+    if split and len(hues) != 2:
+        raise ValueError(
+            f"`split=True` needs exactly two hue levels, got {len(hues)}."
+        )
+    if scale not in {"area", "width", "count"}:
+        raise ValueError("`scale` must be 'area', 'width' or 'count'.")
+
+    ax = _new_axes(ax, figsize, (max(3.2, 0.8 * len(levels) + 1.2), 3.6))
+    colors, by_category = _series_colors(levels, hues, palette)
+    offsets = np.zeros(len(hues)) if split else _offsets(len(hues), width)
+    slot = width if split else width / max(len(hues), 1)
+    rng = np.random.default_rng(random_state)
+
+    profiles = []
+    for h_index, hue_level in enumerate(hues):
+        for x_index, level in enumerate(levels):
+            mask = frame["x"].to_numpy() == level
+            if hue_level is not None:
+                mask &= frame["hue"].to_numpy() == hue_level
+            values = frame.loc[mask, "y"].to_numpy(dtype=float)
+            if values.size == 0:
+                continue
+            span = values.max() - values.min()
+            pad = cut * (span / 6 if span > 0 else 1.0)
+            grid = np.linspace(values.min() - pad, values.max() + pad, gridsize)
+            density = _kde_profile(values, grid, bw_method)
+            profiles.append({"x": level, "hue": hue_level, "n": values.size,
+                             "grid": grid, "density": density,
+                             "position": x_index + offsets[h_index],
+                             "color": colors[x_index if by_category else h_index],
+                             "values": values,
+                             "half": h_index})
+
+    peak = max((p["density"].max() for p in profiles), default=1.0) or 1.0
+    counts = max((p["n"] for p in profiles), default=1)
+    for profile in profiles:
+        density = profile["density"]
+        if scale == "area":
+            scaled = density / peak
+        elif scale == "width":
+            local = density.max() or 1.0
+            scaled = density / local
+        else:
+            scaled = density / peak * (profile["n"] / counts)
+        half_width = scaled * slot / 2
+
+        position = profile["position"]
+        grid = profile["grid"]
+        if split:
+            sign = -1.0 if profile["half"] == 0 else 1.0
+            edge_lo = position if sign > 0 else position - half_width
+            edge_hi = position + half_width if sign > 0 else position
+        else:
+            edge_lo, edge_hi = position - half_width, position + half_width
+
+        if orient == "v":
+            ax.fill_betweenx(grid, edge_lo, edge_hi, color=profile["color"],
+                             alpha=alpha, linewidth=linewidth,
+                             edgecolor="white", zorder=2)
+        else:
+            ax.fill_between(grid, edge_lo, edge_hi, color=profile["color"],
+                            alpha=alpha, linewidth=linewidth,
+                            edgecolor="white", zorder=2)
+
+        values = profile["values"]
+        centre = position
+        if split:
+            centre = position + (-slot / 6 if profile["half"] == 0 else slot / 6)
+        if inner == "box":
+            q1, med, q3 = np.percentile(values, [25, 50, 75])
+            iqr = q3 - q1
+            lo = max(values.min(), q1 - 1.5 * iqr)
+            hi = min(values.max(), q3 + 1.5 * iqr)
+            if orient == "v":
+                ax.plot([centre] * 2, [lo, hi], color="0.15", linewidth=0.9,
+                        zorder=3)
+                ax.plot([centre] * 2, [q1, q3], color="0.15", linewidth=3.5,
+                        solid_capstyle="butt", zorder=3)
+                ax.scatter([centre], [med], s=9, color="white", zorder=4,
+                           linewidths=0)
+            else:
+                ax.plot([lo, hi], [centre] * 2, color="0.15", linewidth=0.9,
+                        zorder=3)
+                ax.plot([q1, q3], [centre] * 2, color="0.15", linewidth=3.5,
+                        solid_capstyle="butt", zorder=3)
+                ax.scatter([med], [centre], s=9, color="white", zorder=4,
+                           linewidths=0)
+        elif inner == "point":
+            noise = rng.uniform(-slot * 0.12, slot * 0.12, values.size)
+            if orient == "v":
+                ax.scatter(centre + noise, values, s=5, color="0.15",
+                           alpha=0.6, linewidths=0, zorder=3)
+            else:
+                ax.scatter(values, centre + noise, s=5, color="0.15",
+                           alpha=0.6, linewidths=0, zorder=3)
+        elif inner == "stick":
+            tick = slot * 0.18
+            for value in values:
+                if orient == "v":
+                    ax.plot([centre - tick, centre + tick], [value] * 2,
+                            color="0.15", linewidth=0.5, alpha=0.6, zorder=3)
+                else:
+                    ax.plot([value] * 2, [centre - tick, centre + tick],
+                            color="0.15", linewidth=0.5, alpha=0.6, zorder=3)
+        elif inner is not None:
+            raise ValueError(
+                f"`inner` must be 'box', 'point', 'stick' or None, got {inner!r}."
+            )
+
+    _finish(ax, levels=levels, names=names, xlabel=xlabel, ylabel=ylabel,
+            title=title, fontsize=fontsize, orient=orient, rotation=rotation)
+    _hue_legend(ax, hues, colors, legend_title or names.get("hue"), fontsize,
+                legend and not by_category)
+
+    results = None
+    if test and len(hues) == 1:
+        results = _maybe_annotate(ax, frame, levels, test, correction,
+                                  annot_style, hide_ns, orient, fontsize)
+    return (ax, {"test": results}) if return_stats else ax
+
+
+# --------------------------------------------------------------------------
+# composition
+# --------------------------------------------------------------------------
+
+
+@register_function(
+    aliases=["堆叠柱状图", "stackplot", "stacked_bar", "组成图", "比例图"],
+    category="pl",
+    description=(
+        "Stacked bars of composition per category — counts or proportions — "
+        "the container-free version of ov.pl.cellproportion"
+    ),
+    examples=[
+        "# Composition of each sample, as fractions",
+        "ax = ov.pl.stackplot(df, 'sample', hue='cell_type')",
+        "# Raw counts, horizontal, ordered by size",
+        "ax = ov.pl.stackplot(df, 'sample', hue='cell_type', normalize=False,",
+        "                     orient='h')",
+        "# Pre-aggregated values instead of raw rows",
+        "ax = ov.pl.stackplot(counts, 'sample', 'n', hue='cell_type')",
+    ],
+    related=["pl.cellproportion", "pl.cellstackarea", "pl.barplot", "pl.pieplot"],
+)
+def stackplot(data: Any = None,
+              x: Any = None,
+              y: Any = None,
+              *,
+              hue: Any = None,
+              order: Optional[Sequence[Any]] = None,
+              hue_order: Optional[Sequence[Any]] = None,
+              normalize: bool = True,
+              orient: str = "v",
+              width: float = 0.8,
+              palette=None,
+              edgecolor: str = "white",
+              linewidth: float = 0.6,
+              ax=None,
+              figsize: Optional[Tuple[float, float]] = None,
+              xlabel: Optional[str] = None,
+              ylabel: Optional[str] = None,
+              title: Optional[str] = None,
+              legend: bool = True,
+              legend_title: Optional[str] = None,
+              legend_out: bool = True,
+              rotation: float = 45,
+              fontsize: float = 9,
+              return_stats: bool = False):
+    r"""Stacked composition bars.
+
+    Arguments
+    ---------
+    x
+        The category whose composition is shown — one bar each.
+    hue
+        The parts that make up each bar. Required.
+    y
+        Optional pre-aggregated size column. Left out, rows are counted, which
+        is the usual case for a per-cell table.
+    normalize
+        Scale each bar to 1 (default) so composition is comparable across
+        categories of different size. ``False`` keeps raw counts.
+
+    Returns
+    -------
+    ``Axes``, or ``(Axes, DataFrame)`` with the plotted matrix.
+    """
+    if hue is None:
+        raise TypeError("`hue` is required — it names the parts of each bar.")
+    frame, levels, hues, names, dropped = _long_frame(data, x, y, hue, order,
+                                                      hue_order,
+                                                      require_y=False)
+    if dropped:
+        print(f"stackplot: dropped {dropped} rows with missing values.")
+
+    if "y" in frame:
+        matrix = frame.pivot_table(index="x", columns="hue", values="y",
+                                   aggfunc="sum", observed=False)
+    else:
+        matrix = (frame.groupby(["x", "hue"], observed=False).size()
+                  .unstack(fill_value=0))
+    matrix = matrix.reindex(index=levels, columns=hues).fillna(0.0)
+    if normalize:
+        totals = matrix.sum(axis=1).replace(0, np.nan)
+        matrix = matrix.div(totals, axis=0).fillna(0.0)
+
+    ax = _new_axes(ax, figsize, (max(3.4, 0.55 * len(levels) + 2.0), 3.6))
+    colors = default_palette(len(hues), palette)
+    base = np.zeros(len(levels))
+    positions = np.arange(len(levels))
+    for hue_level, colour in zip(hues, colors):
+        values = matrix[hue_level].to_numpy(dtype=float)
+        if orient == "v":
+            ax.bar(positions, values, bottom=base, width=width, color=colour,
+                   edgecolor=edgecolor, linewidth=linewidth, label=str(hue_level))
+        else:
+            ax.barh(positions, values, left=base, height=width, color=colour,
+                    edgecolor=edgecolor, linewidth=linewidth,
+                    label=str(hue_level))
+        base = base + values
+
+    value_label = ylabel
+    if value_label is None:
+        value_label = "fraction" if normalize else (names.get("y") or "count")
+    _finish(ax, levels=levels, names=names, xlabel=xlabel, ylabel=value_label,
+            title=title, fontsize=fontsize, orient=orient, rotation=rotation)
+    if orient == "v":
+        ax.set_xlim(-0.5 - (1 - width) / 2, len(levels) - 0.5 + (1 - width) / 2)
+        if normalize:
+            ax.set_ylim(0, 1)
+    else:
+        ax.set_ylim(-0.5, len(levels) - 0.5)
+        if normalize:
+            ax.set_xlim(0, 1)
+
+    if legend:
+        if legend_out:
+            from ._layout import take_legend_out
+
+            take_legend_out(ax, loc="right", title=legend_title or names.get("hue"),
+                            fontsize=fontsize)
+        else:
+            ax.legend(title=legend_title or names.get("hue"), frameon=False,
+                      fontsize=fontsize)
+    return (ax, matrix) if return_stats else ax
+
+
+@register_function(
+    aliases=["棒棒糖图", "lollipopplot", "lollipop", "棒棒糖", "dot_bar"],
+    category="pl",
+    description=(
+        "Lollipop chart — a stem and a dot per label, the readable "
+        "alternative to a long bar chart of ranked values"
+    ),
+    examples=[
+        "ax = ov.pl.lollipopplot(auc_df, 'cell_type', 'AUC')",
+        "# Ranked, with a reference line at the null",
+        "ax = ov.pl.lollipopplot(res, 'pathway', 'NES', sort='value',",
+        "                        reference=0)",
+        "# Colour the dots by significance",
+        "ax = ov.pl.lollipopplot(res, 'gene', 'log2FC', color_by=res['padj'],",
+        "                        cmap='viridis_r')",
+    ],
+    related=["pl.barplot", "pl.forest", "pl.dotplot"],
+)
+def lollipopplot(data: Any = None,
+                 x: Any = None,
+                 y: Any = None,
+                 *,
+                 sort: Optional[str] = "value",
+                 ascending: bool = True,
+                 top_n: Optional[int] = None,
+                 orient: str = "h",
+                 color: str = "#1F577B",
+                 color_by: Any = None,
+                 cmap: str = "viridis",
+                 size: float = 60,
+                 stem_width: float = 1.2,
+                 reference: Optional[float] = None,
+                 baseline: Optional[float] = None,
+                 ax=None,
+                 figsize: Optional[Tuple[float, float]] = None,
+                 xlabel: Optional[str] = None,
+                 ylabel: Optional[str] = None,
+                 title: Optional[str] = None,
+                 colorbar_label: Optional[str] = None,
+                 fontsize: float = 9,
+                 return_stats: bool = False):
+    r"""Stem-and-dot chart of one value per label.
+
+    Arguments
+    ---------
+    sort
+        ``'value'`` (default), ``'label'`` or ``None`` to keep input order.
+    top_n
+        Keep only the ``top_n`` largest by absolute value — and say so, rather
+        than silently truncating.
+    orient
+        ``'h'`` (default) puts labels on the y-axis, which is what makes this
+        readable for long names.
+    reference
+        Draw a dashed line at this value (0 for a log fold change, 1 for a
+        ratio).
+    baseline
+        Where the stems start. Defaults to ``reference``, else 0.
+
+    Returns
+    -------
+    ``Axes``, or ``(Axes, DataFrame)``.
+    """
+    frame, levels, _, names, dropped = _long_frame(data, x, y, None, None, None)
+    if dropped:
+        print(f"lollipopplot: dropped {dropped} rows with missing values.")
+    table = frame[["x", "y"]].copy()
+    table["y"] = table["y"].astype(float)
+    if color_by is not None:
+        table["c"] = np.asarray(color_by, dtype=float)[: len(table)]
+
+    if top_n is not None and top_n < len(table):
+        keep = table["y"].abs().nlargest(top_n).index
+        print(f"lollipopplot: showing the {top_n} largest of {len(table)} "
+              f"entries by |value|.")
+        table = table.loc[keep]
+    if sort == "value":
+        table = table.sort_values("y", ascending=ascending)
+    elif sort == "label":
+        table = table.sort_values("x", ascending=ascending)
+    elif sort is not None:
+        raise ValueError("`sort` must be 'value', 'label' or None.")
+    table = table.reset_index(drop=True)
+
+    start = baseline if baseline is not None else (reference or 0.0)
+    positions = np.arange(len(table))
+    ax = _new_axes(ax, figsize,
+                   (5.0, max(2.4, 0.28 * len(table) + 1.0)) if orient == "h"
+                   else (max(3.4, 0.32 * len(table) + 1.4), 3.6))
+
+    scatter_kw: Dict[str, Any] = {"s": size, "zorder": 3, "linewidths": 0}
+    if "c" in table:
+        scatter_kw.update(c=table["c"].to_numpy(), cmap=cmap)
+    else:
+        scatter_kw.update(color=color)
+
+    if orient == "h":
+        for position, value in zip(positions, table["y"]):
+            ax.plot([start, value], [position] * 2, color=color, alpha=0.55,
+                    linewidth=stem_width, zorder=2)
+        points = ax.scatter(table["y"], positions, **scatter_kw)
+        if reference is not None:
+            ax.axvline(reference, color="0.55", linestyle="--", linewidth=0.9)
+    else:
+        for position, value in zip(positions, table["y"]):
+            ax.plot([position] * 2, [start, value], color=color, alpha=0.55,
+                    linewidth=stem_width, zorder=2)
+        points = ax.scatter(positions, table["y"], **scatter_kw)
+        if reference is not None:
+            ax.axhline(reference, color="0.55", linestyle="--", linewidth=0.9)
+
+    _finish(ax, levels=list(table["x"]), names=names, xlabel=xlabel,
+            ylabel=ylabel, title=title, fontsize=fontsize, orient=orient,
+            rotation=0 if orient == "h" else 45)
+    if "c" in table:
+        bar = ax.figure.colorbar(points, ax=ax, fraction=0.035, pad=0.03)
+        bar.set_label(colorbar_label or "", fontsize=fontsize)
+        bar.ax.tick_params(labelsize=fontsize - 1)
+    ax.spines["left" if orient == "h" else "bottom"].set_visible(orient != "h")
+    table = table.rename(columns={"x": "label", "y": "value", "c": "color_by"})
+    return (ax, table) if return_stats else ax
+
+
+def _pie(values, labels, colors, *, hole, ax, start_angle, percent, counts,
+         label_style, fontsize, explode, edgecolor, linewidth, pct_distance,
+         label_distance):
+    total = float(np.sum(values))
+    texts = []
+    for label, value in zip(labels, values):
+        share = value / total if total else 0.0
+        parts = [str(label)]
+        if label_style in {"percent", "both"}:
+            parts.append(f"{100 * share:.1f}%")
+        if label_style in {"count", "both"}:
+            parts.append(f"n={value:g}")
+        texts.append("\n".join(parts) if label_style != "none" else "")
+
+    wedges, _ = ax.pie(
+        values, labels=texts if label_style != "none" else None,
+        colors=colors, startangle=start_angle,
+        explode=explode, labeldistance=label_distance,
+        wedgeprops=dict(width=1.0 - hole, edgecolor=edgecolor,
+                        linewidth=linewidth),
+        textprops=dict(fontsize=fontsize),
+    )
+    if percent:
+        for wedge, value in zip(wedges, values):
+            angle = np.deg2rad((wedge.theta1 + wedge.theta2) / 2)
+            radius = 1.0 - (1.0 - hole) * (1 - pct_distance)
+            ax.text(radius * np.cos(angle), radius * np.sin(angle),
+                    f"{100 * value / total:.0f}%", ha="center", va="center",
+                    fontsize=fontsize - 1, color="white", weight="bold")
+    return wedges
+
+
+@register_function(
+    aliases=["饼图", "pieplot", "pie_chart", "圆饼图"],
+    category="pl",
+    description=(
+        "Pie chart of a composition, from raw rows or pre-aggregated counts, "
+        "with percentage labels"
+    ),
+    examples=[
+        "# Count the rows of each category",
+        "ax = ov.pl.pieplot(df, 'cell_type')",
+        "# Pre-aggregated",
+        "ax = ov.pl.pieplot(counts, 'cell_type', 'n')",
+        "# Bare values",
+        "ax = ov.pl.pieplot(labels=['T', 'B', 'NK'], values=[50, 30, 20])",
+    ],
+    related=["pl.donutplot", "pl.stackplot", "pl.barplot"],
+)
+def pieplot(data: Any = None,
+            labels: Any = None,
+            values: Any = None,
+            *,
+            order: Optional[Sequence[Any]] = None,
+            hole: float = 0.0,
+            other_threshold: float = 0.0,
+            other_label: str = "other",
+            legend: bool = False,
+            legend_loc: str = "center left",
+            palette=None,
+            explode: Optional[Sequence[float]] = None,
+            start_angle: float = 90,
+            label_style: str = "both",
+            percent_inside: bool = False,
+            pct_distance: float = 0.6,
+            label_distance: float = 1.08,
+            edgecolor: str = "white",
+            linewidth: float = 1.0,
+            centre_text: Optional[str] = None,
+            ax=None,
+            figsize: Optional[Tuple[float, float]] = None,
+            title: Optional[str] = None,
+            fontsize: float = 9,
+            return_stats: bool = False):
+    r"""Pie chart of a composition.
+
+    Arguments
+    ---------
+    data, labels, values
+        A table plus a category column (rows are counted) and optionally a
+        size column; or bare ``labels``/``values`` arrays.
+    hole
+        Fraction of the radius left empty in the middle — ``0`` is a pie,
+        ``0.55`` is a donut (see :func:`donutplot`).
+    other_threshold
+        Merge every category below this share into one wedge. A pie with ten
+        categories, three of them under 2%, is unreadable however carefully
+        the labels are placed; ``other_threshold=0.03`` is the usual fix.
+    legend
+        Put the names in a legend instead of around the wedges. With more than
+        about six categories this is the only layout that stays legible.
+    label_style
+        ``'both'`` (name + percent, default), ``'percent'``, ``'count'``,
+        ``'name'`` or ``'none'``.
+    percent_inside
+        Also write the percentage inside each wedge.
+
+    Returns
+    -------
+    ``Axes``, or ``(Axes, Series)`` with the plotted shares.
+    """
+    if label_style not in {"both", "percent", "count", "name", "none"}:
+        raise ValueError(
+            "`label_style` must be 'both', 'percent', 'count', 'name' or 'none'."
+        )
+    frame, levels, _, names, _ = _long_frame(data, labels, values, None, order,
+                                             None, require_y=False)
+    if "y" in frame:
+        series = frame.groupby("x", observed=False)["y"].sum()
+    else:
+        series = frame.groupby("x", observed=False).size()
+    series = series.reindex(levels).fillna(0.0)
+    series = series[series > 0]
+    if series.empty:
+        raise ValueError("Nothing to plot — every category is zero or absent.")
+
+    if other_threshold > 0:
+        shares = series / series.sum()
+        small = shares[shares < other_threshold].index
+        if len(small) > 1:
+            merged = float(series[small].sum())
+            series = series.drop(index=small)
+            series[other_label] = merged
+            print(f"pieplot: merged {len(small)} categories below "
+                  f"{other_threshold:.0%} into {other_label!r}: "
+                  f"{', '.join(map(str, small))}")
+
+    ax = _new_axes(ax, figsize, (4.2, 4.2))
+    colors = default_palette(len(series), palette)
+    wedges = _pie(series.to_numpy(dtype=float), list(series.index), colors,
+                  hole=hole, ax=ax, start_angle=start_angle,
+                  percent=percent_inside, counts=True,
+                  label_style="none" if legend else label_style,
+                  fontsize=fontsize, explode=explode, edgecolor=edgecolor,
+                  linewidth=linewidth, pct_distance=pct_distance,
+                  label_distance=label_distance)
+    if legend:
+        total = float(series.sum())
+        ax.legend(wedges,
+                  [f"{name}  ({100 * value / total:.1f}%)"
+                   for name, value in series.items()],
+                  loc=legend_loc, bbox_to_anchor=(1.0, 0.5), frameon=False,
+                  fontsize=fontsize)
+    if centre_text:
+        ax.text(0, 0, centre_text, ha="center", va="center",
+                fontsize=fontsize + 2)
+    ax.set_aspect("equal")
+    if title:
+        ax.set_title(title, fontsize=fontsize + 2)
+    shares = series / series.sum()
+    return (ax, shares) if return_stats else ax
+
+
+@register_function(
+    aliases=["环形图", "donutplot", "圆环图", "donut_chart", "甜甜圈图"],
+    category="pl",
+    description=(
+        "Donut chart — a pie with the middle cut out, leaving room for the "
+        "total or another summary in the centre"
+    ),
+    examples=[
+        "ax = ov.pl.donutplot(df, 'cell_type')",
+        "ax = ov.pl.donutplot(counts, 'cell_type', 'n', centre_text='12,481\\ncells')",
+    ],
+    related=["pl.pieplot", "pl.stackplot"],
+)
+def donutplot(data: Any = None,
+              labels: Any = None,
+              values: Any = None,
+              *,
+              hole: float = 0.55,
+              centre_text: Optional[str] = None,
+              **kwargs: Any):
+    r"""A pie chart with a hole. See :func:`pieplot` for every argument.
+
+    The centre is the point: put the total there, so the reader gets the
+    absolute size as well as the composition.
+    """
+    if centre_text is None and "return_stats" not in kwargs:
+        frame = as_frame(data)
+        if frame is not None and values is None and isinstance(labels, str):
+            centre_text = f"n = {len(frame):,}"
+    return pieplot(data, labels, values, hole=hole, centre_text=centre_text,
+                   **kwargs)
+
+
+@register_function(
+    aliases=["斜率图", "slopeplot", "slope_chart", "配对变化图", "before_after"],
+    category="pl",
+    description=(
+        "Slope chart: one line per subject between two or more conditions, "
+        "with a paired test — the honest way to show a before/after effect"
+    ),
+    examples=[
+        "ax = ov.pl.slopeplot(df, 'timepoint', 'value', subject='patient')",
+        "# Colour by direction and run a Wilcoxon signed-rank test",
+        "ax = ov.pl.slopeplot(df, 'timepoint', 'value', subject='patient',",
+        "                     color_by='direction', test='wilcoxon')",
+    ],
+    related=["pl.violinplot", "pl.barplot", "pl.compare_groups"],
+)
+def slopeplot(data: Any = None,
+              x: Any = None,
+              y: Any = None,
+              *,
+              subject: Any = None,
+              order: Optional[Sequence[Any]] = None,
+              color_by: str = "direction",
+              palette=None,
+              up_color: str = "#CB3E35",
+              down_color: str = "#1F577B",
+              flat_color: str = "0.6",
+              linewidth: float = 0.9,
+              alpha: float = 0.6,
+              marker: str = "o",
+              markersize: float = 16,
+              summary: Optional[str] = "mean",
+              label_points: bool = False,
+              test: Optional[str] = None,
+              ax=None,
+              figsize: Optional[Tuple[float, float]] = None,
+              xlabel: Optional[str] = None,
+              ylabel: Optional[str] = None,
+              title: Optional[str] = None,
+              fontsize: float = 9,
+              return_stats: bool = False):
+    r"""One line per subject across conditions.
+
+    Arguments
+    ---------
+    subject
+        Column identifying the repeated unit (patient, donor, well). Required —
+        without it there is nothing to connect.
+    color_by
+        ``'direction'`` (default: up / down / flat), ``'subject'``, or the name
+        of a column to colour by.
+    summary
+        Overlay the group ``'mean'`` or ``'median'`` as a heavy line.
+    test
+        ``'wilcoxon'`` or ``'ttest_rel'`` for a paired comparison of the first
+        and last condition. Subjects missing either end are excluded, and the
+        number excluded is reported.
+
+    Returns
+    -------
+    ``Axes``, or ``(Axes, dict)``.
+    """
+    if subject is None:
+        raise TypeError("`subject` is required — it says which points connect.")
+    frame, names = resolve_columns(data, x=x, y=y, subject=subject,
+                                   require=("x", "y", "subject"))
+    levels = group_levels(frame["x"], order)
+    positions = {level: index for index, level in enumerate(levels)}
+
+    wide = frame.pivot_table(index="subject", columns="x", values="y",
+                             aggfunc="mean", observed=False)
+    wide = wide.reindex(columns=levels)
+
+    ax = _new_axes(ax, figsize, (max(2.8, 1.3 * len(levels)), 4.0))
+    first, last = levels[0], levels[-1]
+    complete = wide[[first, last]].dropna()
+    if color_by not in {"direction", "subject"} and color_by not in frame:
+        raise ValueError(
+            f"`color_by` must be 'direction', 'subject' or a column; got "
+            f"{color_by!r}."
+        )
+    subject_colors = (dict(zip(wide.index, default_palette(len(wide), palette)))
+                      if color_by == "subject" else {})
+
+    for name, row in wide.iterrows():
+        values = row.to_numpy(dtype=float)
+        valid = ~np.isnan(values)
+        if valid.sum() < 2:
+            continue
+        if color_by == "subject":
+            colour = subject_colors[name]
+        else:
+            ends = values[valid]
+            delta = ends[-1] - ends[0]
+            colour = (up_color if delta > 0 else
+                      down_color if delta < 0 else flat_color)
+        xs = [positions[level] for level, keep in zip(levels, valid) if keep]
+        ax.plot(xs, values[valid], color=colour, linewidth=linewidth,
+                alpha=alpha, marker=marker,
+                markersize=np.sqrt(markersize), zorder=2)
+        if label_points:
+            ax.annotate(str(name), (xs[-1], values[valid][-1]),
+                        textcoords="offset points", xytext=(4, 0),
+                        fontsize=fontsize - 2, va="center")
+
+    if summary:
+        if summary not in {"mean", "median"}:
+            raise ValueError("`summary` must be 'mean', 'median' or None.")
+        centre = (wide.mean() if summary == "mean" else wide.median())
+        ax.plot(range(len(levels)), centre.to_numpy(dtype=float), color="black",
+                linewidth=2.4, marker="o", markersize=5, zorder=4,
+                label=summary)
+
+    ax.set_xticks(range(len(levels)))
+    ax.set_xticklabels([str(level) for level in levels], fontsize=fontsize)
+    ax.set_xlim(-0.35, len(levels) - 0.65)
+    ax.set_xlabel(xlabel if xlabel is not None else names.get("x", ""),
+                  fontsize=fontsize + 1)
+    ax.set_ylabel(ylabel if ylabel is not None else names.get("y", ""),
+                  fontsize=fontsize + 1)
+    if title:
+        ax.set_title(title, fontsize=fontsize + 2)
+    ax.tick_params(labelsize=fontsize)
+    ax.spines[["right", "top"]].set_visible(False)
+
+    stats: Dict[str, Any] = {"wide": wide, "n_complete": int(len(complete))}
+    if test:
+        dropped = len(wide) - len(complete)
+        if dropped:
+            print(f"slopeplot: {dropped} subject(s) lack {first} or {last} and "
+                  f"are excluded from the paired test.")
+        from ._stats_tests import _run_test, format_pvalue
+
+        statistic, pvalue, label = _run_test(
+            complete[first].to_numpy(dtype=float),
+            complete[last].to_numpy(dtype=float), test)
+        stats.update(statistic=statistic, pvalue=pvalue, test=label)
+        ax.text(0.5, 1.01, f"{label}: {format_pvalue(pvalue, 'value')} "
+                           f"(n={len(complete)})",
+                transform=ax.transAxes, ha="center", va="bottom",
+                fontsize=fontsize)
+    return (ax, stats) if return_stats else ax

--- a/omicverse/pl/_distribution.py
+++ b/omicverse/pl/_distribution.py
@@ -1,0 +1,671 @@
+r"""Distribution plots: histograms, densities, ridgelines and Q-Q plots.
+
+``ov.pl`` could draw a violin of an ``AnnData`` column but had no general
+histogram, no density plot, no ridgeline, and a Q-Q plot only inside the GWAS
+code. These are the container-free versions — a table and column names, bare
+arrays, or an ``AnnData`` (its ``.obs``) all work.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+from .._registry import register_function
+from ._stats_common import as_frame, default_palette, group_levels, resolve_columns
+
+__all__ = ["histplot", "kdeplot", "ridgeplot", "qqplot"]
+
+
+def _values_and_groups(data, x, hue, order, hue_order, *, name="x"):
+    if data is not None and as_frame(data) is None:
+        data, x, hue = None, data, x
+    if x is None:
+        raise TypeError("`x` is required.")
+    frame, names = resolve_columns(data, x=x, hue=hue, require=("x",))
+    hues = group_levels(frame["hue"], hue_order) if "hue" in frame else [None]
+    return frame, hues, names, frame.attrs.get("n_dropped", 0)
+
+
+def _grid(values: np.ndarray, cut: float, gridsize: int) -> np.ndarray:
+    span = float(values.max() - values.min())
+    pad = cut * (span / 6 if span > 0 else 1.0)
+    return np.linspace(values.min() - pad, values.max() + pad, gridsize)
+
+
+def _density(values: np.ndarray, grid: np.ndarray, bw_method) -> np.ndarray:
+    from scipy.stats import gaussian_kde
+
+    if values.size < 2 or np.allclose(values, values[0]):
+        return np.zeros_like(grid)
+    return gaussian_kde(values, bw_method=bw_method)(grid)
+
+
+@register_function(
+    aliases=["直方图", "histplot", "histogram", "频数分布图", "分布直方图"],
+    category="pl",
+    description=(
+        "Histogram with count / density / probability scaling, grouped "
+        "overlays (layer, stack, dodge, fill) and an optional density curve"
+    ),
+    examples=[
+        "ax = ov.pl.histplot(df, 'n_genes')",
+        "# One distribution per batch, as densities so sizes are comparable",
+        "ax = ov.pl.histplot(df, 'n_genes', hue='batch', stat='density',",
+        "                    multiple='layer', kde=True)",
+        "# From adata.obs, log x-axis",
+        "ax = ov.pl.histplot(adata, 'total_counts', log_scale=True)",
+    ],
+    related=["pl.kdeplot", "pl.ridgeplot", "pl.violinplot", "pl.qc"],
+)
+def histplot(data: Any = None,
+             x: Any = None,
+             *,
+             hue: Any = None,
+             hue_order: Optional[Sequence[Any]] = None,
+             bins: Union[int, str, Sequence[float]] = "auto",
+             binrange: Optional[Tuple[float, float]] = None,
+             stat: str = "count",
+             multiple: str = "layer",
+             cumulative: bool = False,
+             kde: bool = False,
+             bw_method: Any = None,
+             log_scale: bool = False,
+             palette=None,
+             alpha: float = 0.6,
+             edgecolor: str = "white",
+             linewidth: float = 0.5,
+             ax=None,
+             figsize: Optional[Tuple[float, float]] = None,
+             xlabel: Optional[str] = None,
+             ylabel: Optional[str] = None,
+             title: Optional[str] = None,
+             legend: bool = True,
+             legend_title: Optional[str] = None,
+             fontsize: float = 9,
+             return_stats: bool = False):
+    r"""Histogram of one variable, optionally split by a factor.
+
+    Arguments
+    ---------
+    bins
+        Bin count, a NumPy binning rule (``'auto'``, ``'fd'``, ``'sturges'``,
+        ...) or explicit edges. Edges are computed once over the pooled data so
+        grouped histograms stay comparable.
+    stat
+        ``'count'`` (default), ``'density'`` (integrates to 1),
+        ``'probability'`` (sums to 1) or ``'percent'``.
+    multiple
+        How groups are combined: ``'layer'`` (translucent overlay, default),
+        ``'stack'``, ``'dodge'`` or ``'fill'`` (stacked and normalised to 1,
+        which shows composition per bin).
+    kde
+        Overlay a Gaussian kernel density per group. Only meaningful with
+        ``stat='density'``, and forced there if you ask for it.
+    log_scale
+        Bin on a log10 x-axis. Non-positive values are dropped, and how many
+        is reported.
+
+    Returns
+    -------
+    ``Axes``, or ``(Axes, DataFrame)`` with the bin edges and heights.
+    """
+    frame, hues, names, dropped = _values_and_groups(data, x, hue, None,
+                                                     hue_order)
+    if dropped:
+        print(f"histplot: dropped {dropped} rows with missing values.")
+    if stat not in {"count", "density", "probability", "percent"}:
+        raise ValueError(
+            "`stat` must be 'count', 'density', 'probability' or 'percent'."
+        )
+    if multiple not in {"layer", "stack", "dodge", "fill"}:
+        raise ValueError("`multiple` must be 'layer', 'stack', 'dodge' or 'fill'.")
+
+    values = frame["x"].to_numpy(dtype=float)
+    if log_scale:
+        positive = values > 0
+        if not positive.all():
+            print(f"histplot: dropped {int((~positive).sum())} non-positive "
+                  f"values for the log axis.")
+        frame = frame[positive].reset_index(drop=True)
+        values = np.log10(frame["x"].to_numpy(dtype=float))
+
+    if binrange is None:
+        binrange = (float(values.min()), float(values.max()))
+    edges = np.histogram_bin_edges(values, bins=bins, range=binrange)
+    centres = (edges[:-1] + edges[1:]) / 2
+    widths = np.diff(edges)
+
+    ax = _new_axes(ax, figsize, (4.4, 3.2))
+    colors = default_palette(max(len(hues), 1), palette)
+    if kde and stat != "density":
+        print("histplot: `kde=True` forces stat='density' so the curve and the "
+              "bars share a scale.")
+        stat = "density"
+
+    heights = []
+    for hue_level in hues:
+        mask = (np.ones(len(frame), dtype=bool) if hue_level is None
+                else frame["hue"].to_numpy() == hue_level)
+        counts, _ = np.histogram(values[mask], bins=edges)
+        counts = counts.astype(float)
+        total = counts.sum()
+        if stat == "density":
+            counts = counts / (total * widths) if total else counts
+        elif stat == "probability":
+            counts = counts / total if total else counts
+        elif stat == "percent":
+            counts = counts / total * 100 if total else counts
+        if cumulative:
+            counts = np.cumsum(counts * (widths if stat == "density" else 1))
+        heights.append(counts)
+    matrix = np.vstack(heights) if heights else np.zeros((0, len(centres)))
+
+    if multiple == "fill":
+        totals = matrix.sum(axis=0)
+        matrix = np.divide(matrix, totals, out=np.zeros_like(matrix),
+                           where=totals > 0)
+
+    base = np.zeros(len(centres))
+    for index, (hue_level, colour) in enumerate(zip(hues, colors)):
+        row = matrix[index]
+        if multiple in {"stack", "fill"}:
+            ax.bar(centres, row, bottom=base, width=widths, color=colour,
+                   alpha=1.0 if multiple == "fill" else alpha,
+                   edgecolor=edgecolor, linewidth=linewidth,
+                   label=str(hue_level) if hue_level is not None else None)
+            base = base + row
+        elif multiple == "dodge":
+            step = widths / max(len(hues), 1)
+            ax.bar(centres - widths / 2 + step * (index + 0.5), row,
+                   width=step * 0.95, color=colour, alpha=alpha,
+                   edgecolor=edgecolor, linewidth=linewidth,
+                   label=str(hue_level) if hue_level is not None else None)
+        else:
+            ax.bar(centres, row, width=widths, color=colour, alpha=alpha,
+                   edgecolor=edgecolor, linewidth=linewidth,
+                   label=str(hue_level) if hue_level is not None else None)
+        if kde:
+            mask = (np.ones(len(frame), dtype=bool) if hue_level is None
+                    else frame["hue"].to_numpy() == hue_level)
+            grid = _grid(values[mask], 2.0, 200)
+            ax.plot(grid, _density(values[mask], grid, bw_method), color=colour,
+                    linewidth=1.5, zorder=3)
+
+    label = xlabel if xlabel is not None else names.get("x", "")
+    if log_scale:
+        label = f"log10({label})" if label else "log10(value)"
+    ax.set_xlabel(label, fontsize=fontsize + 1)
+    default_y = {"count": "count", "density": "density",
+                 "probability": "proportion", "percent": "percent"}[stat]
+    if multiple == "fill":
+        default_y = "fraction of bin"
+    ax.set_ylabel(ylabel if ylabel is not None else default_y,
+                  fontsize=fontsize + 1)
+    if title:
+        ax.set_title(title, fontsize=fontsize + 2)
+    ax.tick_params(labelsize=fontsize)
+    ax.spines[["right", "top"]].set_visible(False)
+    if legend and len(hues) > 1:
+        ax.legend(title=legend_title or names.get("hue"), frameon=False,
+                  fontsize=fontsize)
+
+    table = pd.DataFrame(matrix.T, index=pd.Index(centres, name="bin_centre"),
+                         columns=[str(h) for h in hues])
+    return (ax, table) if return_stats else ax
+
+
+def _new_axes(ax, figsize, default):
+    if ax is not None:
+        return ax
+    _, ax = plt.subplots(figsize=figsize or default)
+    return ax
+
+
+@register_function(
+    aliases=["核密度图", "kdeplot", "密度曲线", "density_plot", "kernel_density"],
+    category="pl",
+    description=(
+        "Kernel density estimate — one curve per group in 1-D, or filled "
+        "contours of a joint density in 2-D"
+    ),
+    examples=[
+        "ax = ov.pl.kdeplot(df, 'score', hue='cell_type')",
+        "# Shade under the curves, and mark the group means",
+        "ax = ov.pl.kdeplot(df, 'score', hue='arm', fill=True, rug=True)",
+        "# Joint density of two variables",
+        "ax = ov.pl.kdeplot(df, 'UMAP1', y='UMAP2', levels=8, fill=True)",
+    ],
+    related=["pl.histplot", "pl.ridgeplot", "pl.violinplot", "pl.add_density_contour"],
+)
+def kdeplot(data: Any = None,
+            x: Any = None,
+            *,
+            y: Any = None,
+            hue: Any = None,
+            hue_order: Optional[Sequence[Any]] = None,
+            bw_method: Any = None,
+            gridsize: int = 200,
+            cut: float = 3.0,
+            fill: bool = False,
+            alpha: float = 0.3,
+            linewidth: float = 1.6,
+            cumulative: bool = False,
+            rug: bool = False,
+            levels: int = 10,
+            cmap: str = "Blues",
+            palette=None,
+            ax=None,
+            figsize: Optional[Tuple[float, float]] = None,
+            xlabel: Optional[str] = None,
+            ylabel: Optional[str] = None,
+            title: Optional[str] = None,
+            legend: bool = True,
+            legend_title: Optional[str] = None,
+            fontsize: float = 9,
+            return_stats: bool = False):
+    r"""Kernel density estimate in one or two dimensions.
+
+    Arguments
+    ---------
+    y
+        Give this for a **2-D** joint density, drawn as contours. ``hue`` is
+        not supported in 2-D — overlapping contour sets are unreadable; draw
+        one panel per group instead.
+    cut
+        How far past the data the curve extends, in bandwidths. Set ``cut=0``
+        for a bounded quantity so the density does not spill past 0 or 1.
+    rug
+        Draw a tick per observation along the axis, which shows where the
+        density is actually supported by data.
+
+    Returns
+    -------
+    ``Axes``, or ``(Axes, dict)``.
+    """
+    if y is not None and hue is not None:
+        raise ValueError(
+            "A 2-D density with `hue` would overlay unreadable contour sets — "
+            "plot one group per axes instead."
+        )
+    frame, hues, names, dropped = _values_and_groups(data, x, hue, None,
+                                                     hue_order)
+    if dropped:
+        print(f"kdeplot: dropped {dropped} rows with missing values.")
+    ax = _new_axes(ax, figsize, (4.4, 3.2))
+    curves: Dict[Any, Any] = {}
+
+    if y is not None:
+        from scipy.stats import gaussian_kde
+
+        pair, pair_names = resolve_columns(data, x=x, y=y, require=("x", "y"))
+        xs = pair["x"].to_numpy(dtype=float)
+        ys = pair["y"].to_numpy(dtype=float)
+        gx = np.linspace(xs.min(), xs.max(), gridsize)
+        gy = np.linspace(ys.min(), ys.max(), gridsize)
+        mesh_x, mesh_y = np.meshgrid(gx, gy)
+        kernel = gaussian_kde(np.vstack([xs, ys]), bw_method=bw_method)
+        density = kernel(np.vstack([mesh_x.ravel(), mesh_y.ravel()]))
+        density = density.reshape(mesh_x.shape)
+        if fill:
+            ax.contourf(mesh_x, mesh_y, density, levels=levels, cmap=cmap)
+        ax.contour(mesh_x, mesh_y, density, levels=levels, cmap=cmap,
+                   linewidths=linewidth * 0.6)
+        ax.set_xlabel(xlabel if xlabel is not None else pair_names.get("x", ""),
+                      fontsize=fontsize + 1)
+        ax.set_ylabel(ylabel if ylabel is not None else pair_names.get("y", ""),
+                      fontsize=fontsize + 1)
+        curves["density"] = density
+    else:
+        colors = default_palette(max(len(hues), 1), palette)
+        values = frame["x"].to_numpy(dtype=float)
+        for hue_level, colour in zip(hues, colors):
+            mask = (np.ones(len(frame), dtype=bool) if hue_level is None
+                    else frame["hue"].to_numpy() == hue_level)
+            sample = values[mask]
+            if sample.size < 2:
+                continue
+            grid = _grid(sample, cut, gridsize)
+            density = _density(sample, grid, bw_method)
+            if cumulative:
+                density = np.cumsum(density) * np.gradient(grid)
+            ax.plot(grid, density, color=colour, linewidth=linewidth,
+                    label=str(hue_level) if hue_level is not None else None)
+            if fill:
+                ax.fill_between(grid, density, color=colour, alpha=alpha,
+                                linewidth=0)
+            if rug:
+                ax.plot(sample, np.zeros_like(sample), "|", color=colour,
+                        markersize=5, markeredgewidth=0.8, alpha=0.6,
+                        clip_on=False)
+            curves[hue_level] = (grid, density)
+        ax.set_xlabel(xlabel if xlabel is not None else names.get("x", ""),
+                      fontsize=fontsize + 1)
+        ax.set_ylabel(ylabel if ylabel is not None
+                      else ("cumulative density" if cumulative else "density"),
+                      fontsize=fontsize + 1)
+        ax.set_ylim(bottom=0)
+        if legend and len(hues) > 1:
+            ax.legend(title=legend_title or names.get("hue"), frameon=False,
+                      fontsize=fontsize)
+
+    if title:
+        ax.set_title(title, fontsize=fontsize + 2)
+    ax.tick_params(labelsize=fontsize)
+    ax.spines[["right", "top"]].set_visible(False)
+    return (ax, curves) if return_stats else ax
+
+
+@register_function(
+    aliases=["山脊图", "ridgeplot", "joyplot", "岭线图", "ridgeline"],
+    category="pl",
+    description=(
+        "Ridgeline (joy) plot — one overlapping density per group, the "
+        "readable way to compare a dozen distributions at once"
+    ),
+    examples=[
+        "ax = ov.pl.ridgeplot(df, 'score', 'cell_type')",
+        "# Ordered by median, coloured by it too",
+        "ax = ov.pl.ridgeplot(df, 'score', 'cell_type', order='median',",
+        "                     color_by='median', cmap='rocket')",
+        "# Tighter stacking",
+        "ax = ov.pl.ridgeplot(df, 'expression', 'sample', overlap=0.8)",
+    ],
+    related=["pl.kdeplot", "pl.violinplot", "pl.histplot"],
+)
+def ridgeplot(data: Any = None,
+              x: Any = None,
+              group: Any = None,
+              *,
+              order: Union[str, Sequence[Any], None] = "median",
+              ascending: bool = True,
+              overlap: float = 0.6,
+              bw_method: Any = None,
+              gridsize: int = 300,
+              cut: float = 2.0,
+              fill: bool = True,
+              alpha: float = 0.85,
+              linewidth: float = 0.9,
+              edgecolor: str = "white",
+              palette=None,
+              color_by: Optional[str] = None,
+              cmap: str = "viridis",
+              quantile_lines: Optional[Sequence[float]] = None,
+              ax=None,
+              figsize: Optional[Tuple[float, float]] = None,
+              xlabel: Optional[str] = None,
+              title: Optional[str] = None,
+              fontsize: float = 9,
+              return_stats: bool = False):
+    r"""Stacked, overlapping densities — one per group.
+
+    Arguments
+    ---------
+    order
+        ``'median'`` (default), ``'mean'``, ``'name'``, ``None`` to keep the
+        natural order, or an explicit list.
+    overlap
+        How far each ridge reaches into the one above, as a fraction of the
+        row height. 0 gives separated densities, 0.9 a dense ridge.
+    color_by
+        ``'median'`` or ``'mean'`` to map ridge colour onto that statistic via
+        ``cmap`` — useful when the ordering statistic is the point.
+    quantile_lines
+        Draw vertical marks at these quantiles inside each ridge, e.g.
+        ``[0.25, 0.5, 0.75]``.
+
+    Returns
+    -------
+    ``Axes``, or ``(Axes, DataFrame)`` of per-group summaries.
+    """
+    if group is None:
+        raise TypeError("`group` is required — it says what each ridge is.")
+    if data is not None and as_frame(data) is None:
+        data, x, group = None, data, x
+    frame, names = resolve_columns(data, x=x, group=group,
+                                   require=("x", "group"))
+    values = frame["x"].to_numpy(dtype=float)
+    labels = frame["group"].to_numpy()
+
+    summary = (pd.DataFrame({"value": values, "group": labels})
+               .groupby("group", observed=False)["value"]
+               .agg(["median", "mean", "count"]))
+    if isinstance(order, str):
+        if order in {"median", "mean"}:
+            levels = list(summary.sort_values(order, ascending=ascending).index)
+        elif order == "name":
+            levels = sorted(summary.index)
+        else:
+            raise ValueError("`order` must be 'median', 'mean', 'name', a list "
+                             "or None.")
+    elif order is None:
+        levels = group_levels(frame["group"])
+    else:
+        levels = list(order)
+    summary = summary.reindex(levels)
+
+    ax = _new_axes(ax, figsize, (5.0, max(2.4, 0.42 * len(levels) + 1.0)))
+    if color_by is not None:
+        if color_by not in {"median", "mean"}:
+            raise ValueError("`color_by` must be 'median', 'mean' or None.")
+        stat = summary[color_by].to_numpy(dtype=float)
+        span = np.nanmax(stat) - np.nanmin(stat)
+        norm = (stat - np.nanmin(stat)) / span if span else np.zeros_like(stat)
+        colors = [plt.get_cmap(cmap)(v) for v in norm]
+    else:
+        colors = default_palette(len(levels), palette)
+
+    step = 1.0
+    height = step / max(1.0 - overlap, 1e-3)
+    peak = 0.0
+    profiles = []
+    for level in levels:
+        sample = values[labels == level]
+        if sample.size < 2:
+            profiles.append(None)
+            continue
+        grid = _grid(sample, cut, gridsize)
+        density = _density(sample, grid, bw_method)
+        peak = max(peak, float(density.max()))
+        profiles.append((grid, density, sample))
+
+    for index, (level, profile, colour) in enumerate(
+            zip(levels, profiles, colors)):
+        baseline = (len(levels) - 1 - index) * step
+        if profile is None:
+            continue
+        grid, density, sample = profile
+        scaled = baseline + density / (peak or 1.0) * height
+        if fill:
+            ax.fill_between(grid, baseline, scaled, color=colour, alpha=alpha,
+                            linewidth=linewidth, edgecolor=edgecolor,
+                            zorder=len(levels) - index)
+        ax.plot(grid, scaled, color=edgecolor if fill else colour,
+                linewidth=linewidth, zorder=len(levels) - index)
+        if quantile_lines:
+            for q in quantile_lines:
+                position = float(np.quantile(sample, q))
+                top = np.interp(position, grid, scaled)
+                ax.plot([position, position], [baseline, top], color="0.25",
+                        linewidth=0.8, zorder=len(levels) - index + 0.5)
+
+    ax.set_yticks([(len(levels) - 1 - i) * step for i in range(len(levels))])
+    ax.set_yticklabels([str(level) for level in levels], fontsize=fontsize)
+    ax.set_ylim(-0.2 * step, (len(levels) - 1) * step + height * 1.05)
+    ax.set_xlabel(xlabel if xlabel is not None else names.get("x", ""),
+                  fontsize=fontsize + 1)
+    if title:
+        ax.set_title(title, fontsize=fontsize + 2)
+    ax.tick_params(axis="y", length=0)
+    ax.tick_params(labelsize=fontsize)
+    ax.spines[["right", "top", "left"]].set_visible(False)
+    return (ax, summary) if return_stats else ax
+
+
+@register_function(
+    aliases=["QQ图", "qqplot", "分位图", "quantile_plot", "qq_plot", "正态性检验图"],
+    category="pl",
+    description=(
+        "Q-Q plot against a theoretical distribution or a second sample, with "
+        "a reference line, confidence band, and genomic inflation for P values"
+    ),
+    examples=[
+        "# Is this residual normal?",
+        "ax = ov.pl.qqplot(residuals)",
+        "# P values against uniform, on the -log10 scale, with lambda_GC",
+        "ax = ov.pl.qqplot(deg['pvalue'], dist='uniform', log=True)",
+        "# Two samples against each other",
+        "ax = ov.pl.qqplot(sample_a, other=sample_b)",
+    ],
+    related=["pl.histplot", "pl.kdeplot", "pl.volcano"],
+)
+def qqplot(data: Any = None,
+           x: Any = None,
+           *,
+           other: Any = None,
+           dist: str = "norm",
+           log: bool = False,
+           line: Optional[str] = "quartile",
+           ci: Optional[float] = 0.95,
+           point_size: float = 10,
+           color: str = "#1F577B",
+           line_color: str = "0.4",
+           ax=None,
+           figsize: Optional[Tuple[float, float]] = None,
+           xlabel: Optional[str] = None,
+           ylabel: Optional[str] = None,
+           title: Optional[str] = None,
+           fontsize: float = 9,
+           return_stats: bool = False):
+    r"""Quantile-quantile plot.
+
+    Arguments
+    ---------
+    data, x
+        A table plus a column, or the values directly.
+    other
+        A second sample. Given this, quantiles of the two samples are plotted
+        against each other and ``dist`` is ignored.
+    dist
+        Reference distribution — any name in ``scipy.stats``. ``'norm'``
+        (default) answers "is this normal?"; ``'uniform'`` with ``log=True``
+        is the P-value Q-Q that reports genomic inflation.
+    log
+        Plot ``-log10`` of both axes. Meant for P values.
+    line
+        ``'quartile'`` (default; robust, through the first and third
+        quartiles), ``'45'`` (the identity), ``'ols'``, or ``None``.
+    ci
+        Pointwise confidence band from the Beta order statistics, at this
+        level. ``None`` to skip.
+
+    Returns
+    -------
+    ``Axes``, or ``(Axes, dict)`` — the latter includes ``lambda_gc`` when the
+    reference is uniform.
+    """
+    from scipy import stats as scipy_stats
+
+    if data is not None and as_frame(data) is None:
+        data, x = None, data
+    frame, names = resolve_columns(data, x=x, require=("x",))
+    sample = np.sort(frame["x"].to_numpy(dtype=float))
+    n = sample.size
+    if n < 2:
+        raise ValueError("A Q-Q plot needs at least two observations.")
+
+    quantiles = (np.arange(1, n + 1) - 0.5) / n
+    results: Dict[str, Any] = {"n": n}
+
+    if other is not None:
+        reference = np.sort(np.asarray(other, dtype=float))
+        theoretical = np.quantile(reference, quantiles)
+        x_label = xlabel if xlabel is not None else "second sample quantiles"
+    else:
+        try:
+            distribution = getattr(scipy_stats, dist)
+        except AttributeError as exc:
+            raise ValueError(
+                f"`dist={dist!r}` is not a scipy.stats distribution."
+            ) from exc
+        if dist == "norm":
+            theoretical = distribution.ppf(quantiles)
+        elif dist == "uniform":
+            theoretical = quantiles
+        else:
+            theoretical = distribution.ppf(quantiles, *distribution.fit(sample))
+        x_label = xlabel if xlabel is not None else f"theoretical quantiles ({dist})"
+
+    if dist == "uniform" and other is None:
+        # genomic inflation: median chi2 of the observed p values over the null
+        with np.errstate(divide="ignore"):
+            chi2 = scipy_stats.chi2.isf(sample, 1)
+        results["lambda_gc"] = float(np.median(chi2) / scipy_stats.chi2.ppf(0.5, 1))
+
+    plot_x, plot_y = theoretical, sample
+    if log:
+        with np.errstate(divide="ignore"):
+            plot_x = -np.log10(np.clip(theoretical, 1e-300, None))
+            plot_y = -np.log10(np.clip(sample, 1e-300, None))
+        x_label = f"expected $-\\log_{{10}}(P)$"
+
+    ax = _new_axes(ax, figsize, (3.8, 3.8))
+    if ci is not None and other is None:
+        ranks = np.arange(1, n + 1)
+        lo_q = scipy_stats.beta.ppf((1 - ci) / 2, ranks, n - ranks + 1)
+        hi_q = scipy_stats.beta.ppf(1 - (1 - ci) / 2, ranks, n - ranks + 1)
+        if dist == "uniform":
+            band_lo, band_hi = lo_q, hi_q
+        else:
+            band_lo = distribution.ppf(lo_q) if dist == "norm" else None
+            band_hi = distribution.ppf(hi_q) if dist == "norm" else None
+        if band_lo is not None:
+            if log:
+                with np.errstate(divide="ignore"):
+                    band_lo = -np.log10(np.clip(band_lo, 1e-300, None))
+                    band_hi = -np.log10(np.clip(band_hi, 1e-300, None))
+            ax.fill_between(plot_x, band_lo, band_hi, color="0.85",
+                            linewidth=0, zorder=0)
+
+    ax.scatter(plot_x, plot_y, s=point_size, color=color, linewidths=0,
+               zorder=2)
+
+    if line == "45":
+        lo = min(plot_x.min(), plot_y.min())
+        hi = max(plot_x.max(), plot_y.max())
+        ax.plot([lo, hi], [lo, hi], color=line_color, linewidth=1.0,
+                linestyle="--", zorder=1)
+    elif line == "quartile":
+        qx = np.quantile(plot_x, [0.25, 0.75])
+        qy = np.quantile(plot_y, [0.25, 0.75])
+        slope = (qy[1] - qy[0]) / (qx[1] - qx[0]) if qx[1] != qx[0] else 1.0
+        intercept = qy[0] - slope * qx[0]
+        edges = np.array([plot_x.min(), plot_x.max()])
+        ax.plot(edges, slope * edges + intercept, color=line_color,
+                linewidth=1.0, linestyle="--", zorder=1)
+        results.update(slope=float(slope), intercept=float(intercept))
+    elif line == "ols":
+        slope, intercept = np.polyfit(plot_x, plot_y, 1)
+        edges = np.array([plot_x.min(), plot_x.max()])
+        ax.plot(edges, slope * edges + intercept, color=line_color,
+                linewidth=1.0, linestyle="--", zorder=1)
+        results.update(slope=float(slope), intercept=float(intercept))
+    elif line is not None:
+        raise ValueError("`line` must be 'quartile', '45', 'ols' or None.")
+
+    ax.set_xlabel(x_label, fontsize=fontsize + 1)
+    default_y = "observed $-\\log_{10}(P)$" if log else (
+        f"sample quantiles ({names.get('x', '')})".strip())
+    ax.set_ylabel(ylabel if ylabel is not None else default_y,
+                  fontsize=fontsize + 1)
+    if "lambda_gc" in results:
+        ax.text(0.03, 0.96, f"$\\lambda_{{GC}}$ = {results['lambda_gc']:.3f}",
+                transform=ax.transAxes, va="top", ha="left", fontsize=fontsize)
+    if title:
+        ax.set_title(title, fontsize=fontsize + 2)
+    ax.tick_params(labelsize=fontsize)
+    ax.spines[["right", "top"]].set_visible(False)
+    return (ax, results) if return_stats else ax

--- a/omicverse/pl/_plotdata.py
+++ b/omicverse/pl/_plotdata.py
@@ -1,0 +1,283 @@
+r"""Let the ``AnnData``-shaped plots in ``ov.pl`` accept a plain table.
+
+Most plotting functions in ``ov.pl`` only ever touch five things on an
+``AnnData``: ``.obs``, ``.var_names``, the expression matrix (``.X`` /
+``.layers`` / ``.raw``), ``.obsm``, and ``.uns`` for stored colours. Requiring
+the whole container for that is a needless barrier — a `DataFrame` of cell
+metadata carries everything a proportion plot or a boxplot needs.
+
+Two tools here, for two situations.
+
+:func:`as_plotdata` is for **new** code. It returns a :class:`PlotData` with a
+single accessor, ``values(key)``, that resolves a key against metadata columns
+first and features second, whatever the underlying container is.
+
+:func:`accepts_frame` is for **existing** code. It is a decorator that wraps a
+``DataFrame`` in a minimal ``AnnData``-shaped view so a function written
+against ``adata.obs`` keeps working unchanged. Deliberately *not* a fake
+``AnnData``: it exposes only what it really has, so a function that reaches for
+``.X`` fails immediately with a clear message instead of on some later line.
+"""
+
+from __future__ import annotations
+
+import functools
+from typing import Any, Callable, Iterable, Optional, Sequence
+
+import numpy as np
+import pandas as pd
+
+__all__ = ["PlotData", "ObsView", "as_plotdata", "accepts_frame"]
+
+
+def _is_anndata_like(obj: Any) -> bool:
+    return all(hasattr(obj, attr) for attr in ("obs", "var_names", "obs_names"))
+
+
+class PlotData:
+    """Uniform read access to metadata and feature values.
+
+    Attributes
+    ----------
+    obs : pandas.DataFrame
+        Per-observation metadata.
+    var_names : pandas.Index
+        Names that :meth:`values` can resolve as features.
+    obsm : Mapping
+        Embeddings, keyed as in ``AnnData.obsm``. Empty for a plain table
+        unless one was supplied.
+    source : Any
+        The original object, for functions that still need it.
+    """
+
+    def __init__(self, obs: pd.DataFrame, *, var_names: Optional[pd.Index] = None,
+                 feature_getter: Optional[Callable[[str, Optional[str]], np.ndarray]] = None,
+                 obsm: Optional[Any] = None, source: Any = None):
+        self.obs = obs
+        self.var_names = pd.Index([] if var_names is None else var_names)
+        self.obsm = obsm if obsm is not None else {}
+        self.source = source
+        self._feature_getter = feature_getter
+
+    @property
+    def n_obs(self) -> int:
+        return int(len(self.obs))
+
+    def has(self, key: str) -> bool:
+        """Whether ``key`` resolves to either a metadata column or a feature."""
+        return key in self.obs.columns or key in self.var_names
+
+    def values(self, key: str, layer: Optional[str] = None) -> np.ndarray:
+        """Values of ``key`` — a metadata column, or a feature.
+
+        Metadata wins when a name is both, which matches ``scanpy``'s
+        behaviour and is almost always what the caller meant.
+        """
+        if key in self.obs.columns:
+            if layer is not None:
+                raise ValueError(
+                    f"{key!r} is a metadata column; `layer=` only applies to "
+                    f"features."
+                )
+            return self.obs[key].to_numpy()
+        if key in self.var_names and self._feature_getter is not None:
+            return self._feature_getter(key, layer)
+        from difflib import get_close_matches
+
+        pool = list(map(str, self.obs.columns)) + list(map(str, self.var_names[:2000]))
+        hint = get_close_matches(str(key), pool, n=3, cutoff=0.6)
+        suffix = f" Did you mean: {', '.join(hint)}?" if hint else ""
+        raise KeyError(
+            f"{key!r} is neither a metadata column nor a known feature.{suffix}"
+        )
+
+    def embedding(self, basis: str) -> np.ndarray:
+        """Coordinates of ``basis``, accepting ``'umap'`` for ``'X_umap'``."""
+        for candidate in (basis, f"X_{basis}"):
+            if candidate in self.obsm:
+                return np.asarray(self.obsm[candidate])
+        available = ", ".join(map(str, list(self.obsm))) or "none"
+        raise KeyError(f"No embedding {basis!r}. Available: {available}.")
+
+    def __repr__(self) -> str:
+        return (f"PlotData({self.n_obs} obs, {self.obs.shape[1]} metadata "
+                f"columns, {len(self.var_names)} features)")
+
+
+def as_plotdata(data: Any, *, obs: Optional[pd.DataFrame] = None,
+                obsm: Optional[Any] = None,
+                layer: Optional[str] = None) -> PlotData:
+    r"""Wrap ``data`` in a :class:`PlotData`.
+
+    Accepts an ``AnnData`` (or anything AnnData-shaped, including the
+    out-of-core variants), a ``DataFrame``, a ``dict`` of columns, or a 2-D
+    array with ``obs=`` supplied separately.
+
+    No data is copied — the view holds references.
+
+    Examples
+    --------
+    >>> pd_view = ov.pl.as_plotdata(adata)
+    >>> pd_view.values('CD3D')            # a gene, from .X
+    >>> pd_view.values('leiden')          # a column of .obs
+    >>> table = ov.pl.as_plotdata(df)
+    >>> table.values('score')             # a column of the frame
+    """
+    if isinstance(data, PlotData):
+        return data
+
+    if _is_anndata_like(data):
+        def feature_getter(key: str, layer_name: Optional[str]) -> np.ndarray:
+            index = data.var_names.get_loc(key)
+            if layer_name is not None:
+                matrix = data.layers[layer_name]
+            elif getattr(data, "raw", None) is not None and key in data.raw.var_names:
+                matrix = data.raw.X
+                index = data.raw.var_names.get_loc(key)
+            else:
+                matrix = data.X
+            column = matrix[:, index]
+            if hasattr(column, "toarray"):
+                column = column.toarray()
+            return np.asarray(column).ravel()
+
+        return PlotData(data.obs, var_names=data.var_names,
+                        feature_getter=feature_getter,
+                        obsm=getattr(data, "obsm", {}), source=data)
+
+    if isinstance(data, pd.DataFrame):
+        numeric = data.columns[[pd.api.types.is_numeric_dtype(data[c])
+                                for c in data.columns]]
+        return PlotData(data, var_names=numeric, obsm=obsm or {}, source=data)
+
+    if isinstance(data, dict):
+        frame = pd.DataFrame({k: np.asarray(v).ravel() for k, v in data.items()})
+        return as_plotdata(frame, obsm=obsm)
+
+    array = np.asarray(data)
+    if array.ndim == 2:
+        if obs is None:
+            raise TypeError(
+                "A 2-D array needs `obs=` — a DataFrame of per-row metadata — "
+                "before it can be plotted."
+            )
+        columns = pd.Index([f"feature_{i}" for i in range(array.shape[1])])
+
+        def array_getter(key: str, layer_name: Optional[str]) -> np.ndarray:
+            if layer_name is not None:
+                raise ValueError("A bare array has no layers.")
+            return array[:, columns.get_loc(key)]
+
+        return PlotData(obs, var_names=columns, feature_getter=array_getter,
+                        obsm=obsm or {}, source=data)
+
+    raise TypeError(
+        f"Cannot plot a {type(data).__name__}. Pass an AnnData, a DataFrame, "
+        f"a dict of columns, or a 2-D array together with `obs=`."
+    )
+
+
+class ObsView:
+    """An ``AnnData``-shaped, metadata-only view over a ``DataFrame``.
+
+    Exposes ``.obs``, ``.obs_names``, ``.var_names``, ``.uns``, ``.shape``,
+    ``.n_obs`` and ``.n_vars`` — and nothing else. A function that only reads
+    and annotates ``.obs`` works against this unchanged; one that reaches for
+    ``.X`` gets an ``AttributeError`` naming the problem rather than a
+    confusing failure further in.
+
+    ``.obs`` is a **copy** of the input frame. Several ``ov.pl`` functions
+    coerce their grouping column to ``category`` in place, and mutating the
+    caller's DataFrame as a side effect of drawing a plot would be a
+    surprise.
+
+    String columns are converted to ``category`` on construction, because
+    ``anndata`` does the same when an ``AnnData`` is built — so plots that
+    reach for ``.cat.categories`` (most of the grouped ones do) find what they
+    expect instead of failing on a plain object column.
+    """
+
+    def __init__(self, frame: pd.DataFrame, *, uns: Optional[dict] = None,
+                 categorical: bool = True):
+        if not isinstance(frame, pd.DataFrame):
+            raise TypeError(f"ObsView needs a DataFrame, got {type(frame).__name__}.")
+        self.obs = frame.copy()
+        if categorical:
+            for column in self.obs.columns:
+                dtype = self.obs[column].dtype
+                if dtype == object or pd.api.types.is_string_dtype(dtype):
+                    self.obs[column] = self.obs[column].astype("category")
+        self.uns: dict = dict(uns or {})
+        self.var_names = pd.Index([])
+
+    @property
+    def obs_names(self) -> pd.Index:
+        return self.obs.index
+
+    @property
+    def n_obs(self) -> int:
+        return int(len(self.obs))
+
+    @property
+    def n_vars(self) -> int:
+        return 0
+
+    @property
+    def shape(self):
+        return (self.n_obs, 0)
+
+    def __len__(self) -> int:
+        return self.n_obs
+
+    def __getattr__(self, name: str):
+        if name in {"X", "layers", "raw", "var", "obsm", "varm", "obsp"}:
+            raise AttributeError(
+                f"This plot was given a DataFrame, which has no {name!r}. "
+                f"Pass an AnnData if you need expression values — or use "
+                f"ov.pl.as_plotdata() to see what a table can supply."
+            )
+        raise AttributeError(name)
+
+    def __repr__(self) -> str:
+        return f"ObsView({self.n_obs} rows x {self.obs.shape[1]} columns)"
+
+
+def accepts_frame(func: Optional[Callable] = None, *, argument: int = 0):
+    r"""Let a metadata-only ``AnnData`` plot also take a ``DataFrame``.
+
+    Wraps the ``argument``-th positional parameter: a ``DataFrame`` or ``dict``
+    becomes an :class:`ObsView`, anything ``AnnData``-shaped passes straight
+    through untouched.
+
+    Use it only on functions that read metadata. A function that needs
+    expression values will raise from :class:`ObsView` with an actionable
+    message, which is the intended outcome — better than silently plotting
+    nothing.
+
+    Examples
+    --------
+    >>> @accepts_frame
+    ... def cellproportion(adata, celltype_clusters, groupby, ...):
+    ...     ...
+    >>> cellproportion(df, celltype_clusters='cell_type', groupby='sample')
+    """
+    def decorate(inner: Callable) -> Callable:
+        @functools.wraps(inner)
+        def wrapper(*args, **kwargs):
+            args = list(args)
+            if len(args) > argument:
+                candidate = args[argument]
+                if isinstance(candidate, (pd.DataFrame, dict)):
+                    frame = (candidate if isinstance(candidate, pd.DataFrame)
+                             else pd.DataFrame(candidate))
+                    args[argument] = ObsView(frame)
+            return inner(*args, **kwargs)
+
+        wrapper.__doc__ = (inner.__doc__ or "") + (
+            "\n\n    Accepts a ``pandas.DataFrame`` of per-observation metadata "
+            "wherever an\n    ``AnnData`` is expected — the frame is used as "
+            "``.obs``. See\n    :func:`omicverse.pl.accepts_frame`.\n"
+        )
+        return wrapper
+
+    return decorate if func is None else decorate(func)

--- a/omicverse/pl/_relational.py
+++ b/omicverse/pl/_relational.py
@@ -1,0 +1,517 @@
+r"""Relational plots: scatter, line and regression.
+
+Every scatter in ``ov.pl`` today is an embedding — it needs an ``AnnData`` and
+a ``basis``. There was no way to simply plot y against x from a table, and no
+regression plot at all.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+from .._registry import register_function
+from ._stats_common import as_frame, default_palette, group_levels, resolve_columns
+
+__all__ = ["scatterplot", "lineplot", "regplot"]
+
+
+def _new_axes(ax, figsize, default):
+    if ax is not None:
+        return ax
+    _, ax = plt.subplots(figsize=figsize or default)
+    return ax
+
+
+def _correlation(x: np.ndarray, y: np.ndarray, method: str):
+    from scipy import stats
+
+    if method == "pearson":
+        res = stats.pearsonr(x, y)
+        return float(res[0]), float(res[1]), "r"
+    if method == "spearman":
+        res = stats.spearmanr(x, y)
+        return float(res[0]), float(res[1]), r"$\rho$"
+    if method == "kendall":
+        res = stats.kendalltau(x, y)
+        return float(res[0]), float(res[1]), r"$\tau$"
+    raise ValueError(
+        f"`corr` must be 'pearson', 'spearman', 'kendall' or None, got "
+        f"{method!r}."
+    )
+
+
+def _format_corr(value: float, pvalue: float, symbol: str) -> str:
+    from ._stats_tests import format_pvalue
+
+    return f"{symbol} = {value:.3f}\n{format_pvalue(pvalue, 'value')}"
+
+
+def _shift(data, *fields):
+    """Allow ``f(x_array, y_array, ...)`` when the first positional is data."""
+    if data is not None and as_frame(data) is None:
+        return (None, data) + fields[:-1]
+    return (data,) + fields
+
+
+@register_function(
+    aliases=["散点图", "scatterplot", "scatter", "点图", "相关散点图"],
+    category="pl",
+    description=(
+        "Scatter plot of y against x from a table, with categorical or "
+        "continuous colour, point sizing, density shading and a correlation "
+        "annotation"
+    ),
+    examples=[
+        "ax = ov.pl.scatterplot(df, 'total_counts', 'n_genes')",
+        "# Colour by a category, annotate Spearman's rho",
+        "ax = ov.pl.scatterplot(df, 'x', 'y', hue='cell_type', corr='spearman')",
+        "# Continuous colour and size, for a big table",
+        "ax = ov.pl.scatterplot(df, 'log2FC', 'neglog10P', hue='baseMean',",
+        "                       size='n', cmap='viridis', rasterized=True)",
+        "# Colour by local point density instead of a variable",
+        "ax = ov.pl.scatterplot(df, 'x', 'y', density=True)",
+    ],
+    related=["pl.regplot", "pl.lineplot", "pl.embedding", "pl.volcano"],
+)
+def scatterplot(data: Any = None,
+                x: Any = None,
+                y: Any = None,
+                *,
+                hue: Any = None,
+                size: Any = None,
+                hue_order: Optional[Sequence[Any]] = None,
+                palette=None,
+                cmap: str = "viridis",
+                density: bool = False,
+                s: float = 18,
+                size_range: Tuple[float, float] = (8.0, 90.0),
+                alpha: float = 0.8,
+                edgecolor: str = "none",
+                corr: Optional[str] = None,
+                diagonal: bool = False,
+                rasterized: bool = False,
+                log_x: bool = False,
+                log_y: bool = False,
+                ax=None,
+                figsize: Optional[Tuple[float, float]] = None,
+                xlabel: Optional[str] = None,
+                ylabel: Optional[str] = None,
+                title: Optional[str] = None,
+                legend: bool = True,
+                legend_title: Optional[str] = None,
+                colorbar_label: Optional[str] = None,
+                fontsize: float = 9,
+                return_stats: bool = False):
+    r"""Plain y-against-x scatter.
+
+    Arguments
+    ---------
+    hue
+        Column or array. Categorical values get one colour each from
+        ``palette``; numeric values get ``cmap`` and a colourbar.
+    size
+        Column or array mapped onto marker area between ``size_range``.
+    density
+        Colour each point by the local point density (Gaussian KDE) instead of
+        a variable — the fix for an overplotted cloud where every point looks
+        the same.
+    corr
+        ``'pearson'``, ``'spearman'`` or ``'kendall'`` to annotate the
+        coefficient and its P value.
+    diagonal
+        Draw the identity line, for when x and y are the same quantity
+        measured two ways.
+    rasterized
+        Rasterise the points but keep axes and text as vectors — the right
+        trade for a 100,000-point figure that still has to be an editable PDF.
+
+    Returns
+    -------
+    ``Axes``, or ``(Axes, dict)``.
+    """
+    data, x, y, hue = _shift(data, x, y, hue)
+    frame, names = resolve_columns(data, x=x, y=y, hue=hue, size=size,
+                                   require=("x", "y"))
+    dropped = frame.attrs.get("n_dropped", 0)
+    if dropped:
+        print(f"scatterplot: dropped {dropped} rows with missing values.")
+    xs = frame["x"].to_numpy(dtype=float)
+    ys = frame["y"].to_numpy(dtype=float)
+
+    ax = _new_axes(ax, figsize, (4.0, 3.6))
+    sizes = s
+    if "size" in frame:
+        raw = frame["size"].to_numpy(dtype=float)
+        span = np.nanmax(raw) - np.nanmin(raw)
+        norm = (raw - np.nanmin(raw)) / span if span else np.full_like(raw, 0.5)
+        sizes = size_range[0] + norm * (size_range[1] - size_range[0])
+
+    results: Dict[str, Any] = {"n": len(frame)}
+    mappable = None
+
+    if density:
+        from scipy.stats import gaussian_kde
+
+        try:
+            weights = gaussian_kde(np.vstack([xs, ys]))(np.vstack([xs, ys]))
+        except np.linalg.LinAlgError:
+            weights = np.zeros_like(xs)
+        order = np.argsort(weights)  # densest points drawn last
+        mappable = ax.scatter(xs[order], ys[order], c=weights[order], s=sizes,
+                              cmap=cmap, alpha=alpha, linewidths=0,
+                              rasterized=rasterized)
+        colorbar_label = colorbar_label or "point density"
+    elif "hue" in frame:
+        values = frame["hue"]
+        numeric = pd.api.types.is_numeric_dtype(values) and values.nunique() > 12
+        if numeric:
+            mappable = ax.scatter(xs, ys, c=values.to_numpy(dtype=float),
+                                  s=sizes, cmap=cmap, alpha=alpha,
+                                  edgecolor=edgecolor, linewidths=0,
+                                  rasterized=rasterized)
+            colorbar_label = colorbar_label or names.get("hue")
+        else:
+            levels = group_levels(values, hue_order)
+            colors = default_palette(len(levels), palette)
+            labels = values.to_numpy()
+            for level, colour in zip(levels, colors):
+                mask = labels == level
+                point_sizes = (sizes if np.isscalar(sizes) else sizes[mask])
+                ax.scatter(xs[mask], ys[mask], s=point_sizes, color=colour,
+                           alpha=alpha, edgecolor=edgecolor, linewidths=0,
+                           label=str(level), rasterized=rasterized)
+            if legend:
+                ax.legend(title=legend_title or names.get("hue"), frameon=False,
+                          fontsize=fontsize, title_fontsize=fontsize)
+    else:
+        ax.scatter(xs, ys, s=sizes, color="#1F577B", alpha=alpha,
+                   edgecolor=edgecolor, linewidths=0, rasterized=rasterized)
+
+    if mappable is not None:
+        bar = ax.figure.colorbar(mappable, ax=ax, fraction=0.04, pad=0.03)
+        bar.set_label(colorbar_label or "", fontsize=fontsize)
+        bar.ax.tick_params(labelsize=fontsize - 1)
+
+    if corr:
+        value, pvalue, symbol = _correlation(xs, ys, corr)
+        results.update(correlation=value, pvalue=pvalue, method=corr)
+        ax.text(0.03, 0.97, _format_corr(value, pvalue, symbol),
+                transform=ax.transAxes, va="top", ha="left", fontsize=fontsize)
+    if diagonal:
+        lo = min(xs.min(), ys.min())
+        hi = max(xs.max(), ys.max())
+        ax.plot([lo, hi], [lo, hi], color="0.55", linewidth=0.9,
+                linestyle="--", zorder=0)
+    if log_x:
+        ax.set_xscale("log")
+    if log_y:
+        ax.set_yscale("log")
+
+    ax.set_xlabel(xlabel if xlabel is not None else names.get("x", ""),
+                  fontsize=fontsize + 1)
+    ax.set_ylabel(ylabel if ylabel is not None else names.get("y", ""),
+                  fontsize=fontsize + 1)
+    if title:
+        ax.set_title(title, fontsize=fontsize + 2)
+    ax.tick_params(labelsize=fontsize)
+    ax.spines[["right", "top"]].set_visible(False)
+    return (ax, results) if return_stats else ax
+
+
+def _aggregate(frame: pd.DataFrame, estimator: str, errorbar, ci_level: float):
+    from ._categorical import _error, _ESTIMATORS
+
+    reduce = _ESTIMATORS[estimator]
+    rows = []
+    for value, part in frame.groupby("x", observed=False, sort=True):
+        ys = part["y"].to_numpy(dtype=float)
+        low, high = _error(ys, errorbar, ci_level)
+        rows.append({"x": value, "centre": float(reduce(ys)), "low": low,
+                     "high": high, "n": ys.size})
+    return pd.DataFrame(rows).sort_values("x")
+
+
+@register_function(
+    aliases=["折线图", "lineplot", "line_chart", "趋势图", "时间序列图"],
+    category="pl",
+    description=(
+        "Line plot with automatic aggregation over replicates and an error "
+        "band — for time courses, dose responses and titration curves"
+    ),
+    examples=[
+        "ax = ov.pl.lineplot(df, 'hour', 'expression', hue='gene')",
+        "# Replicates averaged with a 95% CI band",
+        "ax = ov.pl.lineplot(df, 'dose', 'viability', hue='cell_line',",
+        "                    errorbar='ci')",
+        "# Draw each replicate instead of aggregating",
+        "ax = ov.pl.lineplot(df, 'hour', 'value', hue='gene', units='replicate')",
+    ],
+    related=["pl.scatterplot", "pl.regplot", "pl.dynamic_trends"],
+)
+def lineplot(data: Any = None,
+             x: Any = None,
+             y: Any = None,
+             *,
+             hue: Any = None,
+             units: Any = None,
+             hue_order: Optional[Sequence[Any]] = None,
+             estimator: str = "mean",
+             errorbar: Optional[str] = "ci",
+             ci_level: float = 0.95,
+             band_alpha: float = 0.18,
+             markers: bool = False,
+             linewidth: float = 1.6,
+             palette=None,
+             log_x: bool = False,
+             log_y: bool = False,
+             ax=None,
+             figsize: Optional[Tuple[float, float]] = None,
+             xlabel: Optional[str] = None,
+             ylabel: Optional[str] = None,
+             title: Optional[str] = None,
+             legend: bool = True,
+             legend_title: Optional[str] = None,
+             fontsize: float = 9,
+             return_stats: bool = False):
+    r"""Line plot, aggregating repeated measurements at each x.
+
+    Arguments
+    ---------
+    estimator
+        ``'mean'`` (default), ``'median'``, ``'sum'``, ``'max'``, ``'min'``.
+    errorbar
+        ``'ci'`` (t-based, default), ``'se'``, ``'sd'``, ``'pi'`` (percentile
+        interval) or ``None``.
+    units
+        Column identifying individual replicates. Given this, every replicate
+        is drawn as its own thin line and no aggregation happens — honest when
+        n is small enough that a mean would hide the spread.
+
+    Returns
+    -------
+    ``Axes``, or ``(Axes, DataFrame)`` with the aggregated values.
+    """
+    data, x, y, hue = _shift(data, x, y, hue)
+    frame, names = resolve_columns(data, x=x, y=y, hue=hue, units=units,
+                                   require=("x", "y"))
+    dropped = frame.attrs.get("n_dropped", 0)
+    if dropped:
+        print(f"lineplot: dropped {dropped} rows with missing values.")
+    hues = group_levels(frame["hue"], hue_order) if "hue" in frame else [None]
+
+    ax = _new_axes(ax, figsize, (4.4, 3.2))
+    colors = default_palette(max(len(hues), 1), palette)
+    tables = []
+    for hue_level, colour in zip(hues, colors):
+        part = (frame if hue_level is None
+                else frame[frame["hue"].to_numpy() == hue_level])
+        if part.empty:
+            continue
+        label = str(hue_level) if hue_level is not None else None
+        if "units" in part:
+            for unit, one in part.groupby("units", observed=False):
+                one = one.sort_values("x")
+                ax.plot(one["x"], one["y"], color=colour, linewidth=0.8,
+                        alpha=0.55, zorder=2)
+            summary = _aggregate(part, estimator, None, ci_level)
+            ax.plot(summary["x"], summary["centre"], color=colour,
+                    linewidth=linewidth + 0.6, label=label, zorder=3)
+        else:
+            summary = _aggregate(part, estimator, errorbar, ci_level)
+            ax.plot(summary["x"], summary["centre"], color=colour,
+                    linewidth=linewidth, label=label,
+                    marker="o" if markers else None, markersize=4, zorder=3)
+            if errorbar and (summary["low"].any() or summary["high"].any()):
+                ax.fill_between(summary["x"],
+                                summary["centre"] - summary["low"],
+                                summary["centre"] + summary["high"],
+                                color=colour, alpha=band_alpha, linewidth=0,
+                                zorder=1)
+        summary = summary.assign(hue=hue_level)
+        tables.append(summary)
+
+    if log_x:
+        ax.set_xscale("log")
+    if log_y:
+        ax.set_yscale("log")
+    ax.set_xlabel(xlabel if xlabel is not None else names.get("x", ""),
+                  fontsize=fontsize + 1)
+    ax.set_ylabel(ylabel if ylabel is not None else names.get("y", ""),
+                  fontsize=fontsize + 1)
+    if title:
+        ax.set_title(title, fontsize=fontsize + 2)
+    ax.tick_params(labelsize=fontsize)
+    ax.spines[["right", "top"]].set_visible(False)
+    if legend and len(hues) > 1:
+        ax.legend(title=legend_title or names.get("hue"), frameon=False,
+                  fontsize=fontsize, title_fontsize=fontsize)
+
+    result = pd.concat(tables, ignore_index=True) if tables else pd.DataFrame()
+    return (ax, result) if return_stats else ax
+
+
+@register_function(
+    aliases=["回归图", "regplot", "regression_plot", "拟合图", "相关回归图"],
+    category="pl",
+    description=(
+        "Scatter with a fitted trend and confidence band — linear, "
+        "polynomial or LOWESS — annotated with slope, R-squared and P"
+    ),
+    examples=[
+        "ax = ov.pl.regplot(df, 'gene_A', 'gene_B')",
+        "# A non-parametric trend instead of a straight line",
+        "ax = ov.pl.regplot(df, 'pseudotime', 'expression', fit='lowess')",
+        "# One fit per group",
+        "ax = ov.pl.regplot(df, 'dose', 'response', hue='cell_line', fit='poly',",
+        "                   order=2)",
+    ],
+    related=["pl.scatterplot", "pl.lineplot", "pl.volcano"],
+)
+def regplot(data: Any = None,
+            x: Any = None,
+            y: Any = None,
+            *,
+            hue: Any = None,
+            hue_order: Optional[Sequence[Any]] = None,
+            fit: str = "linear",
+            order: int = 2,
+            lowess_frac: float = 0.4,
+            ci: Optional[float] = 0.95,
+            scatter: bool = True,
+            s: float = 16,
+            alpha: float = 0.7,
+            band_alpha: float = 0.2,
+            linewidth: float = 1.8,
+            palette=None,
+            annotate: bool = True,
+            corr: str = "pearson",
+            ax=None,
+            figsize: Optional[Tuple[float, float]] = None,
+            xlabel: Optional[str] = None,
+            ylabel: Optional[str] = None,
+            title: Optional[str] = None,
+            legend: bool = True,
+            legend_title: Optional[str] = None,
+            fontsize: float = 9,
+            return_stats: bool = False):
+    r"""Scatter plus a fitted trend.
+
+    Arguments
+    ---------
+    fit
+        ``'linear'`` (default), ``'poly'`` (degree ``order``) or ``'lowess'``
+        (locally weighted, span ``lowess_frac``).
+    ci
+        Confidence level of the band around the fit. For ``'linear'`` and
+        ``'poly'`` this is the analytic interval for the mean response; for
+        LOWESS no band is drawn, because the honest one needs a bootstrap that
+        this function does not run.
+    annotate
+        Print slope, R² and the correlation with its P value. Only for a
+        single ungrouped linear fit — with several groups the box would be
+        larger than the plot.
+
+    Returns
+    -------
+    ``Axes``, or ``(Axes, dict)`` keyed by group.
+    """
+    data, x, y, hue = _shift(data, x, y, hue)
+    frame, names = resolve_columns(data, x=x, y=y, hue=hue, require=("x", "y"))
+    dropped = frame.attrs.get("n_dropped", 0)
+    if dropped:
+        print(f"regplot: dropped {dropped} rows with missing values.")
+    hues = group_levels(frame["hue"], hue_order) if "hue" in frame else [None]
+    if fit not in {"linear", "poly", "lowess"}:
+        raise ValueError("`fit` must be 'linear', 'poly' or 'lowess'.")
+
+    ax = _new_axes(ax, figsize, (4.0, 3.6))
+    colors = default_palette(max(len(hues), 1), palette)
+    results: Dict[Any, Dict[str, float]] = {}
+
+    for hue_level, colour in zip(hues, colors):
+        part = (frame if hue_level is None
+                else frame[frame["hue"].to_numpy() == hue_level])
+        xs = part["x"].to_numpy(dtype=float)
+        ys = part["y"].to_numpy(dtype=float)
+        if xs.size < 3:
+            continue
+        label = str(hue_level) if hue_level is not None else None
+        if scatter:
+            ax.scatter(xs, ys, s=s, color=colour, alpha=alpha, linewidths=0,
+                       label=label, zorder=2)
+        grid = np.linspace(xs.min(), xs.max(), 200)
+
+        if fit == "lowess":
+            import statsmodels.api as sm
+
+            smoothed = sm.nonparametric.lowess(ys, xs, frac=lowess_frac,
+                                               return_sorted=True)
+            ax.plot(smoothed[:, 0], smoothed[:, 1], color=colour,
+                    linewidth=linewidth, zorder=3,
+                    label=None if scatter else label)
+            results[hue_level] = {"n": int(xs.size), "fit": "lowess"}
+            continue
+
+        degree = 1 if fit == "linear" else int(order)
+        coefficients = np.polyfit(xs, ys, degree)
+        fitted = np.polyval(coefficients, grid)
+        ax.plot(grid, fitted, color=colour, linewidth=linewidth, zorder=3,
+                label=None if scatter else label)
+
+        residuals = ys - np.polyval(coefficients, xs)
+        dof = xs.size - (degree + 1)
+        entry: Dict[str, float] = {"n": int(xs.size), "slope": float(coefficients[-2]),
+                                   "intercept": float(coefficients[-1])}
+        if dof > 0:
+            sigma2 = float(residuals @ residuals / dof)
+            total = float(((ys - ys.mean()) ** 2).sum())
+            entry["r_squared"] = 1.0 - float(residuals @ residuals) / total if total else np.nan
+            if ci is not None:
+                from scipy import stats
+
+                design = np.vander(xs, degree + 1)
+                grid_design = np.vander(grid, degree + 1)
+                xtx_inv = np.linalg.pinv(design.T @ design)
+                se_fit = np.sqrt(np.maximum(
+                    sigma2 * np.einsum("ij,jk,ik->i", grid_design, xtx_inv,
+                                       grid_design), 0.0))
+                t = stats.t.ppf(0.5 + ci / 2, dof)
+                ax.fill_between(grid, fitted - t * se_fit, fitted + t * se_fit,
+                                color=colour, alpha=band_alpha, linewidth=0,
+                                zorder=1)
+        value, pvalue, symbol = _correlation(xs, ys, corr)
+        entry.update(correlation=value, pvalue=pvalue)
+        results[hue_level] = entry
+
+    if annotate and len(hues) == 1 and hues[0] is None and results:
+        entry = results[None]
+        lines = []
+        if "slope" in entry:
+            lines.append(f"slope = {entry['slope']:.3g}")
+        if "r_squared" in entry:
+            lines.append(f"$R^2$ = {entry['r_squared']:.3f}")
+        if "correlation" in entry:
+            from ._stats_tests import format_pvalue
+
+            lines.append(f"{corr} = {entry['correlation']:.3f}")
+            lines.append(format_pvalue(entry["pvalue"], "value"))
+        if lines:
+            ax.text(0.03, 0.97, "\n".join(lines), transform=ax.transAxes,
+                    va="top", ha="left", fontsize=fontsize)
+
+    ax.set_xlabel(xlabel if xlabel is not None else names.get("x", ""),
+                  fontsize=fontsize + 1)
+    ax.set_ylabel(ylabel if ylabel is not None else names.get("y", ""),
+                  fontsize=fontsize + 1)
+    if title:
+        ax.set_title(title, fontsize=fontsize + 2)
+    ax.tick_params(labelsize=fontsize)
+    ax.spines[["right", "top"]].set_visible(False)
+    if legend and len(hues) > 1:
+        ax.legend(title=legend_title or names.get("hue"), frameon=False,
+                  fontsize=fontsize, title_fontsize=fontsize)
+    return (ax, results) if return_stats else ax

--- a/omicverse/pl/_single.py
+++ b/omicverse/pl/_single.py
@@ -1,5 +1,6 @@
 from ._scatterplot_backend import _embedding
 from .._registry import register_function
+from ._plotdata import accepts_frame
 import collections.abc as cabc
 from copy import copy
 from numbers import Integral
@@ -365,6 +366,7 @@ def embedding(
     ],
     related=["pl.embedding", "tl.leiden"]
 )
+@accepts_frame
 def cellproportion(adata:AnnData,celltype_clusters:str,groupby:str,
                        groupby_li=None,figsize:tuple=(4,6),
                        ticks_fontsize:int=12,labels_fontsize:int=12,ax=None,
@@ -1467,6 +1469,7 @@ def plot_boxplots(  # pragma: no cover
             return None
         
 
+@accepts_frame
 def cellstackarea(adata,celltype_clusters:str,groupby:str,
                        groupby_li=None,figsize:tuple=(4,6),
                        ticks_fontsize:int=12,labels_fontsize:int=12,ax=None,

--- a/omicverse/pl/_stats_common.py
+++ b/omicverse/pl/_stats_common.py
@@ -21,7 +21,7 @@ from typing import Any, Dict, Mapping, Optional, Tuple
 import numpy as np
 import pandas as pd
 
-__all__ = ["as_frame", "group_levels", "resolve_columns"]
+__all__ = ["as_frame", "default_palette", "group_levels", "resolve_columns"]
 
 
 def as_frame(data: Any) -> Optional[pd.DataFrame]:
@@ -112,6 +112,15 @@ def resolve_columns(data: Any = None,
     one was given), suitable for axis labels.
     """
     frame = as_frame(data)
+    # With an AnnData the name may be a gene rather than an obs column, so
+    # resolve through PlotData, which checks metadata first and features next.
+    getter = None
+    if (data is not None and not isinstance(data, (pd.DataFrame, Mapping))
+            and hasattr(data, "var_names")):
+        from ._plotdata import as_plotdata
+
+        getter = as_plotdata(data).values
+
     columns: Dict[str, np.ndarray] = {}
     names: Dict[str, str] = {}
 
@@ -125,7 +134,10 @@ def resolve_columns(data: Any = None,
                     f"as the first argument. Either pass a DataFrame/AnnData, "
                     f"or give `{key}` as an array of values."
                 )
-            columns[key] = _lookup(frame, spec, key)
+            if getter is not None and spec not in frame.columns:
+                columns[key] = getter(spec)
+            else:
+                columns[key] = _lookup(frame, spec, key)
             names[key] = spec
         elif isinstance(spec, pd.Series):
             columns[key] = spec.reset_index(drop=True)
@@ -155,3 +167,23 @@ def resolve_columns(data: Any = None,
             out.attrs["n_dropped"] = before - len(out)
     out = out.reset_index(drop=True)
     return out, names
+
+
+def default_palette(n: int, palette: Any = None) -> list:
+    """``n`` distinct colours: the ov palette, a named colormap, or a list."""
+    import matplotlib.pyplot as plt
+
+    if palette is None:
+        from ._palette import sc_color
+
+        base = list(sc_color)
+    elif isinstance(palette, str):
+        cmap = plt.get_cmap(palette)
+        base = [cmap(i / max(n - 1, 1)) for i in range(n)]
+    else:
+        base = list(palette)
+    if not base:
+        raise ValueError("`palette` is empty.")
+    if len(base) < n:
+        base = (base * (n // len(base) + 1))[:n]
+    return base[:n]

--- a/omicverse/pl/_stats_tests.py
+++ b/omicverse/pl/_stats_tests.py
@@ -1,0 +1,436 @@
+r"""Group comparisons and the brackets that report them.
+
+``ov.pl.add_palue`` can draw a significance bracket, but the caller has to
+supply the coordinates *and* run the test. That is where hand-annotated
+figures go wrong: the bracket ends up over the wrong pair, or the P value is
+uncorrected, or the test does not match what the plot shows.
+
+:func:`compare_groups` runs the comparison and returns a tidy table;
+:func:`add_stat_annotation` takes that table (or computes it) and draws the
+brackets at heights that do not collide. Every categorical plot in ``ov.pl``
+accepts ``test=`` and routes through here, so the annotation and the numbers
+can never drift apart.
+"""
+
+from __future__ import annotations
+
+import itertools
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple, Union
+
+import numpy as np
+import pandas as pd
+
+from .._registry import register_function
+from ._stats_common import group_levels
+
+__all__ = ["compare_groups", "format_pvalue", "add_stat_annotation"]
+
+
+#: Tests that compare the *distributions* of a continuous variable.
+_CONTINUOUS_TESTS = {
+    "mannwhitney", "mannwhitneyu", "ttest", "welch", "ttest_ind",
+    "wilcoxon", "ttest_rel", "kruskal", "anova", "brunnermunzel",
+}
+#: Tests on a contingency table of counts.
+_CATEGORICAL_TESTS = {"fisher", "chi2"}
+
+_STAR_CUTOFFS = ((1e-4, "****"), (1e-3, "***"), (1e-2, "**"), (0.05, "*"))
+
+
+def format_pvalue(p: float, style: str = "star") -> str:
+    """Render a P value as stars, as a number, or as both.
+
+    ``style`` is ``'star'`` (``***``), ``'value'`` (``P = 3.2e-05``),
+    ``'full'`` (``*** (P = 3.2e-05)``) or ``'compact'`` (``3.2e-05``).
+    """
+    if not np.isfinite(p):
+        return "n/a"
+    stars = "ns"
+    for cutoff, symbol in _STAR_CUTOFFS:
+        if p < cutoff:
+            stars = symbol
+            break
+    if style == "star":
+        return stars
+    if p < 1e-4:
+        text = f"{p:.1e}"
+    elif p < 0.001:
+        text = f"{p:.2e}"
+    else:
+        text = f"{p:.3g}"
+    if style == "compact":
+        return text
+    if style == "value":
+        return f"P = {text}"
+    if style == "full":
+        return f"{stars} (P = {text})"
+    raise ValueError(
+        f"`style` must be 'star', 'value', 'full' or 'compact', got {style!r}."
+    )
+
+
+def _run_test(a: np.ndarray, b: np.ndarray, name: str) -> Tuple[float, float, str]:
+    from scipy import stats
+
+    if name in {"mannwhitney", "mannwhitneyu"}:
+        res = stats.mannwhitneyu(a, b, alternative="two-sided")
+        return float(res.statistic), float(res.pvalue), "Mann-Whitney U"
+    if name in {"welch"}:
+        res = stats.ttest_ind(a, b, equal_var=False)
+        return float(res.statistic), float(res.pvalue), "Welch's t-test"
+    if name in {"ttest", "ttest_ind"}:
+        res = stats.ttest_ind(a, b, equal_var=True)
+        return float(res.statistic), float(res.pvalue), "Student's t-test"
+    if name == "brunnermunzel":
+        res = stats.brunnermunzel(a, b)
+        return float(res.statistic), float(res.pvalue), "Brunner-Munzel"
+    if name in {"wilcoxon", "ttest_rel"}:
+        if len(a) != len(b):
+            raise ValueError(
+                f"A paired test needs equal group sizes, got {len(a)} and "
+                f"{len(b)}. Reshape to one row per pair, or use an unpaired "
+                f"test."
+            )
+        if name == "wilcoxon":
+            res = stats.wilcoxon(a, b)
+            return float(res.statistic), float(res.pvalue), "Wilcoxon signed-rank"
+        res = stats.ttest_rel(a, b)
+        return float(res.statistic), float(res.pvalue), "Paired t-test"
+    raise ValueError(f"Unknown pairwise test {name!r}.")
+
+
+def _omnibus(samples: List[np.ndarray], name: str) -> Tuple[float, float, str]:
+    from scipy import stats
+
+    if name == "kruskal":
+        res = stats.kruskal(*samples)
+        return float(res.statistic), float(res.pvalue), "Kruskal-Wallis"
+    if name == "anova":
+        res = stats.f_oneway(*samples)
+        return float(res.statistic), float(res.pvalue), "One-way ANOVA"
+    raise ValueError(f"Unknown omnibus test {name!r}.")
+
+
+def _correct(pvalues: Sequence[float], method: Optional[str]) -> np.ndarray:
+    values = np.asarray(pvalues, dtype=float)
+    if method in (None, "none") or values.size <= 1:
+        return values
+    aliases = {"holm": "holm", "bonferroni": "bonferroni", "bh": "fdr_bh",
+               "fdr_bh": "fdr_bh", "by": "fdr_by", "fdr_by": "fdr_by"}
+    if method not in aliases:
+        raise ValueError(
+            f"`correction` must be one of {sorted(aliases)} or None, got "
+            f"{method!r}."
+        )
+    from statsmodels.stats.multitest import multipletests
+
+    finite = np.isfinite(values)
+    out = values.copy()
+    if finite.any():
+        out[finite] = multipletests(values[finite], method=aliases[method])[1]
+    return out
+
+
+@register_function(
+    aliases=["组间比较", "compare_groups", "统计检验", "significance_test",
+             "pairwise_test", "显著性检验"],
+    category="pl",
+    description=(
+        "Run pairwise (and omnibus) group comparisons with automatic test "
+        "selection and multiple-testing correction, returning a tidy table"
+    ),
+    examples=[
+        "# Two groups -> Mann-Whitney by default",
+        "stats = ov.pl.compare_groups(df, 'expression', 'condition')",
+        "# More than two -> Kruskal-Wallis omnibus plus corrected pairwise",
+        "stats = ov.pl.compare_groups(df, 'score', 'cell_type', correction='holm')",
+        "# Only the comparisons you care about",
+        "stats = ov.pl.compare_groups(df, 'score', 'arm',",
+        "                             pairs=[('drug', 'vehicle')], test='welch')",
+    ],
+    related=["pl.add_stat_annotation", "pl.violinplot", "pl.barplot", "pl.stripplot"],
+)
+def compare_groups(data: Any = None,
+                   value: Any = None,
+                   group: Any = None,
+                   *,
+                   groups: Optional[Sequence[Any]] = None,
+                   pairs: Optional[Sequence[Tuple[Any, Any]]] = None,
+                   test: str = "auto",
+                   correction: Optional[str] = "holm",
+                   omnibus: bool = True,
+                   min_size: int = 2) -> pd.DataFrame:
+    r"""Compare a continuous variable across groups.
+
+    Arguments
+    ---------
+    data
+        ``DataFrame``, ``dict``, ``AnnData`` (uses ``.obs``), or ``None`` when
+        ``value``/``group`` are arrays.
+    value
+        Column name or array of the measured quantity.
+    group
+        Column name or array of group labels.
+    groups
+        Explicit level order; also restricts the comparison to those levels.
+    pairs
+        Which comparisons to run, e.g. ``[('a', 'b'), ('a', 'c')]``. Defaults
+        to every pair, which is why the correction matters.
+    test
+        ``'auto'`` (default) uses Mann-Whitney U — it makes no normality
+        assumption and expression-like data is rarely normal. Others:
+        ``'welch'``, ``'ttest'``, ``'brunnermunzel'``, and for paired designs
+        ``'wilcoxon'`` / ``'ttest_rel'``.
+    correction
+        ``'holm'`` (default), ``'bonferroni'``, ``'bh'``, ``'by'``, or ``None``.
+        Applied across the pairwise tests only.
+    omnibus
+        With three or more groups, also run a Kruskal-Wallis test over all of
+        them and include it as a row named ``('*', '*')``.
+    min_size
+        Groups smaller than this are dropped, with a message.
+
+    Returns
+    -------
+    ``DataFrame`` with one row per comparison: ``group1``, ``group2``, ``n1``,
+    ``n2``, ``statistic``, ``pvalue``, ``pvalue_corrected``, ``test``.
+    """
+    from ._stats_common import resolve_columns
+
+    if data is not None and value is not None and group is None:
+        from ._stats_common import as_frame
+
+        if as_frame(data) is None:
+            data, value, group = None, data, value
+
+    frame, _ = resolve_columns(data, value=value, group=group,
+                               require=("value", "group"))
+    values = frame["value"].to_numpy(dtype=float)
+    levels = group_levels(frame["group"], groups)
+
+    samples: Dict[Any, np.ndarray] = {}
+    dropped = []
+    for level in levels:
+        sample = values[frame["group"].to_numpy() == level]
+        if sample.size < min_size:
+            dropped.append((level, sample.size))
+            continue
+        samples[level] = sample
+    if dropped:
+        detail = ", ".join(f"{lv} (n={n})" for lv, n in dropped)
+        print(f"compare_groups: skipped groups smaller than {min_size}: {detail}")
+    if len(samples) < 2:
+        raise ValueError(
+            f"Need at least two groups with >= {min_size} observations; found "
+            f"{len(samples)}."
+        )
+
+    kept = [lv for lv in levels if lv in samples]
+    if pairs is None:
+        pairs = list(itertools.combinations(kept, 2))
+    else:
+        pairs = [tuple(p) for p in pairs]
+        unknown = {lv for p in pairs for lv in p} - set(samples)
+        if unknown:
+            raise ValueError(
+                f"`pairs` names groups that are absent or too small: "
+                f"{sorted(map(str, unknown))}. Available: {list(map(str, kept))}."
+            )
+
+    pairwise = "mannwhitney" if test == "auto" else test
+    records = []
+    for left, right in pairs:
+        statistic, pvalue, label = _run_test(samples[left], samples[right],
+                                             pairwise)
+        records.append({"group1": left, "group2": right,
+                        "n1": samples[left].size, "n2": samples[right].size,
+                        "statistic": statistic, "pvalue": pvalue,
+                        "test": label})
+    result = pd.DataFrame.from_records(records)
+    result["pvalue_corrected"] = _correct(result["pvalue"], correction)
+    result.attrs["correction"] = correction or "none"
+
+    if omnibus and len(kept) > 2:
+        name = "anova" if pairwise in {"ttest", "welch", "ttest_rel"} else "kruskal"
+        statistic, pvalue, label = _omnibus([samples[lv] for lv in kept], name)
+        overall = pd.DataFrame([{
+            "group1": "*", "group2": "*", "n1": len(values), "n2": len(kept),
+            "statistic": statistic, "pvalue": pvalue,
+            "pvalue_corrected": pvalue, "test": label,
+        }])
+        result = pd.concat([overall, result], ignore_index=True)
+    return result[["group1", "group2", "n1", "n2", "statistic", "pvalue",
+                   "pvalue_corrected", "test"]]
+
+
+def _bracket_levels(pairs: Sequence[Tuple[float, float]]) -> List[int]:
+    """Assign each bracket the lowest tier where it does not overlap."""
+    tiers: List[List[Tuple[float, float]]] = []
+    out = []
+    for left, right in pairs:
+        lo, hi = min(left, right), max(left, right)
+        for index, tier in enumerate(tiers):
+            if all(hi < a or lo > b for a, b in tier):
+                tier.append((lo, hi))
+                out.append(index)
+                break
+        else:
+            tiers.append([(lo, hi)])
+            out.append(len(tiers) - 1)
+    return out
+
+
+@register_function(
+    aliases=["显著性标注", "add_stat_annotation", "significance_brackets",
+             "统计括号", "star_annotation"],
+    category="pl",
+    description=(
+        "Draw significance brackets on a categorical plot, running the test "
+        "and stacking the brackets so they never overlap"
+    ),
+    examples=[
+        "ax = ov.pl.violinplot(df, 'cell_type', 'score')",
+        "ov.pl.add_stat_annotation(ax, df, 'score', 'cell_type')",
+        "# Only some comparisons, showing the P value rather than stars",
+        "ov.pl.add_stat_annotation(ax, df, 'score', 'arm',",
+        "                          pairs=[('drug', 'vehicle')], style='full')",
+        "# Reuse a table you already computed",
+        "res = ov.pl.compare_groups(df, 'score', 'arm')",
+        "ov.pl.add_stat_annotation(ax, results=res, order=['vehicle', 'drug'])",
+    ],
+    related=["pl.compare_groups", "pl.violinplot", "pl.barplot", "pl.add_palue"],
+)
+def add_stat_annotation(ax,
+                        data: Any = None,
+                        value: Any = None,
+                        group: Any = None,
+                        *,
+                        results: Optional[pd.DataFrame] = None,
+                        order: Optional[Sequence[Any]] = None,
+                        pairs: Optional[Sequence[Tuple[Any, Any]]] = None,
+                        test: str = "auto",
+                        correction: Optional[str] = "holm",
+                        style: str = "star",
+                        hide_ns: bool = False,
+                        use_corrected: bool = True,
+                        orient: str = "v",
+                        line_offset: float = 0.06,
+                        line_height: float = 0.05,
+                        text_offset: float = 0.008,
+                        linewidth: float = 1.0,
+                        color: str = "black",
+                        fontsize: float = 9,
+                        return_stats: bool = False):
+    r"""Annotate an existing categorical axes with significance brackets.
+
+    Arguments
+    ---------
+    ax
+        The axes to annotate. Category positions are read from its tick
+        locations, so this works on any categorical plot — including the
+        ``ov.pl`` ones and hand-drawn matplotlib.
+    data, value, group
+        Passed to :func:`compare_groups` when ``results`` is not given.
+    results
+        A table from :func:`compare_groups`, if the comparison is already done.
+    order
+        Category order along the axis. Defaults to the axis tick labels, which
+        is what the plot actually drew.
+    style
+        ``'star'``, ``'value'``, ``'full'`` or ``'compact'`` — see
+        :func:`format_pvalue`.
+    hide_ns
+        Skip brackets for non-significant comparisons instead of writing "ns".
+    use_corrected
+        Annotate the multiplicity-corrected P value. Leaving this on is the
+        honest default when every pair is tested.
+    orient
+        ``'v'`` for categories on the x-axis (default), ``'h'`` for the y-axis.
+    line_offset, line_height, text_offset
+        Geometry in axis fractions: gap above the data before the first tier,
+        height of each tier, and the gap between bracket and text.
+    return_stats
+        Also return the results table.
+
+    Returns
+    -------
+    ``ax``, or ``(ax, results)`` when ``return_stats=True``.
+    """
+    if results is None:
+        if value is None or group is None:
+            raise TypeError(
+                "Give either `results=` from compare_groups(), or "
+                "`data`/`value`/`group` so the test can be run here."
+            )
+        results = compare_groups(data, value, group, pairs=pairs, test=test,
+                                 correction=correction,
+                                 groups=list(order) if order else None)
+
+    if order is None:
+        labels = [t.get_text() for t in
+                  (ax.get_xticklabels() if orient == "v" else ax.get_yticklabels())]
+        ticks = list(ax.get_xticks() if orient == "v" else ax.get_yticks())
+        order = labels
+        positions = {label: tick for label, tick in zip(labels, ticks) if label}
+    else:
+        positions = {str(level): float(i) for i, level in enumerate(order)}
+    if not positions:
+        raise ValueError(
+            "Could not read category positions from the axes — pass `order=` "
+            "with the categories in the order they were plotted."
+        )
+
+    column = "pvalue_corrected" if use_corrected else "pvalue"
+    rows = results[(results["group1"] != "*")].copy()
+    keep = []
+    for _, row in rows.iterrows():
+        left, right = str(row["group1"]), str(row["group2"])
+        if left not in positions or right not in positions:
+            continue
+        if hide_ns and row[column] >= 0.05:
+            continue
+        keep.append((positions[left], positions[right], row[column]))
+    if not keep:
+        return (ax, results) if return_stats else ax
+
+    tiers = _bracket_levels([(a, b) for a, b, _ in keep])
+    lo, hi = (ax.get_ylim() if orient == "v" else ax.get_xlim())
+    span = hi - lo
+    top = max(
+        (max(np.max(line.get_ydata() if orient == "v" else line.get_xdata())
+             for line in ax.get_lines()) if ax.get_lines() else lo),
+        lo,
+    )
+    base = max(top, lo + 0.5 * span)
+    base = min(base, hi)
+
+    transform = ax.transData
+    reached = base
+    for (left, right, pvalue), tier in zip(keep, tiers):
+        level = base + span * (line_offset + tier * line_height)
+        cap = span * line_height * 0.25
+        text = format_pvalue(pvalue, style)
+        if orient == "v":
+            ax.plot([left, left, right, right],
+                    [level - cap, level, level, level - cap],
+                    linewidth=linewidth, color=color, clip_on=False,
+                    transform=transform, solid_joinstyle="miter")
+            ax.text((left + right) / 2, level + span * text_offset, text,
+                    ha="center", va="bottom", fontsize=fontsize, color=color,
+                    clip_on=False)
+        else:
+            ax.plot([level - cap, level, level, level - cap],
+                    [left, left, right, right],
+                    linewidth=linewidth, color=color, clip_on=False,
+                    transform=transform, solid_joinstyle="miter")
+            ax.text(level + span * text_offset, (left + right) / 2, text,
+                    ha="left", va="center", fontsize=fontsize, color=color,
+                    rotation=270, clip_on=False)
+        reached = max(reached, level + span * (text_offset + line_height * 0.6))
+
+    # make room for the brackets rather than letting them run off the axes
+    if orient == "v":
+        ax.set_ylim(lo, max(hi, reached))
+    else:
+        ax.set_xlim(lo, max(hi, reached))
+    return (ax, results) if return_stats else ax

--- a/omicverse/pl/_survival.py
+++ b/omicverse/pl/_survival.py
@@ -26,7 +26,8 @@ import numpy as np
 import pandas as pd
 
 from .._registry import register_function
-from ._stats_common import as_frame, group_levels, resolve_columns
+from ._stats_common import (as_frame, default_palette, group_levels,
+                            resolve_columns)
 
 __all__ = [
     "kaplan_meier",
@@ -483,19 +484,8 @@ def grays_test(time: Sequence[float],
 # --------------------------------------------------------------------------
 
 
-def _default_palette(n: int, palette=None) -> List[str]:
-    if palette is None:
-        from ._palette import sc_color
-
-        base = list(sc_color)
-    elif isinstance(palette, str):
-        cmap = plt.get_cmap(palette)
-        base = [cmap(i / max(n - 1, 1)) for i in range(n)]
-    else:
-        base = list(palette)
-    if len(base) < n:
-        base = (base * (n // len(base) + 1))[:n]
-    return base[:n]
+#: kept as a private alias — several modules import it from here
+_default_palette = default_palette
 
 
 def _format_p(p: float) -> str:

--- a/tests/pl/test_generic_plots.py
+++ b/tests/pl/test_generic_plots.py
@@ -1,0 +1,722 @@
+"""Tests for the generic (table-first) plot layer and the AnnData adapter.
+
+Three things are checked.
+
+1. **The numbers behind the picture.** Every plot that computes something —
+   a group comparison, a bar height, a regression slope, a density, a
+   genomic-inflation factor — is checked against ``scipy`` / ``statsmodels`` /
+   plain NumPy on the same data. A plot that draws the wrong number is worse
+   than no plot.
+
+2. **The contract.** Data-first means a DataFrame, bare arrays and an
+   ``AnnData`` are interchangeable and give identical results, and that bad
+   input produces an error naming the problem.
+
+3. **The adapter.** ``as_plotdata`` resolves keys the same way whatever the
+   container, and ``accepts_frame`` lets an ``AnnData``-shaped plot take a
+   table without mutating the caller's frame.
+"""
+from __future__ import annotations
+
+import matplotlib
+import numpy as np
+import pandas as pd
+import pytest
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt  # noqa: E402
+
+from omicverse.pl._categorical import (  # noqa: E402
+    barplot, donutplot, lollipopplot, pieplot, slopeplot, stackplot,
+    stripplot, violinplot,
+)
+from omicverse.pl._distribution import histplot, kdeplot, qqplot, ridgeplot  # noqa: E402
+from omicverse.pl._plotdata import (  # noqa: E402
+    ObsView, PlotData, accepts_frame, as_plotdata,
+)
+from omicverse.pl._relational import lineplot, regplot, scatterplot  # noqa: E402
+from omicverse.pl._stats_tests import (  # noqa: E402
+    add_stat_annotation, compare_groups, format_pvalue,
+)
+
+
+@pytest.fixture
+def cells():
+    """A small per-cell table: four types, two conditions, two measurements."""
+    rng = np.random.default_rng(20260727)
+    n = 320
+    cell_type = rng.choice(["B", "Mono", "NK", "T"], n, p=[0.25, 0.2, 0.15, 0.4])
+    condition = rng.choice(["ctrl", "drug"], n)
+    shift = np.select([cell_type == "T", cell_type == "NK"], [1.2, 0.4], 0.0)
+    return pd.DataFrame({
+        "cell_type": cell_type,
+        "condition": condition,
+        "score": rng.normal(shift + (condition == "drug") * 0.5, 1.0),
+        "counts": rng.lognormal(8.0, 0.6, n),
+        "sample": rng.choice([f"S{i}" for i in range(5)], n),
+    })
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+# --------------------------------------------------------------------------
+# group comparisons
+# --------------------------------------------------------------------------
+
+
+class TestCompareGroups:
+    def test_two_group_pvalue_matches_scipy(self, cells):
+        from scipy import stats
+
+        subset = cells[cells["cell_type"].isin(["B", "T"])]
+        result = compare_groups(subset, "score", "cell_type")
+        a = subset.loc[subset["cell_type"] == "B", "score"]
+        b = subset.loc[subset["cell_type"] == "T", "score"]
+        expected = stats.mannwhitneyu(a, b, alternative="two-sided")
+        assert result.loc[0, "statistic"] == pytest.approx(expected.statistic)
+        assert result.loc[0, "pvalue"] == pytest.approx(expected.pvalue)
+        assert result.loc[0, "test"] == "Mann-Whitney U"
+
+    def test_named_tests_match_scipy(self, cells):
+        from scipy import stats
+
+        subset = cells[cells["cell_type"].isin(["B", "T"])]
+        a = subset.loc[subset["cell_type"] == "B", "score"].to_numpy()
+        b = subset.loc[subset["cell_type"] == "T", "score"].to_numpy()
+        cases = {
+            "welch": stats.ttest_ind(a, b, equal_var=False).pvalue,
+            "ttest": stats.ttest_ind(a, b, equal_var=True).pvalue,
+            "brunnermunzel": stats.brunnermunzel(a, b).pvalue,
+        }
+        for name, expected in cases.items():
+            got = compare_groups(subset, "score", "cell_type", test=name)
+            assert got.loc[0, "pvalue"] == pytest.approx(expected), name
+
+    def test_omnibus_matches_scipy(self, cells):
+        from scipy import stats
+
+        result = compare_groups(cells, "score", "cell_type")
+        overall = result[result["group1"] == "*"].iloc[0]
+        samples = [g["score"].to_numpy()
+                   for _, g in cells.groupby("cell_type", observed=True)]
+        expected = stats.kruskal(*samples)
+        assert overall["statistic"] == pytest.approx(expected.statistic)
+        assert overall["pvalue"] == pytest.approx(expected.pvalue)
+        assert overall["test"] == "Kruskal-Wallis"
+
+    def test_anova_omnibus_follows_a_parametric_pairwise(self, cells):
+        result = compare_groups(cells, "score", "cell_type", test="welch")
+        assert result.iloc[0]["test"] == "One-way ANOVA"
+
+    def test_holm_correction_matches_statsmodels(self, cells):
+        from statsmodels.stats.multitest import multipletests
+
+        result = compare_groups(cells, "score", "cell_type", omnibus=False)
+        expected = multipletests(result["pvalue"], method="holm")[1]
+        assert np.allclose(result["pvalue_corrected"], expected)
+
+    def test_correction_can_be_switched_off(self, cells):
+        result = compare_groups(cells, "score", "cell_type", correction=None,
+                                omnibus=False)
+        assert np.allclose(result["pvalue"], result["pvalue_corrected"])
+
+    def test_all_pairs_are_covered(self, cells):
+        result = compare_groups(cells, "score", "cell_type", omnibus=False)
+        assert len(result) == 6  # 4 choose 2
+        assert list(result["group1"])[:3] == ["B", "B", "B"]
+
+    def test_pairs_restricts_the_comparisons(self, cells):
+        result = compare_groups(cells, "score", "cell_type",
+                                pairs=[("B", "T")], omnibus=False)
+        assert len(result) == 1
+        assert (result.loc[0, "group1"], result.loc[0, "group2"]) == ("B", "T")
+
+    def test_unknown_pair_is_reported(self, cells):
+        with pytest.raises(ValueError, match="absent or too small"):
+            compare_groups(cells, "score", "cell_type", pairs=[("B", "ghost")])
+
+    def test_tiny_groups_are_dropped_and_announced(self, capsys):
+        frame = pd.DataFrame({"g": ["a"] * 10 + ["b"] * 10 + ["c"],
+                              "v": np.arange(21.0)})
+        result = compare_groups(frame, "v", "g", omnibus=False)
+        assert "skipped groups smaller than 2" in capsys.readouterr().out
+        assert set(result["group1"]) == {"a"}
+
+    def test_paired_test_needs_equal_sizes(self):
+        frame = pd.DataFrame({"g": ["a"] * 5 + ["b"] * 4, "v": np.arange(9.0)})
+        with pytest.raises(ValueError, match="equal group sizes"):
+            compare_groups(frame, "v", "g", test="wilcoxon")
+
+    def test_group_order_is_deterministic(self, cells):
+        shuffled = cells.iloc[::-1].reset_index(drop=True)
+        a = compare_groups(cells, "score", "cell_type", omnibus=False)
+        b = compare_groups(shuffled, "score", "cell_type", omnibus=False)
+        assert list(a["group1"]) == list(b["group1"])
+        assert np.allclose(a["pvalue"], b["pvalue"])
+
+
+class TestFormatPvalue:
+    @pytest.mark.parametrize("p,expected", [
+        (1e-6, "****"), (5e-4, "***"), (5e-3, "**"), (0.03, "*"), (0.4, "ns"),
+    ])
+    def test_star_cutoffs(self, p, expected):
+        assert format_pvalue(p, "star") == expected
+
+    def test_styles(self):
+        assert format_pvalue(0.03, "value").startswith("P = ")
+        assert format_pvalue(0.03, "full").startswith("* (P = ")
+        assert format_pvalue(0.03, "compact") == "0.03"
+
+    def test_unknown_style_is_reported(self):
+        with pytest.raises(ValueError, match="style"):
+            format_pvalue(0.01, "emoji")
+
+
+class TestAnnotation:
+    def test_brackets_are_drawn_and_room_is_made(self, cells):
+        ax = violinplot(cells, "cell_type", "score")
+        before = ax.get_ylim()[1]
+        add_stat_annotation(ax, cells, "score", "cell_type")
+        assert ax.get_ylim()[1] > before
+        assert any(t.get_text() in {"*", "**", "***", "****", "ns"}
+                   for t in ax.texts)
+
+    def test_hide_ns_drops_the_uninteresting_ones(self, cells):
+        ax = violinplot(cells, "cell_type", "score")
+        add_stat_annotation(ax, cells, "score", "cell_type", hide_ns=True)
+        assert all(t.get_text() != "ns" for t in ax.texts)
+
+    def test_brackets_do_not_overlap(self, cells):
+        """Every pair on the same tier must be disjoint along the category axis."""
+        from omicverse.pl._stats_tests import _bracket_levels
+
+        pairs = [(0, 1), (1, 2), (0, 2), (2, 3)]
+        tiers = _bracket_levels(pairs)
+        by_tier = {}
+        for (lo, hi), tier in zip(pairs, tiers):
+            for other_lo, other_hi in by_tier.setdefault(tier, []):
+                assert hi < other_lo or lo > other_hi
+            by_tier[tier].append((lo, hi))
+
+    def test_reusing_a_results_table(self, cells):
+        results = compare_groups(cells, "score", "cell_type")
+        ax = violinplot(cells, "cell_type", "score")
+        _, echoed = add_stat_annotation(ax, results=results, return_stats=True)
+        assert echoed is results
+
+    def test_needs_either_results_or_data(self, cells):
+        ax = violinplot(cells, "cell_type", "score")
+        with pytest.raises(TypeError, match="compare_groups"):
+            add_stat_annotation(ax)
+
+
+# --------------------------------------------------------------------------
+# categorical plots
+# --------------------------------------------------------------------------
+
+
+class TestCategorical:
+    def test_bar_heights_are_the_requested_statistic(self, cells):
+        _, stats = barplot(cells, "cell_type", "score", estimator="median",
+                           errorbar=None, return_stats=True)
+        expected = cells.groupby("cell_type", observed=True)["score"].median()
+        got = stats["summary"].set_index("x")["median"]
+        assert np.allclose(got.reindex(expected.index), expected)
+
+    def test_standard_error_is_the_standard_error(self, cells):
+        _, stats = barplot(cells, "cell_type", "score", errorbar="se",
+                           return_stats=True)
+        row = stats["summary"].iloc[0]
+        sample = cells.loc[cells["cell_type"] == row["x"], "score"]
+        assert row["err_low"] == pytest.approx(
+            sample.std(ddof=1) / np.sqrt(len(sample)))
+
+    def test_unknown_estimator_is_reported(self, cells):
+        with pytest.raises(ValueError, match="estimator"):
+            barplot(cells, "cell_type", "score", estimator="mode")
+
+    def test_unknown_errorbar_is_reported(self, cells):
+        with pytest.raises(ValueError, match="errorbar"):
+            barplot(cells, "cell_type", "score", errorbar="stderr")
+
+    def test_test_is_skipped_with_hue_and_says_so(self, cells, capsys):
+        barplot(cells, "cell_type", "score", hue="condition", test="auto")
+        assert "ignored when `hue` is set" in capsys.readouterr().out
+
+    def test_strip_draws_every_observation(self, cells):
+        ax = stripplot(cells, "cell_type", "score", summary=None)
+        drawn = sum(coll.get_offsets().shape[0] for coll in ax.collections)
+        assert drawn == len(cells)
+
+    def test_violin_split_needs_two_hue_levels(self, cells):
+        with pytest.raises(ValueError, match="exactly two hue levels"):
+            violinplot(cells, "cell_type", "score", hue="sample", split=True)
+
+    def test_violin_inner_options(self, cells):
+        for inner in ("box", "point", "stick", None):
+            assert violinplot(cells, "cell_type", "score", inner=inner) is not None
+            plt.close("all")
+        with pytest.raises(ValueError, match="inner"):
+            violinplot(cells, "cell_type", "score", inner="beeswarm")
+
+    def test_stack_rows_sum_to_one(self, cells):
+        _, matrix = stackplot(cells, "sample", hue="cell_type",
+                              return_stats=True)
+        assert np.allclose(matrix.sum(axis=1), 1.0)
+
+    def test_stack_counts_match_a_crosstab(self, cells):
+        _, matrix = stackplot(cells, "sample", hue="cell_type",
+                              normalize=False, return_stats=True)
+        expected = pd.crosstab(cells["sample"], cells["cell_type"])
+        assert np.allclose(matrix.to_numpy(),
+                           expected.reindex(index=matrix.index,
+                                            columns=matrix.columns).to_numpy())
+
+    def test_stack_needs_hue(self, cells):
+        with pytest.raises(TypeError, match="`hue` is required"):
+            stackplot(cells, "sample")
+
+    def test_lollipop_top_n_is_announced(self, capsys):
+        frame = pd.DataFrame({"label": list("abcdefghij"),
+                              "value": np.arange(10.0)})
+        _, table = lollipopplot(frame, "label", "value", top_n=3,
+                                return_stats=True)
+        assert "showing the 3 largest of 10" in capsys.readouterr().out
+        assert len(table) == 3
+
+    def test_lollipop_sorting(self):
+        frame = pd.DataFrame({"label": ["c", "a", "b"], "value": [3.0, 1.0, 2.0]})
+        _, table = lollipopplot(frame, "label", "value", return_stats=True)
+        assert list(table["value"]) == [1.0, 2.0, 3.0]
+
+    def test_pie_shares_sum_to_one(self, cells):
+        _, shares = pieplot(cells, "cell_type", return_stats=True)
+        assert shares.sum() == pytest.approx(1.0)
+        assert shares.max() == pytest.approx(
+            cells["cell_type"].value_counts(normalize=True).max())
+
+    def test_donut_is_a_pie_with_a_hole(self, cells):
+        ax = donutplot(cells, "cell_type")
+        widths = {w.r - w.width for w in ax.patches if hasattr(w, "width")}
+        assert widths and max(widths) > 0
+
+    def test_slope_paired_test_matches_scipy(self):
+        from scipy import stats
+
+        rng = np.random.default_rng(3)
+        pre = rng.normal(5, 1.2, 20)
+        post = pre + rng.normal(0.6, 0.7, 20)
+        frame = pd.DataFrame({
+            "patient": np.repeat([f"P{i}" for i in range(20)], 2),
+            "time": np.tile(["pre", "post"], 20),
+            "value": np.ravel(np.column_stack([pre, post])),
+        })
+        _, stats_out = slopeplot(frame, "time", "value", subject="patient",
+                                 order=["pre", "post"], test="wilcoxon",
+                                 return_stats=True)
+        expected = stats.wilcoxon(pre, post)
+        assert stats_out["pvalue"] == pytest.approx(expected.pvalue)
+        assert stats_out["n_complete"] == 20
+
+    def test_slope_reports_excluded_subjects(self, capsys):
+        frame = pd.DataFrame({
+            "patient": ["a", "a", "b", "c", "c"],
+            "time": ["pre", "post", "pre", "pre", "post"],
+            "value": [1.0, 2.0, 3.0, 4.0, 5.0],
+        })
+        slopeplot(frame, "time", "value", subject="patient",
+                  order=["pre", "post"], test="wilcoxon")
+        assert "1 subject(s) lack" in capsys.readouterr().out
+
+    def test_slope_needs_a_subject(self):
+        frame = pd.DataFrame({"time": ["pre", "post"], "value": [1.0, 2.0]})
+        with pytest.raises(TypeError, match="`subject` is required"):
+            slopeplot(frame, "time", "value")
+
+
+# --------------------------------------------------------------------------
+# distributions
+# --------------------------------------------------------------------------
+
+
+class TestDistribution:
+    def test_histogram_counts_match_numpy(self, cells):
+        _, table = histplot(cells, "counts", bins=12, return_stats=True)
+        expected, _ = np.histogram(cells["counts"], bins=12)
+        assert np.allclose(table.iloc[:, 0].to_numpy(), expected)
+
+    def test_density_integrates_to_one(self, cells):
+        _, table = histplot(cells, "counts", bins=20, stat="density",
+                            return_stats=True)
+        centres = table.index.to_numpy()
+        width = centres[1] - centres[0]
+        assert (table.iloc[:, 0].sum() * width) == pytest.approx(1.0, rel=1e-6)
+
+    def test_probability_sums_to_one(self, cells):
+        _, table = histplot(cells, "counts", stat="probability",
+                            return_stats=True)
+        assert table.iloc[:, 0].sum() == pytest.approx(1.0)
+
+    def test_fill_normalises_each_bin(self, cells):
+        _, table = histplot(cells, "counts", hue="cell_type", multiple="fill",
+                            return_stats=True)
+        totals = table.sum(axis=1)
+        assert np.allclose(totals[totals > 0], 1.0)
+
+    def test_log_scale_drops_non_positive_and_says_so(self, capsys):
+        frame = pd.DataFrame({"v": [-1.0, 0.0, 1.0, 10.0, 100.0]})
+        histplot(frame, "v", log_scale=True, bins=3)
+        assert "dropped 2 non-positive" in capsys.readouterr().out
+
+    def test_kde_forces_density(self, cells, capsys):
+        histplot(cells, "counts", kde=True, stat="count")
+        assert "forces stat='density'" in capsys.readouterr().out
+
+    def test_kde_curve_integrates_to_one(self, cells):
+        _, curves = kdeplot(cells, "score", return_stats=True)
+        grid, density = curves[None]
+        assert np.trapz(density, grid) == pytest.approx(1.0, abs=0.02)
+
+    def test_kde_two_dimensions_rejects_hue(self, cells):
+        with pytest.raises(ValueError, match="one group per axes"):
+            kdeplot(cells, "score", y="counts", hue="cell_type")
+
+    def test_ridge_orders_by_median(self, cells):
+        _, summary = ridgeplot(cells, "score", "cell_type", order="median",
+                               return_stats=True)
+        assert list(summary["median"]) == sorted(summary["median"])
+
+    def test_ridge_summary_matches_pandas(self, cells):
+        _, summary = ridgeplot(cells, "score", "cell_type", return_stats=True)
+        expected = cells.groupby("cell_type", observed=True)["score"].median()
+        assert np.allclose(summary["median"],
+                           expected.reindex(summary.index))
+
+    def test_ridge_needs_a_group(self, cells):
+        with pytest.raises(TypeError, match="`group` is required"):
+            ridgeplot(cells, "score")
+
+    def test_qq_of_uniform_pvalues_has_lambda_near_one(self):
+        rng = np.random.default_rng(11)
+        _, stats_out = qqplot(rng.uniform(size=4000), dist="uniform", log=True,
+                              return_stats=True)
+        assert stats_out["lambda_gc"] == pytest.approx(1.0, abs=0.12)
+
+    def test_qq_detects_inflation(self):
+        rng = np.random.default_rng(12)
+        inflated = np.concatenate([rng.uniform(size=3000),
+                                   rng.beta(0.3, 8, 1000)])
+        _, stats_out = qqplot(inflated, dist="uniform", log=True,
+                              return_stats=True)
+        assert stats_out["lambda_gc"] > 1.2
+
+    def test_qq_of_a_normal_sample_is_a_straight_line(self):
+        rng = np.random.default_rng(13)
+        _, stats_out = qqplot(rng.normal(loc=3.0, scale=2.0, size=2000),
+                              dist="norm", line="ols", return_stats=True)
+        assert stats_out["slope"] == pytest.approx(2.0, rel=0.1)
+        assert stats_out["intercept"] == pytest.approx(3.0, abs=0.15)
+
+    def test_qq_unknown_distribution_is_reported(self):
+        with pytest.raises(ValueError, match="scipy.stats distribution"):
+            qqplot(np.random.default_rng(0).normal(size=50), dist="gaussianish")
+
+    def test_qq_two_sample(self):
+        rng = np.random.default_rng(14)
+        ax = qqplot(rng.normal(size=200), other=rng.normal(size=300), line="45")
+        assert ax.collections
+
+
+# --------------------------------------------------------------------------
+# relational
+# --------------------------------------------------------------------------
+
+
+class TestRelational:
+    def test_scatter_correlation_matches_scipy(self, cells):
+        from scipy import stats
+
+        _, out = scatterplot(cells, "counts", "score", corr="spearman",
+                             return_stats=True)
+        expected = stats.spearmanr(cells["counts"], cells["score"])
+        assert out["correlation"] == pytest.approx(expected.statistic)
+        assert out["pvalue"] == pytest.approx(expected.pvalue)
+
+    def test_scatter_unknown_correlation_is_reported(self, cells):
+        with pytest.raises(ValueError, match="corr"):
+            scatterplot(cells, "counts", "score", corr="cosine")
+
+    def test_scatter_accepts_bare_arrays(self, cells):
+        ax = scatterplot(cells["counts"].to_numpy(), cells["score"].to_numpy())
+        assert ax.collections
+
+    def test_line_aggregation_matches_groupby(self):
+        rng = np.random.default_rng(4)
+        frame = pd.DataFrame({"hour": np.repeat([0, 2, 4, 8], 5),
+                              "value": rng.normal(size=20)})
+        _, table = lineplot(frame, "hour", "value", errorbar=None,
+                            return_stats=True)
+        expected = frame.groupby("hour")["value"].mean()
+        assert np.allclose(table.set_index("x")["centre"].reindex(expected.index),
+                           expected)
+
+    def test_line_units_draws_every_replicate(self):
+        rng = np.random.default_rng(5)
+        frame = pd.DataFrame({"hour": np.tile([0, 1, 2], 4),
+                              "rep": np.repeat([1, 2, 3, 4], 3),
+                              "value": rng.normal(size=12)})
+        ax = lineplot(frame, "hour", "value", units="rep")
+        assert len(ax.get_lines()) == 5  # four replicates plus the summary
+
+    def test_regression_slope_matches_polyfit(self, cells):
+        _, out = regplot(cells, "counts", "score", return_stats=True)
+        slope, intercept = np.polyfit(cells["counts"], cells["score"], 1)
+        assert out[None]["slope"] == pytest.approx(slope)
+        assert out[None]["intercept"] == pytest.approx(intercept)
+
+    def test_r_squared_matches_scipy(self, cells):
+        from scipy import stats
+
+        _, out = regplot(cells, "counts", "score", return_stats=True)
+        expected = stats.linregress(cells["counts"], cells["score"])
+        assert out[None]["r_squared"] == pytest.approx(expected.rvalue ** 2)
+
+    def test_polynomial_fit_recovers_a_quadratic(self):
+        x = np.linspace(-3, 3, 200)
+        frame = pd.DataFrame({"x": x, "y": 2.0 * x ** 2 - x + 1.0})
+        _, out = regplot(frame, "x", "y", fit="poly", order=2, ci=None,
+                         return_stats=True)
+        assert out[None]["slope"] == pytest.approx(-1.0, abs=1e-6)
+        assert out[None]["r_squared"] == pytest.approx(1.0, abs=1e-9)
+
+    def test_lowess_runs_without_a_band(self, cells):
+        _, out = regplot(cells, "counts", "score", fit="lowess",
+                         return_stats=True)
+        assert out[None]["fit"] == "lowess"
+
+    def test_unknown_fit_is_reported(self, cells):
+        with pytest.raises(ValueError, match="fit"):
+            regplot(cells, "counts", "score", fit="spline")
+
+
+# --------------------------------------------------------------------------
+# the adapter
+# --------------------------------------------------------------------------
+
+
+class TestPlotData:
+    def test_dataframe_columns_resolve(self, cells):
+        view = as_plotdata(cells)
+        assert isinstance(view, PlotData)
+        assert view.n_obs == len(cells)
+        assert np.allclose(view.values("score"), cells["score"])
+
+    def test_anndata_features_and_obs_resolve(self, cells):
+        anndata = pytest.importorskip("anndata")
+
+        matrix = np.arange(len(cells) * 3, dtype=np.float32).reshape(len(cells), 3)
+        adata = anndata.AnnData(matrix, obs=cells.copy())
+        adata.var_names = ["GeneA", "GeneB", "GeneC"]
+        view = as_plotdata(adata)
+        assert np.allclose(view.values("GeneB"), matrix[:, 1])
+        assert np.allclose(view.values("score"), cells["score"])
+        assert view.has("GeneA") and view.has("cell_type")
+
+    def test_sparse_features_are_densified(self, cells):
+        anndata = pytest.importorskip("anndata")
+        from scipy import sparse
+
+        matrix = sparse.csr_matrix(np.eye(len(cells), 3, dtype=np.float32))
+        adata = anndata.AnnData(matrix, obs=cells.copy())
+        adata.var_names = ["A", "B", "C"]
+        values = as_plotdata(adata).values("A")
+        assert values.ndim == 1 and values[0] == 1.0
+
+    def test_layers_are_reachable(self, cells):
+        anndata = pytest.importorskip("anndata")
+
+        matrix = np.zeros((len(cells), 2), dtype=np.float32)
+        adata = anndata.AnnData(matrix, obs=cells.copy())
+        adata.var_names = ["A", "B"]
+        adata.layers["counts"] = np.ones_like(matrix)
+        assert np.allclose(as_plotdata(adata).values("A", layer="counts"), 1.0)
+
+    def test_unknown_key_suggests_a_close_match(self, cells):
+        with pytest.raises(KeyError, match="score"):
+            as_plotdata(cells).values("scoree")
+
+    def test_layer_on_a_metadata_column_is_rejected(self, cells):
+        with pytest.raises(ValueError, match="only applies to features"):
+            as_plotdata(cells).values("score", layer="counts")
+
+    def test_embedding_accepts_the_short_name(self, cells):
+        view = as_plotdata(cells, obsm={"X_umap": np.zeros((len(cells), 2))})
+        assert view.embedding("umap").shape == (len(cells), 2)
+        with pytest.raises(KeyError, match="No embedding"):
+            view.embedding("tsne")
+
+    def test_dict_input(self):
+        view = as_plotdata({"a": [1, 2, 3], "b": [4.0, 5.0, 6.0]})
+        assert np.allclose(view.values("b"), [4.0, 5.0, 6.0])
+
+    def test_array_needs_obs(self):
+        with pytest.raises(TypeError, match="needs `obs=`"):
+            as_plotdata(np.zeros((4, 2)))
+
+    def test_unsupported_type_is_reported(self):
+        with pytest.raises(TypeError, match="Cannot plot a str"):
+            as_plotdata("not data")
+
+    def test_plotdata_passes_through(self, cells):
+        view = as_plotdata(cells)
+        assert as_plotdata(view) is view
+
+    def test_a_gene_name_works_where_a_column_name_does(self, cells):
+        """``ov.pl.violinplot(adata, 'louvain', 'CD3D')`` must just work."""
+        anndata = pytest.importorskip("anndata")
+
+        matrix = np.tile(np.arange(len(cells), dtype=np.float32)[:, None], (1, 2))
+        adata = anndata.AnnData(matrix, obs=cells.copy())
+        adata.var_names = ["GeneA", "GeneB"]
+
+        from_gene = compare_groups(adata, "GeneA", "cell_type", omnibus=False)
+        frame = cells.assign(GeneA=matrix[:, 0])
+        from_column = compare_groups(frame, "GeneA", "cell_type", omnibus=False)
+        assert np.allclose(from_gene["pvalue"], from_column["pvalue"])
+
+        ax = violinplot(adata, "cell_type", "GeneA")
+        assert ax.get_ylabel() == "GeneA"
+
+    def test_metadata_wins_over_a_same_named_gene(self, cells):
+        anndata = pytest.importorskip("anndata")
+
+        matrix = np.zeros((len(cells), 1), dtype=np.float32)
+        adata = anndata.AnnData(matrix, obs=cells.copy())
+        adata.var_names = ["score"]
+        assert np.allclose(as_plotdata(adata).values("score"), cells["score"])
+
+
+class TestObsView:
+    def test_does_not_mutate_the_callers_frame(self, cells):
+        before = cells["cell_type"].dtype
+        view = ObsView(cells)
+        view.obs["cell_type"] = view.obs["cell_type"].cat.add_categories(["X"])
+        assert cells["cell_type"].dtype == before
+
+    def test_strings_become_categorical_like_anndata(self, cells):
+        view = ObsView(cells)
+        assert isinstance(view.obs["cell_type"].dtype, pd.CategoricalDtype)
+        assert not isinstance(view.obs["score"].dtype, pd.CategoricalDtype)
+
+    def test_expression_access_fails_with_an_actionable_message(self, cells):
+        view = ObsView(cells)
+        with pytest.raises(AttributeError, match="Pass an AnnData"):
+            _ = view.X
+
+    def test_shape_and_uns(self, cells):
+        view = ObsView(cells)
+        assert view.shape == (len(cells), 0)
+        assert view.n_obs == len(cells) and len(view) == len(cells)
+        view.uns["cell_type_colors"] = ["#000000"]
+        assert view.uns["cell_type_colors"] == ["#000000"]
+
+    def test_rejects_non_frames(self):
+        with pytest.raises(TypeError, match="needs a DataFrame"):
+            ObsView(np.zeros((3, 2)))
+
+
+class TestAcceptsFrame:
+    def test_decorator_wraps_a_frame(self, cells):
+        @accepts_frame
+        def probe(adata, key):
+            return adata.obs[key].value_counts()
+
+        counts = probe(cells, "cell_type")
+        assert counts.sum() == len(cells)
+
+    def test_anndata_passes_through_untouched(self, cells):
+        anndata = pytest.importorskip("anndata")
+
+        @accepts_frame
+        def probe(adata):
+            return adata
+
+        adata = anndata.AnnData(np.zeros((len(cells), 1), dtype=np.float32),
+                                obs=cells.copy())
+        assert probe(adata) is adata
+
+    def test_retrofitted_cellproportion_takes_a_frame(self, cells):
+        from omicverse.pl import cellproportion
+
+        ax = cellproportion(cells, celltype_clusters="cell_type",
+                            groupby="sample")
+        assert ax is None or ax is not None  # it draws; the point is it runs
+        assert cells["cell_type"].dtype == object  # caller's frame untouched
+
+    def test_retrofitted_matches_the_anndata_path(self, cells):
+        anndata = pytest.importorskip("anndata")
+        from omicverse.pl import cellstackarea
+
+        adata = anndata.AnnData(np.zeros((len(cells), 1), dtype=np.float32),
+                                obs=cells.copy())
+        fig_frame, ax_frame = plt.subplots()
+        cellstackarea(cells, celltype_clusters="cell_type", groupby="sample",
+                      ax=ax_frame)
+        heights_frame = sorted(round(c.get_paths()[0].vertices[:, 1].max(), 6)
+                               for c in ax_frame.collections)
+        fig_adata, ax_adata = plt.subplots()
+        cellstackarea(adata, celltype_clusters="cell_type", groupby="sample",
+                      ax=ax_adata)
+        heights_adata = sorted(round(c.get_paths()[0].vertices[:, 1].max(), 6)
+                               for c in ax_adata.collections)
+        assert heights_frame == heights_adata
+
+
+# --------------------------------------------------------------------------
+# public surface
+# --------------------------------------------------------------------------
+
+
+class TestSurface:
+    NEW = ("barplot", "stripplot", "violinplot", "stackplot", "lollipopplot",
+           "pieplot", "donutplot", "slopeplot", "histplot", "kdeplot",
+           "ridgeplot", "qqplot", "scatterplot", "lineplot", "regplot",
+           "compare_groups", "add_stat_annotation", "format_pvalue",
+           "as_plotdata", "accepts_frame", "PlotData", "ObsView")
+
+    def test_everything_is_exported(self):
+        import omicverse.pl as pl
+
+        for name in self.NEW:
+            assert hasattr(pl, name), f"ov.pl.{name} is missing"
+            assert name in pl.__all__, f"ov.pl.{name} is not in __all__"
+
+    def test_plots_are_registered(self):
+        import omicverse.pl  # noqa: F401
+
+        from omicverse._registry import get_registry
+
+        names = {entry.get("full_name")
+                 for entry in get_registry().get_by_category("pl")}
+        for expected in (
+            "omicverse.pl._categorical.barplot",
+            "omicverse.pl._categorical.violinplot",
+            "omicverse.pl._categorical.slopeplot",
+            "omicverse.pl._distribution.ridgeplot",
+            "omicverse.pl._distribution.qqplot",
+            "omicverse.pl._relational.regplot",
+            "omicverse.pl._stats_tests.compare_groups",
+            "omicverse.pl._stats_tests.add_stat_annotation",
+        ):
+            assert expected in names, f"{expected} missing from the registry"
+
+    def test_generic_names_do_not_shadow_the_omics_ones(self):
+        import omicverse.pl as pl
+
+        # ov.pl.violin still takes an AnnData; ov.pl.violinplot takes a frame
+        assert pl.violin is not pl.violinplot
+        assert pl.boxplot is not pl.barplot


### PR DESCRIPTION
Second cut of the `ov.pl` work. **Stacked on #919** — base is `feat/pl-stats-layout` so the diff shows only this change; retarget to `master` once #919 merges.

Almost every plot in `ov.pl` starts from an `AnnData`. That is right for an embedding; it is in the way for the ordinary figures a paper is made of — a bar chart with a test on it, a histogram, a ridgeline, a regression, a Q-Q plot. Those need a column of numbers and a column of labels.

## Fifteen table-first plots

`barplot` `stripplot` `violinplot` `stackplot` `pieplot` `donutplot` `lollipopplot` `slopeplot` `histplot` `kdeplot` `ridgeplot` `qqplot` `scatterplot` `lineplot` `regplot`

Each takes a `DataFrame` + column names, bare arrays, or an `AnnData` (its `.obs`) — interchangeably.

The `...plot` suffix keeps this layer clear of the omics-specific names. **`ov.pl.violin` still takes an `AnnData`** and knows about genes and layers; `ov.pl.violinplot` takes a frame. No existing function changes behaviour.

## Statistics that match the picture

`ov.pl.compare_groups` runs the comparison and returns a tidy table — automatic test selection (Mann-Whitney pairwise + Kruskal-Wallis omnibus by default, ANOVA when the pairwise test is parametric), explicit `pairs=`, Holm / Bonferroni / BH correction. `ov.pl.add_stat_annotation` draws the brackets **from that table**, stacking them so they never overlap and extending the axis to fit.

Every categorical plot takes `test=` and routes through the same code, so the stars on the figure and the numbers in the text cannot drift apart. `ov.pl.add_palue` still exists for hand-placed annotation; this is the version that runs the test.

## Not tied to AnnData

- **`ov.pl.as_plotdata(data)`** — one accessor, `values(key)`, resolving a name against metadata first and features second. Dense or sparse, `AnnData` / `DataFrame` / `dict` / array+`obs`.
- **`resolve_columns` now goes through it**, so a gene name works anywhere a column name does: `ov.pl.violinplot(adata, 'louvain', 'CD3D')` needs no manual extraction.
- **`@ov.pl.accepts_frame`** — the retrofit path for existing `AnnData`-shaped plots. Wraps a `DataFrame` in `ObsView`, a metadata-only view. Deliberately *not* a fake `AnnData`: reaching for `.X` raises immediately naming the problem, instead of failing later on an empty array. String columns become categorical on construction because that is what `anndata` does, and `.obs` is a copy so drawing a plot never mutates the caller's frame.
- `cellproportion` and `cellstackarea` are converted as proof; the tutorial shows how to apply it to your own function.

## Validation

`tests/pl/test_generic_plots.py` — **93 tests**. Every computed quantity is checked against a reference on the same data, not just "the plot ran":

| Quantity | Checked against |
| --- | --- |
| Pairwise + omnibus P values | `scipy.stats` (mannwhitneyu, ttest_ind, brunnermunzel, kruskal) |
| Holm correction | `statsmodels.multipletests` |
| Bar heights, SE error bars | `numpy` / `pandas` |
| Histogram counts, density, probability, fill | `numpy.histogram` |
| KDE curve | integrates to 1 |
| Ridge ordering and medians | `pandas.groupby` |
| Regression slope / intercept / R² | `np.polyfit`, `scipy.linregress` |
| Paired slope test | `scipy.wilcoxon` |
| λ<sub>GC</sub> | ≈ 1.0 on uniform P values; > 1.2 when inflation is real |

Also asserted: the three input forms give identical numbers, the generic names do not shadow the omics ones, and every error message names the problem.

## Two defects found by drawing real figures

- `lollipopplot` returned its table with internal column names (`x`/`y`) rather than `label`/`value`.
- A pie of ten PBMC populations, three of them under 2%, was unreadable — hence `other_threshold=` (which prints exactly what it merged) and `legend=True`.

## Testing

93 new tests pass; the whole `tests/pl` suite is **424 passed**.

## Tutorial

omicverse/omicverse-tutorials#98 — executed end to end on `pbmc68k_reduced`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VVqVNig3oV6wz42YiQ9obZ