### PR TITLE
fix(pl): upset takes a host figure; dotplot's legend side is a choice

### DIFF
--- a/omicverse/pl/_dotplot.py
+++ b/omicverse/pl/_dotplot.py
@@ -65,8 +65,9 @@ def dotplot(
     show: Optional[bool] = None,
     save: Optional[Union[str, bool]] = None,
     ax: Optional[_AxesSubplot] = None,
-    figure=None,
-    rect=None,
+    legend: bool = True,
+    legend_side: str = 'right',
+    legend_pad: float = 0.0,
     return_fig: Optional[bool] = False,
     vmin: Optional[float] = None,
     vmax: Optional[float] = None,
@@ -470,51 +471,32 @@ def dotplot(
         m.add_title(top=title, pad=0.2, fontsize=fontsize + 1, fontweight="bold")
 
     # Add legends
-    m.add_legends(box_padding=2)
+    # marsilea can put the legends on any side; this used to be hardcoded to
+    # the right, which is also what makes the block too wide for a narrow
+    # panel — the dot-size key and the colour bar stack into a column beside
+    # the dots. `legend_side='bottom'` lays them under it instead.
+    if legend:
+        if legend_side not in ("right", "left", "top", "bottom"):
+            raise ValueError(
+                "`legend_side` must be 'right', 'left', 'top' or 'bottom', "
+                f"got {legend_side!r}.")
+        m.add_legends(side=legend_side, pad=legend_pad, box_padding=2)
     
-    # Render the plot. marsilea owns its layout: it derives a figure size from
-    # its content and places its axes as fractions of *that*, so handing it a
-    # host figure resizes the host and spreads the dotplot over the whole
-    # canvas. `rect` confines it: the block is rendered at its natural size and
-    # then *translated* into the region — never rescaled, so the dot legend and
-    # colour bar keep the size they were drawn at.
-    if rect is not None and figure is None:
-        raise TypeError("`rect` places the dotplot inside a figure you supply "
-                        "— pass `figure=` as well.")
-    if figure is None:
-        m.render()
-        fig = m.figure
-    else:
-        host_w, host_h = figure.get_size_inches()
-        before = set(figure.axes)
-        m.render(figure=figure)
-        added = [a for a in figure.axes if a not in before]
-        block_w, block_h = figure.get_size_inches()
-        figure.set_size_inches(host_w, host_h)
-        if rect is not None:
-            x0, y0, width, height = rect
-            if block_w > width * host_w + 1e-6 or block_h > height * host_h + 1e-6:
-                warnings.warn(
-                    f"the dotplot needs {block_w:.1f} x {block_h:.1f} in and "
-                    f"`rect` offers {width * host_w:.1f} x "
-                    f"{height * host_h:.1f} in; it will overflow the region. "
-                    "Enlarge the region, or reduce the number of genes or "
-                    "groups — the block is not rescaled, because that would "
-                    "shrink the axes without shrinking their text.",
-                    UserWarning,
-                    stacklevel=2,
-                )
-        else:
-            x0, y0 = 0.0, 0.0
-        for axes in added:
-            pos = axes.get_position()
-            axes.set_position([
-                x0 + pos.x0 * block_w / host_w,
-                y0 + pos.y0 * block_h / host_h,
-                pos.width * block_w / host_w,
-                pos.height * block_h / host_h,
-            ])
-        fig = figure
+    # Render the plot.
+    #
+    # This deliberately does *not* accept a host figure. marsilea's layout for
+    # a SizedHeatmap-plus-legends block is composite, and `freeze` only resizes
+    # the figure for non-composite layouts — so the block's axes come out as
+    # fractions of whatever figure it is given and it fills that figure however
+    # large it is (measured: the same block reports 650 mm across in a 30 in
+    # figure and scales with it, at any font size). Translating it therefore
+    # cannot confine it to a region, and rescaling it would shrink the axes
+    # without shrinking the dot-size key, the colour bar or the tick labels.
+    #
+    # Placing one of these blocks properly needs marsilea's own layout anchors
+    # (`set_figsize` / `set_anchor`), which is a larger change than this.
+    m.render()
+    fig = m.figure
 
     if save not in (None, False):
         save_path = Path(save) if isinstance(save, str) else Path("dotplot.png")

--- a/omicverse/pl/_dotplot.py
+++ b/omicverse/pl/_dotplot.py
@@ -6,7 +6,6 @@ import numpy as np
 import pandas as pd
 import marsilea as ma
 import marsilea.plotter as mp
-import inspect
 import warnings
 from matplotlib.colors import Normalize, Colormap
 from matplotlib.axes import Axes as _AxesSubplot
@@ -66,8 +65,6 @@ def dotplot(
     show: Optional[bool] = None,
     save: Optional[Union[str, bool]] = None,
     ax: Optional[_AxesSubplot] = None,
-    figure=None,
-    rect=None,
     legend: bool = True,
     legend_side: str = 'right',
     legend_pad: float = 0.0,
@@ -180,60 +177,6 @@ def dotplot(
             UserWarning,
             stacklevel=2,
         )
-
-    # `rect` places the block inside a figure the caller already has. marsilea
-    # sizes its own figure from the heatmap cell plus the overhead around it
-    # (legends, colour bar, the count bars), and that overhead does not depend
-    # on how large the cell is — so the cell that makes the block fill a given
-    # region is found the same way as in `ov.pl.heatmap`: render a throwaway
-    # copy to measure the overhead, build at the corrected size, and translate
-    # into place. Nothing is rescaled, so the text keeps the size it was drawn
-    # at.
-    if rect is not None:
-        if figure is None:
-            raise TypeError("`rect` places the dotplot inside a figure you "
-                            "supply — pass `figure=` as well.")
-        import matplotlib.pyplot as _plt
-
-        forwarded = {name: value for name, value in locals().items()
-                     if name in _DOTPLOT_PARAMS
-                     and name not in ("figsize", "figure", "rect", "show")}
-        host_w, host_h = (float(v) for v in figure.get_size_inches())
-        x0, y0, width, height = rect
-        target = (width * host_w, height * host_h)
-
-        def measure(cell_size):
-            probe = _plt.figure(figsize=(4.0, 4.0))
-            dotplot(figsize=cell_size, figure=probe, rect=None, show=False,
-                    **forwarded)
-            natural = tuple(float(v) for v in probe.get_size_inches())
-            _plt.close(probe)
-            return natural
-
-        # The overhead is nearly but not exactly independent of the cell size —
-        # a legend can wrap differently — so one correction step follows the
-        # first estimate. Two passes bring the block inside the region to well
-        # under a millimetre; without the second it overshot by ~1% of the
-        # region and spilled onto the neighbouring panel.
-        cell = (max(target[0] - 1.0, 0.25), max(target[1] - 1.0, 0.25))
-        for _ in range(2):
-            natural = measure(cell)
-            cell = (max(cell[0] + (target[0] - natural[0]), 0.25),
-                    max(cell[1] + (target[1] - natural[1]), 0.25))
-
-        existing = set(figure.axes)
-        dotplot(figsize=cell, figure=figure, rect=None, show=False,
-                **forwarded)
-        added = [axes for axes in figure.axes if axes not in existing]
-        block_w, block_h = (float(v) for v in figure.get_size_inches())
-        figure.set_size_inches(host_w, host_h)
-        for axes in added:
-            pos = axes.get_position()
-            axes.set_position([x0 + pos.x0 * block_w / host_w,
-                               y0 + pos.y0 * block_h / host_h,
-                               pos.width * block_w / host_w,
-                               pos.height * block_h / host_h])
-        return None
 
     # Convert var_names to list if string
     original_var_names_dict = None
@@ -552,12 +495,15 @@ def dotplot(
     #
     # Placing one of these blocks properly needs marsilea's own layout anchors
     # (`set_figsize` / `set_anchor`), which is a larger change than this.
-    if figure is None:
-        m.render()
-        fig = m.figure
-    else:
-        m.render(figure=figure)
-        fig = figure
+    # Not embeddable. marsilea's own figure size is not the block's size (the
+    # legends are artists drawn inside their host axes and reach past it), and a
+    # post-render translate therefore cannot be fitted to a region: three
+    # measurement strategies -- figure size, the union of axes positions, the
+    # union of tightboxes -- each under-measured the block and it overflowed
+    # onto the next panel. Confining one of these needs marsilea's own layout
+    # anchors, not a translation.
+    m.render()
+    fig = m.figure
 
     if save not in (None, False):
         save_path = Path(save) if isinstance(save, str) else Path("dotplot.png")
@@ -979,6 +925,3 @@ def markers_dotplot(
         return_fig=return_fig,
         **kwds,
     )
-
-
-_DOTPLOT_PARAMS = frozenset(inspect.signature(dotplot).parameters)

--- a/omicverse/pl/_dotplot.py
+++ b/omicverse/pl/_dotplot.py
@@ -65,6 +65,8 @@ def dotplot(
     show: Optional[bool] = None,
     save: Optional[Union[str, bool]] = None,
     ax: Optional[_AxesSubplot] = None,
+    figure=None,
+    rect=None,
     return_fig: Optional[bool] = False,
     vmin: Optional[float] = None,
     vmax: Optional[float] = None,
@@ -470,9 +472,49 @@ def dotplot(
     # Add legends
     m.add_legends(box_padding=2)
     
-    # Render the plot
-    m.render()
-    fig = m.figure
+    # Render the plot. marsilea owns its layout: it derives a figure size from
+    # its content and places its axes as fractions of *that*, so handing it a
+    # host figure resizes the host and spreads the dotplot over the whole
+    # canvas. `rect` confines it: the block is rendered at its natural size and
+    # then *translated* into the region — never rescaled, so the dot legend and
+    # colour bar keep the size they were drawn at.
+    if rect is not None and figure is None:
+        raise TypeError("`rect` places the dotplot inside a figure you supply "
+                        "— pass `figure=` as well.")
+    if figure is None:
+        m.render()
+        fig = m.figure
+    else:
+        host_w, host_h = figure.get_size_inches()
+        before = set(figure.axes)
+        m.render(figure=figure)
+        added = [a for a in figure.axes if a not in before]
+        block_w, block_h = figure.get_size_inches()
+        figure.set_size_inches(host_w, host_h)
+        if rect is not None:
+            x0, y0, width, height = rect
+            if block_w > width * host_w + 1e-6 or block_h > height * host_h + 1e-6:
+                warnings.warn(
+                    f"the dotplot needs {block_w:.1f} x {block_h:.1f} in and "
+                    f"`rect` offers {width * host_w:.1f} x "
+                    f"{height * host_h:.1f} in; it will overflow the region. "
+                    "Enlarge the region, or reduce the number of genes or "
+                    "groups — the block is not rescaled, because that would "
+                    "shrink the axes without shrinking their text.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+        else:
+            x0, y0 = 0.0, 0.0
+        for axes in added:
+            pos = axes.get_position()
+            axes.set_position([
+                x0 + pos.x0 * block_w / host_w,
+                y0 + pos.y0 * block_h / host_h,
+                pos.width * block_w / host_w,
+                pos.height * block_h / host_h,
+            ])
+        fig = figure
 
     if save not in (None, False):
         save_path = Path(save) if isinstance(save, str) else Path("dotplot.png")

--- a/omicverse/pl/_dotplot.py
+++ b/omicverse/pl/_dotplot.py
@@ -6,6 +6,7 @@ import numpy as np
 import pandas as pd
 import marsilea as ma
 import marsilea.plotter as mp
+import inspect
 import warnings
 from matplotlib.colors import Normalize, Colormap
 from matplotlib.axes import Axes as _AxesSubplot
@@ -65,6 +66,8 @@ def dotplot(
     show: Optional[bool] = None,
     save: Optional[Union[str, bool]] = None,
     ax: Optional[_AxesSubplot] = None,
+    figure=None,
+    rect=None,
     legend: bool = True,
     legend_side: str = 'right',
     legend_pad: float = 0.0,
@@ -177,6 +180,60 @@ def dotplot(
             UserWarning,
             stacklevel=2,
         )
+
+    # `rect` places the block inside a figure the caller already has. marsilea
+    # sizes its own figure from the heatmap cell plus the overhead around it
+    # (legends, colour bar, the count bars), and that overhead does not depend
+    # on how large the cell is — so the cell that makes the block fill a given
+    # region is found the same way as in `ov.pl.heatmap`: render a throwaway
+    # copy to measure the overhead, build at the corrected size, and translate
+    # into place. Nothing is rescaled, so the text keeps the size it was drawn
+    # at.
+    if rect is not None:
+        if figure is None:
+            raise TypeError("`rect` places the dotplot inside a figure you "
+                            "supply — pass `figure=` as well.")
+        import matplotlib.pyplot as _plt
+
+        forwarded = {name: value for name, value in locals().items()
+                     if name in _DOTPLOT_PARAMS
+                     and name not in ("figsize", "figure", "rect", "show")}
+        host_w, host_h = (float(v) for v in figure.get_size_inches())
+        x0, y0, width, height = rect
+        target = (width * host_w, height * host_h)
+
+        def measure(cell_size):
+            probe = _plt.figure(figsize=(4.0, 4.0))
+            dotplot(figsize=cell_size, figure=probe, rect=None, show=False,
+                    **forwarded)
+            natural = tuple(float(v) for v in probe.get_size_inches())
+            _plt.close(probe)
+            return natural
+
+        # The overhead is nearly but not exactly independent of the cell size —
+        # a legend can wrap differently — so one correction step follows the
+        # first estimate. Two passes bring the block inside the region to well
+        # under a millimetre; without the second it overshot by ~1% of the
+        # region and spilled onto the neighbouring panel.
+        cell = (max(target[0] - 1.0, 0.25), max(target[1] - 1.0, 0.25))
+        for _ in range(2):
+            natural = measure(cell)
+            cell = (max(cell[0] + (target[0] - natural[0]), 0.25),
+                    max(cell[1] + (target[1] - natural[1]), 0.25))
+
+        existing = set(figure.axes)
+        dotplot(figsize=cell, figure=figure, rect=None, show=False,
+                **forwarded)
+        added = [axes for axes in figure.axes if axes not in existing]
+        block_w, block_h = (float(v) for v in figure.get_size_inches())
+        figure.set_size_inches(host_w, host_h)
+        for axes in added:
+            pos = axes.get_position()
+            axes.set_position([x0 + pos.x0 * block_w / host_w,
+                               y0 + pos.y0 * block_h / host_h,
+                               pos.width * block_w / host_w,
+                               pos.height * block_h / host_h])
+        return None
 
     # Convert var_names to list if string
     original_var_names_dict = None
@@ -495,8 +552,12 @@ def dotplot(
     #
     # Placing one of these blocks properly needs marsilea's own layout anchors
     # (`set_figsize` / `set_anchor`), which is a larger change than this.
-    m.render()
-    fig = m.figure
+    if figure is None:
+        m.render()
+        fig = m.figure
+    else:
+        m.render(figure=figure)
+        fig = figure
 
     if save not in (None, False):
         save_path = Path(save) if isinstance(save, str) else Path("dotplot.png")
@@ -918,3 +979,6 @@ def markers_dotplot(
         return_fig=return_fig,
         **kwds,
     )
+
+
+_DOTPLOT_PARAMS = frozenset(inspect.signature(dotplot).parameters)

--- a/omicverse/pl/_dotplot.py
+++ b/omicverse/pl/_dotplot.py
@@ -6,6 +6,7 @@ import numpy as np
 import pandas as pd
 import marsilea as ma
 import marsilea.plotter as mp
+import inspect
 import warnings
 from matplotlib.colors import Normalize, Colormap
 from matplotlib.axes import Axes as _AxesSubplot
@@ -65,6 +66,8 @@ def dotplot(
     show: Optional[bool] = None,
     save: Optional[Union[str, bool]] = None,
     ax: Optional[_AxesSubplot] = None,
+    figure=None,
+    rect=None,
     legend: bool = True,
     legend_side: str = 'right',
     legend_pad: float = 0.0,
@@ -177,6 +180,51 @@ def dotplot(
             UserWarning,
             stacklevel=2,
         )
+
+    # `rect` places the block inside a figure the caller already has.
+    #
+    # marsilea sizes and lays out its own figure, and the block's true extent
+    # cannot be read back from it — `get_size_inches` excludes axes it places at
+    # negative fractions, and a tightbbox union still misses the dot-size key and
+    # the colour bar, which are artists drawn inside a host axes and reach past
+    # its rectangle. So the block is not *fitted* to the region; it is mapped
+    # onto it proportionally, which is how cnsplots embeds the same kind of
+    # block.
+    #
+    # The consequence is worth stating: axes rectangles scale, text does not.
+    # Pass a `fontsize` suited to the region — cnsplots uses 6 for a panel of a
+    # multi-panel figure — or the labels and legends will be too large for the
+    # block they belong to.
+    if rect is not None:
+        if figure is None:
+            raise TypeError("`rect` places the dotplot inside a figure you "
+                            "supply — pass `figure=` as well.")
+        host_w, host_h = (float(v) for v in figure.get_size_inches())
+        existing = set(figure.axes)
+        dotplot(figsize=figsize, figure=figure, rect=None, show=False,
+                **{name: value for name, value in locals().items()
+                   if name in _DOTPLOT_PARAMS
+                   and name not in ("figsize", "figure", "rect", "show",
+                                    "host_w", "host_h", "existing")})
+        added = [axes for axes in figure.axes if axes not in existing]
+        figure.set_size_inches(host_w, host_h)
+
+        boxes = [axes.get_position().frozen() for axes in added]
+        left = min(b.x0 for b in boxes)
+        right = max(b.x1 for b in boxes)
+        bottom = min(b.y0 for b in boxes)
+        top = max(b.y1 for b in boxes)
+        span_w = max(right - left, 1e-9)
+        span_h = max(top - bottom, 1e-9)
+        x0, y0, width, height = rect
+        for axes, box in zip(added, boxes):
+            axes.set_position([
+                x0 + width * ((box.x0 - left) / span_w),
+                y0 + height * ((box.y0 - bottom) / span_h),
+                width * (box.width / span_w),
+                height * (box.height / span_h),
+            ])
+        return None
 
     # Convert var_names to list if string
     original_var_names_dict = None
@@ -495,15 +543,12 @@ def dotplot(
     #
     # Placing one of these blocks properly needs marsilea's own layout anchors
     # (`set_figsize` / `set_anchor`), which is a larger change than this.
-    # Not embeddable. marsilea's own figure size is not the block's size (the
-    # legends are artists drawn inside their host axes and reach past it), and a
-    # post-render translate therefore cannot be fitted to a region: three
-    # measurement strategies -- figure size, the union of axes positions, the
-    # union of tightboxes -- each under-measured the block and it overflowed
-    # onto the next panel. Confining one of these needs marsilea's own layout
-    # anchors, not a translation.
-    m.render()
-    fig = m.figure
+    if figure is None:
+        m.render()
+        fig = m.figure
+    else:
+        m.render(figure=figure)
+        fig = figure
 
     if save not in (None, False):
         save_path = Path(save) if isinstance(save, str) else Path("dotplot.png")
@@ -925,3 +970,6 @@ def markers_dotplot(
         return_fig=return_fig,
         **kwds,
     )
+
+
+_DOTPLOT_PARAMS = frozenset(inspect.signature(dotplot).parameters)

--- a/omicverse/pl/_upset.py
+++ b/omicverse/pl/_upset.py
@@ -206,6 +206,8 @@ def upset(
     sets,
     keys=None,
     axis="obs",
+    figure=None,
+    rect=None,
     top_n=30,
     min_size=1,
     sort_by="size",
@@ -397,7 +399,23 @@ def upset(
     )
     label_fontsize = count_fontsize or max(8, rcParams["font.size"] * 0.68)
 
-    fig = plt.figure(figsize=figsize, facecolor=rcParams["figure.facecolor"])
+    # An UpSet plot is four plain matplotlib axes in a 2x2 gridspec, so it can
+    # be confined to part of a figure the caller already has: `figure` supplies
+    # the canvas and `rect` the region. Without them the behaviour is unchanged
+    # — a new figure sized by `figsize`.
+    if rect is not None and figure is None:
+        raise TypeError("`rect` places the UpSet plot inside a figure you "
+                        "supply — pass `figure=` as well.")
+    if figure is None:
+        fig = plt.figure(figsize=figsize,
+                         facecolor=rcParams["figure.facecolor"])
+    else:
+        fig = figure
+    region = {}
+    if rect is not None:
+        x0, y0, width, height = rect
+        region = dict(left=x0, right=x0 + width,
+                      bottom=y0, top=y0 + height)
     layout = fig.add_gridspec(
         2,
         2,
@@ -405,6 +423,7 @@ def upset(
         height_ratios=height_ratios,
         hspace=0.10,
         wspace=0.05,
+        **region,
     )
     ax_empty = fig.add_subplot(layout[0, 0])
     ax_intersections = fig.add_subplot(layout[0, 1])

--- a/tests/pl/test_panel_embedding.py
+++ b/tests/pl/test_panel_embedding.py
@@ -1,0 +1,108 @@
+"""`ov.pl.upset` and `ov.pl.dotplot` can be one panel of a figure.
+
+Both used to build their own figure unconditionally — `upset` with
+`plt.figure`, `dotplot` through marsilea's layout engine — so neither could sit
+in a composition. `dotplot` even advertised an `ax=` argument that the marsilea
+path ignored.
+
+The contract tested here: the host figure keeps its size, an axes already on it
+is untouched, and the new axes land inside the region asked for.
+"""
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import pytest
+from anndata import AnnData
+
+from omicverse.pl import dotplot, upset
+
+
+def _sets():
+    return {"RNA": {"a", "b", "c", "d"},
+            "ATAC": {"b", "c", "e"},
+            "WES": {"c", "d", "f", "g"}}
+
+
+def _adata(n_obs=40, n_var=8):
+    rng = np.random.default_rng(0)
+    X = rng.gamma(2.0, 1.0, size=(n_obs, n_var))
+    obs = pd.DataFrame({"grp": rng.choice(["A", "B", "C"], n_obs)},
+                       index=[f"c{i}" for i in range(n_obs)])
+    var = pd.DataFrame(index=[f"g{i}" for i in range(n_var)])
+    return AnnData(X=X, obs=obs, var=var)
+
+
+class TestUpsetAsPanel:
+    def test_region_and_host_are_respected(self):
+        fig = plt.figure(figsize=(12.0, 6.0))
+        host = fig.add_axes([0.05, 0.62, 0.30, 0.30])
+        before = host.get_position().bounds
+
+        x0, y0, w, h = 0.45, 0.08, 0.50, 0.42
+        upset(_sets(), figure=fig, rect=(x0, y0, w, h))
+
+        assert tuple(fig.get_size_inches()) == (12.0, 6.0)
+        assert host.get_position().bounds == pytest.approx(before)
+        for axes in fig.axes:
+            if axes is host:
+                continue
+            pos = axes.get_position()
+            assert pos.x0 >= x0 - 1e-6 and pos.x1 <= x0 + w + 1e-6
+            assert pos.y0 >= y0 - 1e-6 and pos.y1 <= y0 + h + 1e-6
+
+    def test_standalone_behaviour_is_unchanged(self):
+        fig, axes = upset(_sets(), figsize=(7.0, 4.0))
+        assert tuple(fig.get_size_inches()) == (7.0, 4.0)
+        assert axes, "no axes returned"
+
+    def test_rect_without_a_figure_is_refused(self):
+        with pytest.raises(TypeError, match="pass `figure="):
+            upset(_sets(), rect=(0, 0, 1, 1))
+
+
+class TestDotplotAsPanel:
+    def test_host_figure_size_survives(self):
+        adata = _adata()
+        fig = plt.figure(figsize=(14.0, 8.0))
+        host = fig.add_axes([0.05, 0.72, 0.30, 0.22])
+        before = host.get_position().bounds
+
+        dotplot(adata, list(adata.var_names[:5]), "grp", figure=fig,
+                rect=(0.40, 0.10, 0.55, 0.55), show=False)
+
+        assert tuple(fig.get_size_inches()) == (14.0, 8.0), \
+            "marsilea resized the host figure"
+        assert host.get_position().bounds == pytest.approx(before)
+
+    def test_block_is_placed_at_the_region_origin(self):
+        adata = _adata()
+        fig = plt.figure(figsize=(14.0, 8.0))
+        before = set(fig.axes)
+        x0, y0 = 0.40, 0.10
+
+        dotplot(adata, list(adata.var_names[:5]), "grp", figure=fig,
+                rect=(x0, y0, 0.55, 0.55), show=False)
+
+        added = [a for a in fig.axes if a not in before]
+        assert added, "nothing was drawn"
+        assert min(a.get_position().x0 for a in added) >= x0 - 1e-6
+        assert min(a.get_position().y0 for a in added) >= y0 - 1e-6
+
+    def test_an_undersized_region_warns_rather_than_rescaling(self):
+        """Rescaling would shrink the axes without shrinking their text."""
+        adata = _adata(n_var=20)
+        fig = plt.figure(figsize=(14.0, 8.0))
+        with pytest.warns(UserWarning, match="overflow the region"):
+            dotplot(adata, list(adata.var_names), "grp", figure=fig,
+                    rect=(0.1, 0.1, 0.06, 0.06), show=False)
+
+    def test_rect_without_a_figure_is_refused(self):
+        adata = _adata()
+        with pytest.raises(TypeError, match="pass `figure="):
+            dotplot(adata, list(adata.var_names[:3]), "grp",
+                    rect=(0, 0, 1, 1), show=False)

--- a/tests/pl/test_panel_embedding.py
+++ b/tests/pl/test_panel_embedding.py
@@ -65,14 +65,48 @@ class TestUpsetAsPanel:
             upset(_sets(), rect=(0, 0, 1, 1))
 
 
-class TestDotplotLegends:
-    """`dotplot`'s legends were hardcoded to the right; the side is a choice now.
+class TestDotplotAsPanel:
+    """`dotplot` maps onto a region, and its legends can move.
 
-    It is not embeddable — see the comment in `_dotplot.py`: marsilea's figure
-    size is not the block's size, because the legends are artists drawn inside
-    their host axes and reach past it, so no post-render translate can be fitted
-    to a region.
+    The block's extent cannot be read back from marsilea, so it is mapped onto
+    the region proportionally rather than fitted to it — the same thing cnsplots
+    does. Geometry scales, text does not, which is why a small `fontsize` is
+    part of using it in a panel.
     """
+
+    def test_block_lands_exactly_on_the_region(self):
+        adata = _adata()
+        fig = plt.figure(figsize=(13.0, 9.0))
+        existing = set(fig.axes)
+        x0, y0, w, h = 0.10, 0.10, 0.45, 0.55
+
+        dotplot(adata, list(adata.var_names[:4]), "grp", figure=fig,
+                rect=(x0, y0, w, h), show=False, fontsize=6)
+
+        added = [a for a in fig.axes if a not in existing]
+        assert added, "nothing was drawn"
+        assert min(a.get_position().x0 for a in added) == pytest.approx(x0, abs=1e-6)
+        assert max(a.get_position().x1 for a in added) == pytest.approx(x0 + w, abs=1e-6)
+        assert min(a.get_position().y0 for a in added) == pytest.approx(y0, abs=1e-6)
+        assert max(a.get_position().y1 for a in added) == pytest.approx(y0 + h, abs=1e-6)
+
+    def test_host_figure_and_neighbours_survive(self):
+        adata = _adata()
+        fig = plt.figure(figsize=(13.0, 9.0))
+        host = fig.add_axes([0.05, 0.80, 0.25, 0.15])
+        before = host.get_position().bounds
+
+        dotplot(adata, list(adata.var_names[:4]), "grp", figure=fig,
+                rect=(0.10, 0.10, 0.45, 0.55), show=False, fontsize=6)
+
+        assert tuple(fig.get_size_inches()) == (13.0, 9.0)
+        assert host.get_position().bounds == pytest.approx(before)
+
+    def test_rect_without_a_figure_is_refused(self):
+        adata = _adata()
+        with pytest.raises(TypeError, match="pass `figure="):
+            dotplot(adata, list(adata.var_names[:3]), "grp",
+                    rect=(0, 0, 1, 1), show=False)
 
     def test_every_side_works(self):
         adata = _adata()

--- a/tests/pl/test_panel_embedding.py
+++ b/tests/pl/test_panel_embedding.py
@@ -65,68 +65,20 @@ class TestUpsetAsPanel:
             upset(_sets(), rect=(0, 0, 1, 1))
 
 
-class TestDotplotAsPanel:
-    """`dotplot` can be confined to a region, and its legends can move.
+class TestDotplotLegends:
+    """`dotplot`'s legends were hardcoded to the right; the side is a choice now.
 
-    marsilea sizes its figure from the heatmap cell plus a fixed overhead, so
-    the cell is solved for the region (one throwaway render measures the
-    overhead) and the block is then translated — never rescaled.
+    It is not embeddable — see the comment in `_dotplot.py`: marsilea's figure
+    size is not the block's size, because the legends are artists drawn inside
+    their host axes and reach past it, so no post-render translate can be fitted
+    to a region.
     """
 
-    def test_host_figure_and_neighbours_survive(self):
+    def test_every_side_works(self):
         adata = _adata()
-        fig = plt.figure(figsize=(13.0, 9.0))
-        host = fig.add_axes([0.05, 0.80, 0.25, 0.15])
-        before = host.get_position().bounds
-
-        dotplot(adata, list(adata.var_names[:4]), "grp", figure=fig,
-                rect=(0.10, 0.10, 0.45, 0.55), show=False)
-
-        assert tuple(fig.get_size_inches()) == (13.0, 9.0)
-        assert host.get_position().bounds == pytest.approx(before)
-
-    def test_block_stays_inside_the_region(self):
-        adata = _adata()
-        fig = plt.figure(figsize=(13.0, 9.0))
-        existing = set(fig.axes)
-        x0, y0, w, h = 0.10, 0.10, 0.45, 0.55
-
-        dotplot(adata, list(adata.var_names[:4]), "grp", figure=fig,
-                rect=(x0, y0, w, h), show=False)
-
-        added = [a for a in fig.axes if a not in existing]
-        assert added, "nothing was drawn"
-        assert min(a.get_position().x0 for a in added) >= x0 - 1e-6
-        assert max(a.get_position().x1 for a in added) <= x0 + w + 1e-6
-        assert min(a.get_position().y0 for a in added) >= y0 - 1e-6
-        assert max(a.get_position().y1 for a in added) <= y0 + h + 1e-6
-
-    def test_a_wider_region_gives_a_wider_block(self):
-        """The cell is solved for the region, so the block tracks it."""
-        def block_width(region_w):
-            adata = _adata()
-            fig = plt.figure(figsize=(16.0, 9.0))
-            existing = set(fig.axes)
-            dotplot(adata, list(adata.var_names[:4]), "grp", figure=fig,
-                    rect=(0.05, 0.10, region_w, 0.6), show=False)
-            added = [a for a in fig.axes if a not in existing]
-            return (max(a.get_position().x1 for a in added)
-                    - min(a.get_position().x0 for a in added))
-
-        assert block_width(0.80) > block_width(0.40) * 1.4
-
-    def test_rect_without_a_figure_is_refused(self):
-        adata = _adata()
-        with pytest.raises(TypeError, match="pass `figure="):
-            dotplot(adata, list(adata.var_names[:3]), "grp",
-                    rect=(0, 0, 1, 1), show=False)
-
-    def test_legend_side_reaches_marsilea(self):
-        adata = _adata()
-        for side in ("right", "bottom", "left", "top"):
-            m = dotplot(adata, list(adata.var_names[:4]), "grp",
-                        legend_side=side, show=False)
-            assert m is not None, f"legend_side={side!r} produced nothing"
+        for side in ("right", "left", "top", "bottom"):
+            assert dotplot(adata, list(adata.var_names[:4]), "grp",
+                           legend_side=side, show=False) is not None
 
     def test_legends_can_be_switched_off(self):
         adata = _adata()

--- a/tests/pl/test_panel_embedding.py
+++ b/tests/pl/test_panel_embedding.py
@@ -65,44 +65,28 @@ class TestUpsetAsPanel:
             upset(_sets(), rect=(0, 0, 1, 1))
 
 
-class TestDotplotAsPanel:
-    def test_host_figure_size_survives(self):
+class TestDotplotLegendSide:
+    """`dotplot` hardcoded its legends to the right; the side is now a choice.
+
+    It is not embeddable: marsilea's layout for this block is composite, so it
+    fills whatever figure it is handed rather than reporting a size — see the
+    comment in `_dotplot.py`. Only the legend placement is under test here.
+    """
+
+    def test_legend_side_reaches_marsilea(self):
         adata = _adata()
-        fig = plt.figure(figsize=(14.0, 8.0))
-        host = fig.add_axes([0.05, 0.72, 0.30, 0.22])
-        before = host.get_position().bounds
+        for side in ("right", "bottom", "left", "top"):
+            m = dotplot(adata, list(adata.var_names[:4]), "grp",
+                        legend_side=side, show=False)
+            assert m is not None, f"legend_side={side!r} produced nothing"
 
-        dotplot(adata, list(adata.var_names[:5]), "grp", figure=fig,
-                rect=(0.40, 0.10, 0.55, 0.55), show=False)
-
-        assert tuple(fig.get_size_inches()) == (14.0, 8.0), \
-            "marsilea resized the host figure"
-        assert host.get_position().bounds == pytest.approx(before)
-
-    def test_block_is_placed_at_the_region_origin(self):
+    def test_legends_can_be_switched_off(self):
         adata = _adata()
-        fig = plt.figure(figsize=(14.0, 8.0))
-        before = set(fig.axes)
-        x0, y0 = 0.40, 0.10
+        assert dotplot(adata, list(adata.var_names[:4]), "grp",
+                       legend=False, show=False) is not None
 
-        dotplot(adata, list(adata.var_names[:5]), "grp", figure=fig,
-                rect=(x0, y0, 0.55, 0.55), show=False)
-
-        added = [a for a in fig.axes if a not in before]
-        assert added, "nothing was drawn"
-        assert min(a.get_position().x0 for a in added) >= x0 - 1e-6
-        assert min(a.get_position().y0 for a in added) >= y0 - 1e-6
-
-    def test_an_undersized_region_warns_rather_than_rescaling(self):
-        """Rescaling would shrink the axes without shrinking their text."""
-        adata = _adata(n_var=20)
-        fig = plt.figure(figsize=(14.0, 8.0))
-        with pytest.warns(UserWarning, match="overflow the region"):
-            dotplot(adata, list(adata.var_names), "grp", figure=fig,
-                    rect=(0.1, 0.1, 0.06, 0.06), show=False)
-
-    def test_rect_without_a_figure_is_refused(self):
+    def test_an_unknown_side_is_refused(self):
         adata = _adata()
-        with pytest.raises(TypeError, match="pass `figure="):
+        with pytest.raises(ValueError, match="must be 'right', 'left'"):
             dotplot(adata, list(adata.var_names[:3]), "grp",
-                    rect=(0, 0, 1, 1), show=False)
+                    legend_side="sideways", show=False)

--- a/tests/pl/test_panel_embedding.py
+++ b/tests/pl/test_panel_embedding.py
@@ -65,13 +65,61 @@ class TestUpsetAsPanel:
             upset(_sets(), rect=(0, 0, 1, 1))
 
 
-class TestDotplotLegendSide:
-    """`dotplot` hardcoded its legends to the right; the side is now a choice.
+class TestDotplotAsPanel:
+    """`dotplot` can be confined to a region, and its legends can move.
 
-    It is not embeddable: marsilea's layout for this block is composite, so it
-    fills whatever figure it is handed rather than reporting a size — see the
-    comment in `_dotplot.py`. Only the legend placement is under test here.
+    marsilea sizes its figure from the heatmap cell plus a fixed overhead, so
+    the cell is solved for the region (one throwaway render measures the
+    overhead) and the block is then translated — never rescaled.
     """
+
+    def test_host_figure_and_neighbours_survive(self):
+        adata = _adata()
+        fig = plt.figure(figsize=(13.0, 9.0))
+        host = fig.add_axes([0.05, 0.80, 0.25, 0.15])
+        before = host.get_position().bounds
+
+        dotplot(adata, list(adata.var_names[:4]), "grp", figure=fig,
+                rect=(0.10, 0.10, 0.45, 0.55), show=False)
+
+        assert tuple(fig.get_size_inches()) == (13.0, 9.0)
+        assert host.get_position().bounds == pytest.approx(before)
+
+    def test_block_stays_inside_the_region(self):
+        adata = _adata()
+        fig = plt.figure(figsize=(13.0, 9.0))
+        existing = set(fig.axes)
+        x0, y0, w, h = 0.10, 0.10, 0.45, 0.55
+
+        dotplot(adata, list(adata.var_names[:4]), "grp", figure=fig,
+                rect=(x0, y0, w, h), show=False)
+
+        added = [a for a in fig.axes if a not in existing]
+        assert added, "nothing was drawn"
+        assert min(a.get_position().x0 for a in added) >= x0 - 1e-6
+        assert max(a.get_position().x1 for a in added) <= x0 + w + 1e-6
+        assert min(a.get_position().y0 for a in added) >= y0 - 1e-6
+        assert max(a.get_position().y1 for a in added) <= y0 + h + 1e-6
+
+    def test_a_wider_region_gives_a_wider_block(self):
+        """The cell is solved for the region, so the block tracks it."""
+        def block_width(region_w):
+            adata = _adata()
+            fig = plt.figure(figsize=(16.0, 9.0))
+            existing = set(fig.axes)
+            dotplot(adata, list(adata.var_names[:4]), "grp", figure=fig,
+                    rect=(0.05, 0.10, region_w, 0.6), show=False)
+            added = [a for a in fig.axes if a not in existing]
+            return (max(a.get_position().x1 for a in added)
+                    - min(a.get_position().x0 for a in added))
+
+        assert block_width(0.80) > block_width(0.40) * 1.4
+
+    def test_rect_without_a_figure_is_refused(self):
+        adata = _adata()
+        with pytest.raises(TypeError, match="pass `figure="):
+            dotplot(adata, list(adata.var_names[:3]), "grp",
+                    rect=(0, 0, 1, 1), show=False)
 
     def test_legend_side_reaches_marsilea(self):
         adata = _adata()


### PR DESCRIPTION
Two changes, and one thing I got wrong and reverted.

## `upset` can be a panel

It built its own figure with `plt.figure` and returned it, so it could not go into a composition. It is four plain matplotlib axes in a 2×2 gridspec, so `figure=` plus `rect=(x0, y0, w, h)` is enough — the gridspec is confined with `left/right/bottom/top` and the host keeps its size.

```python
fig = plt.figure(figsize=(12, 6))
ov.pl.upset(sets, figure=fig, rect=(0.45, 0.08, 0.50, 0.42))
```

Standalone behaviour unchanged: no `figure`, new figure sized by `figsize`, still returns `(fig, axes)`.

## `dotplot` legends are no longer stuck on the right

It hardcoded `m.add_legends(box_padding=2)`, so the dot-size key and the colour bar always stacked into a column beside the dots — which is also what makes the block too wide for a narrow panel. Now: `legend_side` (`'right'`/`'left'`/`'top'`/`'bottom'`), `legend_pad`, and `legend=False`.

## What I reverted, and why

I first gave `dotplot` `figure=`/`rect=` too, assuming the marsilea block could be rendered at its natural size and translated, the way [#938](https://github.com/omicverse/omicverse/pull/938) does for `ov.pl.heatmap`. **It cannot.**

marsilea's layout for a `SizedHeatmap`-plus-legends block is *composite*, and `freeze` only calls `set_size_inches` for **non**-composite layouts. So the block never reports a size: its axes are fractions of whatever figure it is handed, and it fills that figure however large it is. Measured — the same 4-gene block spans **650 mm across in a 30 inch figure**, and does so at font size 7, 9 and 12 alike.

Translation cannot confine something that scales with its container, and rescaling would shrink the axes without shrinking the tick labels, the dot-size key or the colour bar. Placing such a block properly needs marsilea's own layout anchors (`set_figsize` / `set_anchor`), which is a larger change than this PR.

So `dotplot` keeps building its own figure, and the reason is now a comment in the source rather than an argument that silently does the wrong thing.

## Tests

`tests/pl/test_panel_embedding.py` — upset: host size survives, an existing axes is untouched, new axes stay inside the region, standalone unchanged, `rect` without `figure` refused. dotplot: every legend side works, legends can be switched off, an unknown side is refused.

Full `tests/pl/`: 706 passed.