### PR TITLE
fix(pl): venn on matplotlib-venn, and volcano axis labels follow rcParams

### DIFF
--- a/omicverse/pl/_bulk.py
+++ b/omicverse/pl/_bulk.py
@@ -28,7 +28,8 @@ def volcano(result,pval_name='qvalue',fc_name='log2FC',pval_max=None,FC_max=None
                      up_fontcolor:str='#e25d5d',down_fontcolor:str='#7388c1',normal_fontcolor:str='#d7d7d7',
                      legend_bbox:tuple=(0.8, -0.2),legend_ncol:int=2,legend_fontsize:int=12,
                      plot_genes:list=None,plot_genes_num:int=10,plot_genes_fontsize:int=10,
-                     ticks_fontsize:int=12,pval_threshold:float=0.05,fc_max:float=1.5,fc_min:float=-1.5,
+                     ticks_fontsize:int=None,pval_threshold:float=0.05,fc_max:float=1.5,fc_min:float=-1.5,
+                     label_fontsize:float=None,
                      ax = None,):
     r"""
     Create a volcano plot for differential expression analysis.
@@ -76,14 +77,18 @@ def volcano(result,pval_name='qvalue',fc_name='log2FC',pval_max=None,FC_max=None
         Number of top genes automatically annotated when ``plot_genes`` is None.
     plot_genes_fontsize : int
         Font size for annotated gene labels.
-    ticks_fontsize : int
-        Tick label font size.
+    ticks_fontsize : int or None
+        Tick label font size. When ``None`` follows ``rcParams['xtick.labelsize']``.
     pval_threshold : float
         Significance threshold used to define highlighted genes.
     fc_max : float
         Positive fold-change cutoff.
     fc_min : float
         Negative fold-change cutoff.
+    label_fontsize : float or None
+        Font size of the x/y axis labels. When ``None`` follows
+        ``rcParams['axes.labelsize']`` so the labels match surrounding panels
+        instead of the fixed title font size.
     ax : matplotlib.axes.Axes or None
         Existing axes object to draw on.
         
@@ -276,8 +281,17 @@ def volcano(result,pval_name='qvalue',fc_name='log2FC',pval_max=None,FC_max=None
             linestyle="--",
             color='black')
     #设置横标签与纵标签
-    ax.set_ylabel(rf'$-log_{{10}}({pval_name})$',titlefont)
-    ax.set_xlabel(r'$log_{2}FC$',titlefont)
+    # The axis labels used to inherit titlefont's fixed size (14), which dwarfs
+    # the 5-6pt labels of neighbouring panels in a multi-panel figure. Decouple
+    # only the size: keep the mathtext/weight styling from titlefont, but let
+    # the size follow rcParams['axes.labelsize'] (or an explicit label_fontsize)
+    # so the labels scale with the surrounding font.
+    if label_fontsize is None:
+        label_fontsize = plt.rcParams['axes.labelsize']
+    label_font = dict(titlefont)
+    label_font['size'] = label_fontsize
+    ax.set_ylabel(rf'$-log_{{10}}({pval_name})$',label_font)
+    ax.set_xlabel(r'$log_{2}FC$',label_font)
     #设置标题
     ax.set_title(title,titlefont)
 
@@ -299,6 +313,10 @@ def volcano(result,pval_name='qvalue',fc_name='log2FC',pval_max=None,FC_max=None
     ax.spines['bottom'].set_visible(True)
     ax.spines['left'].set_visible(True)
 
+    # Tick labels were also pinned at 12, larger than the rest of a small panel.
+    # Default to rcParams['xtick.labelsize'] so they track the surrounding font.
+    if ticks_fontsize is None:
+        ticks_fontsize = plt.rcParams['xtick.labelsize']
     ax.set_xticks([round(i,2) for i in ax.get_xticks()[1:-1]],#获取x坐标轴内容
         [round(i,2) for i in ax.get_xticks()[1:-1]],#更新x坐标轴内容
         fontsize=ticks_fontsize,
@@ -358,45 +376,113 @@ def volcano(result,pval_name='qvalue',fc_name='log2FC',pval_max=None,FC_max=None
     related=["bulk.pyDEG.deg_analysis"]
 )
 def venn(sets={}, out='./', palette='bgrc',
-             ax=False, ext='png', dpi=300, fontsize=3.5,
-             bbox_to_anchor=(.5, .99),nc=2,cs=4):
+             ax=False, ext='png', dpi=300, fontsize=None,
+             bbox_to_anchor=(.5, .99),nc=2,cs=4, figsize=(4,4)):
     r"""
     Create a Venn diagram to visualize set overlaps.
