### PR TITLE
feat(pl): size the panels, not just the canvas, in multipanel

### DIFF
--- a/omicverse/pl/_layout.py
+++ b/omicverse/pl/_layout.py
@@ -130,6 +130,118 @@ def _figsize_inches(width, height, units: str, dpi: float,
     return w_in, h_in
 
 
+def _as_pair(value, name: str) -> Tuple[float, float]:
+    if isinstance(value, (int, float)):
+        return float(value), float(value)
+    pair = tuple(float(v) for v in value)
+    if len(pair) != 2:
+        raise ValueError(f"`{name}` takes one number or two, got {value!r}.")
+    return pair
+
+
+def _as_margins(value) -> Tuple[float, float, float, float]:
+    if isinstance(value, (int, float)):
+        return (float(value),) * 4
+    quad = tuple(float(v) for v in value)
+    if len(quad) != 4:
+        raise ValueError(
+            f"`margins` takes one number or four (left, right, bottom, top), "
+            f"got {value!r}."
+        )
+    return quad
+
+
+def _panel_geometry(grid, panel_size, panel_widths, panel_heights,
+                    margins, spacing, units, dpi, gridspec_kw):
+    """Derive the canvas and gridspec margins from absolute panel sizes.
+
+    Returns ``None`` when no panel size was asked for, which leaves the caller
+    on the ordinary figure-sized path.
+
+    A gridspec positions its panels in figure fractions, so fixing a panel in
+    millimetres means solving for the fractions that reproduce it on a canvas
+    that is itself derived from the panels. That is only well posed on a
+    regular grid: on a mosaic a panel may span two columns, and "the panel
+    width" is then not one number.
+    """
+    if panel_size is None and panel_widths is None and panel_heights is None:
+        return None
+    if grid is None:
+        raise ValueError(
+            "Panel sizes need a regular grid — pass `(nrows, ncols)` or a "
+            "panel count. A mosaic panel can span several columns, so it has "
+            "no single width to fix."
+        )
+    for ratio_key in ("width_ratios", "height_ratios"):
+        if ratio_key in gridspec_kw:
+            raise ValueError(
+                f"`{ratio_key}` is relative and panel sizes are absolute — "
+                f"give one or the other. Per-column sizes go in `panel_widths` "
+                f"/ `panel_heights`."
+            )
+
+    nrows, ncols = grid
+    if panel_size is not None:
+        if panel_widths is not None or panel_heights is not None:
+            raise ValueError(
+                "`panel_size` sets every panel; use `panel_widths` / "
+                "`panel_heights` instead to vary them per column or row."
+            )
+        pw, ph = _as_pair(panel_size, "panel_size")
+        widths = [pw] * ncols
+        heights = [ph] * nrows
+    else:
+        if panel_widths is None or panel_heights is None:
+            raise ValueError(
+                "Give both `panel_widths` and `panel_heights` (or use "
+                "`panel_size`) — a panel needs both dimensions fixed for the "
+                "canvas to be derivable."
+            )
+        widths = [float(v) for v in panel_widths]
+        heights = [float(v) for v in panel_heights]
+        if len(widths) != ncols or len(heights) != nrows:
+            raise ValueError(
+                f"`panel_widths` needs {ncols} values (one per column) and "
+                f"`panel_heights` needs {nrows} (one per row); got "
+                f"{len(widths)} and {len(heights)}."
+            )
+    if min(widths) <= 0 or min(heights) <= 0:
+        raise ValueError("Panel sizes must be positive.")
+
+    left_m, right_m, bottom_m, top_m = _as_margins(margins)
+    h_gap, v_gap = _as_pair(spacing, "spacing")
+
+    panels_w = sum(widths) + h_gap * (ncols - 1)
+    panels_h = sum(heights) + v_gap * (nrows - 1)
+    fig_w = panels_w + left_m + right_m
+    fig_h = panels_h + bottom_m + top_m
+    if fig_w <= 0 or fig_h <= 0:
+        raise ValueError(
+            f"Margins leave no room for the panels: figure would be "
+            f"{fig_w}x{fig_h} {units}."
+        )
+
+    factor = _to_inch_factor(units, dpi)
+    # gridspec's left/right/bottom/top are figure fractions; wspace/hspace are
+    # gap-over-mean-panel. Converting here is what keeps the drawn panel equal
+    # to the number the caller asked for.
+    mean_w = sum(widths) / ncols
+    mean_h = sum(heights) / nrows
+    return {
+        "figsize_in": (fig_w * factor, fig_h * factor),
+        "gridspec_kw": {
+            "left": left_m / fig_w,
+            "right": 1.0 - right_m / fig_w,
+            "bottom": bottom_m / fig_h,
+            "top": 1.0 - top_m / fig_h,
+            "wspace": (h_gap / mean_w) if ncols > 1 else 0.0,
+            "hspace": (v_gap / mean_h) if nrows > 1 else 0.0,
+            "width_ratios": widths,
+            "height_ratios": heights,
+        },
+    }
+
+
 @register_function(
     aliases=["画布", "figure", "figure_size", "出版尺寸", "期刊尺寸", "journal figure"],
     category="pl",
@@ -229,12 +341,20 @@ def _panel_labels(n: int, label: Union[bool, str, Sequence[str]]) -> Optional[Li
     category="pl",
     description=(
         "Lay out a labelled multi-panel figure (grid or mosaic) at a physical "
-        "size, with automatic a/b/c panel tags"
+        "size, with automatic a/b/c panel tags. Size the canvas with `width`, "
+        "or size the panels themselves with `panel_size` when a journal "
+        "specifies the panel rather than the figure"
     ),
     examples=[
         "# 2x2 grid, 183 mm wide (Nature double column)",
         "fig, ax = ov.pl.multipanel((2, 2), width='nature-double', height=120)",
         "ov.pl.volcano(deg, ax=ax['a'])",
+        "# Panels fixed at 45x100 mm each; the canvas is derived from them",
+        "fig, ax = ov.pl.multipanel((2, 3), panel_size=(45, 100))",
+        "# Per-column widths, a figure number, and a colour cycle bound to a panel",
+        "fig, ax = ov.pl.multipanel((1, 3), panel_widths=[45, 60, 30],",
+        "                           panel_heights=[80], title='Figure 1',",
+        "                           panel_styles={'a': {'color_cycle': ['#4C72B0', '#DD8452']}})",
         "# Mosaic: a wide panel on top of two narrow ones",
         "fig, ax = ov.pl.multipanel('AA\\nBC', width=183, height=110)",
         "ax['A'].plot(x, y)",
@@ -257,6 +377,14 @@ def multipanel(layout: Union[int, Tuple[int, int], str, Sequence[Sequence[Any]]]
                sharey: bool = False,
                editable_text: bool = True,
                constrained: bool = True,
+               panel_size: Optional[Tuple[float, float]] = None,
+               panel_widths: Optional[Sequence[float]] = None,
+               panel_heights: Optional[Sequence[float]] = None,
+               margins: Union[float, Tuple[float, float, float, float]] = 14.0,
+               spacing: Union[float, Tuple[float, float]] = 8.0,
+               title: Optional[str] = None,
+               title_kw: Optional[Mapping[str, Any]] = None,
+               panel_styles: Optional[Mapping[Any, Mapping[str, Any]]] = None,
                **gridspec_kw: Any):
     r"""Build a multi-panel figure and label the panels.
 
@@ -279,9 +407,49 @@ def multipanel(layout: Union[int, Tuple[int, int], str, Sequence[Sequence[Any]]]
         Extra keyword arguments forwarded to :func:`add_panel_label`.
     sharex, sharey
         Share axes across panels.
+    panel_size, panel_widths, panel_heights
+        Size the **panels** instead of the figure, in ``units``. A journal that
+        specifies a panel ("each panel 45 mm wide") cannot be satisfied by
+        ``width`` plus ``width_ratios``, because those fix the canvas and let
+        the panels fall where they may — the drawn panel then depends on how
+        much room the tick labels happened to need.
+
+        ``panel_size=(w, h)`` gives every panel that size; ``panel_widths`` /
+        ``panel_heights`` give per-column and per-row sizes. The figure is
+        sized to fit: ``sum(panels) + spacing + margins``.
+
+        This turns constrained layout **off** — the two are contradictory, one
+        reflows to fit content and the other refuses to. That makes ``margins``
+        load-bearing: anything outside the axes (tick labels, y-labels, panel
+        tags) has to fit in them, and will be clipped rather than accommodated.
+        Grid layouts only; a mosaic's spans have no single panel width.
+    margins
+        Space outside the panels, in ``units`` — one number, or
+        ``(left, right, bottom, top)``. Only consulted when panels are sized.
+    spacing
+        Gap between panels, in ``units`` — one number, or ``(horizontal,
+        vertical)``. Only consulted when panels are sized.
+    title
+        Figure title, e.g. ``'Figure 1'``, drawn with ``fig.suptitle``.
+    title_kw
+        Extra keyword arguments for the title, e.g. ``{'x': 0.02, 'ha': 'left'}``
+        to left-align it.
+    panel_styles
+        Per-panel settings, keyed the same way ``axes`` is. ``color_cycle``
+        calls :meth:`~matplotlib.axes.Axes.set_prop_cycle`; every other key is
+        passed to :meth:`~matplotlib.axes.Axes.set`, so ``title``, ``xlabel``,
+        ``xlim`` and friends all work::
+
+            panel_styles={'a': {'color_cycle': ['#4C72B0', '#DD8452'],
+                                'title': 'Baseline'}}
+
+        Binding the cycle to the panel means the plotting calls that follow do
+        not each have to carry the colour.
     **gridspec_kw
         Passed to the gridspec — e.g. ``width_ratios``, ``height_ratios``,
-        ``wspace``, ``hspace``.
+        ``wspace``, ``hspace``. ``width_ratios`` / ``height_ratios`` are
+        relative and are therefore rejected alongside ``panel_widths`` /
+        ``panel_heights``, which are absolute.
 
     Returns
     -------
@@ -310,9 +478,25 @@ def multipanel(layout: Union[int, Tuple[int, int], str, Sequence[Sequence[Any]]]
 
     if editable_text:
         set_editable_text(True)
-    w_in, h_in = _figsize_inches(width, height, units, dpi, aspect)
-    fig = plt.figure(figsize=(w_in, h_in), dpi=dpi,
-                     layout="constrained" if constrained else None)
+
+    sized_panels = _panel_geometry(
+        grid, panel_size, panel_widths, panel_heights,
+        margins, spacing, units, dpi, gridspec_kw,
+    )
+    if sized_panels is None:
+        w_in, h_in = _figsize_inches(width, height, units, dpi, aspect)
+        fig = plt.figure(figsize=(w_in, h_in), dpi=dpi,
+                         layout="constrained" if constrained else None)
+    else:
+        # Panels are absolute, so the canvas is derived and constrained layout
+        # must stay off — it exists precisely to move panels around.
+        if width is not None or height is not None:
+            raise ValueError(
+                "Give either the figure size (`width`/`height`) or the panel "
+                "size (`panel_size`/`panel_widths`/`panel_heights`), not both "
+                "— with panels sized, the figure size is derived from them."
+            )
+        fig = plt.figure(figsize=sized_panels["figsize_in"], dpi=dpi, layout=None)
 
     if grid is not None:
         nrows, ncols = grid
@@ -320,6 +504,8 @@ def multipanel(layout: Union[int, Tuple[int, int], str, Sequence[Sequence[Any]]]
         keys = labels if labels is not None else [
             (r, c) for r in range(nrows) for c in range(ncols)
         ]
+        if sized_panels is not None:
+            gridspec_kw = dict(gridspec_kw, **sized_panels["gridspec_kw"])
         gs = fig.add_gridspec(nrows, ncols, **gridspec_kw)
         axes: Dict[Any, Any] = {}
         first = None
@@ -358,6 +544,32 @@ def multipanel(layout: Union[int, Tuple[int, int], str, Sequence[Sequence[Any]]]
         for ax, text in zip(ordered, labels):
             if text not in axes:
                 axes[text] = ax
+
+    if title is not None:
+        fig.suptitle(title, **(dict(title_kw) if title_kw else {}))
+
+    if panel_styles:
+        unknown = [k for k in panel_styles if k not in axes]
+        if unknown:
+            raise KeyError(
+                f"panel_styles names panels that do not exist: {sorted(map(str, unknown))}. "
+                f"Available: {sorted(map(str, axes))}."
+            )
+        # Iterate over the axes, not the mapping: a panel reachable under two
+        # keys ('A' and 'a') would otherwise have its style applied twice, and
+        # a prop cycle applied twice is silently reset to its start.
+        applied: set = set()
+        for key, style in panel_styles.items():
+            ax = axes[key]
+            if id(ax) in applied:
+                continue
+            applied.add(id(ax))
+            settings = dict(style)
+            cycle = settings.pop("color_cycle", None)
+            if cycle is not None:
+                ax.set_prop_cycle(color=list(cycle))
+            if settings:
+                ax.set(**settings)
 
     return fig, axes
 

--- a/tests/pl/test_layout_panel_sizes.py
+++ b/tests/pl/test_layout_panel_sizes.py
@@ -1,0 +1,185 @@
+"""Panels sized in millimetres come out that size, and the extras that ride along.
+
+``width`` plus ``width_ratios`` fixes the canvas and lets the panels fall where
+they may, so the drawn panel depends on how much room the tick labels happened
+to need. A journal that specifies the panel — "each panel 45 mm wide" — cannot
+be satisfied that way. ``panel_size`` / ``panel_widths`` / ``panel_heights``
+invert the derivation: the panels are given, the canvas follows.
+
+These tests measure the drawn axes rather than trusting the arithmetic, because
+the arithmetic is only right if the gridspec fraction conversion is right.
+"""
+
+from __future__ import annotations
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import pytest
+
+import omicverse as ov
+
+MM_PER_IN = 25.4
+
+
+def panel_mm(ax, fig) -> tuple[float, float]:
+    """The panel as drawn, in millimetres."""
+    box = ax.get_position()
+    fig_w_in, fig_h_in = fig.get_size_inches()
+    return (box.width * fig_w_in * MM_PER_IN, box.height * fig_h_in * MM_PER_IN)
+
+
+def test_uniform_panel_size_is_what_gets_drawn():
+    fig, axes = ov.pl.multipanel((2, 3), panel_size=(45, 100),
+                                 margins=14, spacing=8)
+    for key in "abcdef":
+        w, h = panel_mm(axes[key], fig)
+        assert w == pytest.approx(45.0, abs=0.05), f"panel {key} is {w} mm wide"
+        assert h == pytest.approx(100.0, abs=0.05), f"panel {key} is {h} mm tall"
+
+
+def test_the_canvas_is_derived_from_the_panels():
+    """3x45 + 2x8 gaps + 2x14 margins = 187 wide; 2x100 + 8 + 28 = 236 tall."""
+    fig, _ = ov.pl.multipanel((2, 3), panel_size=(45, 100), margins=14, spacing=8)
+    w_mm, h_mm = (v * MM_PER_IN for v in fig.get_size_inches())
+    assert w_mm == pytest.approx(3 * 45 + 2 * 8 + 2 * 14, abs=0.05)
+    assert h_mm == pytest.approx(2 * 100 + 1 * 8 + 2 * 14, abs=0.05)
+
+
+def test_per_column_and_per_row_sizes():
+    fig, axes = ov.pl.multipanel((2, 3), panel_widths=[45, 60, 30],
+                                 panel_heights=[80, 50],
+                                 margins=(20, 6, 16, 10), spacing=(9, 7))
+    expected = {"a": (45, 80), "b": (60, 80), "c": (30, 80),
+                "d": (45, 50), "e": (60, 50), "f": (30, 50)}
+    for key, (want_w, want_h) in expected.items():
+        w, h = panel_mm(axes[key], fig)
+        assert (w, h) == (pytest.approx(want_w, abs=0.05),
+                          pytest.approx(want_h, abs=0.05)), f"panel {key}"
+
+
+def test_asymmetric_margins_do_not_leak_into_the_panel():
+    """A bigger left margin must move the panels, not shrink them."""
+    fig_a, axes_a = ov.pl.multipanel((1, 2), panel_size=(40, 40), margins=10)
+    fig_b, axes_b = ov.pl.multipanel((1, 2), panel_size=(40, 40),
+                                     margins=(40, 10, 10, 10))
+    assert panel_mm(axes_a["a"], fig_a) == pytest.approx(
+        panel_mm(axes_b["a"], fig_b), abs=0.05)
+    assert axes_b["a"].get_position().x0 > axes_a["a"].get_position().x0
+
+
+def test_units_are_honoured():
+    fig_mm, axes_mm = ov.pl.multipanel((1, 1), panel_size=(50.8, 25.4),
+                                       units="mm", margins=0, spacing=0)
+    fig_in, axes_in = ov.pl.multipanel((1, 1), panel_size=(2.0, 1.0),
+                                       units="in", margins=0, spacing=0)
+    assert panel_mm(axes_mm["a"], fig_mm) == pytest.approx(
+        panel_mm(axes_in["a"], fig_in), abs=0.05)
+
+
+class TestRefusals:
+    """Contradictory inputs must say so rather than silently picking one."""
+
+    def test_figure_size_and_panel_size_together(self):
+        with pytest.raises(ValueError, match="not both"):
+            ov.pl.multipanel((1, 2), width=100, panel_size=(40, 40))
+
+    def test_a_mosaic_has_no_single_panel_width(self):
+        with pytest.raises(ValueError, match="regular grid"):
+            ov.pl.multipanel("AB", panel_size=(40, 40))
+
+    def test_relative_ratios_alongside_absolute_sizes(self):
+        with pytest.raises(ValueError, match="relative"):
+            ov.pl.multipanel((1, 2), panel_widths=[40, 40], panel_heights=[40],
+                             width_ratios=[1, 2])
+
+    def test_one_of_widths_or_heights_is_not_enough(self):
+        with pytest.raises(ValueError, match="both"):
+            ov.pl.multipanel((1, 2), panel_widths=[40, 40])
+
+    def test_wrong_number_of_column_sizes(self):
+        with pytest.raises(ValueError, match="one per column"):
+            ov.pl.multipanel((1, 3), panel_widths=[40, 40], panel_heights=[40])
+
+    def test_margins_that_leave_no_room(self):
+        with pytest.raises(ValueError):
+            ov.pl.multipanel((1, 1), panel_size=(40, 40), margins=(-30, -30, 0, 0))
+
+
+class TestPanelStyles:
+    def test_color_cycle_binds_to_the_panel(self):
+        fig, axes = ov.pl.multipanel(
+            (1, 2), width=120, height=50,
+            panel_styles={"a": {"color_cycle": ["#4C72B0", "#DD8452"]}})
+        first = axes["a"].plot([0, 1], [0, 1])[0].get_color()
+        second = axes["a"].plot([0, 1], [1, 0])[0].get_color()
+        assert (first, second) == ("#4C72B0", "#DD8452")
+        # The other panel keeps the global cycle.
+        assert axes["b"].plot([0, 1], [0, 1])[0].get_color() not in {"#4C72B0"}
+
+    def test_other_keys_reach_axes_set(self):
+        fig, axes = ov.pl.multipanel(
+            (1, 1), width=80, height=50,
+            panel_styles={"a": {"title": "Baseline", "xlabel": "t",
+                                "xlim": (0, 10)}})
+        assert axes["a"].get_title() == "Baseline"
+        assert axes["a"].get_xlabel() == "t"
+        assert axes["a"].get_xlim() == (0, 10)
+
+    def test_a_dual_keyed_panel_is_styled_once(self):
+        """A mosaic panel answers to 'A' and 'a'; applying twice would reset.
+
+        ``set_prop_cycle`` restarts the cycle, so styling the same axes through
+        both of its keys would put the first two lines on the same colour —
+        silently, and only visible in the drawn figure.
+        """
+        fig, axes = ov.pl.multipanel(
+            "AB", width=100, height=40,
+            panel_styles={"A": {"color_cycle": ["#111111", "#222222"]},
+                          "a": {"color_cycle": ["#111111", "#222222"]}})
+        assert axes["A"] is axes["a"]
+        first = axes["A"].plot([0, 1], [0, 1])[0].get_color()
+        second = axes["A"].plot([0, 1], [1, 0])[0].get_color()
+        assert first != second, "the prop cycle was reset by a second application"
+
+    def test_unknown_panel_is_refused(self):
+        with pytest.raises(KeyError, match="do not exist"):
+            ov.pl.multipanel((1, 2), width=100, height=40,
+                             panel_styles={"z": {"title": "nope"}})
+
+
+class TestFigureTitle:
+    def test_title_is_drawn(self):
+        fig, _ = ov.pl.multipanel((1, 2), width=120, height=50, title="Figure 1")
+        assert fig._suptitle is not None
+        assert fig._suptitle.get_text() == "Figure 1"
+
+    def test_title_kw_reaches_suptitle(self):
+        fig, _ = ov.pl.multipanel((1, 2), width=120, height=50, title="Figure 2",
+                                  title_kw={"x": 0.02, "ha": "left"})
+        assert fig._suptitle.get_ha() == "left"
+
+    def test_no_title_by_default(self):
+        fig, _ = ov.pl.multipanel((1, 2), width=120, height=50)
+        assert fig._suptitle is None
+
+
+class TestBackwardCompatibility:
+    """Every pre-existing call shape must behave exactly as before."""
+
+    def test_mosaic_with_ratios(self):
+        fig, axes = ov.pl.multipanel("AAB\nCDB", width="nature-double",
+                                     height=90, width_ratios=[1, 1, 1.3])
+        assert set("ABCDabcd") <= set(axes)
+        assert axes["A"] is axes["a"]
+        w_mm = fig.get_size_inches()[0] * MM_PER_IN
+        assert w_mm == pytest.approx(183.0, abs=0.05)
+
+    def test_plain_grid(self):
+        fig, axes = ov.pl.multipanel((2, 2), width=120, height=80)
+        assert sorted(axes) == ["a", "b", "c", "d"]
+
+    def test_unlabelled_grid_is_keyed_by_position(self):
+        fig, axes = ov.pl.multipanel((2, 2), width=120, height=80, label=False)
+        assert sorted(axes) == [(0, 0), (0, 1), (1, 0), (1, 1)]


### PR DESCRIPTION
`width` plus `width_ratios` fixes the canvas and lets the panels fall where they may, so the panel that gets drawn depends on how much room the tick labels happened to need. A journal that specifies the **panel** — "each panel 45 mm wide" — cannot be satisfied that way.

This inverts the derivation: give the panels, and the canvas follows.

```python
fig, ax = ov.pl.multipanel((2, 3), panel_size=(45, 100))
fig, ax = ov.pl.multipanel((2, 3), panel_widths=[45, 60, 30],
                           panel_heights=[80, 50],
                           margins=(20, 6, 16, 10), spacing=(9, 7))
```

Measured, not assumed — the tests read the drawn axes back, because the arithmetic is only right if the conversion into gridspec's figure fractions is right:

| requested | drawn |
|---|---|
| `panel_size=(45, 100)`, 2x3 | every panel 45.00 x 100.00 mm |
| `panel_widths=[45,60,30]`, `panel_heights=[80,50]` | 45/60/30 x 80/50 mm, exact |

Exact to 0.05 mm, including asymmetric margins (a bigger left margin moves the panels, it does not shrink them) and unit round-trips (50.8 mm == 2.0 in).

**The tradeoff, stated in the docstring rather than discovered later:** this turns constrained layout off, because the two are contradictory — one reflows to fit content, the other refuses to. That makes `margins` load-bearing: anything outside the axes (tick labels, y-labels, panel tags) has to fit in them and is clipped rather than accommodated. Panel sizes also need a regular grid — a mosaic panel can span columns and so has no single width, and asking for one now says so instead of guessing.

## Two smaller additions

**`title` / `title_kw`** — a figure number is part of the figure. Writing `fig.suptitle` afterwards is easy to forget on exactly the panel that needed it.

**`panel_styles`** — per-panel settings, keyed like `axes`. `color_cycle` binds a cycle to the panel so the plotting calls that follow do not each have to carry the colour; every other key goes to `Axes.set`, so `title`, `xlabel`, `xlim` work.

```python
fig, ax = ov.pl.multipanel((1, 3), panel_widths=[45, 60, 30], panel_heights=[80],
                           title='Figure 1',
                           panel_styles={'a': {'color_cycle': ['#4C72B0', '#DD8452'],
                                               'title': 'Baseline'}})
```

A panel reachable under two keys (`'A'` and `'a'` on a mosaic) is styled **once**. Applying a prop cycle twice silently restarts it, which would put the first two lines on the same colour — visible only in the drawn figure, never in an error. There is a test for that specifically.

## Compatibility

Every addition is keyword-only and defaults to the previous behaviour. `tests/pl` is **577 passed, 2 skipped** — unchanged from master. Mosaics, plain grids, `label=False` position keys and the journal presets all behave as before, with explicit tests pinning each.

Contradictory inputs raise rather than silently picking one: figure size *and* panel size, `width_ratios` (relative) alongside `panel_widths` (absolute), a mosaic with `panel_size`, half a specification, the wrong number of column sizes, margins that leave no room, and `panel_styles` naming a panel that does not exist.

Every example in the `@register_function` entry was executed as written before shipping — a registry example that does not run is the failure mode this codebase has been cleaning up all week.

## Where this came from

Comparing our multipanel against [cnsplots](https://cnsplots.farid.one/latest/examples/showcase.html), which builds panels imperatively (`mp.panel("A", 45, 100)` sets an implicit current-axes, and the next plotting call draws into it). Our declarative-plus-named-addressing shape is better for a caller that cannot see the figure — drawing into the wrong panel is a silent success there and a `KeyError` here — but cnsplots was right about two things we lacked: panels sized in real units, and style bound to the panel rather than repeated at every call. Those are what this adds; the implicit current-axes is deliberately not adopted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)