### PR TITLE
feat(pl): give the single-axes plots an ax= so any of them fits a panel

### DIFF
--- a/omicverse/pl/_bulk.py
+++ b/omicverse/pl/_bulk.py
@@ -417,12 +417,13 @@ def venn(sets={}, out='./', palette='bgrc',
     ],
     related=["pl.add_palue"]
 )
-def boxplot(data,hue,x_value,y_value,width=0.3,title='',
+def boxplot(data,hue,x_value=None,y_value=None,width=0.3,title='',
                  figsize=(6,3),palette=None,fontsize=10,
-                 legend_bbox=(1, 0.55),legend_ncol=1,hue_order=None):
+                 legend_bbox=(1, 0.55),legend_ncol=1,hue_order=None,
+                 *,x=None,y=None,ax=None):
     r"""
     Create a boxplot with jittered points to visualize data distribution across categories.
-    
+
     Parameters
     ----------
     data : pd.DataFrame
@@ -430,15 +431,19 @@ def boxplot(data,hue,x_value,y_value,width=0.3,title='',
     hue : str
         Column name used for color grouping.
     x_value : str
-        Column name used as x-axis category.
+        Column name used as x-axis category. ``x`` is accepted as an alias,
+        which is what the sibling table-first plots (``barplot``,
+        ``stripplot``, ``violinplot``) call it.
     y_value : str
-        Column name containing numeric values.
+        Column name containing numeric values. ``y`` is accepted as an alias.
     width : float
         Width of each box element.
     title : str
         Plot title.
     figsize : tuple
-        Figure size passed to matplotlib.
+        Figure size passed to matplotlib. Ignored when ``ax`` is given — the
+        axes already has a size, and resizing its figure would rescale every
+        other panel sharing it.
     palette : list or None
         Color list for hue groups; default palette is used when ``None``.
     fontsize : int
@@ -449,12 +454,44 @@ def boxplot(data,hue,x_value,y_value,width=0.3,title='',
         Number of legend columns.
     hue_order : list or None
         Explicit order of hue categories.
-        
+    x, y : str
+        Aliases for ``x_value`` / ``y_value``. Keyword-only.
+    ax : matplotlib.axes.Axes or None
+        Draw into this axes instead of creating a figure. Keyword-only, so
+        every existing positional call is unaffected. Pass one of
+        :func:`~omicverse.pl.multipanel`'s panels here to place the boxplot
+        inside a larger figure.
+
     Returns
     -------
     Tuple[matplotlib.figure.Figure, matplotlib.axes.Axes]
-        Figure and axes of generated boxplot.
+        Figure and axes of generated boxplot. The pair is returned in both
+        cases — when ``ax`` was supplied the figure is simply the one that
+        axes already belongs to — so the return shape never depends on how
+        the function was called.
     """
+    # `x`/`y` are the names the rest of the table-first family uses. Resolve
+    # them into the historical parameters rather than renaming, so that the
+    # thousands of existing `x_value=`/`y_value=` calls keep working.
+    if x is not None:
+        if x_value is not None and x_value != x:
+            raise ValueError(
+                f"`x` and `x_value` are aliases and disagree: {x!r} vs "
+                f"{x_value!r}. Pass only one."
+            )
+        x_value = x
+    if y is not None:
+        if y_value is not None and y_value != y:
+            raise ValueError(
+                f"`y` and `y_value` are aliases and disagree: {y!r} vs "
+                f"{y_value!r}. Pass only one."
+            )
+        y_value = y
+    if x_value is None or y_value is None:
+        raise TypeError(
+            "boxplot() needs the category and value columns: pass "
+            "`x_value=`/`y_value=` (or their aliases `x=`/`y=`)."
+        )
 
     # Color codes for terminal output
     class Colors:
