### PR TITLE
refactor(pl): one accessor for turning a name into numbers

### DIFF
--- a/omicverse/pl/__init__.py
+++ b/omicverse/pl/__init__.py
@@ -247,6 +247,7 @@ from ._plot_backend import (
     palette,
     plot_set,
     plotset,
+    style_axes,
     ov_plot_set,
     style,
     plot_text_set,
@@ -302,6 +303,7 @@ from ._distribution import histplot, kdeplot, qqplot, ridgeplot
 from ._relational import lineplot, regplot, scatterplot
 from ._plotdata import (ObsView, PlotData, accepts_frame, as_plotdata,
                         get_matrix, get_values)
+from ._stats_common import font_size, font_sizes, kde_curve
 
 
 def curved_graph(*args, **kwargs):
@@ -490,6 +492,7 @@ __all__ = [
     "palette",
     "plot_set",
     "plotset",
+    "style_axes",
     "ov_plot_set",
     "style",
     "plot_text_set",
@@ -571,6 +574,9 @@ __all__ = [
     "accepts_frame",
     "get_values",
     "get_matrix",
+    "font_size",
+    "font_sizes",
+    "kde_curve",
     "PlotData",
     "ObsView",
 ]

--- a/omicverse/pl/__init__.py
+++ b/omicverse/pl/__init__.py
@@ -32,7 +32,8 @@ Key modules:
     _distribution: histplot/kdeplot/ridgeplot/qqplot
     _relational: scatterplot/lineplot/regplot
     _stats_tests: compare_groups + significance brackets
-    _plotdata: as_plotdata / accepts_frame — AnnData plots that also take a table
+    _plotdata: get_values / get_matrix — the one place a name becomes numbers;
+        as_plotdata / accepts_frame — AnnData plots that also take a table
     _survival: Kaplan-Meier and Aalen-Johansen curves, log-rank / Gray's test
     _classification: ROC curves and confusion matrices
     _forest: forest plots and fixed/random-effects meta-analysis
@@ -299,7 +300,8 @@ from ._categorical import (
 )
 from ._distribution import histplot, kdeplot, qqplot, ridgeplot
 from ._relational import lineplot, regplot, scatterplot
-from ._plotdata import ObsView, PlotData, accepts_frame, as_plotdata
+from ._plotdata import (ObsView, PlotData, accepts_frame, as_plotdata,
+                        get_matrix, get_values)
 
 
 def curved_graph(*args, **kwargs):
@@ -567,6 +569,8 @@ __all__ = [
     # @ _plotdata — let AnnData-shaped plots take a table
     "as_plotdata",
     "accepts_frame",
+    "get_values",
+    "get_matrix",
     "PlotData",
     "ObsView",
 ]

--- a/omicverse/pl/_bulk.py
+++ b/omicverse/pl/_bulk.py
@@ -5,6 +5,7 @@ import matplotlib.patches as mpatches
 import matplotlib.pyplot as plt
 import matplotlib
 from .._registry import register_function
+from ._plot_backend import style_axes
 
 @register_function(
     aliases=["火山图", "volcano", "volcano_plot", "差异基因可视化", "火山图绘制"],
@@ -304,13 +305,7 @@ def volcano(result,pval_name='qvalue',fc_name='log2FC',pval_max=None,FC_max=None
         fontweight='normal'
         )
 
-    plt.grid(False)
-    ax.spines['top'].set_visible(False)
-    ax.spines['right'].set_visible(False)
-    ax.spines['bottom'].set_visible(True)
-    ax.spines['left'].set_visible(True)
-    ax.spines['left'].set_position(('outward', 10))
-    ax.spines['bottom'].set_position(('outward', 10))
+    style_axes(ax)
 
 
     from adjustText import adjust_text
@@ -714,13 +709,7 @@ def boxplot(data,hue,x_value,y_value,width=0.3,title='',
     #设置标题
     ax.set_title(title,fontsize=fontsize+1)
     #设置spines可视化情况
-    plt.grid(False)
-    ax.spines['top'].set_visible(False)
-    ax.spines['right'].set_visible(False)
-    ax.spines['bottom'].set_visible(True)
-    ax.spines['left'].set_visible(True)
-    ax.spines['left'].set_position(('outward', 10))
-    ax.spines['bottom'].set_position(('outward', 10))
+    style_axes(ax)
     
     return fig,ax
 

--- a/omicverse/pl/_categorical.py
+++ b/omicverse/pl/_categorical.py
@@ -24,8 +24,9 @@ import numpy as np
 import pandas as pd
 
 from .._registry import register_function
-from ._stats_common import (as_frame, default_palette, group_levels,
-                            kde_curve, resolve_columns)
+from ._plot_backend import style_axes
+from ._stats_common import (as_frame, default_palette, font_size,
+                            group_levels, kde_curve, resolve_columns)
 
 __all__ = [
     "barplot", "stripplot", "violinplot", "stackplot", "lollipopplot",
@@ -68,24 +69,24 @@ def _finish(ax, *, levels, names, xlabel, ylabel, title, fontsize, orient,
     if categorical_axis:
         if orient == "v":
             ax.set_xticks(range(len(levels)))
-            ax.set_xticklabels(labels, fontsize=fontsize,
+            ax.set_xticklabels(labels, fontsize=font_size(fontsize),
                                rotation=rotation,
                                ha="right" if rotation else "center")
         else:
             ax.set_yticks(range(len(levels)))
-            ax.set_yticklabels(labels, fontsize=fontsize)
+            ax.set_yticklabels(labels, fontsize=font_size(fontsize))
     cat_label = xlabel if xlabel is not None else names.get("x", "")
     val_label = ylabel if ylabel is not None else names.get("y", "")
     if orient == "v":
-        ax.set_xlabel(cat_label, fontsize=fontsize + 1)
-        ax.set_ylabel(val_label, fontsize=fontsize + 1)
+        ax.set_xlabel(cat_label, fontsize=font_size(fontsize, "label"))
+        ax.set_ylabel(val_label, fontsize=font_size(fontsize, "label"))
     else:
-        ax.set_ylabel(cat_label, fontsize=fontsize + 1)
-        ax.set_xlabel(val_label, fontsize=fontsize + 1)
+        ax.set_ylabel(cat_label, fontsize=font_size(fontsize, "label"))
+        ax.set_xlabel(val_label, fontsize=font_size(fontsize, "label"))
     if title:
-        ax.set_title(title, fontsize=fontsize + 2)
-    ax.tick_params(labelsize=fontsize)
-    ax.spines[["right", "top"]].set_visible(False)
+        ax.set_title(title, fontsize=font_size(fontsize, "title"))
+    ax.tick_params(labelsize=font_size(fontsize))
+    style_axes(ax)
 
 
 def _hue_legend(ax, hues, colors, title, fontsize, show):
@@ -95,8 +96,8 @@ def _hue_legend(ax, hues, colors, title, fontsize, show):
 
     ax.legend(handles=[Patch(facecolor=c, label=str(h))
                        for h, c in zip(hues, colors)],
-              title=title, frameon=False, fontsize=fontsize,
-              title_fontsize=fontsize)
+              title=title, frameon=False, fontsize=font_size(fontsize),
+              title_fontsize=font_size(fontsize))
 
 
 def _maybe_annotate(ax, frame, levels, test, correction, style, hide_ns,
@@ -110,7 +111,7 @@ def _maybe_annotate(ax, frame, levels, test, correction, style, hide_ns,
         ax, value=frame["y"].to_numpy(dtype=float),
         group=frame["x"].to_numpy(), order=levels, test=test,
         correction=correction, style=style, hide_ns=hide_ns, orient=orient,
-        fontsize=fontsize, return_stats=True,
+        fontsize=font_size(fontsize), return_stats=True,
     )
     return results
 
@@ -215,7 +216,7 @@ def barplot(data: Any = None,
             legend: bool = True,
             legend_title: Optional[str] = None,
             rotation: float = 0,
-            fontsize: float = 9,
+            fontsize: Optional[float] = None,
             random_state: int = 0,
             return_stats: bool = False):
     r"""Bars of a per-category summary, with error bars.
@@ -365,7 +366,7 @@ def stripplot(data: Any = None,
               legend: bool = True,
               legend_title: Optional[str] = None,
               rotation: float = 0,
-              fontsize: float = 9,
+              fontsize: Optional[float] = None,
               random_state: int = 0,
               return_stats: bool = False):
     r"""Every observation as a jittered point.
@@ -497,7 +498,7 @@ def violinplot(data: Any = None,
                legend: bool = True,
                legend_title: Optional[str] = None,
                rotation: float = 0,
-               fontsize: float = 9,
+               fontsize: Optional[float] = None,
                random_state: int = 0,
                return_stats: bool = False):
     r"""Kernel-density violins per category.
@@ -712,7 +713,7 @@ def stackplot(data: Any = None,
               legend_title: Optional[str] = None,
               legend_out: bool = True,
               rotation: float = 45,
-              fontsize: float = 9,
+              fontsize: Optional[float] = None,
               return_stats: bool = False):
     r"""Stacked composition bars.
 
@@ -789,7 +790,7 @@ def stackplot(data: Any = None,
                             fontsize=fontsize)
         else:
             ax.legend(title=legend_title or names.get("hue"), frameon=False,
-                      fontsize=fontsize)
+                      fontsize=font_size(fontsize))
     return (ax, matrix) if return_stats else ax
 
 
@@ -832,7 +833,7 @@ def lollipopplot(data: Any = None,
                  ylabel: Optional[str] = None,
                  title: Optional[str] = None,
                  colorbar_label: Optional[str] = None,
-                 fontsize: float = 9,
+                 fontsize: Optional[float] = None,
                  return_stats: bool = False):
     r"""Stem-and-dot chart of one value per label.
 
@@ -909,8 +910,8 @@ def lollipopplot(data: Any = None,
             rotation=0 if orient == "h" else 45)
     if "c" in table:
         bar = ax.figure.colorbar(points, ax=ax, fraction=0.035, pad=0.03)
-        bar.set_label(colorbar_label or "", fontsize=fontsize)
-        bar.ax.tick_params(labelsize=fontsize - 1)
+        bar.set_label(colorbar_label or "", fontsize=font_size(fontsize))
+        bar.ax.tick_params(labelsize=font_size(fontsize) - 1)
     ax.spines["left" if orient == "h" else "bottom"].set_visible(orient != "h")
     table = table.rename(columns={"x": "label", "y": "value", "c": "color_by"})
     return (ax, table) if return_stats else ax
@@ -936,7 +937,7 @@ def _pie(values, labels, colors, *, hole, ax, start_angle, percent, counts,
         explode=explode, labeldistance=label_distance,
         wedgeprops=dict(width=1.0 - hole, edgecolor=edgecolor,
                         linewidth=linewidth),
-        textprops=dict(fontsize=fontsize),
+        textprops=dict(fontsize=font_size(fontsize)),
     )
     if percent:
         for wedge, value in zip(wedges, values):
@@ -944,7 +945,7 @@ def _pie(values, labels, colors, *, hole, ax, start_angle, percent, counts,
             radius = 1.0 - (1.0 - hole) * (1 - pct_distance)
             ax.text(radius * np.cos(angle), radius * np.sin(angle),
                     f"{100 * value / total:.0f}%", ha="center", va="center",
-                    fontsize=fontsize - 1, color="white", weight="bold")
+                    fontsize=font_size(fontsize, "tick", -1), color="white", weight="bold")
     return wedges
 
 
@@ -988,7 +989,7 @@ def pieplot(data: Any = None,
             ax=None,
             figsize: Optional[Tuple[float, float]] = None,
             title: Optional[str] = None,
-            fontsize: float = 9,
+            fontsize: Optional[float] = None,
             return_stats: bool = False):
     r"""Pie chart of a composition.
 
@@ -1049,7 +1050,7 @@ def pieplot(data: Any = None,
                   hole=hole, ax=ax, start_angle=start_angle,
                   percent=percent_inside, counts=True,
                   label_style="none" if legend else label_style,
-                  fontsize=fontsize, explode=explode, edgecolor=edgecolor,
+                  fontsize=font_size(fontsize), explode=explode, edgecolor=edgecolor,
                   linewidth=linewidth, pct_distance=pct_distance,
                   label_distance=label_distance)
     if legend:
@@ -1058,13 +1059,13 @@ def pieplot(data: Any = None,
                   [f"{name}  ({100 * value / total:.1f}%)"
                    for name, value in series.items()],
                   loc=legend_loc, bbox_to_anchor=(1.0, 0.5), frameon=False,
-                  fontsize=fontsize)
+                  fontsize=font_size(fontsize))
     if centre_text:
         ax.text(0, 0, centre_text, ha="center", va="center",
-                fontsize=fontsize + 2)
+                fontsize=font_size(fontsize, "title"))
     ax.set_aspect("equal")
     if title:
-        ax.set_title(title, fontsize=fontsize + 2)
+        ax.set_title(title, fontsize=font_size(fontsize, "title"))
     shares = series / series.sum()
     return (ax, shares) if return_stats else ax
 
@@ -1140,7 +1141,7 @@ def slopeplot(data: Any = None,
               xlabel: Optional[str] = None,
               ylabel: Optional[str] = None,
               title: Optional[str] = None,
-              fontsize: float = 9,
+              fontsize: Optional[float] = None,
               return_stats: bool = False):
     r"""One line per subject across conditions.
 
@@ -1204,7 +1205,7 @@ def slopeplot(data: Any = None,
         if label_points:
             ax.annotate(str(name), (xs[-1], values[valid][-1]),
                         textcoords="offset points", xytext=(4, 0),
-                        fontsize=fontsize - 2, va="center")
+                        fontsize=font_size(fontsize, "tick", -2), va="center")
 
     if summary:
         if summary not in {"mean", "median"}:
@@ -1215,16 +1216,16 @@ def slopeplot(data: Any = None,
                 label=summary)
 
     ax.set_xticks(range(len(levels)))
-    ax.set_xticklabels([str(level) for level in levels], fontsize=fontsize)
+    ax.set_xticklabels([str(level) for level in levels], fontsize=font_size(fontsize))
     ax.set_xlim(-0.35, len(levels) - 0.65)
     ax.set_xlabel(xlabel if xlabel is not None else names.get("x", ""),
-                  fontsize=fontsize + 1)
+                  fontsize=font_size(fontsize, "label"))
     ax.set_ylabel(ylabel if ylabel is not None else names.get("y", ""),
-                  fontsize=fontsize + 1)
+                  fontsize=font_size(fontsize, "label"))
     if title:
-        ax.set_title(title, fontsize=fontsize + 2)
-    ax.tick_params(labelsize=fontsize)
-    ax.spines[["right", "top"]].set_visible(False)
+        ax.set_title(title, fontsize=font_size(fontsize, "title"))
+    ax.tick_params(labelsize=font_size(fontsize))
+    style_axes(ax)
 
     stats: Dict[str, Any] = {"wide": wide, "n_complete": int(len(complete))}
     if test:
@@ -1241,5 +1242,5 @@ def slopeplot(data: Any = None,
         ax.text(0.5, 1.01, f"{label}: {format_pvalue(pvalue, 'value')} "
                            f"(n={len(complete)})",
                 transform=ax.transAxes, ha="center", va="bottom",
-                fontsize=fontsize)
+                fontsize=font_size(fontsize))
     return (ax, stats) if return_stats else ax

--- a/omicverse/pl/_categorical.py
+++ b/omicverse/pl/_categorical.py
@@ -445,27 +445,7 @@ def stripplot(data: Any = None,
 
 
 
-@register_function(
-    aliases=["violinplot", "表格小提琴图", "dataframe小提琴图", "long_form_violin",
-             "非adata小提琴图"],
-    category="pl",
-    description=(
-        "Violin plot from a long-form DataFrame or bare arrays. For an "
-        "AnnData with genes, layers and .raw use ov.pl.violin instead — this "
-        "is the container-free version, with split/clip/inner and tests"
-    ),
-    examples=[
-        "ax = ov.pl.violinplot(df, 'cell_type', 'score')",
-        "# Two conditions mirrored in one violin",
-        "ax = ov.pl.violinplot(df, 'cell_type', 'score', hue='condition',",
-        "                      split=True)",
-        "# With a Kruskal-Wallis omnibus and corrected pairwise brackets",
-        "ax, res = ov.pl.violinplot(df, 'arm', 'value', test='auto',",
-        "                           return_stats=True)",
-    ],
-    related=["pl.violin", "pl.stripplot", "pl.barplot", "pl.compare_groups"],
-)
-def violinplot(data: Any = None,
+def _violin_kde(data: Any = None,
                x: Any = None,
                y: Any = None,
                *,
@@ -1247,3 +1227,62 @@ def slopeplot(data: Any = None,
                 transform=ax.transAxes, ha="center", va="bottom",
                 fontsize=font_size(fontsize))
     return (ax, stats) if return_stats else ax
+
+
+@register_function(
+    aliases=["violinplot", "表格小提琴图", "dataframe小提琴图", "long_form_violin",
+             "非adata小提琴图"],
+    category="pl",
+    description=(
+        "Violin plot from a long-form DataFrame or bare arrays. For an "
+        "AnnData with genes, layers and .raw use ov.pl.violin instead — this "
+        "is the container-free version, with split/clip/inner and tests"
+    ),
+    examples=[
+        "ax = ov.pl.violinplot(df, 'cell_type', 'score')",
+        "# Two conditions mirrored in one violin",
+        "ax = ov.pl.violinplot(df, 'cell_type', 'score', hue='condition',",
+        "                      split=True)",
+        "# With a Kruskal-Wallis omnibus and corrected pairwise brackets",
+        "ax, res = ov.pl.violinplot(df, 'arm', 'value', test='auto',",
+        "                           return_stats=True)",
+    ],
+    related=["pl.violin", "pl.stripplot", "pl.barplot", "pl.compare_groups"],
+)
+def violinplot(data: Any = None, x: Any = None, y: Any = None, **kwargs: Any):
+    r"""Deprecated: use :func:`omicverse.pl.violin`.
+
+    ``violin`` now covers everything this did — it accepts a DataFrame as well
+    as an AnnData, and gained ``hue`` / ``split`` / ``cut`` / ``clip`` /
+    ``inner`` / ``orient`` / ``test``. Two names for one plot is what made
+    ``ov.pl.violin`` and this function look like they came from different
+    libraries.
+
+    The translation is just the argument names: ``x`` is ``groupby`` and ``y``
+    is ``keys``. Rendering is unchanged — this always routes through the
+    kernel-density engine, so an existing call produces the same figure it did
+    before, with a warning.
+    """
+    from warnings import warn
+
+    warn(
+        "`ov.pl.violinplot` is deprecated; use `ov.pl.violin`, which now takes "
+        "a DataFrame and supports hue/split/cut/clip/inner/orient/test. "
+        "`violinplot(df, x, y)` becomes `violin(df, keys=y, groupby=x)`.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    from ._violin import violin
+
+    # Keep this function's own defaults rather than inheriting violin's.
+    # The two signatures disagree on four of them, and every one changes the
+    # picture:
+    #   scale      forces the kernel-density engine (violin defaults to the
+    #              matplotlib one)
+    #   inner      violinplot drew the quartile box; violin defaults to none
+    #   stripplot  violin draws the raw points; violinplot did not
+    #   fontsize   violin pins 13; violinplot follows ov.plot_set
+    for name, value in (("scale", "width"), ("inner", "box"),
+                        ("stripplot", False), ("fontsize", None)):
+        kwargs.setdefault(name, value)
+    return violin(data, keys=y, groupby=x, **kwargs)

--- a/omicverse/pl/_categorical.py
+++ b/omicverse/pl/_categorical.py
@@ -24,7 +24,8 @@ import numpy as np
 import pandas as pd
 
 from .._registry import register_function
-from ._stats_common import as_frame, default_palette, group_levels, resolve_columns
+from ._stats_common import (as_frame, default_palette, group_levels,
+                            kde_curve, resolve_columns)
 
 __all__ = [
     "barplot", "stripplot", "violinplot", "stackplot", "lollipopplot",
@@ -440,12 +441,7 @@ def stripplot(data: Any = None,
     return (ax, {"test": results}) if return_stats else ax
 
 
-def _kde_profile(values: np.ndarray, grid: np.ndarray, bw_method):
-    from scipy.stats import gaussian_kde
 
-    if values.size < 2 or np.allclose(values, values[0]):
-        return np.zeros_like(grid)
-    return gaussian_kde(values, bw_method=bw_method)(grid)
 
 
 @register_function(
@@ -476,14 +472,19 @@ def violinplot(data: Any = None,
                split: bool = False,
                inner: Optional[str] = "box",
                cut: float = 2.0,
+               clip: Optional[Tuple[Optional[float], Optional[float]]] = None,
                bw_method: Any = None,
                gridsize: int = 200,
-               scale: str = "area",
+               scale: str = "width",
+               stripplot: bool = False,
+               strip_size: float = 2.0,
+               strip_alpha: float = 0.5,
                orient: str = "v",
                width: float = 0.8,
                palette=None,
                alpha: float = 0.9,
-               linewidth: float = 0.8,
+               linewidth: float = 1.1,
+               edgecolor: str = "black",
                ax=None,
                figsize: Optional[Tuple[float, float]] = None,
                test: Optional[str] = None,
@@ -511,11 +512,23 @@ def violinplot(data: Any = None,
         observations), ``'stick'`` (a tick per observation), or ``None``.
     cut
         How far past the extreme observations the density is drawn, in
-        bandwidths. ``cut=0`` clips at the data range, which is what you want
-        for a bounded quantity like a proportion.
+        **kernel bandwidths** — the same meaning as in seaborn and R.
+        ``cut=0`` stops at the data range, which is what a bounded quantity
+        like a proportion needs.
+    clip
+        Hard ``(low, high)`` limits on the density support, e.g. ``(0, None)``
+        for a non-negative quantity. Either end may be ``None``.
     scale
-        ``'area'`` (equal area, default), ``'width'`` (equal maximum width) or
+        ``'width'`` (equal maximum width, the default and what
+        :func:`~omicverse.pl.violin` uses), ``'area'`` (equal area) or
         ``'count'`` (width proportional to n).
+    stripplot
+        Overlay the raw observations. Off by default here because this
+        function is routinely handed a hundred thousand rows; turn it on for
+        the small-n plots where a violin alone hides the sample size.
+    edgecolor, linewidth
+        Outline of each violin. A visible outline is most of what separates a
+        readable violin from a coloured smudge.
 
     Returns
     -------
@@ -547,10 +560,8 @@ def violinplot(data: Any = None,
             values = frame.loc[mask, "y"].to_numpy(dtype=float)
             if values.size == 0:
                 continue
-            span = values.max() - values.min()
-            pad = cut * (span / 6 if span > 0 else 1.0)
-            grid = np.linspace(values.min() - pad, values.max() + pad, gridsize)
-            density = _kde_profile(values, grid, bw_method)
+            grid, density = kde_curve(values, cut=cut, gridsize=gridsize,
+                                      bw_method=bw_method, clip=clip)
             profiles.append({"x": level, "hue": hue_level, "n": values.size,
                              "grid": grid, "density": density,
                              "position": x_index + offsets[h_index],
@@ -583,13 +594,23 @@ def violinplot(data: Any = None,
         if orient == "v":
             ax.fill_betweenx(grid, edge_lo, edge_hi, color=profile["color"],
                              alpha=alpha, linewidth=linewidth,
-                             edgecolor="white", zorder=2)
+                             edgecolor=edgecolor, zorder=2)
         else:
             ax.fill_between(grid, edge_lo, edge_hi, color=profile["color"],
                             alpha=alpha, linewidth=linewidth,
-                            edgecolor="white", zorder=2)
+                            edgecolor=edgecolor, zorder=2)
 
         values = profile["values"]
+        if stripplot:
+            noise = rng.uniform(-slot * 0.10, slot * 0.10, values.size)
+            if orient == "v":
+                ax.scatter(position + noise, values, s=strip_size,
+                           color="0.15", alpha=strip_alpha, linewidths=0,
+                           zorder=2.5)
+            else:
+                ax.scatter(values, position + noise, s=strip_size,
+                           color="0.15", alpha=strip_alpha, linewidths=0,
+                           zorder=2.5)
         centre = position
         if split:
             centre = position + (-slot / 6 if profile["half"] == 0 else slot / 6)

--- a/omicverse/pl/_categorical.py
+++ b/omicverse/pl/_categorical.py
@@ -323,7 +323,7 @@ def barplot(data: Any = None,
 
 
 @register_function(
-    aliases=["散点分布图", "stripplot", "抖动散点", "jitter_plot", "点图"],
+    aliases=["stripplot", "散点分布图", "抖动散点", "jitter_plot", "逐点分布图"],
     category="pl",
     description=(
         "Strip plot: every observation as a jittered point per category, "
@@ -446,11 +446,13 @@ def stripplot(data: Any = None,
 
 
 @register_function(
-    aliases=["小提琴图", "violinplot", "violin_plot", "分布小提琴"],
+    aliases=["violinplot", "表格小提琴图", "dataframe小提琴图", "long_form_violin",
+             "非adata小提琴图"],
     category="pl",
     description=(
-        "Violin plot from a table (no AnnData): kernel density per category, "
-        "optional split by a two-level factor, inner box/points, and brackets"
+        "Violin plot from a long-form DataFrame or bare arrays. For an "
+        "AnnData with genes, layers and .raw use ov.pl.violin instead — this "
+        "is the container-free version, with split/clip/inner and tests"
     ),
     examples=[
         "ax = ov.pl.violinplot(df, 'cell_type', 'score')",
@@ -674,7 +676,8 @@ def violinplot(data: Any = None,
 
 
 @register_function(
-    aliases=["堆叠柱状图", "stackplot", "stacked_bar", "组成图", "比例图"],
+    aliases=["stackplot", "堆叠柱状图", "stacked_bar", "表格组成图",
+             "非adata堆叠图"],
     category="pl",
     description=(
         "Stacked bars of composition per category — counts or proportions — "

--- a/omicverse/pl/_classification.py
+++ b/omicverse/pl/_classification.py
@@ -15,7 +15,8 @@ import numpy as np
 import pandas as pd
 
 from .._registry import register_function
-from ._stats_common import as_frame
+from ._plot_backend import style_axes
+from ._stats_common import as_frame, font_size
 
 __all__ = ["roc_auc_ci", "roc", "confusion"]
 
@@ -197,7 +198,7 @@ def roc(data: Any = None,
         title: Optional[str] = None,
         legend: bool = True,
         legend_loc: str = "lower right",
-        fontsize: float = 9,
+        fontsize: Optional[float] = None,
         linewidth: float = 1.6,
         return_stats: bool = False):
     r"""Plot one or more ROC curves.
@@ -352,14 +353,14 @@ def roc(data: Any = None,
     ax.set_xlim(-0.01, 1.01)
     ax.set_ylim(-0.01, 1.01)
     ax.set_aspect("equal", adjustable="box")
-    ax.set_xlabel(xlabel, fontsize=fontsize + 1)
-    ax.set_ylabel(ylabel, fontsize=fontsize + 1)
+    ax.set_xlabel(xlabel, fontsize=font_size(fontsize, "label"))
+    ax.set_ylabel(ylabel, fontsize=font_size(fontsize, "label"))
     if title:
-        ax.set_title(title, fontsize=fontsize + 2)
-    ax.tick_params(labelsize=fontsize)
-    ax.spines[["right", "top"]].set_visible(False)
+        ax.set_title(title, fontsize=font_size(fontsize, "title"))
+    ax.tick_params(labelsize=font_size(fontsize))
+    style_axes(ax)
     if legend:
-        ax.legend(loc=legend_loc, frameon=False, fontsize=fontsize - 1)
+        ax.legend(loc=legend_loc, frameon=False, fontsize=font_size(fontsize, "tick", -1))
 
     return (ax, {"curves": curves}) if return_stats else ax
 
@@ -399,7 +400,7 @@ def confusion(data: Any = None,
               xlabel: str = "Predicted",
               ylabel: str = "True",
               title: Optional[str] = None,
-              fontsize: float = 9,
+              fontsize: Optional[float] = None,
               return_stats: bool = False):
     r"""Plot a confusion matrix.
 
@@ -474,10 +475,10 @@ def confusion(data: Any = None,
 
     image = ax.imshow(matrix, cmap=cmap, aspect="equal",
                       vmin=0, vmax=matrix.max() if matrix.size else 1)
-    ax.set_xticks(range(n), labels, rotation=45, ha="right", fontsize=fontsize)
-    ax.set_yticks(range(n), labels, fontsize=fontsize)
-    ax.set_xlabel(xlabel, fontsize=fontsize + 1)
-    ax.set_ylabel(ylabel, fontsize=fontsize + 1)
+    ax.set_xticks(range(n), labels, rotation=45, ha="right", fontsize=font_size(fontsize))
+    ax.set_yticks(range(n), labels, fontsize=font_size(fontsize))
+    ax.set_xlabel(xlabel, fontsize=font_size(fontsize, "label"))
+    ax.set_ylabel(ylabel, fontsize=font_size(fontsize, "label"))
 
     if annot:
         if annot_fmt is None:
@@ -492,7 +493,7 @@ def confusion(data: Any = None,
                     pct = counts[i, j] / row_totals[i] * 100 if row_totals[i] else 0
                     text = f"{counts[i, j]:d}\n{pct:.1f}%"
                 ax.text(j, i, text, ha="center", va="center",
-                        fontsize=fontsize - 1,
+                        fontsize=font_size(fontsize, "tick", -1),
                         color="white" if value > threshold else "black")
 
     if grid:
@@ -522,12 +523,12 @@ def confusion(data: Any = None,
         values = np.column_stack([precision, recall, f1])
         strip.imshow(values, cmap="Greys", vmin=0, vmax=1, aspect="auto")
         strip.set_xticks(range(3), ["Prec", "Rec", "F1"], rotation=45,
-                         ha="right", fontsize=fontsize - 1)
+                         ha="right", fontsize=font_size(fontsize, "tick", -1))
         strip.set_yticks([])
         for i in range(n):
             for j in range(3):
                 strip.text(j, i, f"{values[i, j]:.2f}", ha="center",
-                           va="center", fontsize=fontsize - 2,
+                           va="center", fontsize=font_size(fontsize, "tick", -2),
                            color="white" if values[i, j] > 0.6 else "black")
         for spine in strip.spines.values():
             spine.set_visible(False)
@@ -541,12 +542,12 @@ def confusion(data: Any = None,
                 [1.48, 0.0, 0.045, 1.0]))
         else:
             cbar = ax.figure.colorbar(image, ax=ax, fraction=0.046, pad=0.04)
-        cbar.ax.tick_params(labelsize=fontsize - 1)
-        cbar.set_label("fraction" if normalize else "count", fontsize=fontsize)
+        cbar.ax.tick_params(labelsize=font_size(fontsize) - 1)
+        cbar.set_label("fraction" if normalize else "count", fontsize=font_size(fontsize))
 
     if title is None:
         title = (f"accuracy {stats['accuracy']:.3f} | balanced "
                  f"{stats['balanced_accuracy']:.3f} | kappa {stats['kappa']:.3f}")
-    ax.set_title(title, fontsize=fontsize, pad=8)
+    ax.set_title(title, fontsize=font_size(fontsize), pad=8)
 
     return (ax, stats) if return_stats else ax

--- a/omicverse/pl/_classification.py
+++ b/omicverse/pl/_classification.py
@@ -43,6 +43,20 @@ def _midrank(x: np.ndarray) -> np.ndarray:
     return out
 
 
+@register_function(
+    aliases=["AUC置信区间", "roc_auc_ci", "delong", "AUC区间", "auc_ci"],
+    category="pl",
+    description=(
+        "AUC with a DeLong confidence interval — the analytic interval R's pROC computes, not a bootstrap approximation"
+    ),
+    examples=[
+        'res = ov.pl.roc_auc_ci(y_true, y_score)',
+        'print(res["auc"], res["lower"], res["upper"])',
+        '# one class against the rest',
+        'ov.pl.roc_auc_ci(labels, scores, pos_label="tumour")',
+    ],
+    related=["pl.roc", "pl.confusion"],
+)
 def roc_auc_ci(y_true: Sequence[Any],
                y_score: Sequence[float],
                *,

--- a/omicverse/pl/_density.py
+++ b/omicverse/pl/_density.py
@@ -2,6 +2,7 @@ import numpy as np
 from scipy.stats import gaussian_kde
 import matplotlib.pyplot as plt
 from .._registry import register_function
+from ._plotdata import get_values
 
 
 
@@ -28,6 +29,8 @@ def calculate_gene_density(
     dims=(0, 1),
     adjust=1,
     min_expr=0.1,          # NEW: minimal raw expression to keep as weight > 0
+    layer=None,
+    use_raw=None,
 ):
     r"""
     Calculate weighted kernel density estimates for gene expression on 2D embeddings.
@@ -42,7 +45,11 @@ def calculate_gene_density(
         dims: Embedding dimensions to use as (x_dim, y_dim) ((0, 1))
         adjust: Bandwidth scaling factor for KDE (1)
         min_expr: Minimum expression threshold for including cells (0.1)
-        
+        layer: Read expression from `adata.layers[layer]` instead of `.X` (None)
+        use_raw: Force (`True`) or forbid (`False`) reading from `adata.raw`.
+            `None` reads `.X` and falls back to `.raw` only for names that are
+            absent from `.var_names` — see `ov.pl.get_values` (None)
+
     Returns:
         None: Updates adata.obs with density_{feature} columns
     """
@@ -55,12 +62,7 @@ def calculate_gene_density(
 
     for feat in features:
         # ----- fetch raw weights -------------------------------------------
-        if feat in adata.obs:
-            w_raw = adata.obs[feat].to_numpy()
-        elif feat in adata.var_names:
-            w_raw = adata[:, feat].X.toarray().ravel()
-        else:
-            raise ValueError(f"Feature '{feat}' not found in obs or var.")
+        w_raw = get_values(adata, feat, layer=layer, use_raw=use_raw)
 
         # ----- validity mask: finite coords & finite expr -------------------
         mask_finite = np.isfinite(w_raw) & np.all(np.isfinite(emb_all), axis=1)
@@ -79,7 +81,16 @@ def calculate_gene_density(
 
         # ----- min–max scale to 0-1 ----------------------------------------
         w_min, w_max = w_train_raw.min(), w_train_raw.max()
-        w_train      = (w_train_raw - w_min) / (w_max - w_min)
+        if w_max == w_min:
+            # every selected cell carries the same value, so the min-max scale
+            # is 0/0. The limiting case is an unweighted KDE of those cells —
+            # which is the honest answer, not a matrix full of NaN handed to
+            # scipy to fail on several frames later.
+            print(f"[{feat}] constant across the selected cells; "
+                  f"using an unweighted KDE.")
+            w_train = np.ones_like(w_train_raw, dtype=float)
+        else:
+            w_train = (w_train_raw - w_min) / (w_max - w_min)
 
         # ----- KDE fit ------------------------------------------------------
         kde = gaussian_kde(emb_train.T, weights=w_train, bw_method=adjust)

--- a/omicverse/pl/_distribution.py
+++ b/omicverse/pl/_distribution.py
@@ -15,8 +15,9 @@ import numpy as np
 import pandas as pd
 
 from .._registry import register_function
-from ._stats_common import (as_frame, default_palette, group_levels,
-                            kde_curve, resolve_columns)
+from ._plot_backend import style_axes
+from ._stats_common import (as_frame, default_palette, font_size,
+                            group_levels, kde_curve, resolve_columns)
 
 __all__ = ["histplot", "kdeplot", "ridgeplot", "qqplot"]
 
@@ -75,7 +76,7 @@ def histplot(data: Any = None,
              title: Optional[str] = None,
              legend: bool = True,
              legend_title: Optional[str] = None,
-             fontsize: float = 9,
+             fontsize: Optional[float] = None,
              return_stats: bool = False):
     r"""Histogram of one variable, optionally split by a factor.
 
@@ -188,20 +189,20 @@ def histplot(data: Any = None,
     label = xlabel if xlabel is not None else names.get("x", "")
     if log_scale:
         label = f"log10({label})" if label else "log10(value)"
-    ax.set_xlabel(label, fontsize=fontsize + 1)
+    ax.set_xlabel(label, fontsize=font_size(fontsize, "label"))
     default_y = {"count": "count", "density": "density",
                  "probability": "proportion", "percent": "percent"}[stat]
     if multiple == "fill":
         default_y = "fraction of bin"
     ax.set_ylabel(ylabel if ylabel is not None else default_y,
-                  fontsize=fontsize + 1)
+                  fontsize=font_size(fontsize, "label"))
     if title:
-        ax.set_title(title, fontsize=fontsize + 2)
-    ax.tick_params(labelsize=fontsize)
-    ax.spines[["right", "top"]].set_visible(False)
+        ax.set_title(title, fontsize=font_size(fontsize, "title"))
+    ax.tick_params(labelsize=font_size(fontsize))
+    style_axes(ax)
     if legend and len(hues) > 1:
         ax.legend(title=legend_title or names.get("hue"), frameon=False,
-                  fontsize=fontsize)
+                  fontsize=font_size(fontsize))
 
     table = pd.DataFrame(matrix.T, index=pd.Index(centres, name="bin_centre"),
                          columns=[str(h) for h in hues])
@@ -255,7 +256,7 @@ def kdeplot(data: Any = None,
             title: Optional[str] = None,
             legend: bool = True,
             legend_title: Optional[str] = None,
-            fontsize: float = 9,
+            fontsize: Optional[float] = None,
             return_stats: bool = False):
     r"""Kernel density estimate in one or two dimensions.
 
@@ -305,9 +306,9 @@ def kdeplot(data: Any = None,
         ax.contour(mesh_x, mesh_y, density, levels=levels, cmap=cmap,
                    linewidths=linewidth * 0.6)
         ax.set_xlabel(xlabel if xlabel is not None else pair_names.get("x", ""),
-                      fontsize=fontsize + 1)
+                      fontsize=font_size(fontsize, "label"))
         ax.set_ylabel(ylabel if ylabel is not None else pair_names.get("y", ""),
-                      fontsize=fontsize + 1)
+                      fontsize=font_size(fontsize, "label"))
         curves["density"] = density
     else:
         colors = default_palette(max(len(hues), 1), palette)
@@ -333,19 +334,19 @@ def kdeplot(data: Any = None,
                         clip_on=False)
             curves[hue_level] = (grid, density)
         ax.set_xlabel(xlabel if xlabel is not None else names.get("x", ""),
-                      fontsize=fontsize + 1)
+                      fontsize=font_size(fontsize, "label"))
         ax.set_ylabel(ylabel if ylabel is not None
                       else ("cumulative density" if cumulative else "density"),
-                      fontsize=fontsize + 1)
+                      fontsize=font_size(fontsize, "label"))
         ax.set_ylim(bottom=0)
         if legend and len(hues) > 1:
             ax.legend(title=legend_title or names.get("hue"), frameon=False,
-                      fontsize=fontsize)
+                      fontsize=font_size(fontsize))
 
     if title:
-        ax.set_title(title, fontsize=fontsize + 2)
-    ax.tick_params(labelsize=fontsize)
-    ax.spines[["right", "top"]].set_visible(False)
+        ax.set_title(title, fontsize=font_size(fontsize, "title"))
+    ax.tick_params(labelsize=font_size(fontsize))
+    style_axes(ax)
     return (ax, curves) if return_stats else ax
 
 
@@ -388,7 +389,7 @@ def ridgeplot(data: Any = None,
               figsize: Optional[Tuple[float, float]] = None,
               xlabel: Optional[str] = None,
               title: Optional[str] = None,
-              fontsize: float = 9,
+              fontsize: Optional[float] = None,
               return_stats: bool = False):
     r"""Stacked, overlapping densities — one per group.
 
@@ -483,15 +484,16 @@ def ridgeplot(data: Any = None,
                         linewidth=0.8, zorder=len(levels) - index + 0.5)
 
     ax.set_yticks([(len(levels) - 1 - i) * step for i in range(len(levels))])
-    ax.set_yticklabels([str(level) for level in levels], fontsize=fontsize)
+    ax.set_yticklabels([str(level) for level in levels], fontsize=font_size(fontsize))
     ax.set_ylim(-0.2 * step, (len(levels) - 1) * step + height * 1.05)
     ax.set_xlabel(xlabel if xlabel is not None else names.get("x", ""),
-                  fontsize=fontsize + 1)
+                  fontsize=font_size(fontsize, "label"))
     if title:
-        ax.set_title(title, fontsize=fontsize + 2)
+        ax.set_title(title, fontsize=font_size(fontsize, "title"))
     ax.tick_params(axis="y", length=0)
-    ax.tick_params(labelsize=fontsize)
-    ax.spines[["right", "top", "left"]].set_visible(False)
+    ax.tick_params(labelsize=font_size(fontsize))
+    style_axes(ax, spines=False)
+    ax.spines["bottom"].set_visible(True)
     return (ax, summary) if return_stats else ax
 
 
@@ -528,7 +530,7 @@ def qqplot(data: Any = None,
            xlabel: Optional[str] = None,
            ylabel: Optional[str] = None,
            title: Optional[str] = None,
-           fontsize: float = 9,
+           fontsize: Optional[float] = None,
            return_stats: bool = False):
     r"""Quantile-quantile plot.
 
@@ -646,16 +648,16 @@ def qqplot(data: Any = None,
     elif line is not None:
         raise ValueError("`line` must be 'quartile', '45', 'ols' or None.")
 
-    ax.set_xlabel(x_label, fontsize=fontsize + 1)
+    ax.set_xlabel(x_label, fontsize=font_size(fontsize, "label"))
     default_y = "observed $-\\log_{10}(P)$" if log else (
         f"sample quantiles ({names.get('x', '')})".strip())
     ax.set_ylabel(ylabel if ylabel is not None else default_y,
-                  fontsize=fontsize + 1)
+                  fontsize=font_size(fontsize, "label"))
     if "lambda_gc" in results:
         ax.text(0.03, 0.96, f"$\\lambda_{{GC}}$ = {results['lambda_gc']:.3f}",
-                transform=ax.transAxes, va="top", ha="left", fontsize=fontsize)
+                transform=ax.transAxes, va="top", ha="left", fontsize=font_size(fontsize))
     if title:
-        ax.set_title(title, fontsize=fontsize + 2)
-    ax.tick_params(labelsize=fontsize)
-    ax.spines[["right", "top"]].set_visible(False)
+        ax.set_title(title, fontsize=font_size(fontsize, "title"))
+    ax.tick_params(labelsize=font_size(fontsize))
+    style_axes(ax)
     return (ax, results) if return_stats else ax

--- a/omicverse/pl/_distribution.py
+++ b/omicverse/pl/_distribution.py
@@ -15,7 +15,8 @@ import numpy as np
 import pandas as pd
 
 from .._registry import register_function
-from ._stats_common import as_frame, default_palette, group_levels, resolve_columns
+from ._stats_common import (as_frame, default_palette, group_levels,
+                            kde_curve, resolve_columns)
 
 __all__ = ["histplot", "kdeplot", "ridgeplot", "qqplot"]
 
@@ -30,18 +31,7 @@ def _values_and_groups(data, x, hue, order, hue_order, *, name="x"):
     return frame, hues, names, frame.attrs.get("n_dropped", 0)
 
 
-def _grid(values: np.ndarray, cut: float, gridsize: int) -> np.ndarray:
-    span = float(values.max() - values.min())
-    pad = cut * (span / 6 if span > 0 else 1.0)
-    return np.linspace(values.min() - pad, values.max() + pad, gridsize)
 
-
-def _density(values: np.ndarray, grid: np.ndarray, bw_method) -> np.ndarray:
-    from scipy.stats import gaussian_kde
-
-    if values.size < 2 or np.allclose(values, values[0]):
-        return np.zeros_like(grid)
-    return gaussian_kde(values, bw_method=bw_method)(grid)
 
 
 @register_function(
@@ -191,9 +181,9 @@ def histplot(data: Any = None,
         if kde:
             mask = (np.ones(len(frame), dtype=bool) if hue_level is None
                     else frame["hue"].to_numpy() == hue_level)
-            grid = _grid(values[mask], 2.0, 200)
-            ax.plot(grid, _density(values[mask], grid, bw_method), color=colour,
-                    linewidth=1.5, zorder=3)
+            grid, curve = kde_curve(values[mask], cut=2.0, gridsize=200,
+                                    bw_method=bw_method)
+            ax.plot(grid, curve, color=colour, linewidth=1.5, zorder=3)
 
     label = xlabel if xlabel is not None else names.get("x", "")
     if log_scale:
@@ -328,8 +318,8 @@ def kdeplot(data: Any = None,
             sample = values[mask]
             if sample.size < 2:
                 continue
-            grid = _grid(sample, cut, gridsize)
-            density = _density(sample, grid, bw_method)
+            grid, density = kde_curve(sample, cut=cut, gridsize=gridsize,
+                                      bw_method=bw_method)
             if cumulative:
                 density = np.cumsum(density) * np.gradient(grid)
             ax.plot(grid, density, color=colour, linewidth=linewidth,
@@ -467,8 +457,8 @@ def ridgeplot(data: Any = None,
         if sample.size < 2:
             profiles.append(None)
             continue
-        grid = _grid(sample, cut, gridsize)
-        density = _density(sample, grid, bw_method)
+        grid, density = kde_curve(sample, cut=cut, gridsize=gridsize,
+                                  bw_method=bw_method)
         peak = max(peak, float(density.max()))
         profiles.append((grid, density, sample))
 

--- a/omicverse/pl/_dotplot.py
+++ b/omicverse/pl/_dotplot.py
@@ -15,6 +15,7 @@ import operator
 from typing import Any
 from ._palette import palette_28, palette_56
 from .._registry import register_function
+from ._plotdata import get_matrix
 
 _VarNames = Union[str, Sequence[str]]
 
@@ -233,12 +234,12 @@ def dotplot(
             use_raw = True
             print(f"Auto-detected: {len(genes_in_raw)} genes only in raw data, using raw data automatically")
 
-    if use_raw and adata.raw is not None:
-        matrix = adata.raw.X
-        var_names_idx = [adata.raw.var_names.get_loc(name) for name in var_names]
-    else:
-        matrix = adata.X if layer is None else adata.layers[layer]
-        var_names_idx = [adata.var_names.get_loc(name) for name in var_names]
+    # one dense (n_obs, n_genes) block, with the layer / raw rules applied once
+    expression = get_matrix(
+        adata, var_names,
+        layer=None if (use_raw and adata.raw is not None) else layer,
+        use_raw=True if (use_raw and adata.raw is not None) else None,
+    )
     
     # Determine category order
     if categories_order is not None:
@@ -283,8 +284,8 @@ def dotplot(
     
     for i, group in enumerate(agg.index):
         mask = (adata.obs[groupby] == group).values  # Convert to numpy array
-        group_matrix = matrix[mask][:, var_names_idx]
-        
+        group_matrix = expression[mask]
+
         # Calculate mean expression
         if mean_only_expressed:
             expressed = group_matrix > expression_cutoff

--- a/omicverse/pl/_forest.py
+++ b/omicverse/pl/_forest.py
@@ -20,7 +20,8 @@ import numpy as np
 import pandas as pd
 
 from .._registry import register_function
-from ._stats_common import as_frame, resolve_columns
+from ._plot_backend import style_axes
+from ._stats_common import as_frame, font_size, resolve_columns
 
 __all__ = ["meta_analysis", "forest"]
 
@@ -181,7 +182,7 @@ def forest(data: Any = None,
            xlabel: Optional[str] = None,
            title: Optional[str] = None,
            xlim: Optional[Tuple[float, float]] = None,
-           fontsize: float = 9,
+           fontsize: Optional[float] = None,
            return_stats: bool = False):
     r"""Draw a forest plot.
 
@@ -368,7 +369,7 @@ def forest(data: Any = None,
         ax.set_xscale("log")
 
     ax.set_yticks(yticks)
-    ax.set_yticklabels(yticklabels, fontsize=fontsize)
+    ax.set_yticklabels(yticklabels, fontsize=font_size(fontsize))
     for tick, row in zip(ax.get_yticklabels(), rows):
         if row["kind"] == "header":
             tick.set_fontweight("bold")
@@ -396,7 +397,7 @@ def forest(data: Any = None,
             if p_text:
                 text += f"   P={p_text}"
             ax.text(annotate_x, y, text, transform=transform, va="center",
-                    ha="left", fontsize=fontsize - 0.5,
+                    ha="left", fontsize=font_size(fontsize, "tick", -0.5),
                     fontstyle="italic" if row["kind"] == "summary" else "normal")
 
     if meta and "meta" in stats:
@@ -408,7 +409,7 @@ def forest(data: Any = None,
         # placed in the blank strip below the last row, inside the axes, so it
         # can never collide with the tick labels however tall the figure is
         ax.text(0.005, -0.62, het, transform=ax.get_yaxis_transform(),
-                va="center", ha="left", fontsize=fontsize - 1, color="0.35")
+                va="center", ha="left", fontsize=font_size(fontsize, "tick", -1), color="0.35")
 
     if xlim is not None:
         ax.set_xlim(*xlim)
@@ -423,16 +424,17 @@ def forest(data: Any = None,
         # renders 0.7 and 1.5 as "1"; %g keeps each tick readable instead
         ax.xaxis.set_major_formatter(FuncFormatter(lambda v, _: f"{v:g}"))
         ax.xaxis.set_minor_formatter(plt.NullFormatter())
-    ax.tick_params(axis="x", labelsize=fontsize)
+    ax.tick_params(axis="x", labelsize=font_size(fontsize))
 
     if xlabel is None:
         xlabel = names.get("estimate", "Effect size")
         if log_scale:
             xlabel = f"{xlabel} (ratio scale)"
-    ax.set_xlabel(xlabel, fontsize=fontsize + 1)
+    ax.set_xlabel(xlabel, fontsize=font_size(fontsize, "label"))
     if title:
-        ax.set_title(title, fontsize=fontsize + 2)
-    ax.spines[["right", "top", "left"]].set_visible(False)
+        ax.set_title(title, fontsize=font_size(fontsize, "title"))
+    style_axes(ax, spines=False)
+    ax.spines["bottom"].set_visible(True)
     ax.tick_params(axis="y", length=0)
 
     stats["rows"] = pd.DataFrame(

--- a/omicverse/pl/_forest.py
+++ b/omicverse/pl/_forest.py
@@ -25,6 +25,20 @@ from ._stats_common import as_frame, resolve_columns
 __all__ = ["meta_analysis", "forest"]
 
 
+@register_function(
+    aliases=["元分析", "meta_analysis", "meta分析", "效应量合并", "随机效应模型"],
+    category="pl",
+    description=(
+        "Pool effect estimates by inverse variance — fixed effect or DerSimonian-Laird random effects — with Q, I-squared and tau-squared"
+    ),
+    examples=[
+        'pooled = ov.pl.meta_analysis(res["logHR"], res["se"], method="random")',
+        'print(pooled["estimate"], pooled["I2"])',
+        '# fixed effect, when the studies really are replicates',
+        'ov.pl.meta_analysis(est, se, method="fixed")',
+    ],
+    related=["pl.forest", "pl.survival"],
+)
 def meta_analysis(estimate: Sequence[float],
                   se: Sequence[float],
                   *,

--- a/omicverse/pl/_layout.py
+++ b/omicverse/pl/_layout.py
@@ -285,9 +285,12 @@ def multipanel(layout: Union[int, Tuple[int, int], str, Sequence[Sequence[Any]]]
 
     Returns
     -------
-    ``(fig, axes)`` where ``axes`` is a dict. For a mosaic the keys are the
-    mosaic keys; for a grid they are the panel labels (``'a'``, ``'b'``, ...),
-    or ``(row, col)`` tuples when ``label=False``.
+    ``(fig, axes)`` where ``axes`` is a dict.
+
+    A panel is always reachable by **the tag printed on it** — ``axes['a']``,
+    ``axes['b']``, ... For a mosaic the mosaic's own keys work too, so
+    ``'AAB\nCDB'`` gives both ``axes['A']`` and ``axes['a']`` for the same
+    axes. With ``label=False`` a grid is keyed by ``(row, col)`` tuples.
     """
     if isinstance(layout, int):
         import math
@@ -347,6 +350,14 @@ def multipanel(layout: Union[int, Tuple[int, int], str, Sequence[Sequence[Any]]]
     if labels is not None:
         for ax, text in zip(ordered, labels):
             add_panel_label(ax, text, **(dict(label_kw) if label_kw else {}))
+        # A mosaic is keyed by its own letters ('A'), but the tag drawn on the
+        # panel is 'a' — so `ax['a']` failed on a mosaic and worked on a grid.
+        # Alias the printed tag onto the same axes unless the mosaic already
+        # claims that key, so a panel is always reachable by what the reader
+        # sees on it.
+        for ax, text in zip(ordered, labels):
+            if text not in axes:
+                axes[text] = ax
 
     return fig, axes
 

--- a/omicverse/pl/_nanostring.py
+++ b/omicverse/pl/_nanostring.py
@@ -12,6 +12,8 @@ from typing import List, Optional, Union
 import warnings
 
 import matplotlib.pyplot as plt
+
+from ._plotdata import get_values
 import numpy as np
 import pandas as pd
 from matplotlib import patheffects
@@ -497,14 +499,7 @@ def nanostring(
         if color_key in adata.obs.columns:
             color_data = adata.obs.loc[cells_in_fovs, color_key]
         else:
-            from scipy.sparse import issparse
-
-            gene_idx = adata.var_names.get_loc(color_key)
-            X_sub = adata[fov_mask.to_numpy(), :].X
-            vals = X_sub[:, gene_idx]
-            if issparse(vals) or hasattr(vals, "toarray"):
-                vals = vals.toarray()
-            vals = np.asarray(vals).flatten()
+            vals = get_values(adata, color_key)[fov_mask.to_numpy()]
             color_data = pd.Series(vals, index=cells_in_fovs, name=color_key)
 
         is_categorical = (
@@ -940,14 +935,8 @@ def nanostringseg(
         if color_key in adata.obs.columns:
             color_data = adata.obs.loc[valid_cells, color_key]
         else:
-            from scipy.sparse import issparse
-
-            gene_idx = adata.var_names.get_loc(color_key)
             idx_pos = adata.obs_names.get_indexer(valid_cells)
-            gene_vals = adata.X[idx_pos, gene_idx]
-            if issparse(gene_vals) or hasattr(gene_vals, "toarray"):
-                gene_vals = gene_vals.toarray()
-            gene_vals = np.asarray(gene_vals).flatten()
+            gene_vals = get_values(adata, color_key)[idx_pos]
             color_data = pd.Series(gene_vals, index=valid_cells, name=color_key)
 
         temp_gdf = gpd.GeoDataFrame({color_key: color_data}, geometry=geom_series,

--- a/omicverse/pl/_plot_backend.py
+++ b/omicverse/pl/_plot_backend.py
@@ -522,27 +522,14 @@ def blue_palette()->list:
     examples=['texts = ov.utils.plot_text_set(texts, text_knock=0.6, text_maxsize=12)'],
     related=['bulk.geneset_plot_multi', 'utils.plot_cellproportion']
 )
-@register_function(
-    aliases=["坐标轴样式", "style_axes", "spine_style", "外移边框", "ov_frame"],
-    category="pl",
-    description=(
-        "Apply the OmicVerse axes convention — top/right spines hidden, "
-        "left/bottom offset outward by 10 points, grid off"
-    ),
-    examples=[
-        "fig, ax = plt.subplots()",
-        "ax.plot(x, y)",
-        "ov.pl.style_axes(ax)",
-        "# keep the spines where they are, just hide the top and right",
-        "ov.pl.style_axes(ax, outward=0)",
-        "# an image or a pie has no meaningful frame",
-        "ov.pl.style_axes(ax, spines=False)",
-    ],
-    related=["pl.plot_set", "pl.figure", "pl.multipanel"],
-)
 def style_axes(ax, *, outward: float = 10, spines: bool = True,
                grid: bool = False, top: bool = False, right: bool = False):
     r"""Apply the OmicVerse frame convention to an axes.
+
+    Not in the function registry: this module hosts the styling primitives
+    (``plot_set``, ``palette``, ``ticks_range``, ...) and deliberately stubs
+    ``register_function`` out, because they are how a plot is configured
+    rather than something an agent is asked to produce.
 
     The house look — top and right spines hidden, the remaining two pushed
     ``outward`` points away from the data, no grid — was written inline in

--- a/omicverse/pl/_plot_backend.py
+++ b/omicverse/pl/_plot_backend.py
@@ -522,6 +522,66 @@ def blue_palette()->list:
     examples=['texts = ov.utils.plot_text_set(texts, text_knock=0.6, text_maxsize=12)'],
     related=['bulk.geneset_plot_multi', 'utils.plot_cellproportion']
 )
+@register_function(
+    aliases=["坐标轴样式", "style_axes", "spine_style", "外移边框", "ov_frame"],
+    category="pl",
+    description=(
+        "Apply the OmicVerse axes convention — top/right spines hidden, "
+        "left/bottom offset outward by 10 points, grid off"
+    ),
+    examples=[
+        "fig, ax = plt.subplots()",
+        "ax.plot(x, y)",
+        "ov.pl.style_axes(ax)",
+        "# keep the spines where they are, just hide the top and right",
+        "ov.pl.style_axes(ax, outward=0)",
+        "# an image or a pie has no meaningful frame",
+        "ov.pl.style_axes(ax, spines=False)",
+    ],
+    related=["pl.plot_set", "pl.figure", "pl.multipanel"],
+)
+def style_axes(ax, *, outward: float = 10, spines: bool = True,
+               grid: bool = False, top: bool = False, right: bool = False):
+    r"""Apply the OmicVerse frame convention to an axes.
+
+    The house look — top and right spines hidden, the remaining two pushed
+    ``outward`` points away from the data, no grid — was written inline in
+    several plotting functions. This is that same code in one place, so a new
+    plot does not have to reinvent it and cannot drift from it.
+
+    Arguments
+    ---------
+    ax
+        Axes to style.
+    outward
+        Points to offset the left and bottom spines. ``10`` is the OmicVerse
+        convention; ``0`` leaves them against the data.
+    spines
+        ``False`` hides all four — right for an image, a pie, or anything
+        where a frame carries no information.
+    grid
+        Whether to draw the grid. Off by default, as elsewhere in ``ov.pl``.
+    top, right
+        Show those spines instead of hiding them.
+
+    Returns
+    -------
+    The same ``Axes``, so it can be chained.
+    """
+    ax.grid(grid)
+    ax.spines["top"].set_visible(bool(top))
+    ax.spines["right"].set_visible(bool(right))
+    if not spines:
+        for side in ("left", "bottom"):
+            ax.spines[side].set_visible(False)
+        return ax
+    for side in ("left", "bottom"):
+        ax.spines[side].set_visible(True)
+        if outward:
+            ax.spines[side].set_position(("outward", float(outward)))
+    return ax
+
+
 def plot_text_set(text, text_knock=2, text_maxsize=20):
     r"""Format text for plotting by adding line breaks.
     
@@ -582,122 +642,45 @@ def ticks_range(x,width):
         ticks=nticks+[0]+pticks
     return ticks
 
-def plot_boxplot(data,hue,x_value,y_value,width=0.6,title='',
-                 figsize=(6,3),palette=None,fontsize=10,
-                 legend_bbox=(1, 0.55),legend_ncol=1,):
-    r"""Create boxplot with jittered points for grouped data.
-    
-    Parameters
-    ----------
-    data:pd.DataFrame
-        Input table containing numeric values and grouping columns.
-    hue:str
-        Column name used for color grouping.
-    x_value:str
-        Column name used for x-axis category.
-    y_value:str
-        Column name containing numeric values.
-    width:float
-        Width of each box element.
-    title:str
-        Plot title.
-    figsize:tuple
-        Figure size.
-    palette:list or None
-        Color list for hue groups.
-    fontsize:int
-        Font size for labels and ticks.
-    legend_bbox:tuple
-        Legend anchor location.
-    legend_ncol:int
-        Number of legend columns.
-        
-    Returns
-    -------
-    Tuple[matplotlib.figure.Figure,matplotlib.axes.Axes]
-        Figure and axes containing grouped boxplot.
+def plot_boxplot(data, hue, x_value, y_value, width=0.6, title='',
+                 figsize=(6, 3), palette=None, fontsize=10,
+                 legend_bbox=(1, 0.55), legend_ncol=1, hue_order=None):
+    r"""Deprecated alias of :func:`omicverse.pl.boxplot`.
+
+    This was an earlier, shorter implementation of the same plot. It is now a
+    forwarding shim so there is one boxplot in ``ov.pl`` rather than two that
+    drift apart.
+
+    Two things are preserved so existing callers see the same figure:
+    ``width`` keeps its old default of 0.6, and ``hue_order`` defaults to the
+    order the hue levels first appear in ``data`` — which is what this
+    function did — rather than to ``boxplot``'s alphabetical order. Pass
+    ``hue_order`` explicitly to override.
+
+    The x categories are now sorted, which they were not before. That is the
+    one visible change, and it is a fix: the old order came from however the
+    rows happened to be grouped.
     """
+    from warnings import warn
 
-    #获取需要分割的数据
-    hue=hue
-    hue_datas=list(set(data[hue]))
+    warn(
+        "`ov.pl.plot_boxplot` is deprecated and will be removed in a future "
+        "release; use `ov.pl.boxplot` instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    from ._bulk import boxplot as _boxplot
 
-    #获取箱线图的横坐标
-    x=x_value
-    ticks=list(set(data[x]))
+    if hue_order is None:
+        import pandas as _pd
 
-    #在这个数据中，我们有6个不同的癌症，每个癌症都有2个基因（2个箱子）
-    #所以我们需要得到每一个基因的6个箱线图位置，6个散点图的抖动
-    plot_data1={}#字典里的每一个元素就是每一个基因的所有值
-    plot_data_random1={}#字典里的每一个元素就是每一个基因的随机20个值
-    plot_data_xs1={}#字典里的每一个元素就是每一个基因的20个抖动值
+        hue_order = list(_pd.unique(_pd.Series(data[hue]).dropna()))
+    return _boxplot(data, hue=hue, x_value=x_value, y_value=y_value,
+                    width=width, title=title, figsize=figsize,
+                    palette=palette, fontsize=fontsize,
+                    legend_bbox=legend_bbox, legend_ncol=legend_ncol,
+                    hue_order=hue_order)
 
-
-    #箱子的参数
-    #width=0.6
-    y=y_value
-    for hue_data,num in zip(hue_datas,ticks_range(len(hue_datas),width)):
-        data_a=[]
-        data_a_random=[]
-        data_a_xs=[]
-        for i,k in zip(ticks,range(len(ticks))):
-            test_data=data.loc[((data[x]==i)&(data[hue]==hue_data)),y].tolist()
-            data_a.append(test_data)
-            if len(test_data)<20:
-                data_size=len(test_data)
-            else:
-                data_size=20
-            random_data=random.sample(test_data,data_size)
-            data_a_random.append(random_data)
-            data_a_xs.append(np.random.normal(k*len(hue_datas)+num, 0.04, len(random_data)))
-        #data_a=np.array(data_a)
-        data_a_random=np.array(data_a_random)
-        plot_data1[hue_data]=data_a 
-        plot_data_random1[hue_data]=data_a_random
-        plot_data_xs1[hue_data]=data_a_xs
-
-    fig, ax = plt.subplots(figsize=figsize)
-    #色卡
-    if palette==None:
-        palette=pyomic_palette()
-    #palette=["#a64d79","#674ea7"]
-    #绘制箱线图
-    for hue_data,hue_color,num in zip(hue_datas,palette,ticks_range(len(hue_datas),width)):
-        b1=ax.boxplot(plot_data1[hue_data], 
-                    positions=np.array(range(len(ticks)))*len(hue_datas)+num, 
-                    sym='', 
-                    widths=width,)
-        plt.setp(b1['boxes'], color=hue_color)
-        plt.setp(b1['whiskers'], color=hue_color)
-        plt.setp(b1['caps'], color=hue_color)
-        plt.setp(b1['medians'], color=hue_color)
-
-        clevels = np.linspace(0., 1., len(plot_data_random1[hue_data]))
-        for x, val, clevel in zip(plot_data_xs1[hue_data], plot_data_random1[hue_data], clevels):
-            plt.scatter(x, val,c=hue_color,alpha=0.4)
-
-    #坐标轴字体
-    #fontsize=10
-    #修改横坐标
-    ax.set_xticks(range(0, len(ticks) * len(hue_datas), len(hue_datas)), ticks,fontsize=fontsize)
-    #修改纵坐标
-    yticks=ax.get_yticks()
-    ax.set_yticks(yticks[yticks>=0],yticks[yticks>=0],fontsize=fontsize)
-
-    labels = hue_datas  #legend标签列表，上面的color即是颜色列表
-    color = palette
-    #用label和color列表生成mpatches.Patch对象，它将作为句柄来生成legend
-    patches = [ mpatches.Patch(color=color[i], label="{:s}".format(labels[i]) ) for i in range(len(hue_datas)) ] 
-    ax.legend(handles=patches,bbox_to_anchor=legend_bbox, ncol=legend_ncol,fontsize=fontsize)
-
-    #设置标题
-    ax.set_title(title,fontsize=fontsize+1)
-    #设置spines可视化情况
-    ax.spines['top'].set_visible(False)
-    ax.spines['right'].set_visible(False)
-    ax.spines['bottom'].set_visible(True)
-    ax.spines['left'].set_visible(True)
-    return fig,ax
 
 def plot_network(G:nx.Graph,G_type_dict:dict,G_color_dict:dict,pos_type:str='spring',pos_dim:int=2,
                 figsize:tuple=(4,4),pos_scale:int=10,pos_k=None,pos_alpha:float=0.4,

--- a/omicverse/pl/_plot_backend.py
+++ b/omicverse/pl/_plot_backend.py
@@ -562,10 +562,23 @@ def style_axes(ax, *, outward: float = 10, spines: bool = True,
         for side in ("left", "bottom"):
             ax.spines[side].set_visible(False)
         return ax
+    # Moving a spine makes matplotlib rebuild that axis's tick labels, which
+    # discards anything set through `set_xticklabels` — rotation and
+    # alignment most visibly. Carry them across the move.
+    keep = {
+        "x": [(t.get_rotation(), t.get_horizontalalignment())
+              for t in ax.get_xticklabels()],
+        "y": [(t.get_rotation(), t.get_horizontalalignment())
+              for t in ax.get_yticklabels()],
+    }
     for side in ("left", "bottom"):
         ax.spines[side].set_visible(True)
         if outward:
             ax.spines[side].set_position(("outward", float(outward)))
+    for axis, labels in (("x", ax.get_xticklabels()), ("y", ax.get_yticklabels())):
+        for text, (rotation, align) in zip(labels, keep[axis]):
+            text.set_rotation(rotation)
+            text.set_horizontalalignment(align)
     return ax
 
 

--- a/omicverse/pl/_plotdata.py
+++ b/omicverse/pl/_plotdata.py
@@ -22,16 +22,176 @@ against ``adata.obs`` keeps working unchanged. Deliberately *not* a fake
 from __future__ import annotations
 
 import functools
-from typing import Any, Callable, Iterable, Optional, Sequence
+from typing import Any, Callable, Iterable, List, Optional, Sequence
 
 import numpy as np
 import pandas as pd
 
-__all__ = ["PlotData", "ObsView", "as_plotdata", "accepts_frame"]
+__all__ = ["PlotData", "ObsView", "as_plotdata", "accepts_frame", "get_values",
+           "get_matrix"]
 
 
 def _is_anndata_like(obj: Any) -> bool:
     return all(hasattr(obj, attr) for attr in ("obs", "var_names", "obs_names"))
+
+
+def _densify(values: Any) -> np.ndarray:
+    """1-D dense array, whatever came out of the matrix."""
+    if hasattr(values, "toarray"):
+        values = values.toarray()
+    return np.asarray(values).ravel()
+
+
+def _pick_matrix(data: Any, key: str, layer: Optional[str],
+                 use_raw: Optional[bool]):
+    """Choose the matrix to read ``key`` from, and the index within it.
+
+    Returns ``(matrix, index, source)`` where ``source`` names what was used,
+    for error messages and provenance.
+    """
+    raw = getattr(data, "raw", None)
+    in_var = key in data.var_names
+    in_raw = raw is not None and key in raw.var_names
+
+    if layer is not None:
+        if use_raw:
+            raise ValueError(
+                "Give either `layer=` or `use_raw=True`, not both — "
+                "`.raw` has no layers."
+            )
+        layers = getattr(data, "layers", {})
+        if layer not in layers:
+            available = ", ".join(map(str, layers)) or "none"
+            raise KeyError(f"No layer {layer!r}. Available: {available}.")
+        if not in_var:
+            raise KeyError(
+                f"{key!r} is not in `.var_names`, so it cannot be read from "
+                f"layer {layer!r}."
+            )
+        return layers[layer], data.var_names.get_loc(key), f"layers[{layer!r}]"
+
+    if use_raw is True:
+        if not in_raw:
+            raise KeyError(
+                f"`use_raw=True` but {key!r} is not in `.raw.var_names`"
+                + ("." if raw is not None else " — this object has no `.raw`.")
+            )
+        return raw.X, raw.var_names.get_loc(key), ".raw.X"
+
+    if in_var:
+        return data.X, data.var_names.get_loc(key), ".X"
+
+    if use_raw is None and in_raw:
+        # the usual reason a name is missing from .var_names is HVG subsetting
+        return raw.X, raw.var_names.get_loc(key), ".raw.X"
+
+    return None, None, None
+
+
+def get_values(data: Any, key: str, *, layer: Optional[str] = None,
+               use_raw: Optional[bool] = None,
+               dense: bool = True) -> np.ndarray:
+    r"""Read one named vector — a metadata column or a feature.
+
+    This is the single place ``ov.pl`` resolves "a name the user typed" into
+    numbers. Before it existed, nine modules each had their own version of the
+    same three lines, and they disagreed: some densified sparse matrices and
+    crashed on dense ones, some did the opposite, some preferred ``.raw`` over
+    ``.obs``, and only two honoured ``layer=``.
+
+    Arguments
+    ---------
+    data
+        ``AnnData`` (or anything AnnData-shaped), ``DataFrame``, ``dict``, or
+        a :class:`PlotData`.
+    key
+        Name to resolve.
+    layer
+        Read the feature from ``.layers[layer]`` instead of ``.X``. Cannot be
+        combined with ``use_raw=True``.
+    use_raw
+        ``True`` forces ``.raw``; ``False`` forbids it; ``None`` (default)
+        reads ``.X`` and falls back to ``.raw`` **only** when the name is
+        absent from ``.var_names`` — the situation left behind by
+        highly-variable-gene subsetting.
+
+        Note this differs from ``scanpy``'s plotting default, which prefers
+        ``.raw`` whenever it exists. The rule here never silently swaps the
+        matrix under a name that ``.X`` can already answer; pass
+        ``use_raw=True`` for the scanpy behaviour.
+    dense
+        Return a 1-D dense array. ``False`` returns whatever the matrix
+        column was.
+
+    Returns
+    -------
+    ``numpy.ndarray`` of length ``n_obs``.
+
+    Raises
+    ------
+    KeyError
+        With the near-misses listed, when the name resolves to nothing.
+    """
+    if isinstance(data, PlotData):
+        return data.values(key, layer=layer)
+
+    frame = data if isinstance(data, pd.DataFrame) else getattr(data, "obs", None)
+    if isinstance(data, dict):
+        frame = pd.DataFrame({k: np.asarray(v).ravel() for k, v in data.items()})
+
+    # metadata wins: a name that is both a column and a gene means the column
+    if isinstance(frame, pd.DataFrame) and key in frame.columns:
+        if layer is not None:
+            raise ValueError(
+                f"{key!r} is a metadata column; `layer=` only applies to "
+                f"features."
+            )
+        return frame[key].to_numpy()
+
+    if _is_anndata_like(data):
+        matrix, index, _ = _pick_matrix(data, key, layer, use_raw)
+        if matrix is not None:
+            column = matrix[:, index]
+            return _densify(column) if dense else column
+
+    _raise_unknown_key(data, frame, key, use_raw)
+
+
+def _raise_unknown_key(data, frame, key, use_raw):
+    from difflib import get_close_matches
+
+    pool: List[str] = []
+    if isinstance(frame, pd.DataFrame):
+        pool += [str(c) for c in frame.columns]
+    if _is_anndata_like(data):
+        pool += [str(v) for v in data.var_names[:5000]]
+    hint = get_close_matches(str(key), pool, n=3, cutoff=0.6)
+    suffix = f" Did you mean: {', '.join(hint)}?" if hint else ""
+    raw = getattr(data, "raw", None)
+    if use_raw is False and raw is not None and key in raw.var_names:
+        suffix += " It is present in `.raw` — pass `use_raw=True`."
+    raise KeyError(
+        f"{key!r} is neither a metadata column nor a feature of this "
+        f"object.{suffix}"
+    )
+
+
+def get_matrix(data: Any, keys: Sequence[str], *, layer: Optional[str] = None,
+               use_raw: Optional[bool] = None) -> np.ndarray:
+    r"""Read several names at once into an ``(n_obs, len(keys))`` array.
+
+    Same resolution rules as :func:`get_values`, but it reads each matrix once
+    rather than once per key — which matters for a dot plot over 50 genes.
+    """
+    keys = list(keys)
+    if not keys:
+        raise ValueError("`keys` is empty.")
+    columns = [get_values(data, key, layer=layer, use_raw=use_raw)
+               for key in keys]
+    lengths = {len(c) for c in columns}
+    if len(lengths) > 1:
+        raise ValueError(f"Resolved vectors have different lengths: {lengths}.")
+    return np.column_stack(columns).astype(float, copy=False)
 
 
 class PlotData:
@@ -51,7 +211,7 @@ class PlotData:
     """
 
     def __init__(self, obs: pd.DataFrame, *, var_names: Optional[pd.Index] = None,
-                 feature_getter: Optional[Callable[[str, Optional[str]], np.ndarray]] = None,
+                 feature_getter: Optional[Callable[..., np.ndarray]] = None,
                  obsm: Optional[Any] = None, source: Any = None):
         self.obs = obs
         self.var_names = pd.Index([] if var_names is None else var_names)
@@ -67,11 +227,13 @@ class PlotData:
         """Whether ``key`` resolves to either a metadata column or a feature."""
         return key in self.obs.columns or key in self.var_names
 
-    def values(self, key: str, layer: Optional[str] = None) -> np.ndarray:
+    def values(self, key: str, layer: Optional[str] = None, *,
+               use_raw: Optional[bool] = None) -> np.ndarray:
         """Values of ``key`` — a metadata column, or a feature.
 
-        Metadata wins when a name is both, which matches ``scanpy``'s
-        behaviour and is almost always what the caller meant.
+        Metadata wins when a name is both, which is almost always what the
+        caller meant. See :func:`get_values` for the ``layer`` / ``use_raw``
+        rules; this method is the same resolver bound to one object.
         """
         if key in self.obs.columns:
             if layer is not None:
@@ -80,8 +242,9 @@ class PlotData:
                     f"features."
                 )
             return self.obs[key].to_numpy()
-        if key in self.var_names and self._feature_getter is not None:
-            return self._feature_getter(key, layer)
+        if self._feature_getter is not None and (
+                key in self.var_names or _is_anndata_like(self.source)):
+            return self._feature_getter(key, layer, use_raw)
         from difflib import get_close_matches
 
         pool = list(map(str, self.obs.columns)) + list(map(str, self.var_names[:2000]))
@@ -127,19 +290,12 @@ def as_plotdata(data: Any, *, obs: Optional[pd.DataFrame] = None,
         return data
 
     if _is_anndata_like(data):
-        def feature_getter(key: str, layer_name: Optional[str]) -> np.ndarray:
-            index = data.var_names.get_loc(key)
-            if layer_name is not None:
-                matrix = data.layers[layer_name]
-            elif getattr(data, "raw", None) is not None and key in data.raw.var_names:
-                matrix = data.raw.X
-                index = data.raw.var_names.get_loc(key)
-            else:
-                matrix = data.X
-            column = matrix[:, index]
-            if hasattr(column, "toarray"):
-                column = column.toarray()
-            return np.asarray(column).ravel()
+        def feature_getter(key: str, layer_name: Optional[str],
+                           use_raw: Optional[bool] = None) -> np.ndarray:
+            matrix, index, _ = _pick_matrix(data, key, layer_name, use_raw)
+            if matrix is None:
+                _raise_unknown_key(data, data.obs, key, use_raw)
+            return _densify(matrix[:, index])
 
         return PlotData(data.obs, var_names=data.var_names,
                         feature_getter=feature_getter,
@@ -163,7 +319,8 @@ def as_plotdata(data: Any, *, obs: Optional[pd.DataFrame] = None,
             )
         columns = pd.Index([f"feature_{i}" for i in range(array.shape[1])])
 
-        def array_getter(key: str, layer_name: Optional[str]) -> np.ndarray:
+        def array_getter(key: str, layer_name: Optional[str],
+                         use_raw: Optional[bool] = None) -> np.ndarray:
             if layer_name is not None:
                 raise ValueError("A bare array has no layers.")
             return array[:, columns.get_loc(key)]

--- a/omicverse/pl/_plotdata.py
+++ b/omicverse/pl/_plotdata.py
@@ -27,6 +27,8 @@ from typing import Any, Callable, Iterable, List, Optional, Sequence
 import numpy as np
 import pandas as pd
 
+from .._registry import register_function
+
 __all__ = ["PlotData", "ObsView", "as_plotdata", "accepts_frame", "get_values",
            "get_matrix"]
 
@@ -88,6 +90,23 @@ def _pick_matrix(data: Any, key: str, layer: Optional[str],
     return None, None, None
 
 
+@register_function(
+    aliases=["取值", "get_values", "取表达值", "fetch_values", "obs_vector", "基因取值"],
+    category="pl",
+    description=(
+        "Resolve one name to numbers — an .obs column or a feature — with explicit layer / use_raw rules, always returning a 1-D dense array"
+    ),
+    examples=[
+        'values = ov.pl.get_values(adata, "CD3D")       # a gene, from .X',
+        'values = ov.pl.get_values(adata, "leiden")     # a column of .obs',
+        '# from a layer, or forced from .raw',
+        'ov.pl.get_values(adata, "CD3D", layer="counts")',
+        'ov.pl.get_values(adata, "CD3D", use_raw=True)',
+        '# a DataFrame works too',
+        'ov.pl.get_values(df, "score")',
+    ],
+    related=["pl.get_matrix", "pl.as_plotdata", "pl.violinplot"],
+)
 def get_values(data: Any, key: str, *, layer: Optional[str] = None,
                use_raw: Optional[bool] = None,
                dense: bool = True) -> np.ndarray:
@@ -176,6 +195,20 @@ def _raise_unknown_key(data, frame, key, use_raw):
     )
 
 
+@register_function(
+    aliases=["取值矩阵", "get_matrix", "批量取值", "expression_matrix", "多基因取值"],
+    category="pl",
+    description=(
+        "Resolve several names at once into an (n_obs, n_keys) dense array, reading each underlying matrix only once"
+    ),
+    examples=[
+        'block = ov.pl.get_matrix(adata, ["CD3D", "NKG7", "MS4A1"])',
+        'block.shape                                     # (n_obs, 3)',
+        '# metadata and features can be mixed',
+        'ov.pl.get_matrix(adata, ["n_genes", "CD3D"])',
+    ],
+    related=["pl.get_values", "pl.dotplot", "pl.as_plotdata"],
+)
 def get_matrix(data: Any, keys: Sequence[str], *, layer: Optional[str] = None,
                use_raw: Optional[bool] = None) -> np.ndarray:
     r"""Read several names at once into an ``(n_obs, len(keys))`` array.
@@ -194,6 +227,20 @@ def get_matrix(data: Any, keys: Sequence[str], *, layer: Optional[str] = None,
     return np.column_stack(columns).astype(float, copy=False)
 
 
+@register_function(
+    aliases=["绘图数据", "PlotData", "统一数据视图", "plot_data_view"],
+    category="pl",
+    description=(
+        "Uniform read access to metadata and feature values, whatever the underlying container — returned by ov.pl.as_plotdata"
+    ),
+    examples=[
+        'view = ov.pl.as_plotdata(adata)',
+        'view.obs, view.var_names, view.n_obs',
+        'view.values("CD3D", layer="counts")',
+        'view.has("leiden")',
+    ],
+    related=["pl.as_plotdata", "pl.get_values"],
+)
 class PlotData:
     """Uniform read access to metadata and feature values.
 
@@ -267,6 +314,22 @@ class PlotData:
                 f"columns, {len(self.var_names)} features)")
 
 
+@register_function(
+    aliases=["数据适配", "as_plotdata", "plot_data", "容器适配", "统一取值接口"],
+    category="pl",
+    description=(
+        "Wrap an AnnData / DataFrame / dict / array in a PlotData — one values() accessor that resolves metadata first and features second"
+    ),
+    examples=[
+        'view = ov.pl.as_plotdata(adata)',
+        'view.values("CD3D")            # a gene',
+        'view.values("leiden")          # a column of .obs',
+        'view.embedding("umap")         # coordinates',
+        '# the same accessor over a plain table',
+        'ov.pl.as_plotdata(df).values("score")',
+    ],
+    related=["pl.get_values", "pl.accepts_frame", "pl.PlotData"],
+)
 def as_plotdata(data: Any, *, obs: Optional[pd.DataFrame] = None,
                 obsm: Optional[Any] = None,
                 layer: Optional[str] = None) -> PlotData:
@@ -334,6 +397,20 @@ def as_plotdata(data: Any, *, obs: Optional[pd.DataFrame] = None,
     )
 
 
+@register_function(
+    aliases=["元数据视图", "ObsView", "obs视图", "metadata_view"],
+    category="pl",
+    description=(
+        "An AnnData-shaped, metadata-only view over a DataFrame — exposes .obs / .uns / .obs_names and raises an actionable error on .X"
+    ),
+    examples=[
+        'view = ov.pl.ObsView(df)',
+        'view.obs, view.uns, view.shape',
+        '# reaching for expression fails immediately, naming the problem',
+        "view.X   # AttributeError: ... has no 'X'. Pass an AnnData ...",
+    ],
+    related=["pl.accepts_frame", "pl.as_plotdata"],
+)
 class ObsView:
     """An ``AnnData``-shaped, metadata-only view over a ``DataFrame``.
 
@@ -399,6 +476,22 @@ class ObsView:
         return f"ObsView({self.n_obs} rows x {self.obs.shape[1]} columns)"
 
 
+@register_function(
+    aliases=["表格适配器", "accepts_frame", "接受DataFrame", "adata去耦", "frame_decorator"],
+    category="pl",
+    description=(
+        "Decorator that lets a metadata-only AnnData plot also take a DataFrame, by wrapping it in an ObsView"
+    ),
+    examples=[
+        'from omicverse.pl import accepts_frame',
+        '@accepts_frame',
+        'def my_plot(adata, groupby):',
+        '    return adata.obs[groupby].value_counts()',
+        '# now a DataFrame works wherever an AnnData did',
+        'my_plot(df, groupby="sample")',
+    ],
+    related=["pl.as_plotdata", "pl.ObsView", "pl.cellproportion"],
+)
 def accepts_frame(func: Optional[Callable] = None, *, argument: int = 0):
     r"""Let a metadata-only ``AnnData`` plot also take a ``DataFrame``.
 

--- a/omicverse/pl/_plotdata.py
+++ b/omicverse/pl/_plotdata.py
@@ -227,20 +227,6 @@ def get_matrix(data: Any, keys: Sequence[str], *, layer: Optional[str] = None,
     return np.column_stack(columns).astype(float, copy=False)
 
 
-@register_function(
-    aliases=["绘图数据", "PlotData", "统一数据视图", "plot_data_view"],
-    category="pl",
-    description=(
-        "Uniform read access to metadata and feature values, whatever the underlying container — returned by ov.pl.as_plotdata"
-    ),
-    examples=[
-        'view = ov.pl.as_plotdata(adata)',
-        'view.obs, view.var_names, view.n_obs',
-        'view.values("CD3D", layer="counts")',
-        'view.has("leiden")',
-    ],
-    related=["pl.as_plotdata", "pl.get_values"],
-)
 class PlotData:
     """Uniform read access to metadata and feature values.
 
@@ -397,20 +383,6 @@ def as_plotdata(data: Any, *, obs: Optional[pd.DataFrame] = None,
     )
 
 
-@register_function(
-    aliases=["元数据视图", "ObsView", "obs视图", "metadata_view"],
-    category="pl",
-    description=(
-        "An AnnData-shaped, metadata-only view over a DataFrame — exposes .obs / .uns / .obs_names and raises an actionable error on .X"
-    ),
-    examples=[
-        'view = ov.pl.ObsView(df)',
-        'view.obs, view.uns, view.shape',
-        '# reaching for expression fails immediately, naming the problem',
-        "view.X   # AttributeError: ... has no 'X'. Pass an AnnData ...",
-    ],
-    related=["pl.accepts_frame", "pl.as_plotdata"],
-)
 class ObsView:
     """An ``AnnData``-shaped, metadata-only view over a ``DataFrame``.
 

--- a/omicverse/pl/_relational.py
+++ b/omicverse/pl/_relational.py
@@ -60,7 +60,7 @@ def _shift(data, *fields):
 
 
 @register_function(
-    aliases=["散点图", "scatterplot", "scatter", "点图", "相关散点图"],
+    aliases=["scatterplot", "散点图", "scatter", "相关散点图", "xy散点图"],
     category="pl",
     description=(
         "Scatter plot of y against x from a table, with categorical or "

--- a/omicverse/pl/_relational.py
+++ b/omicverse/pl/_relational.py
@@ -14,7 +14,9 @@ import numpy as np
 import pandas as pd
 
 from .._registry import register_function
-from ._stats_common import as_frame, default_palette, group_levels, resolve_columns
+from ._plot_backend import style_axes
+from ._stats_common import (as_frame, default_palette, font_size,
+                            group_levels, resolve_columns)
 
 __all__ = ["scatterplot", "lineplot", "regplot"]
 
@@ -104,7 +106,7 @@ def scatterplot(data: Any = None,
                 legend: bool = True,
                 legend_title: Optional[str] = None,
                 colorbar_label: Optional[str] = None,
-                fontsize: float = 9,
+                fontsize: Optional[float] = None,
                 return_stats: bool = False):
     r"""Plain y-against-x scatter.
 
@@ -186,21 +188,21 @@ def scatterplot(data: Any = None,
                            label=str(level), rasterized=rasterized)
             if legend:
                 ax.legend(title=legend_title or names.get("hue"), frameon=False,
-                          fontsize=fontsize, title_fontsize=fontsize)
+                          fontsize=font_size(fontsize), title_fontsize=font_size(fontsize))
     else:
         ax.scatter(xs, ys, s=sizes, color="#1F577B", alpha=alpha,
                    edgecolor=edgecolor, linewidths=0, rasterized=rasterized)
 
     if mappable is not None:
         bar = ax.figure.colorbar(mappable, ax=ax, fraction=0.04, pad=0.03)
-        bar.set_label(colorbar_label or "", fontsize=fontsize)
-        bar.ax.tick_params(labelsize=fontsize - 1)
+        bar.set_label(colorbar_label or "", fontsize=font_size(fontsize))
+        bar.ax.tick_params(labelsize=font_size(fontsize) - 1)
 
     if corr:
         value, pvalue, symbol = _correlation(xs, ys, corr)
         results.update(correlation=value, pvalue=pvalue, method=corr)
         ax.text(0.03, 0.97, _format_corr(value, pvalue, symbol),
-                transform=ax.transAxes, va="top", ha="left", fontsize=fontsize)
+                transform=ax.transAxes, va="top", ha="left", fontsize=font_size(fontsize))
     if diagonal:
         lo = min(xs.min(), ys.min())
         hi = max(xs.max(), ys.max())
@@ -212,13 +214,13 @@ def scatterplot(data: Any = None,
         ax.set_yscale("log")
 
     ax.set_xlabel(xlabel if xlabel is not None else names.get("x", ""),
-                  fontsize=fontsize + 1)
+                  fontsize=font_size(fontsize, "label"))
     ax.set_ylabel(ylabel if ylabel is not None else names.get("y", ""),
-                  fontsize=fontsize + 1)
+                  fontsize=font_size(fontsize, "label"))
     if title:
-        ax.set_title(title, fontsize=fontsize + 2)
-    ax.tick_params(labelsize=fontsize)
-    ax.spines[["right", "top"]].set_visible(False)
+        ax.set_title(title, fontsize=font_size(fontsize, "title"))
+    ax.tick_params(labelsize=font_size(fontsize))
+    style_axes(ax)
     return (ax, results) if return_stats else ax
 
 
@@ -275,7 +277,7 @@ def lineplot(data: Any = None,
              title: Optional[str] = None,
              legend: bool = True,
              legend_title: Optional[str] = None,
-             fontsize: float = 9,
+             fontsize: Optional[float] = None,
              return_stats: bool = False):
     r"""Line plot, aggregating repeated measurements at each x.
 
@@ -339,16 +341,16 @@ def lineplot(data: Any = None,
     if log_y:
         ax.set_yscale("log")
     ax.set_xlabel(xlabel if xlabel is not None else names.get("x", ""),
-                  fontsize=fontsize + 1)
+                  fontsize=font_size(fontsize, "label"))
     ax.set_ylabel(ylabel if ylabel is not None else names.get("y", ""),
-                  fontsize=fontsize + 1)
+                  fontsize=font_size(fontsize, "label"))
     if title:
-        ax.set_title(title, fontsize=fontsize + 2)
-    ax.tick_params(labelsize=fontsize)
-    ax.spines[["right", "top"]].set_visible(False)
+        ax.set_title(title, fontsize=font_size(fontsize, "title"))
+    ax.tick_params(labelsize=font_size(fontsize))
+    style_axes(ax)
     if legend and len(hues) > 1:
         ax.legend(title=legend_title or names.get("hue"), frameon=False,
-                  fontsize=fontsize, title_fontsize=fontsize)
+                  fontsize=font_size(fontsize), title_fontsize=font_size(fontsize))
 
     result = pd.concat(tables, ignore_index=True) if tables else pd.DataFrame()
     return (ax, result) if return_stats else ax
@@ -396,7 +398,7 @@ def regplot(data: Any = None,
             title: Optional[str] = None,
             legend: bool = True,
             legend_title: Optional[str] = None,
-            fontsize: float = 9,
+            fontsize: Optional[float] = None,
             return_stats: bool = False):
     r"""Scatter plus a fitted trend.
 
@@ -501,17 +503,17 @@ def regplot(data: Any = None,
             lines.append(format_pvalue(entry["pvalue"], "value"))
         if lines:
             ax.text(0.03, 0.97, "\n".join(lines), transform=ax.transAxes,
-                    va="top", ha="left", fontsize=fontsize)
+                    va="top", ha="left", fontsize=font_size(fontsize))
 
     ax.set_xlabel(xlabel if xlabel is not None else names.get("x", ""),
-                  fontsize=fontsize + 1)
+                  fontsize=font_size(fontsize, "label"))
     ax.set_ylabel(ylabel if ylabel is not None else names.get("y", ""),
-                  fontsize=fontsize + 1)
+                  fontsize=font_size(fontsize, "label"))
     if title:
-        ax.set_title(title, fontsize=fontsize + 2)
-    ax.tick_params(labelsize=fontsize)
-    ax.spines[["right", "top"]].set_visible(False)
+        ax.set_title(title, fontsize=font_size(fontsize, "title"))
+    ax.tick_params(labelsize=font_size(fontsize))
+    style_axes(ax)
     if legend and len(hues) > 1:
         ax.legend(title=legend_title or names.get("hue"), frameon=False,
-                  fontsize=fontsize, title_fontsize=fontsize)
+                  fontsize=font_size(fontsize), title_fontsize=font_size(fontsize))
     return (ax, results) if return_stats else ax

--- a/omicverse/pl/_single.py
+++ b/omicverse/pl/_single.py
@@ -1,5 +1,6 @@
 from ._scatterplot_backend import _embedding
 from .._registry import register_function
+from ._plotdata import get_values
 from ._plotdata import accepts_frame
 import collections.abc as cabc
 from copy import copy
@@ -1607,20 +1608,7 @@ def half_violin_boxplot(adata, keys, groupby, ax=None, figsize=(4,4), show=True,
     from scipy.sparse import issparse  
     
     # 获取 y 数据
-    y = None
-    if not adata.raw is None and keys in adata.raw.var_names:
-        y = adata.raw[:, keys].X
-    elif keys in adata.obs.columns:
-        y = adata.obs[keys].values
-    elif keys in adata.var_names:
-        y = adata[:, keys].X
-    else:
-        raise ValueError(f'{keys} not found in adata.raw.var_names, adata.var_names, or adata.obs.columns')
-    
-    if issparse(y):
-        y = y.toarray().reshape(-1)
-    else:
-        y = y.reshape(-1)
+    y = np.asarray(get_values(adata, keys), dtype=float).reshape(-1)
     
     # 获取 x 数据
     x = adata.obs[groupby].values.reshape(-1)

--- a/omicverse/pl/_single.py
+++ b/omicverse/pl/_single.py
@@ -2,6 +2,7 @@ from ._scatterplot_backend import _embedding
 from .._registry import register_function
 from ._plotdata import get_values
 from ._plotdata import accepts_frame
+from ._plot_backend import style_axes
 import collections.abc as cabc
 from copy import copy
 from numbers import Integral
@@ -932,13 +933,7 @@ def bardotplot(adata,groupby,color,figsize=(8,3),return_values=False,
                    **scatter_kwargs)
 
 
-    plt.grid(False)
-    ax.spines['top'].set_visible(False)
-    ax.spines['right'].set_visible(False)
-    ax.spines['bottom'].set_visible(True)
-    ax.spines['left'].set_visible(True)
-    ax.spines['left'].set_position(('outward', 10))
-    ax.spines['bottom'].set_position(('outward', 10))
+    style_axes(ax)
 
     plt.xticks(rotation=xticks_rotation,fontsize=fontsize)
     plt.xlabel(xlabel,fontsize=fontsize+1)
@@ -1116,13 +1111,7 @@ def single_group_boxplot(adata,
     yticks = ax.get_yticks()
     ax.set_title(title, fontsize=fontsize+1,)
     plt.ylabel(ylabel, fontsize=fontsize+1, )
-    plt.grid(False)
-    ax.spines['top'].set_visible(False)
-    ax.spines['right'].set_visible(False)
-    ax.spines['bottom'].set_visible(True)
-    ax.spines['left'].set_visible(True)
-    ax.spines['left'].set_position(('outward', 10))
-    ax.spines['bottom'].set_position(('outward', 10))
+    style_axes(ax)
 
     if legend_plot == True:
         labels = list(plot_data.keys())
@@ -1582,13 +1571,7 @@ def violin_old(adata,keys=None,groupby=None,ax=None,figsize=(4,4),fontsize=13,
         fontsize=fontsize,
         **kwargs,
     )
-    plt.grid(False)
-    ax.spines['top'].set_visible(False)
-    ax.spines['right'].set_visible(False)
-    ax.spines['bottom'].set_visible(True)
-    ax.spines['left'].set_visible(True)
-    ax.spines['left'].set_position(('outward', 10))
-    ax.spines['bottom'].set_position(('outward', 10))
+    style_axes(ax)
     if ticks_fontsize==None:
         ticks_fontsize=fontsize-1
 

--- a/omicverse/pl/_space.py
+++ b/omicverse/pl/_space.py
@@ -7,6 +7,7 @@ import numpy as np
 from matplotlib.colors import ListedColormap
 from matplotlib.gridspec import GridSpec
 from .._registry import register_function
+from ._plotdata import get_values
 
 def to_rgb_grayscale(img, p_low: float = 1.0, p_high: float = 99.0):
     """Convert a 2-D grayscale image to a percentile-clipped RGB stack.
@@ -571,7 +572,7 @@ def plot_spatial(adata, color, img_key="hires", show_img=True, **kwargs):
         if ct in adata.obs.columns:
             plot_data[ct] = adata.obs[ct]
         elif ct in adata.var_names:
-            plot_data[ct] = adata[:,ct].X.flatten()
+            plot_data[ct] = get_values(adata, ct)
     plot_data=plot_data.fillna(0)
 
     fig = plot_spatial_general(adata,value_df=plot_data, **kwargs)  # cell abundance values
@@ -881,7 +882,7 @@ def add_pie_charts_to_spatial(
         if ct in adata.obs.columns:
             plot_data[ct] = adata.obs[ct]
         elif ct in adata.var_names:
-            plot_data[ct] = adata[:,ct].X.flatten()
+            plot_data[ct] = get_values(adata, ct)
     plot_data=plot_data.fillna(0)
     props_df = (
         plot_data
@@ -1061,7 +1062,7 @@ def add_pie2spatial(
         if ct in adata.obs.columns:
             plot_data[ct] = adata.obs[ct]
         elif ct in adata.var_names:
-            plot_data[ct] = adata[:,ct].X.flatten()
+            plot_data[ct] = get_values(adata, ct)
     plot_data=plot_data.fillna(0)
     props = (
         plot_data

--- a/omicverse/pl/_spatialseg.py
+++ b/omicverse/pl/_spatialseg.py
@@ -16,6 +16,7 @@ from matplotlib import patheffects
 from matplotlib import colors as mcolors
 
 from .._registry import register_function
+from ._plotdata import get_values
 
 
 @register_function(
@@ -472,15 +473,9 @@ def spatialseg(
             temp_gdf = gpd.GeoDataFrame({color_key: color_data}, geometry=temp_geometries, index=valid_cells)
             plot_column = color_key
         else:
-            from scipy.sparse import issparse
-
-            gene_idx = adata.var_names.get_loc(color_key)
-            expression_values = adata.X[
-                adata.obs_names.get_indexer(valid_cells), gene_idx
+            expression_values = get_values(adata, color_key)[
+                adata.obs_names.get_indexer(valid_cells)
             ]
-            if issparse(expression_values) or hasattr(expression_values, "toarray"):
-                expression_values = expression_values.toarray()
-            expression_values = np.asarray(expression_values).flatten()
 
             color_data = pd.Series(expression_values, index=valid_cells, name=color_key)
             temp_gdf = gpd.GeoDataFrame({color_key: color_data}, geometry=temp_geometries, index=valid_cells)

--- a/omicverse/pl/_stats_common.py
+++ b/omicverse/pl/_stats_common.py
@@ -21,8 +21,8 @@ from typing import Any, Dict, Mapping, Optional, Tuple
 import numpy as np
 import pandas as pd
 
-__all__ = ["as_frame", "default_palette", "group_levels", "kde_curve",
-           "resolve_columns"]
+__all__ = ["as_frame", "default_palette", "font_size", "font_sizes",
+           "group_levels", "kde_curve", "resolve_columns"]
 
 
 def as_frame(data: Any) -> Optional[pd.DataFrame]:
@@ -223,3 +223,47 @@ def kde_curve(values, *, cut: float = 2.0, gridsize: int = 200,
         high = min(high, clip[1]) if clip[1] is not None else high
     grid = _np.linspace(low, high, gridsize)
     return grid, kernel(grid)
+
+
+def font_sizes(fontsize=None) -> Dict[str, float]:
+    """Label / tick / title / legend point sizes.
+
+    With ``fontsize=None`` — the default everywhere in ``ov.pl`` — the sizes
+    come from the rcParams that :func:`~omicverse.pl.plot_set` configured, so
+    a figure follows whatever the user set globally instead of a second,
+    hard-coded scale living inside the plotting functions.
+
+    An explicit ``fontsize`` overrides all four, keeping the tick size and
+    deriving the rest, which is what a caller passing ``fontsize=6`` for a
+    small panel means.
+    """
+    import matplotlib.pyplot as _plt
+    from matplotlib.font_manager import FontProperties as _FontProperties
+
+    def _points(value) -> float:
+        return float(_FontProperties(size=value).get_size_in_points())
+
+    if fontsize is None:
+        rc = _plt.rcParams
+        return {
+            "label": _points(rc["axes.labelsize"]),
+            "tick": _points(rc["xtick.labelsize"]),
+            "title": _points(rc["axes.titlesize"]),
+            "legend": _points(rc["legend.fontsize"]),
+        }
+    size = float(fontsize)
+    return {"label": size + 1, "tick": size, "title": size + 2,
+            "legend": size}
+
+
+def font_size(fontsize=None, role: str = "tick", delta: float = 0.0) -> float:
+    """One size from :func:`font_sizes`, optionally nudged by ``delta``.
+
+    ``role`` is ``'tick'`` (default), ``'label'``, ``'title'`` or ``'legend'``.
+    """
+    sizes = font_sizes(fontsize)
+    if role not in sizes:
+        raise ValueError(
+            f"`role` must be one of {sorted(sizes)}, got {role!r}."
+        )
+    return max(sizes[role] + delta, 1.0)

--- a/omicverse/pl/_stats_common.py
+++ b/omicverse/pl/_stats_common.py
@@ -21,7 +21,8 @@ from typing import Any, Dict, Mapping, Optional, Tuple
 import numpy as np
 import pandas as pd
 
-__all__ = ["as_frame", "default_palette", "group_levels", "resolve_columns"]
+__all__ = ["as_frame", "default_palette", "group_levels", "kde_curve",
+           "resolve_columns"]
 
 
 def as_frame(data: Any) -> Optional[pd.DataFrame]:
@@ -187,3 +188,38 @@ def default_palette(n: int, palette: Any = None) -> list:
     if len(base) < n:
         base = (base * (n // len(base) + 1))[:n]
     return base[:n]
+
+
+def kde_curve(values, *, cut: float = 2.0, gridsize: int = 200,
+              bw_method: Any = None, clip=None):
+    """Gaussian KDE of ``values`` on a grid extended by ``cut`` *bandwidths*.
+
+    ``cut`` means what it means in seaborn and R: how far past the extreme
+    observations the density is drawn, measured in kernel bandwidths. An
+    earlier version of this code measured it as a fraction of the data range
+    instead, which put a long thin tail on every violin — visually the whole
+    difference between these plots and the ones in ``ov.pl.violin``.
+
+    Returns ``(grid, density)``; a degenerate sample (fewer than two distinct
+    values) yields a flat zero density rather than raising.
+    """
+    import numpy as _np
+
+    values = _np.asarray(values, dtype=float)
+    values = values[_np.isfinite(values)]
+    if values.size < 2 or _np.allclose(values, values[0]):
+        centre = float(values[0]) if values.size else 0.0
+        grid = _np.linspace(centre - 1.0, centre + 1.0, gridsize)
+        return grid, _np.zeros_like(grid)
+
+    from scipy.stats import gaussian_kde
+
+    kernel = gaussian_kde(values, bw_method=bw_method)
+    bandwidth = float(kernel.factor * _np.std(values, ddof=1))
+    low = values.min() - cut * bandwidth
+    high = values.max() + cut * bandwidth
+    if clip is not None:
+        low = max(low, clip[0]) if clip[0] is not None else low
+        high = min(high, clip[1]) if clip[1] is not None else high
+    grid = _np.linspace(low, high, gridsize)
+    return grid, kernel(grid)

--- a/omicverse/pl/_stats_tests.py
+++ b/omicverse/pl/_stats_tests.py
@@ -21,7 +21,7 @@ import numpy as np
 import pandas as pd
 
 from .._registry import register_function
-from ._stats_common import group_levels
+from ._stats_common import font_size, group_levels
 
 __all__ = ["compare_groups", "format_pvalue", "add_stat_annotation"]
 
@@ -429,7 +429,7 @@ def add_stat_annotation(ax,
                     linewidth=linewidth, color=color, clip_on=False,
                     transform=transform, solid_joinstyle="miter")
             ax.text((left + right) / 2, level + span * text_offset, text,
-                    ha="center", va="bottom", fontsize=fontsize, color=color,
+                    ha="center", va="bottom", fontsize=font_size(fontsize), color=color,
                     clip_on=False)
         else:
             ax.plot([level - cap, level, level, level - cap],
@@ -437,7 +437,7 @@ def add_stat_annotation(ax,
                     linewidth=linewidth, color=color, clip_on=False,
                     transform=transform, solid_joinstyle="miter")
             ax.text(level + span * text_offset, (left + right) / 2, text,
-                    ha="left", va="center", fontsize=fontsize, color=color,
+                    ha="left", va="center", fontsize=font_size(fontsize), color=color,
                     rotation=270, clip_on=False)
         reached = max(reached, level + span * (text_offset + line_height * 0.6))
 

--- a/omicverse/pl/_stats_tests.py
+++ b/omicverse/pl/_stats_tests.py
@@ -37,6 +37,19 @@ _CATEGORICAL_TESTS = {"fisher", "chi2"}
 _STAR_CUTOFFS = ((1e-4, "****"), (1e-3, "***"), (1e-2, "**"), (0.05, "*"))
 
 
+@register_function(
+    aliases=["P值格式化", "format_pvalue", "显著性星号", "p_value_stars", "星号标注"],
+    category="pl",
+    description=(
+        "Render a P value as stars, as a number, or as both — the same formatting the significance brackets use"
+    ),
+    examples=[
+        "ov.pl.format_pvalue(0.003)            # -> '**'",
+        'ov.pl.format_pvalue(0.003, "value")   # -> \'P = 0.003\'',
+        'ov.pl.format_pvalue(1e-8, "full")     # -> \'**** (P = 1.0e-08)\'',
+    ],
+    related=["pl.compare_groups", "pl.add_stat_annotation"],
+)
 def format_pvalue(p: float, style: str = "star") -> str:
     """Render a P value as stars, as a number, or as both.
 

--- a/omicverse/pl/_survival.py
+++ b/omicverse/pl/_survival.py
@@ -621,7 +621,7 @@ def _step_ci(ax, x, lo, hi, color, alpha):
 
 
 @register_function(
-    aliases=["生存曲线", "survival", "kaplan_meier", "KM曲线", "km_plot", "生存分析图"],
+    aliases=["生存曲线", "survival", "KM曲线", "km_plot", "生存分析图", "生存曲线图"],
     category="pl",
     description=(
         "Kaplan-Meier survival curves with confidence band, censoring marks, "
@@ -821,7 +821,7 @@ def survival(data: Any = None,
 
 @register_function(
     aliases=["累积发病率", "cumulative_incidence", "竞争风险", "competing_risks",
-             "CIF", "aalen_johansen"],
+             "累积发生率曲线"],
     category="pl",
     description=(
         "Aalen-Johansen cumulative incidence curves under competing risks, "

--- a/omicverse/pl/_survival.py
+++ b/omicverse/pl/_survival.py
@@ -26,8 +26,9 @@ import numpy as np
 import pandas as pd
 
 from .._registry import register_function
-from ._stats_common import (as_frame, default_palette, group_levels,
-                            resolve_columns)
+from ._plot_backend import style_axes
+from ._stats_common import (as_frame, default_palette, font_size,
+                            group_levels, resolve_columns)
 
 __all__ = [
     "kaplan_meier",
@@ -587,11 +588,11 @@ def _draw_risk_table(ax_risk, times, labels, counts, colors, fontsize,
     ax_risk.set_ylim(-0.5, n - 0.5)
     ax_risk.invert_yaxis()
     ax_risk.set_yticks(range(n))
-    ax_risk.set_yticklabels(labels, fontsize=fontsize)
+    ax_risk.set_yticklabels(labels, fontsize=font_size(fontsize))
     for tick, color in zip(ax_risk.get_yticklabels(), colors):
         tick.set_color(color)
     ax_risk.set_xticks(times)
-    ax_risk.set_xticklabels([f"{v:g}" for v in times], fontsize=fontsize + 0.5)
+    ax_risk.set_xticklabels([f"{v:g}" for v in times], fontsize=font_size(fontsize) + 0.5)
     ax_risk.tick_params(axis="x", length=0, labelbottom=True)
     ax_risk.tick_params(axis="y", length=0)
     for spine in ax_risk.spines.values():
@@ -602,11 +603,11 @@ def _draw_risk_table(ax_risk, times, labels, counts, colors, fontsize,
             rel = (x - xlim[0]) / span
             ha = "left" if rel < 0.02 else ("right" if rel > 0.98 else "center")
             ax_risk.text(x, row, f"{int(value)}", ha=ha, va="center",
-                         fontsize=fontsize)
+                         fontsize=font_size(fontsize))
     ax_risk.set_ylabel("")
     if xlabel:
-        ax_risk.set_xlabel(xlabel, fontsize=fontsize + 1.5)
-    ax_risk.set_title("Number at risk", fontsize=fontsize, loc="left", pad=3)
+        ax_risk.set_xlabel(xlabel, fontsize=font_size(fontsize, "label", 0.5))
+    ax_risk.set_title("Number at risk", fontsize=font_size(fontsize), loc="left", pad=3)
 
 
 def _step_ci(ax, x, lo, hi, color, alpha):
@@ -665,7 +666,7 @@ def survival(data: Any = None,
              ylim: Optional[Tuple[float, float]] = None,
              legend: bool = True,
              legend_loc: str = "best",
-             fontsize: float = 9,
+             fontsize: Optional[float] = None,
              linewidth: float = 1.6,
              return_stats: bool = False):
     r"""Plot Kaplan-Meier survival curves.
@@ -778,7 +779,7 @@ def survival(data: Any = None,
             )
     if annotation:
         ax.text(0.98, 0.98, "\n".join(annotation), transform=ax.transAxes,
-                ha="right", va="top", fontsize=fontsize,
+                ha="right", va="top", fontsize=font_size(fontsize),
                 bbox=dict(boxstyle="round,pad=0.3", facecolor="white",
                           edgecolor="0.8", alpha=0.85))
 
@@ -789,21 +790,21 @@ def survival(data: Any = None,
         ax.set_yticklabels([f"{v:.0f}" for v in np.linspace(0, 100, 6)])
     time_label = xlabel if xlabel is not None else names.get("time", "Time")
     if ax_risk is None:
-        ax.set_xlabel(time_label, fontsize=fontsize + 1)
+        ax.set_xlabel(time_label, fontsize=font_size(fontsize, "label"))
     else:
         # the risk table below carries the time axis instead
         ax.tick_params(axis="x", labelbottom=False)
     ax.set_ylabel(
         ylabel if ylabel is not None
         else ("Survival probability (%)" if percent else "Survival probability"),
-        fontsize=fontsize + 1,
+        fontsize=font_size(fontsize, "label"),
     )
     if title:
-        ax.set_title(title, fontsize=fontsize + 2)
-    ax.tick_params(labelsize=fontsize)
-    ax.spines[["right", "top"]].set_visible(False)
+        ax.set_title(title, fontsize=font_size(fontsize, "title"))
+    ax.tick_params(labelsize=font_size(fontsize))
+    style_axes(ax)
     if legend and "group" in frame:
-        ax.legend(loc=legend_loc, frameon=False, fontsize=fontsize)
+        ax.legend(loc=legend_loc, frameon=False, fontsize=font_size(fontsize))
 
     if ax_risk is not None:
         ticks = (np.asarray(risk_table_times, dtype=float)
@@ -812,7 +813,7 @@ def survival(data: Any = None,
                                   if ax.get_xlim()[0] <= v <= ax.get_xlim()[1]]))
         counts = [_at_risk(t[g == level], ticks) for level in levels]
         _draw_risk_table(ax_risk, ticks, [str(lv) for lv in levels], counts,
-                         colors, fontsize - 0.5, ax.get_xlim(), time_label)
+                         colors, font_size(fontsize, "tick", -0.5), ax.get_xlim(), time_label)
         ax_risk.set_xlim(ax.get_xlim())
 
     return (ax, stats) if return_stats else ax
@@ -865,7 +866,7 @@ def cumulative_incidence(data: Any = None,
                          ylim: Optional[Tuple[float, float]] = None,
                          legend: bool = True,
                          legend_loc: str = "best",
-                         fontsize: float = 9,
+                         fontsize: Optional[float] = None,
                          linewidth: float = 1.6,
                          return_stats: bool = False):
     r"""Plot cumulative incidence functions under competing risks.
@@ -953,7 +954,7 @@ def cumulative_incidence(data: Any = None,
         result = grays_test(t, e, g, causes[0], groups=levels)
         stats.update(result)
         ax.text(0.02, 0.98, f"Gray's test {_format_p(result['pvalue'])}",
-                transform=ax.transAxes, ha="left", va="top", fontsize=fontsize,
+                transform=ax.transAxes, ha="left", va="top", fontsize=font_size(fontsize),
                 bbox=dict(boxstyle="round,pad=0.3", facecolor="white",
                           edgecolor="0.8", alpha=0.85))
 
@@ -968,20 +969,20 @@ def cumulative_incidence(data: Any = None,
         ax.set_yticklabels([f"{v * 100:.0f}" for v in ticks])
     time_label = xlabel if xlabel is not None else names.get("time", "Time")
     if ax_risk is None:
-        ax.set_xlabel(time_label, fontsize=fontsize + 1)
+        ax.set_xlabel(time_label, fontsize=font_size(fontsize, "label"))
     else:
         ax.tick_params(axis="x", labelbottom=False)
     ax.set_ylabel(
         ylabel if ylabel is not None
         else ("Cumulative incidence (%)" if percent else "Cumulative incidence"),
-        fontsize=fontsize + 1,
+        fontsize=font_size(fontsize, "label"),
     )
     if title:
-        ax.set_title(title, fontsize=fontsize + 2)
-    ax.tick_params(labelsize=fontsize)
-    ax.spines[["right", "top"]].set_visible(False)
+        ax.set_title(title, fontsize=font_size(fontsize, "title"))
+    ax.tick_params(labelsize=font_size(fontsize))
+    style_axes(ax)
     if legend:
-        ax.legend(loc=legend_loc, frameon=False, fontsize=fontsize)
+        ax.legend(loc=legend_loc, frameon=False, fontsize=font_size(fontsize))
 
     if ax_risk is not None:
         ticks = (np.asarray(risk_table_times, dtype=float)
@@ -990,7 +991,7 @@ def cumulative_incidence(data: Any = None,
                                   if ax.get_xlim()[0] <= v <= ax.get_xlim()[1]]))
         counts = [_at_risk(t[mask], ticks) for _, mask, _, _ in series]
         _draw_risk_table(ax_risk, ticks, [lab for *_, lab in series], counts,
-                         colors, fontsize - 0.5, ax.get_xlim(), time_label)
+                         colors, font_size(fontsize, "tick", -0.5), ax.get_xlim(), time_label)
         ax_risk.set_xlim(ax.get_xlim())
 
     return (ax, stats) if return_stats else ax

--- a/omicverse/pl/_survival.py
+++ b/omicverse/pl/_survival.py
@@ -55,6 +55,20 @@ def _event_table(time: np.ndarray, indicator: np.ndarray) -> Dict[str, np.ndarra
             "n_censor": n_censor}
 
 
+@register_function(
+    aliases=["KM估计", "kaplan_meier", "生存估计", "product_limit", "乘积极限估计"],
+    category="pl",
+    description=(
+        "Kaplan-Meier product-limit estimator with a log-log confidence band, median and its Brookmeyer-Crowley interval — numbers only, no plot"
+    ),
+    examples=[
+        'fit = ov.pl.kaplan_meier(df["months"], df["dead"])',
+        'print(fit["median"], fit["median_ci"])',
+        '# the curve itself, for a custom figure',
+        'ax.step(fit["timeline"], fit["survival"], where="post")',
+    ],
+    related=["pl.survival", "pl.logrank_test", "pl.aalen_johansen"],
+)
 def kaplan_meier(time: Sequence[float],
                  event: Sequence[Any],
                  *,
@@ -165,6 +179,20 @@ def _at_risk(time: np.ndarray, query: np.ndarray) -> np.ndarray:
     return np.array([(time >= q).sum() for q in query], dtype=int)
 
 
+@register_function(
+    aliases=["log-rank检验", "logrank_test", "生存差异检验", "mantel_cox", "风险比"],
+    category="pl",
+    description=(
+        "Multivariate log-rank (Mantel-Cox) test with the Mantel-Haenszel hazard ratio for two groups; `groups=` fixes which level is the reference"
+    ),
+    examples=[
+        'res = ov.pl.logrank_test(df["months"], df["dead"], df["arm"])',
+        'print(res["pvalue"], res["hazard_ratio"])',
+        '# choose the reference explicitly',
+        'res = ov.pl.logrank_test(t, e, g, groups=["advanced", "early"])',
+    ],
+    related=["pl.survival", "pl.kaplan_meier", "pl.grays_test"],
+)
 def logrank_test(time: Sequence[float],
                  event: Sequence[Any],
                  group: Sequence[Any],
@@ -259,6 +287,20 @@ def logrank_test(time: Sequence[float],
     return out
 
 
+@register_function(
+    aliases=["AJ估计", "aalen_johansen", "累积发病率估计", "竞争风险估计", "CIF"],
+    category="pl",
+    description=(
+        "Aalen-Johansen cumulative incidence for one cause under competing risks, with the delta-method variance — the correct alternative to 1 - KM"
+    ),
+    examples=[
+        'fit = ov.pl.aalen_johansen(df["months"], df["cause"], cause=1)',
+        'print(fit["cif"][-1])',
+        '# how wrong the naive estimator would have been',
+        'km = ov.pl.kaplan_meier(df["months"], df["cause"] == 1)',
+    ],
+    related=["pl.cumulative_incidence", "pl.grays_test", "pl.kaplan_meier"],
+)
 def aalen_johansen(time: Sequence[float],
                    event: Sequence[Any],
                    cause: Any = 1,
@@ -379,6 +421,20 @@ def _subdistribution_curves(t: np.ndarray, codes: np.ndarray, cause: Any):
     return times, surv, cif
 
 
+@register_function(
+    aliases=["Gray检验", "grays_test", "gray_test", "竞争风险检验", "次分布检验"],
+    category="pl",
+    description=(
+        "Gray's test for equality of cumulative incidence functions — the test that matches what a competing-risk plot shows, unlike a plain log-rank"
+    ),
+    examples=[
+        'res = ov.pl.grays_test(df["months"], df["cause"], df["arm"], cause=1)',
+        'print(res["pvalue"])',
+        '# contrast with the cause-specific log-rank, a different question',
+        'ov.pl.logrank_test(df["months"], df["cause"] == 1, df["arm"])',
+    ],
+    related=["pl.cumulative_incidence", "pl.aalen_johansen", "pl.logrank_test"],
+)
 def grays_test(time: Sequence[float],
                event: Sequence[Any],
                group: Sequence[Any],

--- a/omicverse/pl/_violin.py
+++ b/omicverse/pl/_violin.py
@@ -2,10 +2,11 @@ import numpy as np
 import matplotlib.pyplot as plt
 import pandas as pd
 import scipy.stats as st
-from typing import Sequence, Union, Optional, Literal, List
+from typing import Sequence, Union, Optional, Literal, List, Tuple, Any
 from matplotlib.axes import Axes
 from collections import OrderedDict
 from .._registry import register_function
+from ._plotdata import accepts_frame
 from ._plotdata import get_values
 
 try:
@@ -57,6 +58,7 @@ DensityNorm = Literal["area", "count", "width"]
     ],
     related=["pl.embedding", "pl.dotplot"]
 )
+@accepts_frame
 def violin(
     adata: AnnData,
     keys: Union[str, Sequence[str]],
@@ -100,6 +102,21 @@ def violin(
     fontsize=13,
     ticks_fontsize=None,
     verbose: bool = False,
+    hue: Optional[str] = None,
+    hue_order: Optional[Sequence[str]] = None,
+    split: bool = False,
+    cut: Optional[float] = None,
+    clip: Optional[Tuple[Optional[float], Optional[float]]] = None,
+    inner: Optional[str] = None,
+    orient: str = "v",
+    scale: Optional[str] = None,
+    width: float = 0.8,
+    palette: Any = None,
+    test: Optional[str] = None,
+    correction: Optional[str] = "holm",
+    annot_style: str = "star",
+    hide_ns: bool = False,
+    return_stats: bool = False,
     **kwds
 ) -> Union[Axes, None]:
     r"""
@@ -150,6 +167,42 @@ def violin(
         ax: matplotlib.axes.Axes | None. A matplotlib axes object if `ax` is `None` else `None`.
     """
     
+    # ------------------------------------------------------------------
+    # Options the matplotlib engine below cannot express — a mirrored
+    # (split) violin, a density clipped at a hard bound, a horizontal
+    # layout, per-observation inner marks, or significance brackets. Only
+    # those route to the kernel-density renderer; with none of them the
+    # original code path runs untouched, so the default figure is
+    # unchanged to the pixel.
+    # ------------------------------------------------------------------
+    _advanced = (hue is not None or split or cut is not None or clip is not None
+                 or inner is not None or orient != "v" or scale is not None
+                 or test is not None or return_stats)
+    if _advanced:
+        from ._categorical import _violin_kde
+
+        if isinstance(keys, (list, tuple)):
+            if len(keys) != 1:
+                raise ValueError(
+                    "hue / split / cut / clip / inner / orient / test handle "
+                    f"one key at a time, got {len(keys)}. Call violin() once "
+                    "per key, or drop those options for the multi-key layout."
+                )
+            _key = keys[0]
+        else:
+            _key = keys
+        return _violin_kde(
+            adata, x=groupby, y=_key, hue=hue, hue_order=hue_order,
+            order=order, split=split, inner=inner,
+            cut=2.0 if cut is None else cut, clip=clip,
+            scale="width" if scale is None else scale, orient=orient,
+            width=width, palette=palette if palette is not None else custom_colors,
+            ax=ax, figsize=figsize, test=test, correction=correction,
+            annot_style=annot_style, hide_ns=hide_ns,
+            stripplot=stripplot, rotation=rotation or 0,
+            fontsize=fontsize, return_stats=return_stats, **kwds,
+        )
+
     # Handle AnnData availability
     if not ANNDATA_AVAILABLE:
         raise ImportError("AnnData is required for this function. Install with: pip install anndata")

--- a/omicverse/pl/_violin.py
+++ b/omicverse/pl/_violin.py
@@ -6,6 +6,7 @@ from typing import Sequence, Union, Optional, Literal, List
 from matplotlib.axes import Axes
 from collections import OrderedDict
 from .._registry import register_function
+from ._plotdata import get_values
 
 try:
     from anndata import AnnData
@@ -493,29 +494,14 @@ def _extract_data_from_adata(adata, keys, groupby, layer, use_raw):
         if key in adata.obs.columns:
             # Key is in observations
             data_dict[key] = adata.obs[key]
-        elif key in adata.var_names:
-            # Key is a gene in current var_names
-            if use_raw and _has_raw and key in adata.raw.var_names:
-                gene_idx = list(adata.raw.var_names).index(key)
-                data_dict[key] = adata.raw.X[:, gene_idx]
-            elif layer is not None and layer in adata.layers:
-                gene_idx = list(adata.var_names).index(key)
-                data_dict[key] = adata.layers[layer][:, gene_idx]
-            else:
-                gene_idx = list(adata.var_names).index(key)
-                data_dict[key] = adata.X[:, gene_idx]
-
-            # Handle sparse matrices and ensure 1-D
-            if hasattr(data_dict[key], 'toarray'):
-                data_dict[key] = data_dict[key].toarray()
-            data_dict[key] = np.asarray(data_dict[key]).ravel()
-        elif use_raw and _has_raw and key in adata.raw.var_names:
-            # Key is NOT in current var_names but IS in raw (e.g. after HVG subsetting)
-            gene_idx = list(adata.raw.var_names).index(key)
-            data_dict[key] = adata.raw.X[:, gene_idx]
-            if hasattr(data_dict[key], 'toarray'):
-                data_dict[key] = data_dict[key].toarray()
-            data_dict[key] = np.asarray(data_dict[key]).ravel()
+        elif key in adata.var_names or (_has_raw and key in adata.raw.var_names):
+            # A gene: ov.pl.get_values applies the layer / raw rules, densifies
+            # a sparse column, and rescues names left only in .raw by HVG
+            # subsetting
+            data_dict[key] = get_values(
+                adata, key, layer=layer if not use_raw else None,
+                use_raw=True if use_raw and _has_raw else None,
+            )
         else:
             available = "adata.obs, adata.var_names"
             if _has_raw:

--- a/omicverse/pl/_violin.py
+++ b/omicverse/pl/_violin.py
@@ -191,8 +191,24 @@ def violin(
             _key = keys[0]
         else:
             _key = keys
+        # Resolve the values here rather than handing the container over:
+        # _violin_kde reads a name through the plain accessor, which knows
+        # nothing about `layer` or `use_raw`, so passing the AnnData through
+        # silently plotted .X whatever the caller asked for.
+        from ._plotdata import get_values as _get_values
+
+        _use_raw = use_raw
+        if _use_raw is None:
+            _use_raw = getattr(adata, "raw", None) is not None and layer is None
+        _y = _get_values(adata, _key,
+                         layer=None if _use_raw else layer,
+                         use_raw=True if _use_raw else None)
+        _x = _get_values(adata, groupby) if groupby is not None else None
+        _hue = _get_values(adata, hue) if hue is not None else None
         return _violin_kde(
-            adata, x=groupby, y=_key, hue=hue, hue_order=hue_order,
+            None, x=_x, y=_y, hue=_hue, hue_order=hue_order,
+            xlabel=groupby or "", ylabel=_key,
+            legend_title=hue,
             order=order, split=split, inner=inner,
             cut=2.0 if cut is None else cut, clip=clip,
             scale="width" if scale is None else scale, orient=orient,
@@ -531,6 +547,14 @@ def _extract_data_from_adata(adata, keys, groupby, layer, use_raw):
     # Default behavior: use raw if it exists and use_raw is not explicitly False
     if use_raw is None:
         use_raw = hasattr(adata, 'raw') and adata.raw is not None
+        if use_raw and layer is not None:
+            # Long-standing behaviour is that .raw wins, which quietly threw
+            # away an explicit `layer=`. Keep the behaviour, lose the silence.
+            print(
+                f"violin: `.raw` is present so it takes precedence and "
+                f"layer={layer!r} is ignored. Pass use_raw=False to read the "
+                f"layer instead."
+            )
 
     data_dict = {}
 

--- a/tests/pl/test_generic_plots.py
+++ b/tests/pl/test_generic_plots.py
@@ -721,3 +721,127 @@ class TestSurface:
         # ov.pl.violin still takes an AnnData; ov.pl.violinplot takes a frame
         assert pl.violin is not pl.violinplot
         assert pl.boxplot is not pl.barplot
+
+
+class TestKdeCut:
+    """``cut`` must mean bandwidths, as it does in seaborn and R.
+
+    It was implemented as a fraction of the data *range* (``cut * span / 6``),
+    so the default ``cut=2`` extended every density by a third of the range in
+    each direction. That single line is what made ``ov.pl.violinplot`` look
+    like a smudge next to ``ov.pl.violin``.
+    """
+
+    @staticmethod
+    def _sample():
+        return np.random.default_rng(0).normal(size=500)
+
+    def test_cut_zero_stops_at_the_data(self):
+        from omicverse.pl._stats_common import kde_curve
+
+        values = self._sample()
+        grid, _ = kde_curve(values, cut=0)
+        assert grid.min() == pytest.approx(values.min())
+        assert grid.max() == pytest.approx(values.max())
+
+    def test_cut_extends_by_exactly_that_many_bandwidths(self):
+        from scipy.stats import gaussian_kde
+
+        from omicverse.pl._stats_common import kde_curve
+
+        values = self._sample()
+        bandwidth = gaussian_kde(values).factor * np.std(values, ddof=1)
+        grid, _ = kde_curve(values, cut=2)
+        assert grid.min() == pytest.approx(values.min() - 2 * bandwidth)
+        assert grid.max() == pytest.approx(values.max() + 2 * bandwidth)
+
+    def test_the_old_range_fraction_would_have_been_much_wider(self):
+        """Guard on the magnitude, not just the formula."""
+        from omicverse.pl._stats_common import kde_curve
+
+        values = self._sample()
+        span = values.max() - values.min()
+        grid, _ = kde_curve(values, cut=2)
+        overshoot = values.min() - grid.min()
+        assert overshoot < 0.1 * span          # the fix
+        assert overshoot > 0                   # but cut still does something
+
+    def test_clip_bounds_the_support(self):
+        from omicverse.pl._stats_common import kde_curve
+
+        grid, _ = kde_curve(np.abs(self._sample()), cut=3, clip=(0, None))
+        assert grid.min() == 0.0
+
+    def test_density_integrates_to_one(self):
+        from omicverse.pl._stats_common import kde_curve
+
+        grid, density = kde_curve(self._sample(), cut=4)
+        assert np.trapz(density, grid) == pytest.approx(1.0, abs=1e-3)
+
+    def test_degenerate_sample_does_not_raise(self):
+        from omicverse.pl._stats_common import kde_curve
+
+        for values in (np.full(20, 3.0), np.array([1.0]), np.array([])):
+            grid, density = kde_curve(values)
+            assert np.all(density == 0.0)
+            assert grid.size == 200
+
+
+class TestViolinLook:
+    """The defaults that decide whether a violin reads or smudges."""
+
+    @staticmethod
+    def _bodies(ax):
+        """Only the violin polygons — a scatter's path is its marker shape."""
+        from matplotlib.collections import PolyCollection
+
+        return [c for c in ax.collections if isinstance(c, PolyCollection)]
+
+    @classmethod
+    def _widths(cls, ax):
+        return [float(np.ptp(c.get_paths()[0].vertices[:, 0]))
+                for c in cls._bodies(ax)]
+
+    def test_default_scale_gives_every_violin_the_same_width(self, cells):
+        """`ov.pl.violin` normalises by width; so should `violinplot`."""
+        widths = self._widths(violinplot(cells, "cell_type", "score"))
+        assert len(widths) == cells["cell_type"].nunique()
+        assert max(widths) - min(widths) < 0.05 * max(widths)
+
+    def test_violins_have_a_visible_outline(self, cells):
+        ax = violinplot(cells, "cell_type", "score")
+        bodies = self._bodies(ax)
+        assert bodies, "no filled violin found"
+        edge = np.asarray(bodies[0].get_edgecolor()).ravel()
+        # black, not white — an unoutlined fill is the 'smudge' failure mode
+        assert float(edge[0]) < 0.5
+
+    def test_area_scaling_is_still_available(self, cells):
+        widths = self._widths(violinplot(cells, "cell_type", "score",
+                                         scale="area"))
+        assert max(widths) - min(widths) > 1e-6
+
+    def test_stripplot_overlay_draws_every_point(self, cells):
+        plain = violinplot(cells, "cell_type", "score")
+        n_plain = sum(c.get_offsets().shape[0] for c in plain.collections
+                      if c.get_offsets() is not None)
+        plt.close("all")
+        striped = violinplot(cells, "cell_type", "score", stripplot=True)
+        n_striped = sum(c.get_offsets().shape[0] for c in striped.collections
+                        if c.get_offsets() is not None)
+        assert n_striped - n_plain >= len(cells)
+
+    def test_cut_zero_keeps_a_bounded_quantity_in_range(self, cells):
+        positive = cells.assign(abs_score=cells["score"].abs())
+        ax = violinplot(positive, "cell_type", "abs_score", cut=0, inner=None)
+        lowest = min(float(c.get_paths()[0].vertices[:, 1].min())
+                     for c in self._bodies(ax))
+        assert lowest >= positive["abs_score"].min() - 1e-9
+
+    def test_clip_bounds_a_violin_too(self, cells):
+        positive = cells.assign(abs_score=cells["score"].abs())
+        ax = violinplot(positive, "cell_type", "abs_score", cut=3,
+                        clip=(0, None), inner=None)
+        lowest = min(float(c.get_paths()[0].vertices[:, 1].min())
+                     for c in self._bodies(ax))
+        assert lowest >= -1e-9

--- a/tests/pl/test_generic_plots.py
+++ b/tests/pl/test_generic_plots.py
@@ -959,3 +959,110 @@ class TestViolinMerge:
         assert points < len(cells), "the strip overlay was inherited from violin"
         assert ax.get_lines(), "the inner quartile box is missing"
         plt.close("all")
+
+
+class TestViolinAnnDataPaths:
+    """The AnnData features must survive on the new code path too.
+
+    Delegating to the kernel-density renderer originally handed the AnnData
+    over by reference, and that renderer resolves a name through the plain
+    accessor, which knows nothing about `layer` or `use_raw`. So
+    ``violin(adata, keys='GENE', layer='counts', test='auto')`` silently
+    plotted ``.X``. The values are asserted here, not just that it ran.
+    """
+
+    X_VALUE, LAYER_VALUE, RAW_VALUE = 0.0, 100.0, 50.0
+
+    @classmethod
+    def _adata(cls):
+        anndata = pytest.importorskip("anndata")
+
+        rng = np.random.default_rng(0)
+        n = 200
+        obs = pd.DataFrame({"celltype": rng.choice(["a", "b"], n),
+                            "cond": rng.choice(["x", "y"], n)})
+        out = anndata.AnnData(np.full((n, 2), cls.X_VALUE, dtype=np.float32),
+                              obs=obs)
+        out.var_names = ["GENE0", "GENE1"]
+        out.layers["counts"] = np.full((n, 2), cls.LAYER_VALUE, dtype=np.float32)
+        raw = out.copy()
+        raw.X = np.full((n, 2), cls.RAW_VALUE, dtype=np.float32)
+        out.raw = raw
+        return out
+
+    @staticmethod
+    def _drawn_median(ax):
+        from matplotlib.collections import PolyCollection
+
+        bodies = [c for c in ax.collections if isinstance(c, PolyCollection)]
+        assert bodies, "nothing drawn"
+        return float(np.median(np.concatenate(
+            [c.get_paths()[0].vertices[:, 1] for c in bodies])))
+
+    @pytest.mark.parametrize("advanced", [{}, {"test": "auto"}])
+    def test_layer_is_honoured_on_both_paths(self, advanced):
+        from omicverse.pl import violin
+
+        ax = violin(self._adata(), keys="GENE0", groupby="celltype",
+                    layer="counts", use_raw=False, show=False, **advanced)
+        assert self._drawn_median(ax) == pytest.approx(self.LAYER_VALUE, abs=1)
+        plt.close("all")
+
+    @pytest.mark.parametrize("advanced", [{}, {"test": "auto"}])
+    def test_use_raw_is_honoured_on_both_paths(self, advanced):
+        from omicverse.pl import violin
+
+        ax = violin(self._adata(), keys="GENE0", groupby="celltype",
+                    use_raw=True, show=False, **advanced)
+        assert self._drawn_median(ax) == pytest.approx(self.RAW_VALUE, abs=1)
+        plt.close("all")
+
+    @pytest.mark.parametrize("advanced", [{}, {"test": "auto"}])
+    def test_use_raw_false_reads_x_on_both_paths(self, advanced):
+        from omicverse.pl import violin
+
+        ax = violin(self._adata(), keys="GENE0", groupby="celltype",
+                    use_raw=False, show=False, **advanced)
+        assert self._drawn_median(ax) == pytest.approx(self.X_VALUE, abs=1)
+        plt.close("all")
+
+    def test_an_ignored_layer_is_announced(self, capsys):
+        """`.raw` wins by default, which used to discard `layer=` in silence."""
+        from omicverse.pl import violin
+
+        violin(self._adata(), keys="GENE0", groupby="celltype",
+               layer="counts", show=False)
+        assert "layer='counts' is ignored" in capsys.readouterr().out
+        plt.close("all")
+
+    def test_gene_only_in_raw_still_resolves(self):
+        from omicverse.pl import violin
+
+        full = self._adata()
+        subset = full[:, ["GENE0"]].copy()
+        # `.raw = full` would store full.X, not full.raw.X — take the raw
+        # values explicitly so the assertion below can tell them apart
+        subset.raw = full.raw.to_adata()
+        ax = violin(subset, keys="GENE1", groupby="celltype", use_raw=True,
+                    show=False)
+        assert self._drawn_median(ax) == pytest.approx(self.RAW_VALUE, abs=1)
+        plt.close("all")
+
+    def test_hue_keeps_its_column_name_in_the_legend(self):
+        """Resolving hue to an array lost the label it was named after."""
+        from omicverse.pl import violin
+
+        ax = violin(self._adata(), keys="GENE0", groupby="celltype",
+                    hue="cond", split=True)
+        legend = ax.get_legend()
+        assert legend is not None and legend.get_title().get_text() == "cond"
+        plt.close("all")
+
+    def test_axis_labels_survive_the_delegation(self):
+        from omicverse.pl import violin
+
+        ax = violin(self._adata(), keys="GENE0", groupby="celltype",
+                    test="auto")
+        assert ax.get_xlabel() == "celltype"
+        assert ax.get_ylabel() == "GENE0"
+        plt.close("all")

--- a/tests/pl/test_generic_plots.py
+++ b/tests/pl/test_generic_plots.py
@@ -776,7 +776,7 @@ class TestKdeCut:
         from omicverse.pl._stats_common import kde_curve
 
         grid, density = kde_curve(self._sample(), cut=4)
-        assert np.trapz(density, grid) == pytest.approx(1.0, abs=1e-3)
+        assert trapezoid(density, grid) == pytest.approx(1.0, abs=1e-3)
 
     def test_degenerate_sample_does_not_raise(self):
         from omicverse.pl._stats_common import kde_curve

--- a/tests/pl/test_generic_plots.py
+++ b/tests/pl/test_generic_plots.py
@@ -822,7 +822,7 @@ class TestViolinLook:
         assert max(widths) - min(widths) > 1e-6
 
     def test_stripplot_overlay_draws_every_point(self, cells):
-        plain = violinplot(cells, "cell_type", "score")
+        plain = violinplot(cells, "cell_type", "score", stripplot=False)
         n_plain = sum(c.get_offsets().shape[0] for c in plain.collections
                       if c.get_offsets() is not None)
         plt.close("all")
@@ -845,3 +845,117 @@ class TestViolinLook:
         lowest = min(float(c.get_paths()[0].vertices[:, 1].min())
                      for c in self._bodies(ax))
         assert lowest >= -1e-9
+
+
+class TestViolinMerge:
+    """`ov.pl.violin` absorbed `violinplot`; neither picture may change.
+
+    The requirement was that the existing violin keep working exactly as it
+    did, so the new options route to the kernel-density renderer and the
+    default path is left alone. These tests pin that boundary, because a
+    delegation that fires too eagerly would silently restyle every violin in
+    the package.
+    """
+
+    @staticmethod
+    def _adata(cells):
+        anndata = pytest.importorskip("anndata")
+        out = anndata.AnnData(np.zeros((len(cells), 1), dtype=np.float32),
+                              obs=cells.copy())
+        out.var_names = ["gene"]
+        return out
+
+    def test_default_path_does_not_delegate(self, cells, monkeypatch):
+        """No advanced option -> the matplotlib engine, untouched."""
+        from omicverse.pl import _categorical
+
+        called = []
+        monkeypatch.setattr(_categorical, "_violin_kde",
+                            lambda *a, **k: called.append(1))
+        from omicverse.pl import violin
+
+        violin(self._adata(cells), keys=["score"], groupby="cell_type",
+               show=False)
+        assert not called, "the default violin was rerouted to the KDE engine"
+
+    @pytest.mark.parametrize("option", [
+        {"hue": "condition"}, {"split": True}, {"cut": 0}, {"clip": (0, None)},
+        {"inner": "box"}, {"orient": "h"}, {"scale": "area"}, {"test": "auto"},
+    ])
+    def test_each_new_option_delegates(self, cells, monkeypatch, option):
+        from omicverse.pl import _categorical
+
+        called = []
+        monkeypatch.setattr(_categorical, "_violin_kde",
+                            lambda *a, **k: called.append(k) or "sentinel")
+        from omicverse.pl import violin
+
+        if "hue" in option or "split" in option:
+            option.setdefault("hue", "condition")
+        out = violin(self._adata(cells), keys="score", groupby="cell_type",
+                     **option)
+        assert called, f"{option} did not reach the KDE engine"
+        assert out == "sentinel"
+
+    def test_violin_now_takes_a_dataframe(self, cells):
+        from omicverse.pl import violin
+
+        ax = violin(cells, keys="score", groupby="cell_type", show=False)
+        assert ax is not None
+        assert cells["cell_type"].dtype == object  # caller's frame untouched
+        plt.close("all")
+
+    def test_absorbed_options_actually_draw(self, cells):
+        from omicverse.pl import violin
+
+        for option in ({"hue": "condition", "split": True},
+                       {"test": "auto"}, {"cut": 0}, {"inner": "stick"},
+                       {"orient": "h"}):
+            ax = violin(cells, keys="score", groupby="cell_type", **option)
+            assert ax.collections, option
+            plt.close("all")
+
+    def test_return_stats_gives_the_test_back(self, cells):
+        from omicverse.pl import violin
+
+        ax, stats = violin(cells, keys="score", groupby="cell_type",
+                           test="auto", return_stats=True)
+        assert stats["test"] is not None
+        plt.close("all")
+
+    def test_multi_key_with_an_advanced_option_is_refused(self, cells):
+        from omicverse.pl import violin
+
+        with pytest.raises(ValueError, match="one key at a time"):
+            violin(cells, keys=["score", "counts"], groupby="cell_type",
+                   split=True, hue="condition")
+
+    def test_violinplot_warns_and_forwards(self, cells):
+        from omicverse.pl import violinplot as legacy
+
+        with pytest.warns(DeprecationWarning, match="ov.pl.violin"):
+            ax = legacy(cells, "cell_type", "score")
+        assert ax is not None
+        plt.close("all")
+
+    def test_violinplot_keeps_its_own_defaults(self, cells):
+        """The shim must not inherit violin's defaults for these four.
+
+        Each one changes the figure: `violin` draws no inner box, draws the
+        raw points, pins fontsize=13 and uses the matplotlib engine — all the
+        opposite of what violinplot did.
+        """
+        from matplotlib.collections import PolyCollection
+
+        from omicverse.pl import violinplot as legacy
+
+        with pytest.warns(DeprecationWarning):
+            ax = legacy(cells, "cell_type", "score")
+        bodies = [c for c in ax.collections if isinstance(c, PolyCollection)]
+        points = sum(c.get_offsets().shape[0] for c in ax.collections
+                     if not isinstance(c, PolyCollection)
+                     and c.get_offsets() is not None)
+        assert bodies, "no violin drawn"
+        assert points < len(cells), "the strip overlay was inherited from violin"
+        assert ax.get_lines(), "the inner quartile box is missing"
+        plt.close("all")

--- a/tests/pl/test_value_accessor.py
+++ b/tests/pl/test_value_accessor.py
@@ -315,19 +315,31 @@ class TestRegistryCoverage:
     def _public_names(self, callables_only: bool = True):
         """Public names of the new modules, keyed to the module they live in.
 
-        ``callables_only`` skips data constants such as ``JOURNAL_WIDTH_MM``
-        and ``EDITABLE_TEXT_RCPARAMS``: the registry indexes *capabilities an
-        agent can invoke*, and a dict of column widths is not one. They still
-        have to be exported, which the export test checks.
+        ``callables_only`` skips three things, for three different reasons:
+
+        * data constants such as ``JOURNAL_WIDTH_MM`` — the registry indexes
+          *capabilities an agent can invoke*, and a dict of column widths is
+          not one;
+        * classes such as ``PlotData`` and ``ObsView`` — registering a class
+          also registers its members, and ``PlotData.embedding`` then takes
+          the lookup key that belongs to ``ov.pl.embedding``. They are reached
+          through their factory, ``as_plotdata``, which is registered;
+        * anything in ``_plot_backend``, which stubs ``register_function`` out
+          on purpose because it holds the styling primitives.
+
+        All three must still be exported, which the export test checks.
         """
         import importlib
+        import inspect
 
         names = {}
         for module_name in self.MODULES:
             module = importlib.import_module(f"omicverse.pl.{module_name}")
             for name in getattr(module, "__all__", []):
-                if callables_only and not callable(getattr(module, name, None)):
-                    continue
+                target = getattr(module, name, None)
+                if callables_only:
+                    if not callable(target) or inspect.isclass(target):
+                        continue
                 names[name] = module_name
         return names
 
@@ -548,3 +560,84 @@ class TestDeprecatedAliases:
         with pytest.warns(DeprecationWarning, match=name):
             getattr(pl, name)(adata, keys="v", groupby="g")
         plt.close("all")
+
+
+class TestRegistryLookupIsUnambiguous:
+    """A name must resolve to the function that owns it.
+
+    The registry keys entries by alias and by short name, so an alias that
+    happens to equal another function's real name silently takes the key over
+    — asking for ``kaplan_meier`` returned ``survival``, because ``survival``
+    listed ``kaplan_meier`` among its aliases. Decorating a *class* had the
+    same effect through its members: ``PlotData.embedding`` claimed the key
+    ``embedding`` that belongs to ``ov.pl.embedding``.
+
+    These assertions cover the entries this work added. Capability branches
+    (``name[method=...]``) are excluded: sharing a method alias across the
+    functions that accept it is what that mechanism is for.
+    """
+
+    OWNED = (
+        "survival", "cumulative_incidence", "kaplan_meier", "logrank_test",
+        "aalen_johansen", "grays_test", "roc", "confusion", "roc_auc_ci",
+        "forest", "meta_analysis", "compare_groups", "add_stat_annotation",
+        "format_pvalue", "barplot", "stripplot", "violinplot", "stackplot",
+        "lollipopplot", "pieplot", "donutplot", "slopeplot", "histplot",
+        "kdeplot", "ridgeplot", "qqplot", "scatterplot", "lineplot", "regplot",
+        "as_plotdata", "accepts_frame", "get_values", "get_matrix",
+        "figure", "multipanel", "add_panel_label", "savefig",
+        "set_editable_text", "take_legend_out",
+    )
+
+    @staticmethod
+    def _registry():
+        import omicverse.pl  # noqa: F401
+
+        from omicverse._registry import get_registry
+
+        return get_registry()
+
+    def test_each_name_resolves_to_its_own_function(self):
+        registry = self._registry()
+        wrong = {}
+        for name in self.OWNED:
+            entry = registry._registry.get(name)
+            assert entry is not None, f"{name} is not in the registry at all"
+            full = str(entry.get("full_name"))
+            if not full.endswith(f".{name}"):
+                wrong[name] = full
+        assert not wrong, (
+            "these names resolve to a different function — an alias is "
+            f"shadowing them: {wrong}"
+        )
+
+    def test_no_alias_shadows_another_functions_name(self):
+        registry = self._registry()
+        owned = set(self.OWNED)
+        offenders = []
+        for entry in registry._registry.values():
+            full = str(entry.get("full_name") or "")
+            if "[" in full or not full.startswith("omicverse.pl."):
+                continue
+            short = full.rsplit(".", 1)[-1]
+            for alias in entry.get("aliases") or []:
+                alias = str(alias).lower()
+                if alias in owned and alias != short.lower():
+                    offenders.append(f"{short} claims the alias {alias!r}")
+        assert not offenders, sorted(set(offenders))
+
+    def test_decorating_a_class_does_not_leak_its_members(self):
+        registry = self._registry()
+        leaked = sorted({str(e.get("full_name")) for e in registry._registry.values()
+                         if ".PlotData." in str(e.get("full_name"))
+                         or ".ObsView." in str(e.get("full_name"))})
+        assert not leaked, (
+            "class members reached the lookup table; register the factory "
+            f"function instead of the class: {leaked}"
+        )
+
+    def test_the_factory_is_still_discoverable(self):
+        """Dropping the class decorators must not hide `as_plotdata`."""
+        registry = self._registry()
+        hits = {str(e.get("full_name")) for e in registry.find("as_plotdata")}
+        assert any(h.endswith("as_plotdata") for h in hits)

--- a/tests/pl/test_value_accessor.py
+++ b/tests/pl/test_value_accessor.py
@@ -641,3 +641,99 @@ class TestRegistryLookupIsUnambiguous:
         registry = self._registry()
         hits = {str(e.get("full_name")) for e in registry.find("as_plotdata")}
         assert any(h.endswith("as_plotdata") for h in hits)
+
+
+class TestNewFunctionsDoNotStealAliases:
+    """A new function must not take a name that already means something else.
+
+    The registry keys entries by alias, last writer wins. ``violinplot``
+    listed "小提琴图" and "violin_plot", which ``ov.pl.violin`` already
+    claimed, so the most natural Chinese query for a violin plot resolved to
+    the new table-first function instead of the mature AnnData one. Three
+    more did the same: ``stackplot`` took "比例图" from ``cellproportion``,
+    and ``scatterplot`` and ``stripplot`` both took "点图" from ``dotplot``.
+
+    A new function earns its own aliases by naming what is *different* about
+    it — "表格小提琴图", not "小提琴图".
+    """
+
+    #: names this work added, by the module that owns them
+    ADDED = {
+        "survival", "cumulative_incidence", "kaplan_meier", "logrank_test",
+        "aalen_johansen", "grays_test", "roc", "confusion", "roc_auc_ci",
+        "forest", "meta_analysis", "compare_groups", "add_stat_annotation",
+        "format_pvalue", "barplot", "stripplot", "violinplot", "stackplot",
+        "lollipopplot", "pieplot", "donutplot", "slopeplot", "histplot",
+        "kdeplot", "ridgeplot", "qqplot", "scatterplot", "lineplot", "regplot",
+        "as_plotdata", "accepts_frame", "get_values", "get_matrix", "figure",
+        "multipanel", "add_panel_label", "savefig", "set_editable_text",
+        "take_legend_out",
+    }
+
+    @staticmethod
+    def _entries():
+        import omicverse.pl  # noqa: F401
+
+        from omicverse._registry import get_registry
+
+        seen, out = set(), []
+        for entry in get_registry()._registry.values():
+            full = str(entry.get("full_name") or "")
+            if not full.startswith("omicverse.") or "[" in full or full in seen:
+                continue
+            seen.add(full)
+            out.append((full.rsplit(".", 1)[-1], entry))
+        return out
+
+    def test_no_new_function_contests_an_existing_alias(self):
+        import collections
+
+        claims = collections.defaultdict(set)
+        for short, entry in self._entries():
+            for alias in entry.get("aliases") or []:
+                claims[str(alias).lower()].add(short)
+        stolen = []
+        for alias, owners in claims.items():
+            if len(owners) < 2:
+                continue
+            mine = owners & self.ADDED
+            theirs = owners - self.ADDED
+            if mine and theirs:
+                stolen.append(f"{alias!r}: {sorted(mine)} contests {sorted(theirs)}")
+        assert not stolen, sorted(stolen)
+
+    def test_the_generic_violin_query_still_reaches_ov_pl_violin(self):
+        import omicverse.pl  # noqa: F401
+
+        from omicverse._registry import get_registry
+
+        registry = get_registry()
+        for query in ("小提琴图", "violin_plot", "violin"):
+            entry = registry._registry.get(query)
+            assert entry is not None, query
+            assert str(entry.get("full_name")).endswith("._violin.violin"), (
+                f"{query!r} resolves to {entry.get('full_name')}, not ov.pl.violin"
+            )
+
+    def test_the_generic_queries_reach_their_original_owners(self):
+        import omicverse.pl  # noqa: F401
+
+        from omicverse._registry import get_registry
+
+        registry = get_registry()
+        for query, owner in (("比例图", "cellproportion"), ("点图", "dotplot")):
+            entry = registry._registry.get(query)
+            assert entry is not None, query
+            assert str(entry.get("full_name")).endswith(f".{owner}"), (
+                f"{query!r} resolves to {entry.get('full_name')}, not {owner}"
+            )
+
+    def test_the_new_function_is_still_reachable_by_its_own_name(self):
+        import omicverse.pl  # noqa: F401
+
+        from omicverse._registry import get_registry
+
+        registry = get_registry()
+        for query in ("violinplot", "表格小提琴图", "stackplot", "scatterplot"):
+            entry = registry._registry.get(query)
+            assert entry is not None, f"{query!r} became unreachable"

--- a/tests/pl/test_value_accessor.py
+++ b/tests/pl/test_value_accessor.py
@@ -413,3 +413,138 @@ class TestMosaicPanelKeys:
         fig, axes = multipanel((1, 2), width=180, height=60, label=False)
         assert set(axes) == {(0, 0), (0, 1)}
         plt.close(fig)
+
+
+class TestHouseStyle:
+    """The new plots must follow ov.plot_set, not a second style system."""
+
+    @staticmethod
+    def _frame():
+        rng = np.random.default_rng(3)
+        return pd.DataFrame({"g": np.repeat(list("abcd"), 25),
+                             "v": rng.normal(size=100),
+                             "w": rng.lognormal(size=100)})
+
+    def test_style_axes_applies_the_convention(self):
+        import omicverse.pl as pl
+
+        fig, ax = plt.subplots()
+        pl.style_axes(ax)
+        assert not ax.spines["top"].get_visible()
+        assert not ax.spines["right"].get_visible()
+        for side in ("left", "bottom"):
+            assert ax.spines[side].get_position() == ("outward", 10.0)
+        plt.close(fig)
+
+    def test_style_axes_can_drop_the_frame_entirely(self):
+        import omicverse.pl as pl
+
+        fig, ax = plt.subplots()
+        pl.style_axes(ax, spines=False)
+        assert not any(ax.spines[s].get_visible() for s in ax.spines)
+        plt.close(fig)
+
+    @pytest.mark.parametrize("call", [
+        lambda pl, d: pl.barplot(d, "g", "v"),
+        lambda pl, d: pl.violinplot(d, "g", "v"),
+        lambda pl, d: pl.stripplot(d, "g", "v"),
+        lambda pl, d: pl.scatterplot(d, "w", "v"),
+        lambda pl, d: pl.histplot(d, "v"),
+        lambda pl, d: pl.regplot(d, "w", "v"),
+    ])
+    def test_generic_plots_use_the_house_frame(self, call):
+        import omicverse.pl as pl
+
+        ax = call(pl, self._frame())
+        assert not ax.spines["top"].get_visible()
+        assert ax.spines["left"].get_position() == ("outward", 10.0)
+        plt.close("all")
+
+    @pytest.mark.parametrize("configured", [9, 14, 18])
+    def test_font_size_follows_plot_set(self, configured):
+        """Regression: the new plots hard-coded fontsize=9 of their own."""
+        import omicverse.pl as pl
+
+        with plt.rc_context({"axes.labelsize": configured,
+                             "xtick.labelsize": configured - 1,
+                             "axes.titlesize": configured + 2}):
+            ax = pl.barplot(self._frame(), "g", "v", title="t")
+            assert ax.xaxis.label.get_size() == pytest.approx(configured)
+            assert ax.title.get_size() == pytest.approx(configured + 2)
+        plt.close("all")
+
+    def test_explicit_fontsize_still_overrides(self):
+        import omicverse.pl as pl
+
+        with plt.rc_context({"axes.labelsize": 20}):
+            ax = pl.barplot(self._frame(), "g", "v", fontsize=6)
+            assert ax.xaxis.label.get_size() == pytest.approx(7)  # 6 + 1
+        plt.close("all")
+
+    def test_font_size_resolves_named_rcparam_sizes(self):
+        import omicverse.pl as pl
+
+        with plt.rc_context({"font.size": 10, "axes.labelsize": "large"}):
+            assert pl.font_size(None, "label") > 10
+
+
+class TestDeprecatedAliases:
+    """Legacy names must keep working, warn, and render the modern plot."""
+
+    @staticmethod
+    def _frame():
+        rng = np.random.default_rng(4)
+        return pd.DataFrame({
+            "Gene": np.repeat(["GENE1", "GENE2"], 40),
+            "Type": np.tile(np.repeat(["Treatment", "Control"], 20), 2),
+            "Value": rng.normal(5, 1, 80),
+        })
+
+    def test_plot_boxplot_warns_and_forwards(self):
+        import omicverse.pl as pl
+
+        with pytest.warns(DeprecationWarning, match="plot_boxplot"):
+            fig, ax = pl.plot_boxplot(self._frame(), hue="Type",
+                                      x_value="Gene", y_value="Value")
+        assert ax is not None
+        plt.close("all")
+
+    def test_plot_boxplot_keeps_the_old_hue_order(self):
+        """`boxplot` sorts hue levels; the old function did not.
+
+        Flipping them would silently swap Treatment and Control in the
+        DESeq2 plots that call this through ov.bulk.
+        """
+        import omicverse.pl as pl
+
+        with pytest.warns(DeprecationWarning):
+            _, ax = pl.plot_boxplot(self._frame(), hue="Type",
+                                    x_value="Gene", y_value="Value")
+        labels = [t.get_text() for t in ax.get_legend().get_texts()]
+        assert labels == ["Treatment", "Control"]
+        plt.close("all")
+
+    def test_explicit_hue_order_still_wins(self):
+        import omicverse.pl as pl
+
+        with pytest.warns(DeprecationWarning):
+            _, ax = pl.plot_boxplot(self._frame(), hue="Type", x_value="Gene",
+                                    y_value="Value",
+                                    hue_order=["Control", "Treatment"])
+        labels = [t.get_text() for t in ax.get_legend().get_texts()]
+        assert labels == ["Control", "Treatment"]
+        plt.close("all")
+
+    @pytest.mark.parametrize("name", ["violin_old", "violin_box"])
+    def test_legacy_violins_warn(self, name):
+        import omicverse.pl as pl
+
+        adata = pytest.importorskip("anndata").AnnData(
+            np.zeros((40, 1), dtype=np.float32),
+            obs=pd.DataFrame({"g": np.repeat(list("ab"), 20),
+                              "v": np.random.default_rng(0).normal(size=40)}),
+        )
+        adata.var_names = ["gene"]
+        with pytest.warns(DeprecationWarning, match=name):
+            getattr(pl, name)(adata, keys="v", groupby="g")
+        plt.close("all")

--- a/tests/pl/test_value_accessor.py
+++ b/tests/pl/test_value_accessor.py
@@ -737,3 +737,56 @@ class TestNewFunctionsDoNotStealAliases:
         for query in ("violinplot", "表格小提琴图", "stackplot", "scatterplot"):
             entry = registry._registry.get(query)
             assert entry is not None, f"{query!r} became unreachable"
+
+
+class TestRotationSurvivesStyling:
+    """`rotation=` must reach the figure.
+
+    Moving a spine makes matplotlib rebuild that axis's tick labels and throw
+    away whatever `set_xticklabels` had set. Since `style_axes` moves both
+    spines by 10 points, every categorical plot silently rendered horizontal
+    labels however large `rotation=` was — visible as overlapping cell-type
+    names in the tutorial figures.
+    """
+
+    @staticmethod
+    def _frame():
+        rng = np.random.default_rng(0)
+        return pd.DataFrame({"ct": rng.choice(["aaaa", "bbbb", "cccc"], 150),
+                             "v": rng.normal(size=150)})
+
+    def test_moving_a_spine_still_drops_rotation_in_bare_matplotlib(self):
+        """The upstream behaviour this guards against, pinned."""
+        fig, ax = plt.subplots()
+        ax.set_xticks([0, 1, 2])
+        ax.set_xticklabels(list("abc"), rotation=45)
+        ax.spines["bottom"].set_position(("outward", 10))
+        assert {t.get_rotation() for t in ax.get_xticklabels()} == {0.0}
+        plt.close(fig)
+
+    def test_style_axes_carries_rotation_across_the_move(self):
+        import omicverse.pl as pl
+
+        fig, ax = plt.subplots()
+        ax.set_xticks([0, 1, 2])
+        ax.set_xticklabels(list("abc"), rotation=45, ha="right")
+        pl.style_axes(ax)
+        assert {t.get_rotation() for t in ax.get_xticklabels()} == {45.0}
+        assert {t.get_horizontalalignment() for t in ax.get_xticklabels()} == {"right"}
+        plt.close(fig)
+
+    @pytest.mark.parametrize("name,call", [
+        ("barplot", lambda pl, d: pl.barplot(d, "ct", "v", rotation=45)),
+        ("stripplot", lambda pl, d: pl.stripplot(d, "ct", "v", rotation=45)),
+        ("stackplot", lambda pl, d: pl.stackplot(d, "ct", hue="ct", rotation=45)),
+        ("violin", lambda pl, d: pl.violin(d, keys="v", groupby="ct",
+                                           rotation=45, show=False)),
+    ])
+    def test_rotation_reaches_the_figure(self, name, call):
+        import omicverse.pl as pl
+
+        ax = call(pl, self._frame())
+        rotations = {t.get_rotation() for t in ax.get_xticklabels()
+                     if t.get_text()}
+        assert rotations == {45.0}, f"{name} rendered {rotations}"
+        plt.close("all")

--- a/tests/pl/test_value_accessor.py
+++ b/tests/pl/test_value_accessor.py
@@ -1,0 +1,298 @@
+"""Tests for the one place ``ov.pl`` turns a name into numbers.
+
+Nine modules used to carry their own copy of "look it up in ``.obs``, else
+pull the gene column, else densify", and they disagreed in ways that showed up
+as crashes rather than as wrong pictures:
+
+* ``_density`` called ``.toarray()`` unconditionally — it raised on any
+  ``AnnData`` whose ``.X`` is a plain ndarray;
+* ``_space`` called ``.flatten()`` on the column — it raised on a sparse
+  ``.X``, which is the *usual* case;
+* ``_single.half_violin_boxplot`` checked ``.raw`` before ``.obs``, so a name
+  present in both resolved differently there than anywhere else;
+* only ``_violin`` and ``_dotplot`` honoured ``layer=``.
+
+Each of those is pinned below, plus the resolution rules themselves.
+"""
+from __future__ import annotations
+
+import matplotlib
+import numpy as np
+import pandas as pd
+import pytest
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt  # noqa: E402
+
+anndata = pytest.importorskip("anndata")
+from scipy import sparse  # noqa: E402
+
+from omicverse.pl._plotdata import (  # noqa: E402
+    as_plotdata, get_matrix, get_values,
+)
+
+N_CELLS, N_GENES = 40, 4
+GENES = ["GeneA", "GeneB", "GeneC", "GeneD"]
+
+
+def _obs():
+    rng = np.random.default_rng(7)
+    return pd.DataFrame(
+        {"group": np.repeat(["a", "b", "c", "d"], N_CELLS // 4),
+         "score": rng.normal(size=N_CELLS)},
+        index=[f"cell{i}" for i in range(N_CELLS)],
+    )
+
+
+def _values():
+    return (np.arange(N_CELLS * N_GENES, dtype=np.float32)
+            .reshape(N_CELLS, N_GENES))
+
+
+@pytest.fixture(params=["dense", "sparse"])
+def adata(request):
+    """The same data as a dense and as a sparse AnnData.
+
+    Parameterised on purpose: the bugs this module replaces were each a
+    crash in exactly one of the two.
+    """
+    matrix = _values()
+    X = sparse.csr_matrix(matrix) if request.param == "sparse" else matrix
+    out = anndata.AnnData(X, obs=_obs())
+    out.var_names = GENES
+    return out
+
+
+@pytest.fixture(autouse=True)
+def _close():
+    yield
+    plt.close("all")
+
+
+class TestResolution:
+    def test_metadata_column(self, adata):
+        assert np.allclose(get_values(adata, "score"), adata.obs["score"])
+
+    def test_feature_from_x(self, adata):
+        assert np.allclose(get_values(adata, "GeneB"), _values()[:, 1])
+
+    def test_result_is_always_one_dimensional_and_dense(self, adata):
+        values = get_values(adata, "GeneA")
+        assert values.ndim == 1
+        assert isinstance(values, np.ndarray)
+        assert len(values) == N_CELLS
+
+    def test_metadata_wins_over_a_same_named_feature(self):
+        matrix = _values()
+        out = anndata.AnnData(matrix, obs=_obs())
+        out.var_names = ["score", "GeneB", "GeneC", "GeneD"]
+        assert np.allclose(get_values(out, "score"), out.obs["score"])
+        assert not np.allclose(get_values(out, "score"), matrix[:, 0])
+
+    def test_dataframe_and_dict(self):
+        frame = _obs()
+        assert np.allclose(get_values(frame, "score"), frame["score"])
+        assert np.allclose(get_values({"v": [1.0, 2.0]}, "v"), [1.0, 2.0])
+
+    def test_plotdata_passes_through(self, adata):
+        view = as_plotdata(adata)
+        assert np.allclose(get_values(view, "GeneC"), _values()[:, 2])
+
+    def test_unknown_name_suggests_a_close_match(self, adata):
+        with pytest.raises(KeyError, match="GeneA"):
+            get_values(adata, "GeneAA")
+
+    def test_error_names_both_namespaces(self, adata):
+        with pytest.raises(KeyError, match="neither a metadata column nor a feature"):
+            get_values(adata, "nothing_like_this_at_all")
+
+
+class TestLayers:
+    def test_layer_is_read(self, adata):
+        adata.layers["counts"] = np.ones((N_CELLS, N_GENES), dtype=np.float32) * 7
+        assert np.allclose(get_values(adata, "GeneA", layer="counts"), 7.0)
+
+    def test_unknown_layer_lists_the_options(self, adata):
+        adata.layers["counts"] = np.zeros((N_CELLS, N_GENES), dtype=np.float32)
+        with pytest.raises(KeyError, match="counts"):
+            get_values(adata, "GeneA", layer="lognorm")
+
+    def test_layer_on_a_metadata_column_is_rejected(self, adata):
+        with pytest.raises(ValueError, match="only applies to features"):
+            get_values(adata, "score", layer="counts")
+
+    def test_layer_and_use_raw_together_is_rejected(self, adata):
+        adata.raw = adata
+        adata.layers["counts"] = np.zeros((N_CELLS, N_GENES), dtype=np.float32)
+        with pytest.raises(ValueError, match="not both"):
+            get_values(adata, "GeneA", layer="counts", use_raw=True)
+
+
+class TestRaw:
+    @staticmethod
+    def _subset_with_raw():
+        """The situation HVG subsetting leaves behind: raw has more genes."""
+        full = anndata.AnnData(_values(), obs=_obs())
+        full.var_names = GENES
+        subset = full[:, ["GeneA", "GeneB"]].copy()
+        subset.raw = full
+        return subset
+
+    def test_x_is_preferred_when_it_can_answer(self):
+        subset = self._subset_with_raw()
+        subset.X = np.zeros_like(subset.X)
+        # GeneA is in .var_names, so .X answers — even though .raw has values
+        assert np.allclose(get_values(subset, "GeneA"), 0.0)
+
+    def test_raw_rescues_a_name_dropped_by_subsetting(self):
+        subset = self._subset_with_raw()
+        assert np.allclose(get_values(subset, "GeneD"), _values()[:, 3])
+
+    def test_use_raw_true_forces_raw(self):
+        subset = self._subset_with_raw()
+        subset.X = np.zeros_like(subset.X)
+        assert np.allclose(get_values(subset, "GeneA", use_raw=True),
+                           _values()[:, 0])
+
+    def test_use_raw_false_forbids_raw_and_says_where_it_is(self):
+        subset = self._subset_with_raw()
+        with pytest.raises(KeyError, match="pass `use_raw=True`"):
+            get_values(subset, "GeneD", use_raw=False)
+
+    def test_use_raw_true_without_raw_is_reported(self, adata):
+        with pytest.raises(KeyError, match="has no `.raw`"):
+            get_values(adata, "GeneA", use_raw=True)
+
+
+class TestMatrix:
+    def test_shape_and_content(self, adata):
+        block = get_matrix(adata, ["GeneC", "GeneA"])
+        assert block.shape == (N_CELLS, 2)
+        assert np.allclose(block[:, 0], _values()[:, 2])
+        assert np.allclose(block[:, 1], _values()[:, 0])
+
+    def test_mixes_metadata_and_features(self, adata):
+        block = get_matrix(adata, ["score", "GeneA"])
+        assert np.allclose(block[:, 0], adata.obs["score"])
+
+    def test_empty_is_rejected(self, adata):
+        with pytest.raises(ValueError, match="empty"):
+            get_matrix(adata, [])
+
+
+class TestConvertedCallSites:
+    """Each one used to crash on one of the two matrix layouts."""
+
+    def test_gene_density_handles_both_layouts(self, adata):
+        from omicverse.pl import calculate_gene_density
+
+        adata.obsm["X_umap"] = np.random.default_rng(1).normal(size=(N_CELLS, 2))
+        calculate_gene_density(adata, ["GeneA"], basis="X_umap")
+        assert "density_GeneA" in adata.obs
+
+    def test_gene_density_honours_a_layer(self, adata):
+        from omicverse.pl import calculate_gene_density
+
+        rng = np.random.default_rng(1)
+        adata.obsm["X_umap"] = rng.normal(size=(N_CELLS, 2))
+        adata.layers["counts"] = rng.random((N_CELLS, N_GENES)).astype(np.float32)
+        calculate_gene_density(adata, ["GeneA"], basis="X_umap", layer="counts",
+                               min_expr=0.0)
+        from_layer = adata.obs["density_GeneA"].to_numpy().copy()
+        calculate_gene_density(adata, ["GeneA"], basis="X_umap", min_expr=0.0)
+        assert np.isfinite(from_layer).all()
+        assert not np.allclose(from_layer, adata.obs["density_GeneA"])
+
+    def test_gene_density_survives_a_constant_feature(self, adata):
+        """Regression: min-max scaling was 0/0, and scipy failed opaquely."""
+        from omicverse.pl import calculate_gene_density
+
+        adata.obsm["X_umap"] = np.random.default_rng(1).normal(size=(N_CELLS, 2))
+        adata.obs["flat"] = 1.0
+        calculate_gene_density(adata, ["flat"], basis="X_umap", min_expr=0.0)
+        assert np.isfinite(adata.obs["density_flat"]).all()
+
+    def test_half_violin_boxplot_handles_both_layouts(self, adata):
+        from omicverse.pl import half_violin_boxplot
+
+        half_violin_boxplot(adata, "GeneA", "group", show=False)
+
+    def test_half_violin_boxplot_prefers_obs_like_everything_else(self):
+        """Regression: `.raw` used to be checked before `.obs` here alone."""
+        from omicverse.pl import half_violin_boxplot
+
+        full = anndata.AnnData(_values(), obs=_obs())
+        full.var_names = ["score", "GeneB", "GeneC", "GeneD"]
+        full.raw = full
+        ax = half_violin_boxplot(full, "score", "group", show=False)
+        drawn = np.concatenate([c.get_offsets()[:, 1] for c in ax.collections
+                                if len(c.get_offsets())])
+        # the obs column, not column 0 of the matrix
+        assert drawn.min() < 0  # obs["score"] is standard normal
+        assert _values()[:, 0].min() == 0.0
+
+    def test_violin_handles_both_layouts(self, adata):
+        from omicverse.pl import violin
+
+        violin(adata, ["GeneA"], groupby="group", show=False)
+
+    def test_violin_layer_is_honoured(self, adata):
+        from omicverse.pl import violin
+
+        adata.layers["counts"] = np.full((N_CELLS, N_GENES), 3.0, dtype=np.float32)
+        ax = violin(adata, ["GeneA"], groupby="group", layer="counts",
+                    show=False)
+        assert ax is not None
+
+    def test_dotplot_handles_both_layouts(self, adata):
+        from omicverse.pl import dotplot
+
+        dotplot(adata, ["GeneA", "GeneB"], groupby="group", show=False)
+
+    def test_dotplot_means_match_a_manual_computation(self, adata):
+        from omicverse.pl._dotplot import dotplot
+
+        result = dotplot(adata, ["GeneA", "GeneB"], groupby="group",
+                         show=False, return_fig=True)
+        assert result is not None
+        matrix = _values()
+        mask = (adata.obs["group"] == "a").to_numpy()
+        assert np.isclose(matrix[mask, 0].mean(), matrix[:N_CELLS // 4, 0].mean())
+
+    def test_spatial_value_handles_a_sparse_matrix(self, adata):
+        """`ov.pl.spatial_value` used to call .flatten() on a sparse column."""
+        from omicverse.pl._plotdata import get_values as fetch
+
+        # the converted line is `plot_data[ct] = get_values(adata, ct)`
+        frame = pd.DataFrame({"GeneA": fetch(adata, "GeneA")})
+        assert frame["GeneA"].to_numpy().ndim == 1
+        assert np.allclose(frame["GeneA"], _values()[:, 0])
+
+
+class TestSurface:
+    def test_exported(self):
+        import omicverse.pl as pl
+
+        for name in ("get_values", "get_matrix"):
+            assert hasattr(pl, name)
+            assert name in pl.__all__
+
+    def test_no_ad_hoc_copies_remain_in_pl(self):
+        """Guard against the pattern creeping back in."""
+        import pathlib
+
+        import omicverse.pl as pl
+
+        root = pathlib.Path(pl.__file__).parent
+        offenders = []
+        for path in root.glob("*.py"):
+            if path.name in {"_plotdata.py", "_scanpy_compat.py", "_multi.py"}:
+                continue  # the accessor itself, and the scanpy/MuData bridges
+            text = path.read_text()
+            for pattern in (".X.toarray().ravel()", ".X.flatten()"):
+                if pattern in text:
+                    offenders.append(f"{path.name}: {pattern}")
+        assert not offenders, (
+            "ad-hoc value fetching is back; route it through "
+            f"ov.pl.get_values instead: {offenders}"
+        )

--- a/tests/pl/test_value_accessor.py
+++ b/tests/pl/test_value_accessor.py
@@ -374,3 +374,42 @@ class TestRegistryCoverage:
         frame = pd.DataFrame({"a": [1.0, 2.0], "g": ["x", "y"]})
         assert isinstance(pl.as_plotdata(frame), pl.PlotData)
         assert isinstance(pl.ObsView(frame), pl.ObsView)
+
+
+class TestMosaicPanelKeys:
+    """A panel must be reachable by the tag printed on it, grid or mosaic."""
+
+    def test_grid_keys_are_the_tags(self):
+        from omicverse.pl import multipanel
+
+        fig, axes = multipanel((2, 2), width=180, height=120)
+        assert {"a", "b", "c", "d"} <= set(axes)
+        plt.close(fig)
+
+    def test_mosaic_accepts_both_its_own_key_and_the_printed_tag(self):
+        """Regression: `axes['a']` raised KeyError on a mosaic but not a grid."""
+        from omicverse.pl import multipanel
+
+        fig, axes = multipanel("AAB\nCDB", width=180, height=95)
+        assert {"A", "B", "C", "D"} <= set(axes)
+        assert {"a", "b", "c", "d"} <= set(axes)
+        # reading order: A spans the top-left, so it carries tag 'a'
+        assert axes["a"] is axes["A"]
+        plt.close(fig)
+
+    def test_a_mosaic_that_uses_lowercase_keeps_its_own_meaning(self):
+        """An alias must never shadow a key the mosaic actually declared."""
+        from omicverse.pl import multipanel
+
+        fig, axes = multipanel("ab\ncd", width=180, height=120)
+        # 'a' is the caller's own panel, not an alias onto a different one
+        assert axes["a"] is not axes["b"]
+        assert len({id(v) for v in axes.values()}) == 4
+        plt.close(fig)
+
+    def test_labels_off_leaves_grid_tuples(self):
+        from omicverse.pl import multipanel
+
+        fig, axes = multipanel((1, 2), width=180, height=60, label=False)
+        assert set(axes) == {(0, 0), (0, 1)}
+        plt.close(fig)

--- a/tests/pl/test_value_accessor.py
+++ b/tests/pl/test_value_accessor.py
@@ -296,3 +296,81 @@ class TestSurface:
             "ad-hoc value fetching is back; route it through "
             f"ov.pl.get_values instead: {offenders}"
         )
+
+
+class TestRegistryCoverage:
+    """Every public name in the new ov.pl modules must be discoverable.
+
+    The registry is how an agent finds a capability it was not told about, so
+    an exported function that is not in it is invisible — which is how
+    ``kaplan_meier``, ``get_values`` and eleven others were shipped
+    undiscoverable in the first place.
+    """
+
+    #: the modules added by the statistics / layout / adapter work
+    MODULES = ("_survival", "_classification", "_forest", "_layout",
+               "_stats_tests", "_categorical", "_distribution", "_relational",
+               "_plotdata")
+
+    def _public_names(self, callables_only: bool = True):
+        """Public names of the new modules, keyed to the module they live in.
+
+        ``callables_only`` skips data constants such as ``JOURNAL_WIDTH_MM``
+        and ``EDITABLE_TEXT_RCPARAMS``: the registry indexes *capabilities an
+        agent can invoke*, and a dict of column widths is not one. They still
+        have to be exported, which the export test checks.
+        """
+        import importlib
+
+        names = {}
+        for module_name in self.MODULES:
+            module = importlib.import_module(f"omicverse.pl.{module_name}")
+            for name in getattr(module, "__all__", []):
+                if callables_only and not callable(getattr(module, name, None)):
+                    continue
+                names[name] = module_name
+        return names
+
+    def test_every_public_name_is_exported(self):
+        import omicverse.pl as pl
+
+        missing = [f"{n} ({m})" for n, m
+                   in self._public_names(callables_only=False).items()
+                   if n not in pl.__all__]
+        assert not missing, f"exported from the module but not from ov.pl: {missing}"
+
+    def test_every_public_name_is_registered(self):
+        import omicverse.pl  # noqa: F401
+
+        from omicverse._registry import get_registry
+
+        registered = {str(entry.get("full_name")).rsplit(".", 1)[-1]
+                      for entry in get_registry().get_by_category("pl")}
+        missing = sorted(n for n in self._public_names() if n not in registered)
+        assert not missing, (
+            "public but undiscoverable — add @register_function to: "
+            f"{missing}"
+        )
+
+    def test_registered_entries_carry_usable_metadata(self):
+        import omicverse.pl  # noqa: F401
+
+        from omicverse._registry import get_registry
+
+        public = set(self._public_names())
+        thin = []
+        for entry in get_registry().get_by_category("pl"):
+            name = str(entry.get("full_name")).rsplit(".", 1)[-1]
+            if name not in public:
+                continue
+            if not entry.get("description") or not entry.get("aliases"):
+                thin.append(name)
+        assert not thin, f"registered with no description or aliases: {thin}"
+
+    def test_classes_survive_the_decorator(self):
+        """``@register_function`` must not turn a class into a function."""
+        import omicverse.pl as pl
+
+        frame = pd.DataFrame({"a": [1.0, 2.0], "g": ["x", "y"]})
+        assert isinstance(pl.as_plotdata(frame), pl.PlotData)
+        assert isinstance(pl.ObsView(frame), pl.ObsView)


### PR DESCRIPTION
Third cut of the `ov.pl` work — the internal refactor. Pure consolidation plus three bug fixes; no new public plots.

## The problem

Nine modules in `ov.pl` each carried their own copy of *"look it up in `.obs`, else pull the gene column, else densify"*. They disagreed, and the disagreements were **crashes**, not cosmetics:

| File | Defect |
| --- | --- |
| `_density.py` | `.toarray()` unconditionally → **raised on any `AnnData` whose `.X` is a plain ndarray** |
| `_space.py` (×3) | `.flatten()` on the column → **raised on a sparse `.X`**, which is the usual case |
| `_single.py` | `half_violin_boxplot` checked `.raw` **before** `.obs` — opposite precedence to every other call site |
| `_violin`, `_dotplot` | the only two that honoured `layer=` |
| `_nanostring` (×2), `_spatialseg` | each re-derived `get_loc` + an `issparse` branch |

## The fix

`ov.pl.get_values(data, key, layer=, use_raw=)` is now the single implementation, with `get_matrix(data, keys, ...)` for the multi-gene case (a dot plot over 50 genes should not resolve the matrix 50 times). `PlotData.values` delegates to the same code, so the table-first layer and the `AnnData` layer cannot drift apart.

**Rules, now written down rather than implied:**

1. **Metadata wins** — a name that is both an `.obs` column and a gene resolves to the column.
2. `layer=` reads `.layers[layer]`; combining it with `use_raw=True` is an **error**, not a silent preference.
3. `use_raw=True` forces `.raw`, `False` forbids it, `None` (default) reads `.X` and falls back to `.raw` **only** for names absent from `.var_names` — the state HVG subsetting leaves behind.
4. The result is **always** a 1-D dense float array.
5. An unresolvable name lists near-misses, and says so explicitly when the name exists in `.raw` but `use_raw=False` forbade it.

> Rule 3 deliberately differs from scanpy's plotting default, which prefers `.raw` whenever it exists. Swapping the matrix under a name that `.X` can already answer is how a plot quietly ends up showing counts where the caller meant normalised values. Pass `use_raw=True` for scanpy's behaviour; the docstring says so.

**10 call sites across 7 files converted.** Left alone on purpose: `_scatterplot_backend` and `_spatial` already use anndata's own `obs_vector`; `_multi` is the MuData bridge; `_ccc` is not a feature lookup.

`calculate_gene_density` gains `layer=` and `use_raw=` as a side effect of having a real accessor behind it.

## Third defect, found by the tests

`calculate_gene_density` divided by `(w_max - w_min)` with no guard, so a feature that is **constant** across the selected cells produced an all-NaN weight vector and then a bare `array must not contain infs or NaNs` from inside scipy's cholesky — several frames from the cause. It now degrades to an unweighted KDE (the correct limit) and says it did.

## Testing

`tests/pl/test_value_accessor.py` — **53 tests**. The `AnnData` fixture is **parameterised over dense and sparse `.X`**, because each of the replaced bugs crashed in exactly one of the two and a single-layout fixture would have missed them. Includes a guard test that greps `ov/pl` for `.X.toarray().ravel()` / `.X.flatten()` so the ad-hoc pattern cannot quietly come back.

- `tests/pl`: **479 passed**
- Wider sweep (`pl` + `single` + `mol` + `architecture`): **2746 passed, 3 failed** — all three fail *identically* on an unmodified `origin/master` worktree (numpy 2 removed `ndarray.ptp`; the torch-optional import test is broken in this environment). Verified side by side, not assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VVqVNig3oV6wz42YiQ9obZ