### PR TITLE
fix(io): re-export every spatial reader on the ov.io facade

### DIFF
--- a/omicverse/io/__init__.py
+++ b/omicverse/io/__init__.py
@@ -13,7 +13,9 @@ Compatibility shortcuts:
     - ``ov.io.read_h5ad(...)``
     - ``ov.io.read_10x_h5(...)``
     - ``ov.io.read_10x_mtx(...)``
-    - ``ov.io.read_visium_hd(...)``
+    - ``ov.io.read_visium(...)``, ``ov.io.read_visium_hd(...)``,
+      ``ov.io.read_xenium(...)``, ``ov.io.read_stereoseq(...)`` — every reader
+      in ``ov.io.spatial`` is reachable here under the same name
     - ``ov.io.read_fcs(...)``
     - ``ov.io.read_csv(...)``, ``ov.io.save(...)``, ``ov.io.load(...)``
 """
@@ -22,7 +24,26 @@ from . import bulk, cytometry, general, single, spatial
 from .cytometry import parse_spillover, read_fcs
 from .general import load, read_csv, read_table, save
 from .single import read, read_10x_h5, read_10x_mtx, read_h5ad
-from .spatial import read_nanostring, read_visium_hd, read_visium_hd_bin, read_visium_hd_seg, read_xenium
+# Every public spatial reader is re-exported here, deliberately. The list used
+# to hold five of the eight, and the three it left out were `read_visium`,
+# `read_atera` and `read_stereoseq` — so `ov.io.read_visium_hd` worked while
+# `ov.io.read_visium`, the commonest call of the set, raised AttributeError.
+# Nothing distinguished the five from the three; downstream code and docs read
+# the namespace as uniform and wrote the shorter form, which then failed at
+# runtime. Adding a reader to `spatial.__all__` without adding it here
+# reintroduces that trap.
+from .spatial import (
+    bin_stereoseq,
+    read_atera,
+    read_nanostring,
+    read_stereoseq,
+    read_visium,
+    read_visium_hd,
+    read_visium_hd_bin,
+    read_visium_hd_seg,
+    read_xenium,
+    write_visium_hd_cellseg,
+)
 
 __all__ = [
     "general",
@@ -35,11 +56,16 @@ __all__ = [
     "read_h5ad",
     "read_10x_h5",
     "read_10x_mtx",
+    "read_visium",
     "read_visium_hd",
     "read_visium_hd_bin",
     "read_visium_hd_seg",
+    "write_visium_hd_cellseg",
     "read_nanostring",
     "read_xenium",
+    "read_atera",
+    "read_stereoseq",
+    "bin_stereoseq",
     "read_fcs",
     "parse_spillover",
     "read_csv",

--- a/omicverse/space/_geom.py
+++ b/omicverse/space/_geom.py
@@ -13,9 +13,12 @@ three spatial dimensions; :func:`interpolate` fills the gap between two sections
 The alignment is a fused Gromov-Wasserstein problem, which is what PASTE solves:
 match spots between two slices using both their expression similarity and the
 geometry of each slice, then read a rigid transform off the resulting coupling.
-It is implemented here over POT rather than by depending on PASTE, so the default
-path needs nothing beyond what omicverse already installs; ``method='paste'``
-hands over to the real package when it is present.
+It is implemented here over POT rather than by depending on PASTE, so the
+default path needs one small package instead of the whole PASTE stack —
+``pip install POT``. POT is not declared in any omicverse extra, so a plain
+install does not have it; the import error names the package. ``method='icp'``
+and ``method='rigid'`` are the genuinely dependency-free routes (scipy only),
+and ``method='paste'`` hands over to the real package when it is present.
 """
 from __future__ import annotations
 

