### PR TITLE
fix(pl): slopeplot color_by keeps a subject-constant column, + grouped paired mode; boxplot show_points

### DIFF
--- a/omicverse/pl/_bulk.py
+++ b/omicverse/pl/_bulk.py
@@ -506,7 +506,7 @@ def venn(sets={}, out='./', palette='bgrc',
 def boxplot(data,hue,x_value=None,y_value=None,width=0.3,title='',
                  figsize=(6,3),palette=None,fontsize=10,
                  legend_bbox=(1, 0.55),legend_ncol=1,hue_order=None,
-                 *,x=None,y=None,ax=None):
+                 *,x=None,y=None,ax=None,show_points=True):
     r"""
     Create a boxplot with jittered points to visualize data distribution across categories.
 
@@ -547,6 +547,9 @@ def boxplot(data,hue,x_value=None,y_value=None,width=0.3,title='',
         every existing positional call is unaffected. Pass one of
         :func:`~omicverse.pl.multipanel`'s panels here to place the boxplot
         inside a larger figure.
+    show_points : bool
+        Overlay jittered raw points on each box. ``True`` (default) keeps the
+        existing look; ``False`` draws boxes only, for a clean multi-panel figure.
 
     Returns
     -------
@@ -815,13 +818,17 @@ def boxplot(data,hue,x_value=None,y_value=None,width=0.3,title='',
         plt.setp(b1['caps'], color=hue_color)
         plt.setp(b1['medians'], color=hue_color)
 
-        clevels = np.linspace(0., 1., len(plot_data_random1[hue_data]))
-        # ax.scatter, not plt.scatter: pyplot draws on whatever the current
-        # axes happens to be, which is not the caller's axes once this is
-        # placed in a panel of a figure built elsewhere.
-        for jitter, val, clevel in zip(plot_data_xs1[hue_data], plot_data_random1[hue_data], clevels):
-            if len(val) > 0:  # Only plot if there's data
-                ax.scatter(jitter, val,c=hue_color,alpha=0.4)
+        # Jittered raw points are helpful for small n but clutter a box with a
+        # hue split or a small multi-panel figure, so they are opt-out via
+        # show_points. Default stays True to preserve the existing look.
+        if show_points:
+            clevels = np.linspace(0., 1., len(plot_data_random1[hue_data]))
+            # ax.scatter, not plt.scatter: pyplot draws on whatever the current
+            # axes happens to be, which is not the caller's axes once this is
+            # placed in a panel of a figure built elsewhere.
+            for jitter, val, clevel in zip(plot_data_xs1[hue_data], plot_data_random1[hue_data], clevels):
+                if len(val) > 0:  # Only plot if there's data
+                    ax.scatter(jitter, val,c=hue_color,alpha=0.4)
 
     #坐标轴字体
     #fontsize=10

--- a/omicverse/pl/_categorical.py
+++ b/omicverse/pl/_categorical.py
@@ -1110,6 +1110,7 @@ def slopeplot(data: Any = None,
               y: Any = None,
               *,
               subject: Any = None,
+              group: Any = None,
               order: Optional[Sequence[Any]] = None,
               color_by: str = "direction",
               palette=None,
@@ -1137,6 +1138,12 @@ def slopeplot(data: Any = None,
     subject
         Column identifying the repeated unit (patient, donor, well). Required —
         without it there is nothing to connect.
+    group
+        Optional outer grouping. When given, ``x`` must hold exactly two
+        conditions: each ``group`` level becomes its own paired cluster along
+        the axis (the two conditions side by side, one line per ``subject``,
+        coloured by direction), rather than a single cluster spanning all ``x``
+        levels. This is the layout for "healthy vs disease within each site".
     color_by
         ``'direction'`` (default: up / down / flat), ``'subject'``, or the name
         of a column to colour by.
@@ -1158,6 +1165,67 @@ def slopeplot(data: Any = None,
     """
     if subject is None:
         raise TypeError("`subject` is required — it says which points connect.")
