### PR TITLE
fix(mcp): put leidenalg in the mcp extra so the server can run the tool it advertises

### DIFF
--- a/.github/workflows/mcp-tests.yml
+++ b/.github/workflows/mcp-tests.yml
@@ -9,6 +9,11 @@ on:
       - "scripts/ci/mcp-*.sh"
       - "scripts/ci/mcp-report-versions.py"
       - "requirements/mcp-*.txt"
+      # The MCP runtime is installed as omicverse[tests,mcp], so its dependency
+      # set lives here. Leaving pyproject.toml out meant a change that broke the
+      # MCP install could not trigger these tests -- which is how a missing
+      # leidenalg went unnoticed for six weekly runs.
+      - "pyproject.toml"
   pull_request:
     branches: [master, dev]
     paths:
@@ -17,6 +22,11 @@ on:
       - "scripts/ci/mcp-*.sh"
       - "scripts/ci/mcp-report-versions.py"
       - "requirements/mcp-*.txt"
+      # The MCP runtime is installed as omicverse[tests,mcp], so its dependency
+      # set lives here. Leaving pyproject.toml out meant a change that broke the
+      # MCP install could not trigger these tests -- which is how a missing
+      # leidenalg went unnoticed for six weekly runs.
+      - "pyproject.toml"
   workflow_dispatch:
     inputs:
       profile:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -249,6 +249,13 @@ tests = [
 
 mcp = [
   "mcp>=1.0; python_version >= '3.10'",
+  # The MCP server advertises ov.pp.leiden as a tool, so installing the mcp
+  # extra has to be enough to run it. leidenalg is deliberately not a core
+  # dependency -- it carries a C extension and is not wheel-available
+  # everywhere -- and it currently lives only in [full], which is why anyone
+  # installing omicverse[mcp] hit "Please install the leiden algorithm" on a
+  # tool the server told them existed. igraph is already a core dependency.
+  'leidenalg>=0.9',
 ]
 
 # Proteomics backends for ``ov.protein`` — pure-Python ports of the


### PR DESCRIPTION
`MCP Tests` has failed on every scheduled run since at least 2026-06-22 — six consecutive weeks — while every PR check stayed green. The workflow is path-filtered to `omicverse/mcp/**` and `tests/mcp/**`, so it only runs on its weekly schedule and never appears in a PR's checks.

```
tests/mcp/test_real_p0_pipeline.py::test_full_p0_pipeline
AssertionError: ov.pp.leiden failed: Please install the leiden algorithm
```

`leidenalg` is commented out of the core dependencies deliberately — C extension, not wheel-available everywhere — and survives only in `[full]`. But `scripts/ci/mcp-core-runtime.sh` installs `[tests,mcp]`, and `[mcp]` is a single line of `mcp>=1.0`.

So the MCP server advertises `ov.pp.leiden` as a tool that its own extra cannot install. That is not only a CI artefact: `pip install omicverse[mcp]` followed by a call to that tool meets the same wall.

Adding it to `[mcp]` rather than restoring it to core keeps the platform constraint that motivated commenting it out in the first place. `igraph` is already a core dependency.

Verified by running the test that has been failing: **6 passed**.