--- a/tests/test_io_facade_reexports.py
+++ b/tests/test_io_facade_reexports.py
@@ -1,0 +1,116 @@
+"""Every public reader in an ``omicverse.io`` submodule is reachable on ``ov.io``.
+
+``ov.io`` re-exports its submodules' readers as top-level shortcuts, and the
+list was maintained by hand. It drifted: ``read_visium_hd``, ``read_xenium``
+and ``read_nanostring`` were re-exported while ``read_visium``, ``read_atera``
+and ``read_stereoseq`` were not, so ``ov.io.read_visium`` — the commonest call
+of the set — raised ``AttributeError`` while its Visium-HD sibling worked.
+
+Nothing in the namespace signalled which names were shortcuts and which were
+not, so downstream code and documentation read it as uniform and wrote the
+short form. The failure is invisible until the line actually runs, and the
+error names an attribute rather than the real problem, so it reads like a
+version or install issue.
+
+A hand-maintained mirror needs a test that notices when the mirror stops
+matching. This walks the submodules' own ``__all__`` rather than a second
+hand-written list, so adding a reader to a submodule is enough to make this
+test demand the shortcut too.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+import pytest
+
+import omicverse as ov
+
+# Submodules whose public surface is mirrored on ``ov.io``. ``bulk`` and
+# ``general`` are excluded deliberately: ``general`` holds the format-agnostic
+# helpers that are already listed by hand, and ``bulk`` has no reader worth a
+# shortcut. Add a submodule here when its readers start being referenced as
+# ``ov.io.<name>``.
+MIRRORED_SUBMODULES = ("spatial", "cytometry", "single")
+
+_IO_DIR = pathlib.Path(ov.io.__file__).parent
+
+
+def _declared_all(submodule: str) -> list[str]:
+    """Read ``__all__`` from source, without importing the submodule.
+
+    Reading the AST keeps this test runnable when a submodule's heavy optional
+    backend is absent — the point is the export list, not the implementations.
+    """
+    tree = ast.parse((_IO_DIR / submodule / "__init__.py").read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == "__all__":
+                    return list(ast.literal_eval(node.value))
+    raise AssertionError(f"omicverse/io/{submodule}/__init__.py declares no __all__")
+
+
+def _is_reader(name: str) -> bool:
+    """Only readers are mirrored on the facade, and only readers are the bug.
+
+    A submodule also exports conversion helpers (``convert_to_pandas``,
+    ``wrap_dataframe``, ...). Those are deliberately *not* shortcuts: nobody
+    writes ``ov.io.convert_to_pandas``, and widening the facade to cover them
+    is an API decision, not a drift repair. The drift that actually bites is a
+    reader that is public in its submodule but absent from the facade, because
+    the reader names are what documentation and downstream code reach for.
+    """
+    return name.startswith(("read_", "bin_", "write_"))
+
+
+def _mirrored_names() -> list[tuple[str, str]]:
+    pairs = []
+    for submodule in MIRRORED_SUBMODULES:
+        for name in _declared_all(submodule):
+            if _is_reader(name):
+                pairs.append((submodule, name))
+    return pairs
+
+
+def test_the_audit_has_something_to_audit():
+    """Guard against the AST reader silently returning nothing.
+
+    Without this, a parse change would make every case below vacuous and the
+    suite would go green while checking nothing.
+    """
+    pairs = _mirrored_names()
+    assert len(pairs) > 10, f"expected a real export surface, found {pairs}"
+    assert ("spatial", "read_visium") in pairs
+
+
+@pytest.mark.parametrize("submodule,name", _mirrored_names(),
+                         ids=lambda v: v if isinstance(v, str) else str(v))
+def test_submodule_export_is_reachable_on_the_facade(submodule: str, name: str):
+    assert hasattr(ov.io, name), (
+        f"ov.io.{name} does not resolve, but omicverse/io/{submodule} exports it. "
+        f"Add it to the imports and __all__ in omicverse/io/__init__.py — a name "
+        f"that is public in a submodule but missing from the facade fails only "
+        f"when the line runs, with an AttributeError that hides the cause."
+    )
+
+
+@pytest.mark.parametrize("submodule,name", _mirrored_names(),
+                         ids=lambda v: v if isinstance(v, str) else str(v))
+def test_facade_name_is_the_submodule_object(submodule: str, name: str):
+    """The shortcut must BE the submodule's object, not a same-named other one."""
+    if not hasattr(ov.io, name):
+        pytest.skip("reachability is covered by the test above")
+    facade = getattr(ov.io, name)
+    original = getattr(getattr(ov.io, submodule), name)
+    assert facade is original, (
+        f"ov.io.{name} is not ov.io.{submodule}.{name} — the shortcut points "
+        f"somewhere else, so the two call sites can diverge silently."
+    )
+
+
+def test_every_facade_export_resolves():
+    """The other direction: nothing in ``ov.io.__all__`` is a dead name."""
+    missing = [n for n in ov.io.__all__ if not hasattr(ov.io, n)]
+    assert not missing, f"ov.io.__all__ lists names that do not resolve: {missing}"