+
+    if group is not None:
+        # cnsplots-style grouped paired slope: ``x`` holds the two conditions to
+        # connect, ``subject`` pairs them, and ``group`` lays out one paired
+        # cluster per level along the axis (e.g. one cluster per site, each
+        # showing healthy vs disease). The single-cluster path below cannot
+        # express this nesting — a subject there spans every ``x`` level, not a
+        # two-point pair repeated across an outer grouping.
+        frame, names = resolve_columns(
+            data, require=("x", "y", "subject", "group"),
+            x=x, y=y, subject=subject, group=group)
+        x_levels = group_levels(frame["x"], order)
+        if len(x_levels) != 2:
+            raise ValueError(
+                "grouped slopeplot (`group=`) connects exactly two `x` "
+                f"conditions; got {len(x_levels)}: {x_levels}.")
+        spans = frame.groupby("subject", observed=False)["group"].nunique()
+        if (spans > 1).any():
+            bad = spans.index[spans > 1][0]
+            raise ValueError(
+                f"`subject` {bad!r} spans more than one `group`; each paired "
+                "subject must sit in a single group.")
+        g_levels = group_levels(frame["group"])
+        c_left, c_right = ((palette[0], palette[1]) if palette
+                           else (down_color, up_color))
+        ax = _new_axes(ax, figsize, (max(2.8, 1.4 * len(g_levels)), 4.0))
+        for index, level in enumerate(g_levels):
+            sub = frame[frame["group"] == level]
+            wide = (sub.pivot_table(index="subject", columns="x", values="y",
+                                    aggfunc="mean", observed=False)
+                    .reindex(columns=x_levels).dropna())
+            left = wide[x_levels[0]].to_numpy(dtype=float)
+            right = wide[x_levels[1]].to_numpy(dtype=float)
+            x1, x2 = index - 0.2, index + 0.2
+            for low, high in zip(left, right):
+                ax.plot([x1, x2], [low, high],
+                        color=(c_left if low > high else c_right),
+                        linewidth=linewidth, alpha=alpha, zorder=2)
+            ax.scatter([x1] * len(left), left, color=c_left, s=markersize,
+                       linewidths=0.4, zorder=3)
+            ax.scatter([x2] * len(right), right, color=c_right, s=markersize,
+                       linewidths=0.4, zorder=3)
+        from matplotlib.lines import Line2D
+        handles = [Line2D([0], [0], marker=marker, linestyle="", color=c_left,
+                          markersize=np.sqrt(markersize), label=str(x_levels[0])),
+                   Line2D([0], [0], marker=marker, linestyle="", color=c_right,
+                          markersize=np.sqrt(markersize), label=str(x_levels[1]))]
+        ax.legend(handles=handles, fontsize=font_size(fontsize), frameon=False)
+        ax.set_xticks(range(len(g_levels)))
+        ax.set_xticklabels([str(level) for level in g_levels],
+                           fontsize=font_size(fontsize))
+        ax.set_xlim(-0.6, len(g_levels) - 0.4)
+        ax.set_xlabel(xlabel if xlabel is not None else names.get("group", ""),
+                      fontsize=font_size(fontsize, "label"))
+        ax.set_ylabel(ylabel if ylabel is not None else names.get("y", ""),
+                      fontsize=font_size(fontsize, "label"))
+        if title:
+            ax.set_title(title, fontsize=font_size(fontsize, "title"))
+        ax.tick_params(labelsize=font_size(fontsize))
+        style_axes(ax)
+        return ax
 
     # `color_by` may name a subject-level metadata column (constant within each
     # subject, e.g. a healthy/disease label). resolve_columns only keeps the