-    
+
+    For 2 or 3 sets this draws area-proportional circles via ``matplotlib-venn``
+    (``venn2``/``venn3``) so the numbers sit inside clean, correctly scaled
+    regions instead of the non-proportional ellipses of the ``venn`` package.
+    This follows the approach of cnsplots (Farid Rashidi, BSD-3-Clause); the
+    implementation here is independent. ``matplotlib-venn`` only supports 2 or 3
+    sets, so 4+ sets fall back to the ``venny4py`` backend.
+
     Parameters
     ----------
     sets : dict
-        Dictionary mapping set names to Python sets.
+        Dictionary mapping set names to Python sets. 2 or 3 sets use
+        ``matplotlib-venn``; 4 or more fall back to ``venny4py``.
     out : str
-        Output directory for saved figure.
+        Output directory for saved figure (``venny4py`` fallback only).
     palette : str or list
-        Color palette passed to backend venn renderer.
+        Colors for the set circles. A string such as ``'bgrc'`` is treated as a
+        sequence of single-letter matplotlib colors; a list is used as-is.
     ax : matplotlib.axes.Axes or bool
-        Existing axes; if ``False`` a new figure/axes is created.
+        Existing axes to draw into; if ``False`` a new figure/axes is created.
     ext : str
-        Output file extension.
+        Output file extension (``venny4py`` fallback only).
     dpi : int
-        Resolution of saved image.
-    fontsize : float
-        Font size for labels.
+        Resolution of saved image (``venny4py`` fallback only).
+    fontsize : float or None
+        Font size for the subset counts and set names. When ``None`` it follows
+        ``plt.rcParams['font.size']`` so the labels match the rest of a figure
+        rather than a hard-coded size.
     bbox_to_anchor : tuple
-        Legend anchor position.
+        Legend anchor position (``venny4py`` fallback only).
     nc : int
-        Number of legend columns.
+        Number of legend columns (``venny4py`` fallback only).
     cs : float
-        Legend font size.
-        
+        Legend font size (``venny4py`` fallback only).
+    figsize : tuple
+        Figure size used when ``ax`` is ``False`` and a new figure is created.
+
     Returns
     -------
     matplotlib.axes.Axes or bool
