### PR TITLE
fix(pl): qqplot's confidence band was drawn on the theoretical scale

### DIFF
--- a/omicverse/pl/_distribution.py
+++ b/omicverse/pl/_distribution.py
@@ -605,15 +605,38 @@ def qqplot(data: Any = None,
         x_label = f"expected $-\\log_{{10}}(P)$"
 
     ax = _new_axes(ax, figsize, (3.8, 3.8))
+
+    # The reference line defines the location-scale map from theoretical units
+    # to sample units, and the confidence band has to travel through the same
+    # map. For `dist='norm'` the theoretical axis is the *standard* normal while
+    # the sample keeps its own units, so a band left in theoretical units lands
+    # around zero while the points sit around the sample mean — visibly detached
+    # (sepal_length: band -3.6..3.6 against points 4.3..7.9).
+    def _reference_line():
+        if line == "45":
+            return 1.0, 0.0
+        qx = np.quantile(plot_x, [0.25, 0.75])
+        qy = np.quantile(plot_y, [0.25, 0.75])
+        slope = (qy[1] - qy[0]) / (qx[1] - qx[0]) if qx[1] != qx[0] else 1.0
+        return slope, qy[0] - slope * qx[0]
+
     if ci is not None and other is None:
         ranks = np.arange(1, n + 1)
         lo_q = scipy_stats.beta.ppf((1 - ci) / 2, ranks, n - ranks + 1)
         hi_q = scipy_stats.beta.ppf(1 - (1 - ci) / 2, ranks, n - ranks + 1)
         if dist == "uniform":
+            # p-value scale on both axes: the band is already in sample units.
             band_lo, band_hi = lo_q, hi_q
+        elif dist == "norm":
+            slope, intercept = _reference_line()
+            band_lo = slope * distribution.ppf(lo_q) + intercept
+            band_hi = slope * distribution.ppf(hi_q) + intercept
         else:
-            band_lo = distribution.ppf(lo_q) if dist == "norm" else None
-            band_hi = distribution.ppf(hi_q) if dist == "norm" else None
+            # theoretical quantiles came from parameters fitted to the sample,
+            # so the fitted ppf puts the band in sample units directly.
+            params = distribution.fit(sample)
+            band_lo = distribution.ppf(lo_q, *params)
+            band_hi = distribution.ppf(hi_q, *params)
         if band_lo is not None:
             if log:
                 with np.errstate(divide="ignore"):

--- a/tests/pl/test_generic_plots.py
+++ b/tests/pl/test_generic_plots.py
@@ -1120,3 +1120,78 @@ class TestViolinAnnDataPaths:
         assert ax.get_xlabel() == "celltype"
         assert ax.get_ylabel() == "GENE0"
         plt.close("all")
+
+
+class TestQqplotConfidenceBand:
+    """The band must live on the sample's scale, not the theoretical one.
+
+    With ``dist='norm'`` the x axis is the *standard* normal while y keeps the
+    sample's own units, so a band left in theoretical units sits around zero
+    while the points sit around the sample mean. On sepal-length-like data that
+    put the band at -3.6..3.6 against points at 4.3..7.9 — detached, and
+    useless as a band.
+    """
+
+    @staticmethod
+    def _band(ax):
+        for coll in ax.collections:
+            if type(coll).__name__.startswith("FillBetween"):
+                return coll.get_paths()[0].get_extents()
+        return None
+
+    def test_band_brackets_the_sample_not_the_origin(self):
+        rng = np.random.default_rng(0)
+        sample = rng.normal(loc=6.0, scale=0.8, size=300)
+
+        fig, ax = plt.subplots()
+        qqplot(sample, dist="norm", line="quartile", ax=ax)
+
+        band = self._band(ax)
+        assert band is not None, "no confidence band was drawn"
+        assert band.y0 < sample.min() and band.y1 > sample.max(), (
+            f"band {band.y0:.2f}..{band.y1:.2f} does not bracket the sample "
+            f"{sample.min():.2f}..{sample.max():.2f}")
+
+    def test_band_covers_most_points_for_a_normal_sample(self):
+        """A 95% pointwise band should contain nearly all of a normal sample."""
+        rng = np.random.default_rng(1)
+        sample = rng.normal(loc=-4.0, scale=3.0, size=500)
+
+        fig, ax = plt.subplots()
+        qqplot(sample, dist="norm", line="quartile", ax=ax, ci=0.95)
+
+        band = [c for c in ax.collections
+                if type(c).__name__.startswith("FillBetween")][0]
+        points = [c for c in ax.collections
+                  if type(c).__name__ == "PathCollection"][0].get_offsets()
+        verts = band.get_paths()[0].vertices
+        half = len(verts) // 2
+        lo_x, lo_y = verts[:half, 0], verts[:half, 1]
+        inside = 0
+        for x, y in points:
+            j = int(np.argmin(np.abs(lo_x - x)))
+            hi_y = verts[len(verts) - 1 - j, 1]
+            if min(lo_y[j], hi_y) <= y <= max(lo_y[j], hi_y):
+                inside += 1
+        assert inside / len(points) > 0.9, \
+            f"only {inside}/{len(points)} points fell inside the 95% band"
+
+    def test_a_fitted_distribution_gets_a_band_too(self):
+        """Non-normal dists fit their parameters, so the band is expressible."""
+        rng = np.random.default_rng(2)
+        sample = rng.gamma(shape=3.0, scale=2.0, size=300)
+
+        fig, ax = plt.subplots()
+        qqplot(sample, dist="gamma", line="quartile", ax=ax)
+
+        band = self._band(ax)
+        assert band is not None, "a fitted distribution drew no band"
+        assert band.y1 > sample.mean(), "band is not on the sample's scale"
+
+    def test_uniform_log_path_is_unchanged(self):
+        """The GWAS path already had the band in sample units — keep it."""
+        rng = np.random.default_rng(3)
+        fig, ax = plt.subplots()
+        qqplot(rng.uniform(size=2000), dist="uniform", log=True, ax=ax)
+        band = self._band(ax)
+        assert band is not None and band.y1 > 1.0


### PR DESCRIPTION
## The bug

With `dist='norm'`, the x axis is the **standard** normal while y keeps the sample's own units. The band was left in theoretical units:

```
sepal_length:  band  -3.58 .. 3.58
               points 4.30 .. 7.90
```

So it rendered as a detached grey wedge below the data. Found while reproducing the cnsplots showcase Figure 2, where panel **g** is a qqplot — in a multi-panel figure the stray band reads as a second dataset.

## The fix

A pointwise band belongs around the reference line that was actually drawn, so it now travels through the same location-scale map — `slope * ppf(q) + intercept`, with slope/intercept from the quartile fit.

For `line='45'` the map is the identity, and the band staying on the standard scale is the honest reading: the 45° line asserts the sample *is* standard normal, so a band that misses the points is real information, not a rendering error. statsmodels behaves the same way.

Two paths deliberately unchanged, for opposite reasons:

- **`dist='uniform'`** (the GWAS plot) has p values on both axes — its band was already in sample units.
- **non-normal dists** previously drew *no* band at all (`band_lo = ... if dist == "norm" else None`). They now get one from the parameters already fitted to the sample, which is the scale their theoretical quantiles are on.

## Tests

`tests/pl/test_generic_plots.py::TestQqplotConfidenceBand` — the band brackets the sample rather than the origin; a 95% band contains >90% of a normal sample; a fitted gamma gets a band; the uniform/log path is unchanged. Reinstating the old expression fails the first two, so they pin real behaviour.

Full `tests/pl/`: 704 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)