--- a/tests/test_synbio_number_regressions.py
+++ b/tests/test_synbio_number_regressions.py
@@ -221,6 +221,10 @@ def test_mrna_design_scores_cai_against_the_requested_host():
     E. coli, which inverted the baseline-versus-LinearDesign comparison.
     """
     pytest.importorskip("dnachisel", reason="codon_optimize needs dnachisel")
+    # mrna_design folds the CDS on its way to a design (_mrna.py -> rna_fold),
+    # so ViennaRNA is needed too. Guarding only dnachisel turned a missing
+    # optional backend into a failure instead of a skip.
+    pytest.importorskip("RNA", reason="mrna_design folds via ViennaRNA")
     from omicverse.synbio._expression import cai
 
     design = sb.mrna_design(PROTEIN, method="baseline", host="human")
@@ -233,6 +237,10 @@ def test_mrna_design_scores_cai_against_the_requested_host():
 def test_mrna_design_cai_is_never_a_silent_zero():
     """``except Exception: cai_val = 0.0`` reads as 'terrible codon usage'."""
     pytest.importorskip("dnachisel", reason="codon_optimize needs dnachisel")
+    # mrna_design folds the CDS on its way to a design (_mrna.py -> rna_fold),
+    # so ViennaRNA is needed too. Guarding only dnachisel turned a missing
+    # optional backend into a failure instead of a skip.
+    pytest.importorskip("RNA", reason="mrna_design folds via ViennaRNA")
     design = sb.mrna_design(PROTEIN, method="baseline", host="human")
     assert design.cai > 0.5
 


### PR DESCRIPTION
`ov.io` mirrors its submodules' readers as top-level shortcuts, and the list was maintained by hand. It held **five of the eight** spatial readers:

| on `ov.io` | only on `ov.io.spatial` |
|---|---|
| `read_visium_hd`, `read_visium_hd_bin`, `read_visium_hd_seg`, `read_xenium`, `read_nanostring` | **`read_visium`**, `read_atera`, `read_stereoseq` |

So `ov.io.read_visium_hd` worked while `ov.io.read_visium` — the commonest call of the set — raised `AttributeError`.

Nothing in the namespace distinguished the shortcuts from the rest, so documentation and downstream code read it as uniform and wrote the short form. It fails only when the line runs, and an `AttributeError` on a reader name reads like a version or install problem rather than a missing re-export.

This bit our own agent catalog in three places, one of which instructed readers that `ov.io.read_visium` is the reader "**NOT** `sc.read_visium`" — confidently wrong, and Visium is the most common spatial platform.

All eight are now re-exported, plus `bin_stereoseq` and `write_visium_hd_cellseg` for symmetry.

## The test

`tests/test_io_facade_reexports.py` walks each submodule's own `__all__` rather than a second hand-written list, so adding a reader to a submodule now *requires* the shortcut too — the mirror can no longer drift silently. It also checks the reverse direction (nothing in `ov.io.__all__` is a dead name) and that each shortcut **is** the submodule's object rather than a same-named other one.

Verified by putting the bug back: removing `read_visium` from the facade makes it fail on exactly `test_submodule_export_is_reachable_on_the_facade[spatial-read_visium]`, and restoring it goes green. A test that has never been seen to fail is not yet evidence of anything.

Conversion helpers (`convert_to_pandas`, `wrap_dataframe`, `convert_adata_for_rust`) are deliberately **not** mirrored — the test scopes to readers. Widening the facade to cover them is an API decision, not a drift repair, so I left it alone.

## Two documentation-only fixes in the same pass

**`_geom.py` overstated what the default path needs.** It said the FGW route "needs nothing beyond what omicverse already installs". POT is declared in no extra and is absent from a plain install — `tests/space/test_geom_stereoseq.py` fails with `ModuleNotFoundError: No module named 'ot'` at `_geom.py:189` on a clean environment, which is that claim being wrong in CI right now. The docstring names `pip install POT`, and points at `method='icp'` / `'rigid'` as the genuinely dependency-free routes (scipy only).

**Two mrna regression tests guarded the wrong backend.** They `importorskip("dnachisel")` but `mrna_design` folds the CDS on its way to a design (`_mrna.py:165-167` → `rna_fold`), so on an environment with dnachisel but no ViennaRNA a missing optional backend became a failure instead of a skip.

## Tests

`-k "synbio or io or space"`: **3303 passed, 780 skipped, 10 failed** — the 10 are all `test_geom_stereoseq.py` and all `ModuleNotFoundError: No module named 'ot'`, i.e. pre-existing and exactly the condition the `_geom.py` docstring change now documents. `_geom.py` itself is untouched apart from that docstring.

## Considered and deliberately not done

**De-scanpy-ing `ov.space.niche`.** `_niche.py` uses scanpy only as a kNN+Leiden utility on a plain matrix, which looks like an easy removal. It is not, and I measured why: `sc.pp.neighbors` builds **UMAP fuzzy simplicial connectivities** (weighted), not a plain kNN graph (binary). Swapping in a plain kNN + `leidenalg` on the same synthetic niche input gives **ARI = 0.51** against the current path — 7 clusters versus 12. That is a different answer, not a different labelling of the same answer, and it would move every existing user's niche labels. Removing scanpy honestly would mean reimplementing the fuzzy simplicial set, i.e. depending on `umap-learn` or vendoring it — not obviously better than depending on scanpy, which is a core dependency regardless.

**`mmgbsa`'s frame count.** `md_refine_ns=0` writes ~1000 frames and scores 50 of them; writing fewer would change which frames are scored and therefore shift ΔG on the default path, for an I/O saving. Same reasoning as 2.3.1 left it alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)