### PR TITLE
fix(single): tell users when CopyKAT's genome tables are missing (#903)

### DIFF
--- a/omicverse/single/_cnv.py
+++ b/omicverse/single/_cnv.py
@@ -28,6 +28,35 @@ from anndata import AnnData
 from .._registry import register_function
 
 
+_COPYKAT_INSTALL = "  pip install -U git+https://github.com/omicverse/py-CopyKAT.git"
+
+
+def _check_copykat_data() -> None:
+    """Verify the CopyKAT genome tables are actually reachable.
+
+    pycopykat resolves ``hg20_gene_anno.parquet`` and friends relative to its
+    own package directory; releases up to ``0.1.0.dev1`` looked one level
+    higher instead, which is the repo root for a source checkout but
+    ``site-packages/`` for a wheel install — so the tables were simply absent
+    and the first genome lookup blew up inside ``pandas.read_parquet``
+    (omicverse#903). Probing both locations here turns that into an actionable
+    message before any expensive work starts.
+    """
+    from pathlib import Path
+
+    import pycopykat
+
+    pkg = Path(pycopykat.__file__).resolve().parent
+    if (pkg / "data").is_dir() or (pkg.parent / "data").is_dir():
+        return
+    raise ImportError(
+        "pycopykat is installed but its genome reference tables "
+        f"(hg20/mm10 *_gene_anno.parquet) are missing — looked in {pkg / 'data'}. "
+        "Installs predating pycopykat 0.1.0.dev2 did not ship them. Reinstall with:\n"
+        f"{_COPYKAT_INSTALL}"
+    )
+
+
 def _check_dep(backend: str) -> None:
     """Lazy-import gate. Raises a clean ImportError pointing at the GitHub repo."""
     if backend == "copykat":
@@ -36,8 +65,9 @@ def _check_dep(backend: str) -> None:
         except ImportError as e:
             raise ImportError(
                 "pycopykat is required for method='copykat'. Install via:\n"
-                "  pip install git+https://github.com/omicverse/py-CopyKAT.git"
+                f"{_COPYKAT_INSTALL}"
             ) from e
+        _check_copykat_data()
     elif backend == "infercnv":
         try:
             import pyinfercnv  # noqa: F401

--- a/tests/single/test_cnv_copykat_data.py
+++ b/tests/single/test_cnv_copykat_data.py
@@ -1,0 +1,57 @@
+"""``method='copykat'`` guard for the pycopykat genome reference tables.
+
+pycopykat up to 0.1.0.dev1 kept ``hg20_gene_anno.parquet`` at its repo root
+and resolved it one directory above the package, so a wheel install looked in
+``site-packages/data/`` — a directory that does not exist. The failure only
+surfaced deep inside ``pandas.read_parquet`` (omicverse#903); the guard turns
+it into an ImportError naming the reinstall command.
+"""
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+ov = pytest.importorskip("omicverse")
+
+from omicverse.single._cnv import _check_copykat_data  # noqa: E402
+
+
+def _fake_pycopykat(monkeypatch, pkg_dir):
+    mod = types.ModuleType("pycopykat")
+    mod.__file__ = str(pkg_dir / "__init__.py")
+    monkeypatch.setitem(sys.modules, "pycopykat", mod)
+
+
+def test_accepts_data_inside_the_package(monkeypatch, tmp_path):
+    pkg = tmp_path / "site-packages" / "pycopykat"
+    (pkg / "data").mkdir(parents=True)
+    _fake_pycopykat(monkeypatch, pkg)
+    _check_copykat_data()  # must not raise
+
+
+def test_accepts_the_legacy_source_checkout_layout(monkeypatch, tmp_path):
+    # Editable install: <repo>/pycopykat/ with the tables at <repo>/data/.
+    pkg = tmp_path / "py-CopyKAT" / "pycopykat"
+    pkg.mkdir(parents=True)
+    (pkg.parent / "data").mkdir()
+    _fake_pycopykat(monkeypatch, pkg)
+    _check_copykat_data()  # must not raise
+
+
+def test_rejects_an_install_without_the_tables(monkeypatch, tmp_path):
+    pkg = tmp_path / "site-packages" / "pycopykat"
+    pkg.mkdir(parents=True)
+    _fake_pycopykat(monkeypatch, pkg)
+    with pytest.raises(ImportError, match="genome reference tables"):
+        _check_copykat_data()
+
+
+def test_error_names_the_reinstall_command(monkeypatch, tmp_path):
+    pkg = tmp_path / "site-packages" / "pycopykat"
+    pkg.mkdir(parents=True)
+    _fake_pycopykat(monkeypatch, pkg)
+    with pytest.raises(ImportError) as exc:
+        _check_copykat_data()
+    assert "py-CopyKAT.git" in str(exc.value)


### PR DESCRIPTION
Closes #903.

## Root cause — it is a pycopykat packaging bug

`pycopykat/io/annotation.py` resolved its reference tables as

```python
Path(__file__).resolve().parents[2] / "data"
```

From a source checkout (`<repo>/pycopykat/io/annotation.py`) that is the repo root, where `data/` really lives. From an installed package (`site-packages/pycopykat/io/annotation.py`) it is **`site-packages/data/`** — which is why the reporter saw

```
FileNotFoundError: .../site-packages/data/hg20_gene_anno.parquet
```

and why "查看 omicverse 目录也没有 data 文件夹" — the tables were never in omicverse, and were not in the pycopykat wheel either (`packages = ["pycopykat"]`, `data/` outside it).

Upstream fix: **omicverse/py-CopyKAT#4** moves the four tables to `pycopykat/data/` so the wheel carries them. Merge that first; this PR is the omicverse-side half.

## What this PR changes

`_check_dep("copykat")` now probes for the tables right where the backend is imported and raises

```
ImportError: pycopykat is installed but its genome reference tables
(hg20/mm10 *_gene_anno.parquet) are missing — looked in .../pycopykat/data.
Installs predating pycopykat 0.1.0.dev2 did not ship them. Reinstall with:
  pip install -U git+https://github.com/omicverse/py-CopyKAT.git
```

instead of letting `CNV.run()` start work and then die inside `pandas.read_parquet` with a path nobody can act on. The probe accepts both layouts — `pycopykat/data/` (fixed wheel) and `<repo>/data/` (existing editable checkouts) — so it mirrors pycopykat's own resolution exactly and never fires on a working install.

## Verification

- Reproduced the original failure mode: the environment here had `site-packages/data/` hand-copied as a workaround, i.e. the exact layout the old `parents[2]` expression needs. Deleting that assumption is what the guard now detects.
- Built the fixed pycopykat wheel, unpacked into a clean `site-packages`-shaped directory, and confirmed the guard passes against it and `_data_dir()` resolves to `.../pycopykat/data`.
- New `tests/single/test_cnv_copykat_data.py` — 4 tests covering the packaged layout, the legacy checkout layout, the broken install, and that the message names the reinstall command.
- `pytest tests/single` → **155 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VVqVNig3oV6wz42YiQ9obZ