-        Axes handle returned by caller/backend context.
+        The axes the diagram was drawn into (or the passed-in ``ax``).
     """
-    
-    from ._venn_backend import venny4py
-    venny4py(sets=sets,out=out,ce=palette,asax=ax,ext=ext,
-             dpi=dpi,size=fontsize,bbox_to_anchor=bbox_to_anchor,
-             nc=nc,cs=cs,
-             )
+
+    n = len(sets)
+    if n < 2:
+        raise ValueError(
+            f"ov.pl.venn needs at least 2 sets to draw a Venn diagram, got {n}. "
+            "Pass a dict like {'A': setA, 'B': setB}."
+        )
+
+    # matplotlib-venn only implements venn2/venn3; anything larger keeps the old
+    # venny4py behaviour so existing 4-set calls do not break.
+    if n > 3:
+        from ._venn_backend import venny4py
+        venny4py(sets=sets, out=out, ce=palette, asax=ax, ext=ext,
+                 dpi=dpi, size=fontsize if fontsize is not None else 3.5,
+                 bbox_to_anchor=bbox_to_anchor, nc=nc, cs=cs,
+                 )
+        return ax
+
+    # Optional backend: guard with an actionable message like the other
+    # optional-backend ov.pl functions rather than letting a bare ImportError
+    # surface from deep in the call.
+    try:
+        import matplotlib_venn
+    except ImportError as exc:  # pragma: no cover - exercised only without the dep
+        raise ImportError(
+            "ov.pl.venn needs the `matplotlib-venn` package to draw "
+            "proportional 2/3-set diagrams.\n"
+            "Install with: pip install matplotlib-venn"
+        ) from exc
+
+    if fontsize is None:
+        fontsize = plt.rcParams['font.size']
+
+    # Draw into the caller's axes when given; only mint a new figure otherwise,
+    # so drawing into an existing panel never leaks a stray figure via gca.
+    if ax is False or ax is None:
+        _, ax = plt.subplots(figsize=figsize)
+
+    labels = list(sets.keys())
+    values = [set(sets[k]) for k in labels]
+    colors = tuple(palette[:n])
+
+    if n == 2:
+        diagram = matplotlib_venn.venn2(
+            tuple(values), tuple(labels), set_colors=colors, alpha=0.8, ax=ax)
+        subset_ids = ('10', '01', '11')
+        set_ids = ('A', 'B')
+    else:
+        diagram = matplotlib_venn.venn3(
+            tuple(values), tuple(labels), set_colors=colors, alpha=0.8, ax=ax)
+        subset_ids = ('100', '010', '001', '110', '101', '011', '111')
+        set_ids = ('A', 'B', 'C')
+
+    # Size both the subset counts and the set names off the same font so they
+    # match surrounding panels. Empty regions have no label object, hence the
+    # None guard (get_label_by_id returns None there in matplotlib-venn 1.1.2).
+    for area in subset_ids + set_ids:
+        label = diagram.get_label_by_id(area)
+        if label is not None:
+            label.set_fontsize(fontsize)
+
     return ax
 
 @register_function(

--- a/tests/pl/test_venn.py
+++ b/tests/pl/test_venn.py
@@ -1,0 +1,80 @@
+"""Tests for ov.pl.venn's matplotlib-venn backend.
+
+These pin the behaviour that matters after switching off the non-proportional
+`venn` package: draw into the caller's axes without leaking a figure, keep the
+passed-in set names, emit subset-count texts, and size labels off the font
+(rcParams by default, or an explicit fontsize).
+"""
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import pytest
+
+import omicverse as ov
+
+
+SETS3 = {"A": {1, 2, 3}, "B": {2, 3, 4}, "C": {3, 4, 5}}
+SETS2 = {"Up": {1, 2, 3}, "Down": {3, 4, 5}}
+
+
+def test_venn3_draws_into_ax_without_new_figure():
+    fig, ax = plt.subplots()
+    n_before = len(plt.get_fignums())
+    out = ov.pl.venn(sets=SETS3, ax=ax)
+    # No stray figure minted when an axes is supplied (decoy/gca-leak guard).
+    assert len(plt.get_fignums()) == n_before
+    assert out is ax
+    # Set names are the ones passed in.
+    labels = {t.get_text() for t in ax.texts}
+    assert {"A", "B", "C"}.issubset(labels)
+    # Subset-count texts exist (numbers drawn inside the regions).
+    assert any(t.get_text().isdigit() for t in ax.texts)
+    plt.close(fig)
+
+
+def test_venn2_two_sets():
+    fig, ax = plt.subplots()
+    ov.pl.venn(sets=SETS2, ax=ax)
+    labels = {t.get_text() for t in ax.texts}
+    assert {"Up", "Down"}.issubset(labels)
+    assert any(t.get_text().isdigit() for t in ax.texts)
+    plt.close(fig)
+
+
+def test_explicit_fontsize_is_honoured():
+    fig, ax = plt.subplots()
+    ov.pl.venn(sets=SETS3, ax=ax, fontsize=7)
+    sizes = {round(t.get_fontsize(), 3) for t in ax.texts if t.get_text()}
+    assert sizes == {7.0}
+    plt.close(fig)
+
+
+def test_fontsize_defaults_to_rcparams():
+    fig, ax = plt.subplots()
+    old = plt.rcParams["font.size"]
+    plt.rcParams["font.size"] = 6
+    try:
+        ov.pl.venn(sets=SETS3, ax=ax)
+        sizes = {round(t.get_fontsize(), 3) for t in ax.texts if t.get_text()}
+        assert sizes == {6.0}
+    finally:
+        plt.rcParams["font.size"] = old
+    plt.close(fig)
+
+
+def test_too_many_sets_falls_back_or_errors(tmp_path):
+    # 4 sets are outside matplotlib-venn's 2/3 support; must not raise the
+    # 2/3-only path error. It routes to the venny4py fallback instead.
+    # out=tmp_path keeps the fallback's intersection files out of the repo.
+    fig, ax = plt.subplots()
+    four = {"A": {1}, "B": {2}, "C": {3}, "D": {4}}
+    # Should not raise the "need at least 2" error; fallback handles it.
+    ov.pl.venn(sets=four, ax=ax, out=str(tmp_path) + "/")
+    plt.close("all")
+
+
+def test_too_few_sets_errors():
+    fig, ax = plt.subplots()
+    with pytest.raises(ValueError):
+        ov.pl.venn(sets={"only": {1, 2}}, ax=ax)
+    plt.close(fig)

--- a/tests/pl/test_volcano_fonts.py
+++ b/tests/pl/test_volcano_fonts.py
@@ -1,0 +1,45 @@
+"""Tests for ov.pl.volcano axis-label / tick font sizing.
+
+The axis labels used to inherit titlefont's fixed size (14), dwarfing the
+5-6pt labels of neighbouring panels. They must now follow
+rcParams['axes.labelsize'] by default and honour an explicit label_fontsize.
+"""
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+import omicverse as ov
+
+
+def _fake_deg(n=60, seed=0):
+    rng = np.random.default_rng(seed)
+    fc = rng.normal(0, 2, n)
+    q = rng.uniform(1e-6, 1, n)
+    sig = np.where(fc > 1.5, "up", np.where(fc < -1.5, "down", "normal"))
+    return pd.DataFrame({"log2FC": fc, "qvalue": q, "sig": sig})
+
+
+def test_axis_labels_follow_rcparams_labelsize():
+    df = _fake_deg()
+    old = plt.rcParams["axes.labelsize"]
+    plt.rcParams["axes.labelsize"] = 5
+    try:
+        fig, ax = plt.subplots()
+        ov.pl.volcano(df, plot_genes_num=0, ax=ax)
+        # ~5, not the old fixed 14.
+        assert ax.xaxis.get_label().get_fontsize() == 5
+        assert ax.yaxis.get_label().get_fontsize() == 5
+        plt.close(fig)
+    finally:
+        plt.rcParams["axes.labelsize"] = old
+
+
+def test_explicit_label_fontsize_honoured():
+    df = _fake_deg()
+    fig, ax = plt.subplots()
+    ov.pl.volcano(df, plot_genes_num=0, label_fontsize=9, ax=ax)
+    assert ax.xaxis.get_label().get_fontsize() == 9
+    assert ax.yaxis.get_label().get_fontsize() == 9
+    plt.close(fig)


### PR DESCRIPTION
Two chrome defects that make `ov.pl` plots look wrong in a multi-panel figure — both surfaced building a Nature-style 18-panel showcase.

**`ov.pl.venn`** drew through venny4py: non-proportional ellipses whose set names overlap the region counts. Now dispatches on set count — 2 or 3 sets go through **matplotlib-venn** (proportional circles, clean labels, the way cnsplots does it), >3 falls back to the old backend, <2 raises. Subset-count and set-label fonts follow `rcParams['font.size']` (or explicit `fontsize=`) instead of a fixed 3.5. matplotlib-venn guarded with an actionable ImportError. Also: the decorator's example passed `figsize=`, a parameter the function never accepted (would error) — added it.

**`ov.pl.volcano`** set its axis labels from `titlefont` (default size 14), so `log2FC` / `-log10(qvalue)` rendered at a fixed 14pt regardless of the panel — wildly larger than a 5-6pt figure. Added `label_fontsize` (default `rcParams['axes.labelsize']`) and routed `ticks_fontsize` to `rcParams['xtick.labelsize']`. Mathtext styling unchanged; only the size is decoupled. No data/threshold/colour/gene-label/return changes.

Before/after: venn labels no longer overlap and circles are proportional; volcano axis labels measured at 6pt under `axes.labelsize=6` (was 14).

Design credit: the matplotlib-venn approach follows [cnsplots](https://github.com/faridrashidi/cnsplots) (BSD-3-Clause). 8 new tests, `tests/pl` green (566). Red-checked: reverting either fix fails its tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)