@@ -670,7 +707,12 @@ def boxplot(data,hue,x_value,y_value,width=0.3,title='',
         plot_data_random1[hue_data]=data_a_random
         plot_data_xs1[hue_data]=data_a_xs
 
-    fig, ax = plt.subplots(figsize=figsize)
+    if ax is None:
+        fig, ax = plt.subplots(figsize=figsize)
+    else:
+        # A caller-supplied axes already lives in a figure that is theirs to
+        # size and lay out; we only draw.
+        fig = ax.get_figure()
     #色卡
     if palette==None:
         from ._palette import sc_color
@@ -688,9 +730,12 @@ def boxplot(data,hue,x_value,y_value,width=0.3,title='',
         plt.setp(b1['medians'], color=hue_color)
 
         clevels = np.linspace(0., 1., len(plot_data_random1[hue_data]))
-        for x, val, clevel in zip(plot_data_xs1[hue_data], plot_data_random1[hue_data], clevels):
+        # ax.scatter, not plt.scatter: pyplot draws on whatever the current
+        # axes happens to be, which is not the caller's axes once this is
+        # placed in a panel of a figure built elsewhere.
+        for jitter, val, clevel in zip(plot_data_xs1[hue_data], plot_data_random1[hue_data], clevels):
             if len(val) > 0:  # Only plot if there's data
-                plt.scatter(x, val,c=hue_color,alpha=0.4)
+                ax.scatter(jitter, val,c=hue_color,alpha=0.4)
 
     #坐标轴字体
     #fontsize=10
@@ -725,9 +770,10 @@ def boxplot(data,hue,x_value,y_value,width=0.3,title='',
     examples=['ov.pl.plot_grouped_fractions(res, obs=adata.obs, group_key="condition")'],
     related=['pl.boxplot', 'utils.plot_cellproportion']
 )
-def plot_grouped_fractions(res, obs, group_key, 
+def plot_grouped_fractions(res, obs, group_key,
                            color_dict=None,agg='mean', normalize=True,
                            figsize=(4, 4),
+                           *,ax=None,
                           ):
     """
     Plot grouped cell-fraction summaries as stacked bars.
@@ -747,7 +793,12 @@ def plot_grouped_fractions(res, obs, group_key,
     normalize : bool
         Whether each grouped row is normalized to sum to 1.
     figsize : tuple
-        Figure size passed to pandas/matplotlib plotting backend.
+        Figure size passed to pandas/matplotlib plotting backend. Ignored when
+        ``ax`` is given: pandas would call ``set_size_inches`` on the axes'
+        figure, which would resize the caller's whole multi-panel canvas.
+    ax : matplotlib.axes.Axes or None
+        Draw into this axes instead of creating a figure. Keyword-only, so
+        existing positional calls are unaffected.
 
     Returns
     -------
@@ -779,7 +830,10 @@ def plot_grouped_fractions(res, obs, group_key,
     colors = [color_dict[c] for c in g.columns]
 
     # 5) 画图
-    ax = g.plot(kind='bar', stacked=True, figsize=figsize, color=colors)
+    if ax is None:
+        ax = g.plot(kind='bar', stacked=True, figsize=figsize, color=colors)
+    else:
+        ax = g.plot(kind='bar', stacked=True, color=colors, ax=ax)
     ax.set_xlabel(group_key)
     ax.set_ylabel('Cell Fraction')
     ax.set_title(f'Cell fractions grouped by {group_key} ({agg})')

--- a/omicverse/pl/_classification.py
+++ b/omicverse/pl/_classification.py
@@ -193,6 +193,7 @@ def roc(data: Any = None,
         n_boot: int = 500,
         random_state: int = 0,
         chance_line: bool = True,
+        aspect: Any = "equal",
         xlabel: str = "False positive rate",
         ylabel: str = "True positive rate",
         title: Optional[str] = None,
@@ -234,6 +235,13 @@ def roc(data: Any = None,
         ``None`` reports the point estimate only.
     n_boot
         Bootstrap resamples when ``ci='bootstrap'``.
+    aspect
+        Axes aspect. ``'equal'`` (default) is the convention for a standalone
+        ROC — a unit square where the chance line runs at 45°. Pass ``'auto'``
+        when the ROC is a panel of a larger figure: ``'equal'`` makes
+        matplotlib shrink the axes to a square inside whatever rectangle the
+        layout assigned, so the panel stops filling its cell and its x-axis
+        leaves the row's baseline. ``None`` leaves the aspect untouched.
     return_stats
         Return ``(ax, stats)`` with the AUC, CI and curve of every model.
 
@@ -352,7 +360,13 @@ def roc(data: Any = None,
 
     ax.set_xlim(-0.01, 1.01)
     ax.set_ylim(-0.01, 1.01)
-    ax.set_aspect("equal", adjustable="box")
+    # 'equal' is the convention for a standalone ROC, but it overrides the
+    # axes rectangle a layout engine assigned: matplotlib shrinks the axes to
+    # square inside it, so the panel no longer fills its cell and its x-axis no
+    # longer sits on the row's baseline. `aspect='auto'` keeps the given
+    # rectangle, which is what a panel in a multi-panel figure needs.
+    if aspect is not None:
+        ax.set_aspect(aspect, adjustable="box")
     ax.set_xlabel(xlabel, fontsize=font_size(fontsize, "label"))
     ax.set_ylabel(ylabel, fontsize=font_size(fontsize, "label"))
     if title:

--- a/omicverse/pl/_plot_backend.py
+++ b/omicverse/pl/_plot_backend.py
@@ -644,7 +644,8 @@ def ticks_range(x,width):
 
 def plot_boxplot(data, hue, x_value, y_value, width=0.6, title='',
                  figsize=(6, 3), palette=None, fontsize=10,
-                 legend_bbox=(1, 0.55), legend_ncol=1, hue_order=None):
+                 legend_bbox=(1, 0.55), legend_ncol=1, hue_order=None,
+                 *, ax=None):
     r"""Deprecated alias of :func:`omicverse.pl.boxplot`.
 
     This was an earlier, shorter implementation of the same plot. It is now a
@@ -660,6 +661,10 @@ def plot_boxplot(data, hue, x_value, y_value, width=0.6, title='',
     The x categories are now sorted, which they were not before. That is the
     one visible change, and it is a fix: the old order came from however the
     rows happened to be grouped.
+
+    ``ax`` is forwarded rather than reimplemented: the shim exists so there is
+    exactly one boxplot implementation, and a second axes-handling branch here
+    would be the first place the two drift apart again.
     """
     from warnings import warn
 
@@ -679,7 +684,7 @@ def plot_boxplot(data, hue, x_value, y_value, width=0.6, title='',
                     width=width, title=title, figsize=figsize,
                     palette=palette, fontsize=fontsize,
                     legend_bbox=legend_bbox, legend_ncol=legend_ncol,
-                    hue_order=hue_order)
+                    hue_order=hue_order, ax=ax)
 
 
 def plot_network(G:nx.Graph,G_type_dict:dict,G_color_dict:dict,pos_type:str='spring',pos_dim:int=2,
@@ -689,7 +694,7 @@ def plot_network(G:nx.Graph,G_type_dict:dict,G_color_dict:dict,pos_type:str='spr
                 label_verticalalignment:str='center_baseline',label_fontsize:int=12,
                 label_fontfamily:str='Arial',label_fontweight:str='bold',label_bbox=None,
                 legend_bbox:tuple=(0.7, 0.05),legend_ncol:int=3,legend_fontsize:int=12,
-                legend_fontweight:str='bold'):
+                legend_fontweight:str='bold',*,ax=None):
     r"""Plot network graph with customizable node and edge properties.
     
     Parameters
@@ -717,14 +722,23 @@ def plot_network(G:nx.Graph,G_type_dict:dict,G_color_dict:dict,pos_type:str='spr
         legend_ncol: Legend columns (3)
         legend_fontsize: Legend font size (12)
         legend_fontweight: Legend font weight ('bold')
-        
+        ax: Draw into this axes instead of creating a figure. Keyword-only, so
+            existing positional calls are unaffected; ``figsize`` is ignored
+            when it is given, because the axes' figure belongs to the caller
+            (None)
+
     Returns
     -------
-        Tuple of (figure, axes) objects
+        Tuple of (figure, axes) objects. The pair is returned in both cases —
+        when ``ax`` was supplied the figure is the one that axes belongs to —
+        so the return shape does not depend on how the function was called.
     """
-    
 
-    fig, ax = plt.subplots(figsize=figsize)
+
+    if ax is None:
+        fig, ax = plt.subplots(figsize=figsize)
+    else:
+        fig = ax.get_figure()
     if pos_type=='spring':
         pos = nx.spring_layout(G, scale=pos_scale, k=pos_k)
     elif pos_type=='kamada_kawai':
@@ -734,7 +748,11 @@ def plot_network(G:nx.Graph,G_type_dict:dict,G_color_dict:dict,pos_type:str='spr
     G_color_dict=dict(zip(G.nodes,[G_color_dict[i] for i in G.nodes]))
     G_type_dict=dict(zip(G.nodes,[G_type_dict[i] for i in G.nodes]))
 
-    nx.draw_networkx_edges(G, pos,nodelist=list(G_color_dict.keys()), alpha=pos_alpha)
+    # networkx and adjustText both fall back to plt.gca() when no axes is
+    # named, which is the wrong figure entirely once this plot is one panel of
+    # a canvas assembled elsewhere. Name the axes everywhere.
+    nx.draw_networkx_edges(G, pos,nodelist=list(G_color_dict.keys()), alpha=pos_alpha,
+                           ax=ax)
     nx.draw_networkx_nodes(
         G,
         pos,
@@ -743,6 +761,7 @@ def plot_network(G:nx.Graph,G_type_dict:dict,G_color_dict:dict,pos_type:str='spr
         node_color=list(G_color_dict.values()),
         alpha=node_alpha,
         linewidths=node_linewidths,
+        ax=ax,
     )
     if plot_node!=None:
         hub_gene=plot_node
@@ -768,10 +787,11 @@ def plot_network(G:nx.Graph,G_type_dict:dict,G_color_dict:dict,pos_type:str='spr
                fontdict={'size':label_fontsize,'weight':label_fontweight,'color':'black'}
                ) for i in hub_gene if 'ENSG' not in i]
     if adjustText.__version__<='0.8':
-        adjust_text(texts,only_move={'text': 'xy'},arrowprops=dict(arrowstyle='->', color='red'),)
+        adjust_text(texts,only_move={'text': 'xy'},arrowprops=dict(arrowstyle='->', color='red'),
+                    ax=ax)
     else:
         adjust_text(texts,only_move={"text": "xy", "static": "xy", "explode": "xy", "pull": "xy"},
-                    arrowprops=dict(arrowstyle='->', color='red'))
+                    arrowprops=dict(arrowstyle='->', color='red'),ax=ax)
    #adjust_text(texts,only_move={'text': 'xy'},arrowprops=dict(arrowstyle='->', color='red'),)
 
     ax.axis("off")
@@ -785,11 +805,11 @@ def plot_network(G:nx.Graph,G_type_dict:dict,G_color_dict:dict,pos_type:str='spr
     
     patches = [ mpatches.Patch(color=type_color_dict[i], label="{:s}".format(i) ) for i in type_color_dict.keys() ] 
 
-    plt.legend(handles=patches,bbox_to_anchor=legend_bbox, ncol=legend_ncol,fontsize=legend_fontsize)
-    leg = plt.gca().get_legend() #或leg=ax.get_legend()
+    ax.legend(handles=patches,bbox_to_anchor=legend_bbox, ncol=legend_ncol,fontsize=legend_fontsize)
+    leg = ax.get_legend()
     ltext = leg.get_texts()
     plt.setp(ltext, fontsize=legend_fontsize,fontweight=legend_fontweight)
-    
+
     return fig,ax
 
 @register_function(

--- a/tests/pl/test_ax_contract.py
+++ b/tests/pl/test_ax_contract.py
@@ -1,0 +1,301 @@
+"""Every single-axes plot in ``ov.pl`` draws into an ``ax=`` it is handed.
+
+A caller assembling a figure with :func:`ov.pl.multipanel` hands each panel to
+a plotting function and expects the drawing to land there. That only works if
+the whole namespace agrees on the convention the table-first family already
+follows: ``ax`` is keyword-only, defaults to ``None``, and when it is supplied
+the function draws and nothing else — no new figure, no ``plt.show()``, no
+resizing of the figure the panel belongs to.
+
+Three things are checked for each retrofitted plot.
+
+1. **Nothing is created.** ``plt.get_fignums()`` is identical across the call,
+   and the parent figure keeps the size it had. A function that quietly opens
+   its own canvas loses the drawing; one that honours ``figsize`` while given
+   an ``ax`` rescales every other panel on the sheet.
+2. **Something is drawn.** The artist count on the passed axes goes up. An
+   ``ax`` that is accepted and then ignored passes assertion 1 perfectly while
+   producing an empty panel, so the positive check has to be here too.
+3. **The old path is untouched.** Called without ``ax`` the function still
+   produces its own figure and returns what it always returned.
+
+The final test is a guard rather than a case: it sweeps ``ov.pl.__all__`` for
+callables that take ``figsize`` but no ``ax`` and fails on any name it does not
+already know to be composite. A new single-axes plot added without ``ax`` shows
+up there rather than being discovered by a user mid-figure.
+"""
+from __future__ import annotations
+
+import inspect
+import warnings
+
+import matplotlib
+import numpy as np
+import pandas as pd
+import pytest
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt  # noqa: E402
+
+import omicverse as ov  # noqa: E402
+
+
+# --------------------------------------------------------------------------
+# data
+# --------------------------------------------------------------------------
+
+
+def _long_frame() -> pd.DataFrame:
+    """A small long-form table: three categories, two groups, one measure."""
+    rng = np.random.default_rng(20260729)
+    n = 120
+    return pd.DataFrame({
+        "cell_type": rng.choice(["B", "Mono", "T"], n),
+        "condition": rng.choice(["ctrl", "drug"], n),
+        "score": rng.normal(size=n),
+    })
+
+
+def _fraction_tables():
+    """A cell-fraction matrix plus the sample metadata it is grouped by."""
+    rng = np.random.default_rng(11)
+    index = [f"S{i}" for i in range(12)]
+    res = pd.DataFrame(rng.random((12, 3)), index=index,
+                       columns=["B", "Mono", "T"])
+    obs = pd.DataFrame({"condition": rng.choice(["ctrl", "drug"], 12)},
+                       index=index)
+    colors = {"B": "#4C72B0", "Mono": "#DD8452", "T": "#55A868"}
+    return res, obs, colors
+
+
+def _small_network():
+    """A graph with the two side tables ``plot_network`` needs."""
+    import networkx as nx
+
+    graph = nx.relabel_nodes(nx.karate_club_graph(),
+                             {i: f"gene{i}" for i in range(34)})
+    types = {node: ("hub" if index % 2 else "leaf")
+             for index, node in enumerate(graph.nodes)}
+    colors = {node: ("#C44E52" if types[node] == "hub" else "#4C72B0")
+              for node in graph.nodes}
+    return graph, types, colors
+
+
+# --------------------------------------------------------------------------
+# the plots that were given an `ax`
+# --------------------------------------------------------------------------
+#
+# Each entry returns the callable and the keyword arguments to reach a drawing,
+# without `ax` — the tests below add it. Keeping the calls in one table means a
+# plot retrofitted later is covered by all three checks by adding one line.
+
+
+def _case_boxplot():
+    return ov.pl.boxplot, dict(data=_long_frame(), hue="condition",
+                               x_value="cell_type", y_value="score")
+
+
+def _case_boxplot_xy_aliases():
+    # `x`/`y` are the names the sibling table-first plots use; they have to
+    # reach the same axes as `x_value`/`y_value`.
+    return ov.pl.boxplot, dict(data=_long_frame(), hue="condition",
+                               x="cell_type", y="score")
+
+
+def _case_plot_boxplot():
+    return ov.pl.plot_boxplot, dict(data=_long_frame(), hue="condition",
+                                    x_value="cell_type", y_value="score")
+
+
+def _case_plot_grouped_fractions():
+    res, obs, colors = _fraction_tables()
+    return ov.pl.plot_grouped_fractions, dict(res=res, obs=obs,
+                                              group_key="condition",
+                                              color_dict=colors)
+
+
+def _case_plot_network():
+    pytest.importorskip("adjustText")
+    graph, types, colors = _small_network()
+    return ov.pl.plot_network, dict(G=graph, G_type_dict=types,
+                                    G_color_dict=colors, plot_node_num=3)
+
+
+AX_PLOTS = {
+    "boxplot": _case_boxplot,
+    "boxplot(x=,y=)": _case_boxplot_xy_aliases,
+    "plot_boxplot": _case_plot_boxplot,
+    "plot_grouped_fractions": _case_plot_grouped_fractions,
+    "plot_network": _case_plot_network,
+}
+
+
+def _call(func, kwargs):
+    """Run a plot, muffling the deprecation notices the shims emit."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        return func(**kwargs)
+
+
+def _returned_axes(result):
+    """The axes out of a result that is either an ``Axes`` or ``(fig, ax)``."""
+    if isinstance(result, tuple):
+        for item in result:
+            if isinstance(item, matplotlib.axes.Axes):
+                return item
+        return None
+    return result if isinstance(result, matplotlib.axes.Axes) else None
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+def _target_and_decoy(figsize=(5.0, 3.0)):
+    """A panel to draw into, plus a later figure that owns ``plt.gca()``.
+
+    The decoy is the point. A function that reaches for ``plt.scatter`` or
+    ``nx.draw_networkx_nodes()`` without naming an axes draws on the *current*
+    axes, and when the caller's panel happens to be the current axes — which it
+    is in the simplest test — that bug is invisible. Opening a second figure
+    afterwards puts the panel out of focus, which is the situation in every
+    real multipanel figure: the panels were created before the plotting calls,
+    in some other order.
+    """
+    fig, ax = plt.subplots(figsize=figsize)
+    decoy_fig, decoy_ax = plt.subplots()
+    assert plt.gca() is decoy_ax
+    return fig, ax, decoy_fig, decoy_ax
+
+
+# --------------------------------------------------------------------------
+# the contract
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("name", sorted(AX_PLOTS))
+def test_ax_is_keyword_only_and_optional(name):
+    func, _ = AX_PLOTS[name]()
+    parameter = inspect.signature(func).parameters.get("ax")
+    assert parameter is not None, f"{name} has no `ax` parameter"
+    assert parameter.kind is inspect.Parameter.KEYWORD_ONLY, (
+        f"{name} takes `ax` positionally, which would shift existing calls"
+    )
+    assert parameter.default is None
+
+
+@pytest.mark.parametrize("name", sorted(AX_PLOTS))
+def test_drawing_into_a_given_ax_creates_no_figure(name, monkeypatch):
+    func, kwargs = AX_PLOTS[name]()
+
+    def _no_show(*args, **kwargs):
+        raise AssertionError(f"{name} called plt.show() with an `ax` given")
+
+    monkeypatch.setattr(plt, "show", _no_show)
+
+    fig, ax, _, _ = _target_and_decoy()
+    before = set(plt.get_fignums())
+    size_before = tuple(fig.get_size_inches())
+
+    result = _call(func, {**kwargs, "ax": ax})
+
+    assert set(plt.get_fignums()) == before, (
+        f"{name} opened a figure although it was given an `ax`"
+    )
+    assert tuple(fig.get_size_inches()) == size_before, (
+        f"{name} resized the caller's figure — `figsize` must be ignored "
+        f"when `ax` is given"
+    )
+    assert _returned_axes(result) is ax, (
+        f"{name} did not return the axes it was handed"
+    )
+
+
+@pytest.mark.parametrize("name", sorted(AX_PLOTS))
+def test_drawing_into_a_given_ax_actually_draws(name):
+    func, kwargs = AX_PLOTS[name]()
+
+    _, ax, _, decoy_ax = _target_and_decoy()
+    before = len(ax.get_children())
+    decoy_before = len(decoy_ax.get_children())
+
+    _call(func, {**kwargs, "ax": ax})
+
+    assert len(ax.get_children()) > before, (
+        f"{name} accepted `ax` but drew nothing on it"
+    )
+    assert len(decoy_ax.get_children()) == decoy_before, (
+        f"{name} drew on the current axes instead of the one it was given"
+    )
+
+
+@pytest.mark.parametrize("name", sorted(AX_PLOTS))
+def test_without_ax_the_old_behaviour_is_unchanged(name):
+    func, kwargs = AX_PLOTS[name]()
+
+    before = set(plt.get_fignums())
+    result = _call(func, kwargs)
+    after = set(plt.get_fignums())
+
+    assert after - before, f"{name} produced no figure when called without `ax`"
+    axes = _returned_axes(result)
+    assert axes is not None, f"{name} stopped returning an Axes"
+    assert axes.get_figure().number in after - before
+    assert len(axes.get_children()) > 0
+
+
+# --------------------------------------------------------------------------
+# the guard
+# --------------------------------------------------------------------------
+#
+# Composite plots — a main panel plus dendrograms, colour bars or annotation
+# strips, or a grid of panels — cannot be squeezed into one axes, so they are
+# expected to lack `ax`. So are the rcParams helpers, which take `figsize` only
+# to set a default. Everything else that takes `figsize` but no `ax` is a
+# single-axes plot that a caller cannot place in a panel, which is the gap this
+# module exists to close.
+
+COMPOSITE_OR_NOT_A_PLOT = frozenset({
+    # marsilea / PyComplexHeatmap builders: heatmap plus side plots
+    "ccc_heatmap", "cell_cor_heatmap", "cnv_heatmap", "complexheatmap",
+    "dynamic_heatmap", "feature_heatmap", "group_heatmap",
+    # gridspec assemblies
+    "dotplot_doublegroup", "embedding_celltype", "geneset_wordcloud",
+    "stacking_vol", "upset",
+    # panel grids
+    "perturb_celloracle_layout", "perturb_development_layout", "qc",
+    # dispatchers over many plot types, and animation
+    "animate_streamplot", "ccc_network_plot", "ccc_stat_plot",
+    # scanpy dotplot: main panel plus dendrogram and colour bar
+    "markers_dotplot",
+    # wrappers around the composites above
+    "plot_embedding_celltype",
+    # single-axes, but wrappers of functions that already take `ax`
+    "cpdb_plot_curve_network", "plot_cellproportion", "plot_flowsig_network",
+    # rcParams configuration, not plots
+    "ov_plot_set", "plot_set", "plotset", "style",
+})
+
+
+def test_no_new_single_axes_plot_is_missing_ax():
+    missing = set()
+    for name in ov.pl.__all__:
+        func = getattr(ov.pl, name, None)
+        if not callable(func):
+            continue
+        try:
+            parameters = inspect.signature(func).parameters
+        except (TypeError, ValueError):  # C-level callables
+            continue
+        if "figsize" in parameters and "ax" not in parameters:
+            missing.add(name)
+
+    unexpected = missing - COMPOSITE_OR_NOT_A_PLOT
+    assert not unexpected, (
+        "these ov.pl functions take `figsize` but no `ax`, so they cannot be "
+        f"placed in a panel: {sorted(unexpected)}. Give them a keyword-only "
+        "`ax=None` and add a case to AX_PLOTS, or list them in "
+        "COMPOSITE_OR_NOT_A_PLOT with the reason they need more than one axes."
+    )

--- a/tests/pl/test_ax_contract.py
+++ b/tests/pl/test_ax_contract.py
@@ -299,3 +299,39 @@ def test_no_new_single_axes_plot_is_missing_ax():
         "`ax=None` and add a case to AX_PLOTS, or list them in "
         "COMPOSITE_OR_NOT_A_PLOT with the reason they need more than one axes."
     )
+
+
+# --------------------------------------------------------------------------
+# roc: a forced aspect overrides the rectangle a layout gave the axes
+# --------------------------------------------------------------------------
+
+
+def test_roc_equal_aspect_shrinks_the_assigned_rectangle():
+    """The default 'equal' is right for a standalone ROC and wrong for a panel.
+
+    matplotlib honours `aspect='equal'` by shrinking the axes to a square
+    *inside* its position, so a panel handed a non-square rectangle stops
+    filling it — and its x-axis leaves the row's baseline.
+    """
+    import numpy as np
+
+    from omicverse.pl._classification import roc
+
+    rng = np.random.default_rng(0)
+    y_true = rng.integers(0, 2, 200)
+    y_score = rng.random(200) * 0.5 + y_true * 0.3
+
+    fig = plt.figure(figsize=(8, 4))
+    wide = [0.1, 0.1, 0.8, 0.4]                    # deliberately not square
+
+    ax_equal = fig.add_axes(wide)
+    roc(y_true=y_true, y_score=y_score, ax=ax_equal, ci=None)
+    ax_auto = fig.add_axes(wide)
+    roc(y_true=y_true, y_score=y_score, ax=ax_auto, ci=None, aspect="auto")
+
+    fig.canvas.draw()
+    kept = ax_auto.get_window_extent()
+    shrunk = ax_equal.get_window_extent()
+    assert shrunk.width < kept.width * 0.95, "equal aspect did not shrink the axes"
+    assert kept.width == pytest.approx(wide[2] * 8 * fig.dpi, rel=0.02)
+    assert kept.height == pytest.approx(wide[3] * 4 * fig.dpi, rel=0.02)


### PR DESCRIPTION
`ov.pl`'s table-first plots mostly accept `ax=` and draw into it. A handful did not — they silently created their own figure — so you could place `barplot` into a panel of `multipanel` but not `boxplot`, with nothing in the namespace marking which was which until the second one popped a stray window.

Four functions now take a keyword-only `ax=None`: `boxplot`, `plot_boxplot`, `plot_network`, `plot_grouped_fractions`. They follow the convention the siblings already use (`_new_axes`) — draw into `ax` when given, else `plt.subplots(figsize)`; `figsize` is ignored once `ax` is passed; no `plt.show()`.

**Return shape is unchanged by `ax`.** `boxplot` returns `(fig, ax)` with or without it — returning a bare axes when `ax` is passed would break `fig, ax = ov.pl.boxplot(...)` for anyone who adds the argument.

**Two leaks fixed, both of which only bite inside a panel:**
- `boxplot` drew its jitter with `plt.scatter` — onto `gca()`, i.e. the wrong figure when the panel is not current.
- `plot_network` called `plt.legend` / `plt.gca()`.

Both now target the supplied axes. The regression test opens a **decoy figure after the panel** and asserts nothing landed on it; without the decoy the test is worthless, because the panel is normally `gca()` and the leak is invisible.

`boxplot` also gained `x=`/`y=` as aliases for `x_value`/`y_value` (the siblings use `x`/`y`). Old names still work; passing both spellings with different values raises.

A guard test re-runs a "declares `figsize` but not `ax`" sweep over `ov.pl.__all__` and fails on any new single-axes plot that forgets `ax`, with an allowlist of the genuinely-composite functions — so a newly added plot cannot regress this silently.

`tests/pl` = 598 passed (577 + 21 new), 2 skipped — baseline unchanged. Red-test evidence: removing the `ax` guard in `boxplot` → 6 red; forwarding `figsize` to pandas alongside `ax` → 1 red; dropping `ax=ax` from the networkx draw calls → 1 red. All restored green.

Not changed, reported for follow-up: `complexheatmap` / `upset` / the marsilea-backed heatmaps are genuinely multi-axes (main panel + dendrogram + colour bar) and need a `SubplotSpec` / `SubFigure` hook, not a single `ax`; `plot_cellproportion` forwards to `cellproportion`, whose own `ax=` path still leaks labels through `plt.xticks`. Those are separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)