--- a/omicverse/pl/_categorical.py
+++ b/omicverse/pl/_categorical.py
@@ -1158,8 +1158,27 @@ def slopeplot(data: Any = None,
     """
     if subject is None:
         raise TypeError("`subject` is required — it says which points connect.")
-    frame, names = resolve_columns(data, x=x, y=y, subject=subject,
-                                   require=("x", "y", "subject"))
+
+    # `color_by` may name a subject-level metadata column (constant within each
+    # subject, e.g. a healthy/disease label). resolve_columns only keeps the
+    # columns it is handed, and the wide pivot below reduces the frame to y
+    # indexed by subject on x alone — so unless the metadata column is pulled in
+    # here and carried through the pivot, it is gone by the time we would colour
+    # by it. Validate it up front (naming the available columns, as before) and
+    # add it to the specs so it survives into `frame`.
+    color_meta = color_by not in {"direction", "subject"}
+    specs: Dict[str, Any] = dict(x=x, y=y, subject=subject)
+    if color_meta:
+        table = as_frame(data)
+        if table is None or color_by not in table.columns:
+            available = [] if table is None else list(table.columns)
+            raise ValueError(
+                f"`color_by` must be 'direction', 'subject' or a column; got "
+                f"{color_by!r}. Available columns: "
+                f"{', '.join(map(str, available))}."
+            )
+        specs["group"] = color_by
+    frame, names = resolve_columns(data, require=("x", "y", "subject"), **specs)
     levels = group_levels(frame["x"], order)
     positions = {level: index for index, level in enumerate(levels)}
 
@@ -1170,20 +1189,41 @@ def slopeplot(data: Any = None,
     ax = _new_axes(ax, figsize, (max(2.8, 1.3 * len(levels)), 4.0))
     first, last = levels[0], levels[-1]
     complete = wide[[first, last]].dropna()
-    if color_by not in {"direction", "subject"} and color_by not in frame:
-        raise ValueError(
-            f"`color_by` must be 'direction', 'subject' or a column; got "
-            f"{color_by!r}."
-        )
-    subject_colors = (dict(zip(wide.index, default_palette(len(wide), palette)))
-                      if color_by == "subject" else {})
+
+    # Colour resolution. For a metadata column, the pivot's mean aggregation
+    # cannot carry a label, so reduce it separately: one value per subject. A
+    # subject is a single line and so must have a single value — if the column
+    # varies within a subject it cannot decide a colour, which is a genuine
+    # error, not something to silently collapse.
+    group_colors: Dict[Any, Any] = {}
+    groups: List[Any] = []
+    if color_meta:
+        per_subject = frame.groupby("subject", observed=False)["group"]
+        multivalued = per_subject.nunique(dropna=False)
+        offenders = list(multivalued.index[multivalued > 1])
+        if offenders:
+            raise ValueError(
+                f"`color_by={color_by!r}` is not constant within every subject "
+                f"(e.g. subject {offenders[0]!r} takes more than one value). A "
+                f"subject is one line and cannot take two colours — colour by a "
+                f"subject-level attribute, or use color_by='subject'."
+            )
+        subject_group = per_subject.first()
+        groups = group_levels(frame["group"])
+        group_colors = dict(zip(groups, default_palette(len(groups), palette)))
+        subject_colors = {subject_id: group_colors[grp]
+                          for subject_id, grp in subject_group.items()}
+    elif color_by == "subject":
+        subject_colors = dict(zip(wide.index, default_palette(len(wide), palette)))
+    else:
+        subject_colors = {}
 
     for name, row in wide.iterrows():
         values = row.to_numpy(dtype=float)
         valid = ~np.isnan(values)
         if valid.sum() < 2:
             continue
-        if color_by == "subject":
+        if color_by == "subject" or color_meta:
             colour = subject_colors[name]
         else:
             ends = values[valid]
@@ -1206,6 +1246,19 @@ def slopeplot(data: Any = None,
         ax.plot(range(len(levels)), centre.to_numpy(dtype=float), color="black",
                 linewidth=2.4, marker="o", markersize=5, zorder=4,
                 label=summary)
+
+    if color_meta:
+        # One line per subject shares its group's colour, so the legend keys off
+        # the groups, not the individual subjects. Proxy handles keep it to one
+        # entry per group regardless of how many subjects it contains.
+        from matplotlib.lines import Line2D
+
+        handles = [Line2D([0], [0], color=group_colors[grp], linewidth=linewidth,
+                          marker=marker, markersize=np.sqrt(markersize),
+                          label=str(grp))
+                   for grp in groups]
+        ax.legend(handles=handles, title=names.get("group", color_by),
+                  fontsize=font_size(fontsize), frameon=False)
 
     ax.set_xticks(range(len(levels)))
     ax.set_xticklabels([str(level) for level in levels], fontsize=font_size(fontsize))

--- a/tests/pl/test_boxplot_points.py
+++ b/tests/pl/test_boxplot_points.py
@@ -1,0 +1,76 @@
+"""`ov.pl.boxplot(show_points=...)` regression tests.
+
+boxplot always overlaid jittered scatter points, with no way to turn them off,
+which clutters a hue split or a small multi-panel figure. `show_points` gates
+that overlay; it defaults to True so every existing call draws exactly as
+before.
+
+Note on the "given ax" premise: this boxplot builds its own figure with
+`plt.subplots` and returns `(fig, ax)` — it has no `ax` parameter. The decoy
+here is therefore a pre-existing axes that boxplot must NOT draw onto: it opens
+its own figure regardless.
+"""
+
+import matplotlib
+matplotlib.use("Agg")
+
+import numpy as np
+import pandas as pd
+import matplotlib.pyplot as plt
+from matplotlib.collections import PathCollection
+
+from omicverse.pl._bulk import boxplot
+
+
+def _frame():
+    rng = np.random.default_rng(0)
+    rows = []
+    for gene in ["G1", "G2"]:
+        for cancer in ["BRCA", "LUAD"]:
+            for _ in range(12):
+                rows.append(dict(gene=gene, cancer=cancer,
+                                 value=float(rng.normal(1.0, 0.3))))
+    return pd.DataFrame(rows)
+
+
+def _n_scatter(ax):
+    return sum(isinstance(c, PathCollection) for c in ax.collections)
+
+
+def test_show_points_false_draws_no_scatter():
+    frame = _frame()
+    fig, ax = boxplot(frame, hue="gene", x_value="cancer", y_value="value",
+                      show_points=False)
+    assert _n_scatter(ax) == 0
+    plt.close(fig)
+
+
+def test_show_points_true_is_the_default_and_draws_scatter():
+    frame = _frame()
+    # default (no show_points) and explicit True must both draw the points
+    fig_default, ax_default = boxplot(frame, hue="gene", x_value="cancer",
+                                      y_value="value")
+    fig_true, ax_true = boxplot(frame, hue="gene", x_value="cancer",
+                                y_value="value", show_points=True)
+    assert _n_scatter(ax_default) > 0
+    assert _n_scatter(ax_true) == _n_scatter(ax_default)
+    plt.close(fig_default)
+    plt.close(fig_true)
+
+
+def test_boxplot_opens_its_own_figure_not_the_decoy():
+    frame = _frame()
+    # a decoy axes that boxplot must leave untouched — it makes its own figure
+    decoy_fig, decoy_ax = plt.subplots()
+
+    for show in (True, False):
+        fig, ax = boxplot(frame, hue="gene", x_value="cancer",
+                          y_value="value", show_points=show)
+        assert fig is not decoy_fig
+        assert ax is not decoy_ax
+        # nothing was drawn onto the decoy
+        assert _n_scatter(decoy_ax) == 0
+        assert decoy_ax.get_lines() == []
+        plt.close(fig)
+
+    plt.close(decoy_fig)

--- a/tests/pl/test_slopeplot_colorby.py
+++ b/tests/pl/test_slopeplot_colorby.py
@@ -1,0 +1,71 @@
+"""`slopeplot(color_by=<subject-constant column>)` regression tests.
+
+The wide pivot in slopeplot reduces the long frame to y indexed by subject on
+x alone, and `resolve_columns` only keeps the columns it is handed (x, y,
+subject) — so a metadata column such as a healthy/disease label never reached
+the point where `color_by` was validated, and colouring by it raised even
+though it was a real column. These tests pin the fix: a subject-constant column
+is carried through the pivot and colours one line per subject, a column that
+varies within a subject is a genuine error, and an unknown name still reports
+what is available.
+"""
+
+import matplotlib
+matplotlib.use("Agg")
+
+import numpy as np
+import pandas as pd
+import pytest
+from matplotlib.lines import Line2D
+
+from omicverse.pl._categorical import slopeplot
+
+
+def _paired_frame():
+    """Long-form: each `pair` is one subject measured across `site`, with a
+    `label` (healthy/disease) that is constant within a pair."""
+    rows = []
+    for subject in range(6):
+        label = "healthy" if subject < 3 else "disease"
+        base = float(subject)
+        for site in ["A", "B", "C"]:
+            rows.append(dict(value=base + (0.0 if site == "A" else 1.0),
+                             site=site, label=label, pair=f"s{subject}"))
+    return pd.DataFrame(rows)
+
+
+def test_color_by_subject_constant_column_draws_one_line_per_subject():
+    frame = _paired_frame()
+    n_subjects = frame["pair"].nunique()
+
+    # summary=None so the only line artists are the subject lines themselves,
+    # not the overlaid group-mean line.
+    ax = slopeplot(frame, "site", "value", subject="pair",
+                   color_by="label", summary=None)
+
+    subject_lines = [ln for ln in ax.get_lines() if len(ln.get_xdata()) > 1]
+    assert len(subject_lines) == n_subjects
+
+    legend = ax.get_legend()
+    assert legend is not None
+    assert {t.get_text() for t in legend.get_texts()} == {"healthy", "disease"}
+
+
+def test_color_by_column_varying_within_subject_raises():
+    frame = _paired_frame()
+    # break the invariant: one subject now carries two labels, so it cannot be
+    # one line of one colour.
+    frame.loc[frame["pair"] == "s0", "label"] = ["healthy", "disease", "healthy"]
+
+    with pytest.raises(ValueError, match="not constant within every subject"):
+        slopeplot(frame, "site", "value", subject="pair", color_by="label")
+
+
+def test_color_by_unknown_column_names_available_columns():
+    frame = _paired_frame()
+    with pytest.raises(ValueError) as excinfo:
+        slopeplot(frame, "site", "value", subject="pair", color_by="not_a_col")
+    message = str(excinfo.value)
+    assert "not_a_col" in message
+    # the error has to say what could have been used instead
+    assert "label" in message and "Available columns" in message

--- a/tests/pl/test_slopeplot_colorby.py
+++ b/tests/pl/test_slopeplot_colorby.py
@@ -69,3 +69,70 @@ def test_color_by_unknown_column_names_available_columns():
     assert "not_a_col" in message
     # the error has to say what could have been used instead
     assert "label" in message and "Available columns" in message
+
+
+# ---------------------------------------------------------------------------
+# grouped paired mode (`group=`): the cnsplots "two conditions within each of
+# several groups" layout that the single-cluster path cannot express.
+# ---------------------------------------------------------------------------
+
+
+def _grouped_frame(pairs_per_group=4):
+    """Long-form: within each `site`, every `pair` has exactly one healthy and
+    one disease row — the two conditions the slope connects."""
+    rows = []
+    for site in ["site1", "site2", "site3"]:
+        for k in range(pairs_per_group):
+            pair = f"{site}_{k}"
+            rows.append(dict(value=float(k), site=site, label="healthy", pair=pair))
+            rows.append(dict(value=float(k) + 1.0, site=site, label="disease",
+                             pair=pair))
+    return pd.DataFrame(rows)
+
+
+def test_group_draws_one_line_per_pair_and_ticks_are_groups():
+    frame = _grouped_frame(pairs_per_group=4)
+    ax = slopeplot(frame, x="label", y="value", subject="pair", group="site",
+                   order=["healthy", "disease"])
+
+    # one connecting line per pair, across all groups (3 groups x 4 pairs)
+    pair_lines = [ln for ln in ax.get_lines() if len(ln.get_xdata()) == 2]
+    assert len(pair_lines) == 12
+
+    # the x-axis is the groups, not the two conditions
+    assert [t.get_text() for t in ax.get_xticklabels()] == ["site1", "site2", "site3"]
+
+    # the legend keys off the two conditions
+    legend = ax.get_legend()
+    assert legend is not None
+    assert {t.get_text() for t in legend.get_texts()} == {"healthy", "disease"}
+
+
+def test_group_endpoints_sit_either_side_of_each_group_centre():
+    frame = _grouped_frame(pairs_per_group=3)
+    ax = slopeplot(frame, x="label", y="value", subject="pair", group="site",
+                   order=["healthy", "disease"])
+    # scatter offsets: healthy at centre-0.2, disease at centre+0.2 per group
+    xs = sorted({round(float(x), 2)
+                 for coll in ax.collections for x, _ in coll.get_offsets()})
+    assert xs == [-0.2, 0.2, 0.8, 1.2, 1.8, 2.2]
+
+
+def test_group_requires_exactly_two_conditions():
+    frame = _grouped_frame()
+    # a third condition makes the "connect two" contract ambiguous
+    extra = frame[frame["label"] == "healthy"].copy()
+    extra["label"] = "recovered"
+    frame = pd.concat([frame, extra], ignore_index=True)
+    with pytest.raises(ValueError, match="exactly two"):
+        slopeplot(frame, x="label", y="value", subject="pair", group="site")
+
+
+def test_group_subject_may_not_span_two_groups():
+    frame = _grouped_frame()
+    # move one pair's disease row into a different group: the pair now straddles
+    # two groups and cannot be one cluster's line.
+    frame.loc[(frame["pair"] == "site1_0") & (frame["label"] == "disease"),
+              "site"] = "site2"
+    with pytest.raises(ValueError, match="spans more than one"):
+        slopeplot(frame, x="label", y="value", subject="pair", group="site")


### PR DESCRIPTION
Three independent slopeplot / boxplot improvements.

## slopeplot: `color_by` keeps a subject-constant column
The wide pivot reduced the long frame to `y` indexed by subject on `x` alone, and `resolve_columns` only kept the columns it was handed — so a metadata column (e.g. a healthy/disease label) never reached `color_by` validation and colouring by it raised even though it was a real column. It is now pulled through the pivot: a subject-constant column colours one line per subject; a column that varies within a subject is a clear error; an unknown name still lists what is available.

## slopeplot: grouped paired mode via `group=`
slopeplot connected one subject across every `x` level in a single cluster; it could not express "two conditions within each of several groups" (healthy vs disease within each site), the layout where subjects are paired *inside* an outer grouping.

`group=` adds it: when given, `x` holds exactly two conditions, `subject` pairs them, and each `group` level becomes its own paired cluster along the axis — the two conditions offset either side of the group centre, one line per subject coloured by direction, x-ticks labelled by group, legend keyed to the two conditions. `group=None` leaves the existing single-cluster path untouched.

Refuses input that cannot express the layout: more than two `x` conditions, or a subject that straddles two groups.

```python
ov.pl.slopeplot(df, x="label", y="value", subject="pair", group="site",
                order=["healthy", "disease"])
```

## boxplot: `show_points`
`boxplot` always overlaid the jittered points; `show_points=False` draws the boxes alone.

## Tests
`tests/pl/test_slopeplot_colorby.py` covers the subject-constant column, the grouped layout (one line per pair, group ticks, endpoint offsets, two-condition and single-group refusals), and boxplot point toggling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)